### PR TITLE
feat: event-sourced collaboration (Phase 1)

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ Bicameral MCP is a local-first [Model Context Protocol](https://spec.modelcontex
 - [MCP Tools Reference](#mcp-tools-reference)
 - [Tool Composition](#tool-composition)
 - [Testing](#testing)
+- [Collaboration Modes](#collaboration-modes)
 - [Configuration](#configuration)
 - [Roadmap](#roadmap)
 - [Contributing](#contributing)
@@ -466,6 +467,34 @@ pytest tests/ -v
 Additional test suites cover adversarial inputs (`test_stress_adversarial.py`), failure modes (`test_stress_failure_modes.py`), grounding state machine gaps (`test_grounding_state_machine_gaps.py`), and server smoke tests (`test_server_smoke.py`).
 
 Phase 3 tests produce JSON artifacts (`test-results/e2e/`) with full tool responses and SurrealDB graph dumps for qualitative review. CI runs via GitHub Actions on PRs to `main`, with JUnit XML and HTML reports uploaded as artifacts.
+
+---
+
+## Collaboration Modes
+
+Bicameral runs in one of two modes, set during `bicameral-mcp setup` or in `.bicameral/config.yaml`:
+
+| | Solo (default) | Team |
+|---|---|---|
+| **Who** | Single developer | 2+ developers on the same repo |
+| **Decisions stored** | Local DB only (`ledger.db`) | Local DB **+ git-committed event files** |
+| **Shared via** | Nothing -- local only | Normal `git push` / `git pull` |
+| **Merge conflicts** | N/A | Zero -- per-user directories, append-only files |
+| **On startup** | Connects to local DB | Connects to local DB, then materializes new peer events |
+
+**Team mode layout:**
+
+```
+.bicameral/
+├── events/              ← committed to git (shared truth)
+│   ├── jin@co.com/      ← your events
+│   └── peer@co.com/     ← teammate's events (arrive via git pull)
+├── config.yaml          ← committed (mode: solo | team)
+└── local/               ← gitignored (local materialized state)
+    └── ledger.db
+```
+
+**Switching modes:** Edit `.bicameral/config.yaml` and set `mode: team` or `mode: solo`. On next server startup, the adapter factory picks the right path. No data migration needed -- team mode replays all existing events into the local DB automatically.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -164,7 +164,16 @@ claude mcp add-json bicameral --scope local '{
 ### Local development
 
 ```bash
+# Option A: pipx editable install (puts bicameral-mcp on PATH, uses local source)
+pipx install -e . --force
+
+# Option B: pip editable install (venv-local, includes test deps)
 pip install -e ".[test]"
+```
+
+After either option:
+
+```bash
 bicameral-mcp setup           # interactive config
 bicameral-mcp --smoke-test    # verify all 9 tools register correctly
 bicameral-mcp                 # start MCP server (stdio)

--- a/README.md
+++ b/README.md
@@ -476,25 +476,25 @@ Bicameral runs in one of two modes, set during `bicameral-mcp setup` or in `.bic
 
 | | Solo (default) | Team |
 |---|---|---|
-| **Who** | Single developer | 2+ developers on the same repo |
-| **Decisions stored** | Local DB only (`ledger.db`) | Local DB **+ git-committed event files** |
-| **Shared via** | Nothing -- local only | Normal `git push` / `git pull` |
+| **Who** | Individual testing or evaluation | Any mix of roles -- devs, PMs, designers |
+| **Data** | Local DB only | Local DB + git-committed event files |
+| **Shared via** | Nothing -- fully isolated, zero impact on teammates | Normal `git push` / `git pull` |
 | **Merge conflicts** | N/A | Zero -- per-user directories, append-only files |
-| **On startup** | Connects to local DB | Connects to local DB, then materializes new peer events |
 
-**Team mode layout:**
+**Solo mode** is ideal for trying Bicameral without affecting your team's workflow. All data stays in a gitignored local DB -- no event files, no commits, no side effects. Switch to team mode when you're ready to share.
+
+**Team mode** enables cross-role collaboration through git. A PM ingests a PRD and sprint transcript; when a developer pulls, `bicameral.search` surfaces those decisions as coding context and `bicameral.status` shows what still needs implementation. The PM never touches the code; the developer never sits through the meeting. The decision graph is the handoff.
 
 ```
 .bicameral/
-├── events/              ← committed to git (shared truth)
-│   ├── jin@co.com/      ← your events
-│   └── peer@co.com/     ← teammate's events (arrive via git pull)
+├── events/              ← committed to git (shared decisions)
+│   ├── pm@co.com/       ← PM's ingested PRDs and transcripts
+│   └── dev@co.com/      ← developer's commit syncs
 ├── config.yaml          ← committed (mode: solo | team)
-└── local/               ← gitignored (local materialized state)
-    └── ledger.db
+└── local/               ← gitignored (materialized state)
 ```
 
-**Switching modes:** Edit `.bicameral/config.yaml` and set `mode: team` or `mode: solo`. On next server startup, the adapter factory picks the right path. No data migration needed -- team mode replays all existing events into the local DB automatically.
+**Switching modes:** Set `mode: team` or `mode: solo` in `.bicameral/config.yaml`. No data migration needed.
 
 ---
 

--- a/adapters/ledger.py
+++ b/adapters/ledger.py
@@ -4,26 +4,80 @@ Uses SurrealDBLedgerAdapter backed by embedded SurrealDB (Python SDK v1.x).
 - Default URL: surrealkv://~/.bicameral/ledger.db (persistent)
 - Override via SURREAL_URL env var (e.g. memory:// for tests, ws://host:port for server)
 
+In team mode (.bicameral/config.yaml: mode: team), wraps the adapter with
+TeamWriteAdapter for dual-write (event file + DB) and event materialization.
+
 The adapter is a singleton per process — one connection, reused across tool calls.
 """
 
 from __future__ import annotations
 
+import logging
 import os
+from pathlib import Path
+
+logger = logging.getLogger(__name__)
 
 # Singleton for the real adapter (one connection per process)
 _real_ledger_instance = None
 
 
+def _read_collaboration_mode(repo_path: str) -> str:
+    """Read mode from .bicameral/config.yaml (returns 'solo' or 'team')."""
+    config_path = Path(repo_path) / ".bicameral" / "config.yaml"
+    if not config_path.exists():
+        return "solo"
+    try:
+        import yaml
+        config = yaml.safe_load(config_path.read_text(encoding="utf-8")) or {}
+        return config.get("mode", "solo")
+    except Exception:
+        # yaml not installed or bad file — fall back to basic parsing
+        try:
+            for line in config_path.read_text(encoding="utf-8").splitlines():
+                line = line.strip()
+                if line.startswith("mode:"):
+                    return line.split(":", 1)[1].strip().strip("\"'")
+        except OSError:
+            pass
+    return "solo"
+
+
 def get_ledger():
-    """Return the SurrealDB ledger adapter (singleton)."""
+    """Return the ledger adapter (singleton).
+
+    Returns SurrealDBLedgerAdapter in solo mode, or TeamWriteAdapter in team mode.
+    """
     global _real_ledger_instance
 
     if _real_ledger_instance is None:
         from ledger.adapter import SurrealDBLedgerAdapter
-        _real_ledger_instance = SurrealDBLedgerAdapter(
+
+        inner = SurrealDBLedgerAdapter(
             url=os.getenv("SURREAL_URL", None),
         )
+
+        repo_path = os.getenv("REPO_PATH", ".")
+        mode = _read_collaboration_mode(repo_path)
+
+        if mode == "team":
+            from events.writer import EventFileWriter, _get_git_email
+            from events.materializer import EventMaterializer
+            from events.team_adapter import TeamWriteAdapter
+
+            bicameral_dir = Path(repo_path) / ".bicameral"
+            events_dir = bicameral_dir / "events"
+            local_dir = bicameral_dir / "local"
+
+            author = _get_git_email(repo_path)
+            writer = EventFileWriter(events_dir, author)
+            materializer = EventMaterializer(events_dir, local_dir)
+
+            _real_ledger_instance = TeamWriteAdapter(inner, writer, materializer)
+            logger.info("[ledger] team mode — events at %s (author: %s)", events_dir, author)
+        else:
+            _real_ledger_instance = inner
+
     return _real_ledger_instance
 
 

--- a/events/__init__.py
+++ b/events/__init__.py
@@ -1,0 +1,5 @@
+"""Event-sourced collaboration for bicameral-mcp.
+
+Append-only JSON event files in .bicameral/events/{git-email}/,
+committed to git for cross-team decision sharing.
+"""

--- a/events/materializer.py
+++ b/events/materializer.py
@@ -1,0 +1,108 @@
+"""EventMaterializer — replays event files into the local ledger DB.
+
+On startup in team mode, reads all event files from .bicameral/events/,
+filters to events newer than the watermark, and replays them into the
+SurrealDBLedgerAdapter in chronological order.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from pathlib import Path
+
+logger = logging.getLogger(__name__)
+
+
+class EventMaterializer:
+    """Watermark-based incremental event replay."""
+
+    def __init__(self, events_dir: Path, local_dir: Path) -> None:
+        self._events_dir = events_dir
+        self._watermark_path = local_dir / "watermark"
+        local_dir.mkdir(parents=True, exist_ok=True)
+
+    def _read_watermark(self) -> str:
+        """Read the last-materialized event timestamp (or empty string)."""
+        if self._watermark_path.exists():
+            return self._watermark_path.read_text(encoding="utf-8").strip()
+        return ""
+
+    def _write_watermark(self, timestamp: str) -> None:
+        """Persist the watermark."""
+        self._watermark_path.write_text(timestamp + "\n", encoding="utf-8")
+
+    @staticmethod
+    def _extract_timestamp(filename: str) -> str:
+        """Extract the ISO timestamp prefix from an event filename.
+
+        Filenames look like: 20260410T180000Z-a1b2c3d4.json
+        Returns the timestamp portion: 20260410T180000Z
+        """
+        stem = filename.rsplit(".", 1)[0]  # strip .json
+        return stem.rsplit("-", 1)[0]      # strip -uuid
+
+    async def replay_new_events(self, inner_adapter) -> int:
+        """Replay events newer than the watermark into the inner adapter.
+
+        Args:
+            inner_adapter: SurrealDBLedgerAdapter (must already be connected).
+
+        Returns:
+            Number of events replayed.
+        """
+        if not self._events_dir.exists():
+            return 0
+
+        watermark = self._read_watermark()
+
+        # Glob all event files across all user directories
+        event_files = sorted(
+            self._events_dir.glob("*/*.json"),
+            key=lambda f: f.name,  # lexicographic = chronological
+        )
+
+        # Filter to new events
+        new_events = [
+            f for f in event_files
+            if self._extract_timestamp(f.name) > watermark
+        ]
+
+        if not new_events:
+            return 0
+
+        logger.info(
+            "[materializer] replaying %d new events (watermark: %s)",
+            len(new_events),
+            watermark or "(none)",
+        )
+
+        replayed = 0
+        for event_file in new_events:
+            try:
+                event = json.loads(event_file.read_text(encoding="utf-8"))
+            except (json.JSONDecodeError, OSError) as exc:
+                logger.warning("[materializer] skipping bad event %s: %s", event_file, exc)
+                continue
+
+            event_type = event.get("event_type", "")
+            payload = event.get("payload", {})
+
+            if event_type == "ingest.completed":
+                await inner_adapter.ingest_payload(payload)
+                replayed += 1
+            elif event_type == "link_commit.completed":
+                await inner_adapter.ingest_commit(
+                    payload.get("commit_hash", ""),
+                    payload.get("repo_path", ""),
+                )
+                replayed += 1
+            else:
+                logger.warning("[materializer] unknown event type: %s", event_type)
+
+        # Update watermark to the latest event timestamp
+        latest_ts = self._extract_timestamp(new_events[-1].name)
+        self._write_watermark(latest_ts)
+
+        logger.info("[materializer] replayed %d events, watermark → %s", replayed, latest_ts)
+        return replayed

--- a/events/materializer.py
+++ b/events/materializer.py
@@ -62,11 +62,12 @@ class EventMaterializer:
             key=lambda f: f.name,  # lexicographic = chronological
         )
 
-        # Filter to new events
+        # Filter to new events (>= to handle multiple events in the same second;
+        # upsert idempotency makes re-applying safe)
         new_events = [
             f for f in event_files
-            if self._extract_timestamp(f.name) > watermark
-        ]
+            if self._extract_timestamp(f.name) >= watermark
+        ] if watermark else event_files
 
         if not new_events:
             return 0

--- a/events/models.py
+++ b/events/models.py
@@ -1,0 +1,19 @@
+"""Event envelope model for the event-sourced spec log."""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from typing import Any
+
+from pydantic import BaseModel, Field
+
+
+class EventEnvelope(BaseModel):
+    """Immutable event written to .bicameral/events/{author}/."""
+
+    schema_version: int = 1
+    event_id: str = Field(..., description="Timestamp-UUID composite, e.g. 20260410T180000Z-a1b2c3d4")
+    event_type: str = Field(..., description="e.g. ingest.completed, link_commit.completed")
+    author: str = Field(..., description="Git user email")
+    timestamp: datetime = Field(default_factory=lambda: datetime.now(timezone.utc))
+    payload: dict[str, Any] = Field(default_factory=dict)

--- a/events/team_adapter.py
+++ b/events/team_adapter.py
@@ -28,6 +28,7 @@ class TeamWriteAdapter:
         self._inner = inner
         self._writer = writer
         self._materializer = materializer
+        self._ready = False
 
     async def connect(self) -> None:
         """Connect inner adapter, then replay any new events from peers."""
@@ -35,11 +36,18 @@ class TeamWriteAdapter:
         replayed = await self._materializer.replay_new_events(self._inner)
         if replayed:
             logger.info("[team] materialized %d peer events on startup", replayed)
+        self._ready = True
+
+    async def _ensure_ready(self) -> None:
+        """Lazy connect + materialize on first use."""
+        if not self._ready:
+            await self.connect()
 
     # ── Write methods (intercepted: event file first, then DB) ───────────
 
     async def ingest_payload(self, payload: dict) -> dict:
         """Write ingest event, then delegate to inner adapter."""
+        await self._ensure_ready()
         self._writer.write("ingest.completed", payload)
         return await self._inner.ingest_payload(payload)
 
@@ -47,6 +55,7 @@ class TeamWriteAdapter:
         self, commit_hash: str, repo_path: str, drift_analyzer=None,
     ) -> dict:
         """Write link_commit event, then delegate to inner adapter."""
+        await self._ensure_ready()
         self._writer.write(
             "link_commit.completed",
             {"commit_hash": commit_hash, "repo_path": repo_path},
@@ -66,6 +75,7 @@ class TeamWriteAdapter:
         error: str = "",
     ) -> dict:
         """Source cursor is local bookkeeping — no event emitted."""
+        await self._ensure_ready()
         return await self._inner.upsert_source_cursor(
             repo=repo,
             source_type=source_type,
@@ -79,20 +89,25 @@ class TeamWriteAdapter:
     # ── Read methods (pass-through) ──────────────────────────────────────
 
     async def get_all_decisions(self, filter: str = "all") -> list[dict]:
+        await self._ensure_ready()
         return await self._inner.get_all_decisions(filter=filter)
 
     async def search_by_query(
         self, query: str, max_results: int = 10, min_confidence: float = 0.5,
     ) -> list[dict]:
+        await self._ensure_ready()
         return await self._inner.search_by_query(query, max_results, min_confidence)
 
     async def get_decisions_for_file(self, file_path: str) -> list[dict]:
+        await self._ensure_ready()
         return await self._inner.get_decisions_for_file(file_path)
 
     async def get_undocumented_symbols(self, file_path: str) -> list[str]:
+        await self._ensure_ready()
         return await self._inner.get_undocumented_symbols(file_path)
 
     async def get_source_cursor(
         self, repo: str, source_type: str, source_scope: str = "default",
     ) -> dict | None:
+        await self._ensure_ready()
         return await self._inner.get_source_cursor(repo, source_type, source_scope)

--- a/events/team_adapter.py
+++ b/events/team_adapter.py
@@ -1,0 +1,98 @@
+"""TeamWriteAdapter — dual-write adapter for team collaboration mode.
+
+Wraps SurrealDBLedgerAdapter via composition. On every write operation,
+emits an event file first, then delegates to the inner adapter.
+All read operations pass through directly.
+"""
+
+from __future__ import annotations
+
+import logging
+from pathlib import Path
+
+from .materializer import EventMaterializer
+from .writer import EventFileWriter
+
+logger = logging.getLogger(__name__)
+
+
+class TeamWriteAdapter:
+    """Dual-write: event file + local SurrealDB on every mutation."""
+
+    def __init__(
+        self,
+        inner,
+        writer: EventFileWriter,
+        materializer: EventMaterializer,
+    ) -> None:
+        self._inner = inner
+        self._writer = writer
+        self._materializer = materializer
+
+    async def connect(self) -> None:
+        """Connect inner adapter, then replay any new events from peers."""
+        await self._inner.connect()
+        replayed = await self._materializer.replay_new_events(self._inner)
+        if replayed:
+            logger.info("[team] materialized %d peer events on startup", replayed)
+
+    # ── Write methods (intercepted: event file first, then DB) ───────────
+
+    async def ingest_payload(self, payload: dict) -> dict:
+        """Write ingest event, then delegate to inner adapter."""
+        self._writer.write("ingest.completed", payload)
+        return await self._inner.ingest_payload(payload)
+
+    async def ingest_commit(
+        self, commit_hash: str, repo_path: str, drift_analyzer=None,
+    ) -> dict:
+        """Write link_commit event, then delegate to inner adapter."""
+        self._writer.write(
+            "link_commit.completed",
+            {"commit_hash": commit_hash, "repo_path": repo_path},
+        )
+        return await self._inner.ingest_commit(
+            commit_hash, repo_path, drift_analyzer=drift_analyzer,
+        )
+
+    async def upsert_source_cursor(
+        self,
+        repo: str,
+        source_type: str,
+        source_scope: str = "default",
+        cursor: str = "",
+        last_source_ref: str = "",
+        status: str = "ok",
+        error: str = "",
+    ) -> dict:
+        """Source cursor is local bookkeeping — no event emitted."""
+        return await self._inner.upsert_source_cursor(
+            repo=repo,
+            source_type=source_type,
+            source_scope=source_scope,
+            cursor=cursor,
+            last_source_ref=last_source_ref,
+            status=status,
+            error=error,
+        )
+
+    # ── Read methods (pass-through) ──────────────────────────────────────
+
+    async def get_all_decisions(self, filter: str = "all") -> list[dict]:
+        return await self._inner.get_all_decisions(filter=filter)
+
+    async def search_by_query(
+        self, query: str, max_results: int = 10, min_confidence: float = 0.5,
+    ) -> list[dict]:
+        return await self._inner.search_by_query(query, max_results, min_confidence)
+
+    async def get_decisions_for_file(self, file_path: str) -> list[dict]:
+        return await self._inner.get_decisions_for_file(file_path)
+
+    async def get_undocumented_symbols(self, file_path: str) -> list[str]:
+        return await self._inner.get_undocumented_symbols(file_path)
+
+    async def get_source_cursor(
+        self, repo: str, source_type: str, source_scope: str = "default",
+    ) -> dict | None:
+        return await self._inner.get_source_cursor(repo, source_type, source_scope)

--- a/events/writer.py
+++ b/events/writer.py
@@ -1,0 +1,81 @@
+"""EventFileWriter — atomic JSON event file writer.
+
+Writes immutable event files to .bicameral/events/{author}/ with
+timestamp-UUID filenames. Uses tmp+rename for atomic writes.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import subprocess
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+from uuid import uuid4
+
+from .models import EventEnvelope
+
+logger = logging.getLogger(__name__)
+
+
+def _get_git_email(repo_path: str | Path) -> str:
+    """Get git user.email for the repo (falls back to 'unknown')."""
+    try:
+        result = subprocess.run(
+            ["git", "config", "user.email"],
+            capture_output=True, text=True, timeout=5,
+            cwd=str(repo_path),
+        )
+        email = result.stdout.strip()
+        if email:
+            return email
+    except (subprocess.SubprocessError, OSError):
+        pass
+    return "unknown"
+
+
+class EventFileWriter:
+    """Writes append-only JSON event files to a per-user directory."""
+
+    def __init__(self, events_dir: Path, author_email: str) -> None:
+        self._events_dir = events_dir
+        self._author = author_email
+        self._user_dir = events_dir / author_email
+        self._user_dir.mkdir(parents=True, exist_ok=True)
+
+    @property
+    def author(self) -> str:
+        return self._author
+
+    @property
+    def events_dir(self) -> Path:
+        return self._events_dir
+
+    def write(self, event_type: str, payload: dict[str, Any]) -> Path:
+        """Write an event file atomically. Returns the path to the written file."""
+        now = datetime.now(timezone.utc)
+        ts = now.strftime("%Y%m%dT%H%M%SZ")
+        short_uuid = uuid4().hex[:8]
+
+        envelope = EventEnvelope(
+            event_id=f"{ts}-{short_uuid}",
+            event_type=event_type,
+            author=self._author,
+            timestamp=now,
+            payload=payload,
+        )
+
+        filename = f"{ts}-{short_uuid}.json"
+        path = self._user_dir / filename
+
+        # Atomic write: tmp file then rename
+        tmp = path.with_suffix(".tmp")
+        tmp.write_text(
+            json.dumps(envelope.model_dump(), indent=2, default=str),
+            encoding="utf-8",
+        )
+        tmp.rename(path)
+
+        logger.info("[events] wrote %s/%s", self._author, filename)
+        return path

--- a/setup_wizard.py
+++ b/setup_wizard.py
@@ -151,26 +151,36 @@ def _detect_runner() -> tuple[str, list[str]]:
     return (python, ["-m", "bicameral_mcp"])
 
 
-def _build_config(repo_path: Path) -> dict:
-    """Build the MCP server config object."""
+def _build_config(repo_path: Path, mode: str = "solo") -> dict:
+    """Build the MCP server config object.
+
+    In team mode, local DBs go under .bicameral/local/ (gitignored)
+    so they don't leak into the tracked events directory.
+    """
     command, args = _detect_runner()
     data_dir = repo_path / ".bicameral"
     data_dir.mkdir(parents=True, exist_ok=True)
+
+    if mode == "team":
+        local_dir = data_dir / "local"
+        local_dir.mkdir(parents=True, exist_ok=True)
+    else:
+        local_dir = data_dir
 
     return {
         "command": command,
         "args": args,
         "env": {
             "REPO_PATH": str(repo_path),
-            "SURREAL_URL": f"surrealkv://{data_dir / 'ledger.db'}",
-            "CODE_LOCATOR_SQLITE_DB": str(data_dir / "code-graph.db"),
+            "SURREAL_URL": f"surrealkv://{local_dir / 'ledger.db'}",
+            "CODE_LOCATOR_SQLITE_DB": str(local_dir / "code-graph.db"),
         },
     }
 
 
-def _write_json_config(repo_path: Path, config_path: Path) -> None:
+def _write_json_config(repo_path: Path, config_path: Path, mode: str = "solo") -> None:
     """Write MCP server config to a JSON file (Claude Code / Cursor)."""
-    config = _build_config(repo_path)
+    config = _build_config(repo_path, mode=mode)
     config_path.parent.mkdir(parents=True, exist_ok=True)
 
     existing = {}
@@ -184,9 +194,9 @@ def _write_json_config(repo_path: Path, config_path: Path) -> None:
     config_path.write_text(json.dumps(existing, indent=2) + "\n")
 
 
-def _write_toml_config(repo_path: Path, config_path: Path) -> None:
+def _write_toml_config(repo_path: Path, config_path: Path, mode: str = "solo") -> None:
     """Write MCP server config to a TOML file (Codex)."""
-    config = _build_config(repo_path)
+    config = _build_config(repo_path, mode=mode)
     config_path.parent.mkdir(parents=True, exist_ok=True)
 
     # Build the [mcp_servers.bicameral] TOML section
@@ -224,14 +234,14 @@ def _write_toml_config(repo_path: Path, config_path: Path) -> None:
     config_path.write_text("\n".join(lines) + "\n")
 
 
-def _install_for_agent(agent_key: str, repo_path: Path) -> bool:
+def _install_for_agent(agent_key: str, repo_path: Path, mode: str = "solo") -> bool:
     """Install MCP config for a specific coding agent."""
     agent = AGENTS[agent_key]
     config_path = agent["config_path"](repo_path)
 
     # For Claude Code, try CLI first
     if agent_key == "claude" and shutil.which("claude"):
-        config = _build_config(repo_path)
+        config = _build_config(repo_path, mode=mode)
         config_json = json.dumps(config)
         subprocess.run(
             ["claude", "mcp", "remove", "bicameral", "--scope", "project"],
@@ -247,7 +257,7 @@ def _install_for_agent(agent_key: str, repo_path: Path) -> bool:
 
     # For Codex, try CLI first
     if agent_key == "codex" and shutil.which("codex"):
-        config = _build_config(repo_path)
+        config = _build_config(repo_path, mode=mode)
         env_args = []
         for k, v in config["env"].items():
             env_args.extend(["--env", f"{k}={v}"])
@@ -261,9 +271,9 @@ def _install_for_agent(agent_key: str, repo_path: Path) -> bool:
 
     # Fallback: write config file directly
     if agent.get("config_format") == "toml":
-        _write_toml_config(repo_path, config_path)
+        _write_toml_config(repo_path, config_path, mode=mode)
     else:
-        _write_json_config(repo_path, config_path)
+        _write_json_config(repo_path, config_path, mode=mode)
 
     print(f"  {agent['name']}: wrote {config_path}")
     return True
@@ -409,7 +419,7 @@ def run_setup(repo_hint: str | None = None) -> int:
     # Step 5: Install MCP config for each agent
     print()
     for agent_key in agents:
-        _install_for_agent(agent_key, repo_path)
+        _install_for_agent(agent_key, repo_path, mode=collab_mode)
 
     # Step 6: Install skills (Claude Code only)
     if "claude" in agents:

--- a/setup_wizard.py
+++ b/setup_wizard.py
@@ -293,23 +293,85 @@ def _install_skills(repo_path: Path) -> int:
     return installed
 
 
-def _ensure_gitignore(repo_path: Path) -> None:
-    """Add .bicameral/ to .gitignore if not already there."""
+def _select_collaboration_mode() -> str:
+    """Prompt user for solo or team collaboration mode."""
+    if not _is_interactive():
+        return "solo"
+
+    print("\n  Collaboration mode:")
+    print("    1. Solo  — decisions stored locally (default)")
+    print("    2. Team  — decisions shared via git (append-only event files)")
+    choice = input("  Choice [1/2]: ").strip()
+
+    if choice == "2":
+        return "team"
+    return "solo"
+
+
+def _write_collaboration_config(repo_path: Path, mode: str) -> None:
+    """Write .bicameral/config.yaml with the collaboration mode."""
+    config_path = repo_path / ".bicameral" / "config.yaml"
+    config_path.parent.mkdir(parents=True, exist_ok=True)
+    config_path.write_text(
+        f"# Bicameral collaboration config\nmode: {mode}\n",
+        encoding="utf-8",
+    )
+    print(f"  Collaboration: {mode} mode")
+
+
+def _ensure_gitignore(repo_path: Path, mode: str = "solo") -> None:
+    """Configure .gitignore for the selected collaboration mode.
+
+    Solo mode: ignore all of .bicameral/
+    Team mode: ignore only .bicameral/local/ (events/ and config.yaml are committed)
+    """
     gitignore = repo_path / ".gitignore"
-    entry = ".bicameral/"
+
+    if mode == "team":
+        entries = [".bicameral/local/"]
+        comment = "# Bicameral MCP local data (team mode — events/ is committed)"
+    else:
+        entries = [".bicameral/"]
+        comment = "# Bicameral MCP local data"
 
     if gitignore.exists():
         content = gitignore.read_text()
-        if entry in content:
-            return
-        if not content.endswith("\n"):
+        lines = content.splitlines()
+
+        # Remove any existing bicameral entries to avoid conflicts
+        cleaned = []
+        skip_next_blank = False
+        for line in lines:
+            stripped = line.strip()
+            if stripped in (".bicameral/", ".bicameral/local/"):
+                skip_next_blank = True
+                continue
+            if stripped.startswith("# Bicameral MCP"):
+                skip_next_blank = True
+                continue
+            if skip_next_blank and stripped == "":
+                skip_next_blank = False
+                continue
+            skip_next_blank = False
+            cleaned.append(line)
+
+        # Remove trailing blank lines
+        while cleaned and not cleaned[-1].strip():
+            cleaned.pop()
+
+        content = "\n".join(cleaned)
+        if content and not content.endswith("\n"):
             content += "\n"
-        content += f"\n# Bicameral MCP local data\n{entry}\n"
+        content += f"\n{comment}\n"
+        for entry in entries:
+            content += f"{entry}\n"
         gitignore.write_text(content)
     else:
-        gitignore.write_text(f"# Bicameral MCP local data\n{entry}\n")
+        lines = [comment]
+        lines.extend(entries)
+        gitignore.write_text("\n".join(lines) + "\n")
 
-    print(f"  Added {entry} to .gitignore")
+    print(f"  Updated .gitignore for {mode} mode")
 
 
 def run_setup(repo_hint: str | None = None) -> int:
@@ -335,8 +397,14 @@ def run_setup(repo_hint: str | None = None) -> int:
         print(f"\n  Note: using '{command} -m bicameral_mcp' as runner.")
         print("  Install a package runner for zero-install: pip install pipx")
 
-    # Step 4: Prepare local data + gitignore
-    _ensure_gitignore(repo_path)
+    # Step 4: Collaboration mode + gitignore
+    collab_mode = _select_collaboration_mode()
+    _write_collaboration_config(repo_path, collab_mode)
+    _ensure_gitignore(repo_path, mode=collab_mode)
+
+    if collab_mode == "team":
+        events_dir = repo_path / ".bicameral" / "events"
+        events_dir.mkdir(parents=True, exist_ok=True)
 
     # Step 5: Install MCP config for each agent
     print()

--- a/tests/test_team_events.py
+++ b/tests/test_team_events.py
@@ -1,0 +1,375 @@
+"""Tests for Phase 1: event-sourced collaboration.
+
+Covers: EventFileWriter, EventMaterializer, TeamWriteAdapter, config detection.
+All tests use SURREAL_URL=memory:// and temp directories.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import tempfile
+from pathlib import Path
+
+import pytest
+
+# Ensure in-memory SurrealDB for all tests in this module
+os.environ.setdefault("SURREAL_URL", "memory://")
+
+
+# ── EventFileWriter ──────────────────────────────────────────────────────
+
+
+class TestEventFileWriter:
+    def test_write_creates_file(self, tmp_path):
+        from events.writer import EventFileWriter
+
+        events_dir = tmp_path / "events"
+        writer = EventFileWriter(events_dir, "jin@example.com")
+
+        path = writer.write("ingest.completed", {"repo": "test"})
+
+        assert path.exists()
+        assert path.parent == events_dir / "jin@example.com"
+        assert path.suffix == ".json"
+
+    def test_write_correct_json_structure(self, tmp_path):
+        from events.writer import EventFileWriter
+
+        writer = EventFileWriter(tmp_path / "events", "jin@example.com")
+        path = writer.write("ingest.completed", {"repo": "test", "mappings": []})
+
+        event = json.loads(path.read_text())
+        assert event["schema_version"] == 1
+        assert event["event_type"] == "ingest.completed"
+        assert event["author"] == "jin@example.com"
+        assert event["payload"]["repo"] == "test"
+        assert "event_id" in event
+        assert "timestamp" in event
+
+    def test_write_filename_format(self, tmp_path):
+        from events.writer import EventFileWriter
+
+        writer = EventFileWriter(tmp_path / "events", "test@co.com")
+        path = writer.write("link_commit.completed", {})
+
+        # Filename: 20260410T180000Z-a1b2c3d4.json
+        name = path.stem
+        parts = name.rsplit("-", 1)
+        assert len(parts) == 2
+        assert parts[0].endswith("Z")  # ISO timestamp
+        assert len(parts[1]) == 8       # short UUID
+
+    def test_write_no_tmp_files_left(self, tmp_path):
+        from events.writer import EventFileWriter
+
+        writer = EventFileWriter(tmp_path / "events", "test@co.com")
+        writer.write("ingest.completed", {})
+
+        tmp_files = list((tmp_path / "events" / "test@co.com").glob("*.tmp"))
+        assert tmp_files == []
+
+    def test_write_multiple_events_unique_filenames(self, tmp_path):
+        from events.writer import EventFileWriter
+
+        writer = EventFileWriter(tmp_path / "events", "test@co.com")
+        paths = [writer.write("ingest.completed", {"i": i}) for i in range(5)]
+
+        assert len(set(paths)) == 5
+
+    def test_creates_user_directory(self, tmp_path):
+        from events.writer import EventFileWriter
+
+        events_dir = tmp_path / "events"
+        assert not events_dir.exists()
+
+        EventFileWriter(events_dir, "new@user.com")
+        assert (events_dir / "new@user.com").is_dir()
+
+
+# ── EventMaterializer ───────────────────────────────────────────────────
+
+
+class TestEventMaterializer:
+    def _write_event_file(self, events_dir: Path, author: str, ts: str, event_type: str, payload: dict):
+        """Helper to create a manual event file."""
+        user_dir = events_dir / author
+        user_dir.mkdir(parents=True, exist_ok=True)
+        filename = f"{ts}-deadbeef.json"
+        event = {
+            "schema_version": 1,
+            "event_id": f"{ts}-deadbeef",
+            "event_type": event_type,
+            "author": author,
+            "timestamp": "2026-04-10T18:00:00+00:00",
+            "payload": payload,
+        }
+        (user_dir / filename).write_text(json.dumps(event), encoding="utf-8")
+
+    def test_no_events_returns_zero(self, tmp_path):
+        import asyncio
+        from events.materializer import EventMaterializer
+
+        mat = EventMaterializer(tmp_path / "events", tmp_path / "local")
+
+        class FakeAdapter:
+            pass
+
+        result = asyncio.run(mat.replay_new_events(FakeAdapter()))
+        assert result == 0
+
+    def test_replay_processes_new_events(self, tmp_path):
+        import asyncio
+        from events.materializer import EventMaterializer
+
+        events_dir = tmp_path / "events"
+        self._write_event_file(
+            events_dir, "a@test.com", "20260410T180000Z",
+            "ingest.completed",
+            {"repo": "test", "mappings": []},
+        )
+
+        mat = EventMaterializer(events_dir, tmp_path / "local")
+        calls = []
+
+        class MockAdapter:
+            async def ingest_payload(self, payload):
+                calls.append(("ingest", payload))
+                return {}
+
+        result = asyncio.run(mat.replay_new_events(MockAdapter()))
+        assert result == 1
+        assert len(calls) == 1
+        assert calls[0][0] == "ingest"
+
+    def test_watermark_prevents_replay(self, tmp_path):
+        import asyncio
+        from events.materializer import EventMaterializer
+
+        events_dir = tmp_path / "events"
+        self._write_event_file(
+            events_dir, "a@test.com", "20260410T180000Z",
+            "ingest.completed", {"repo": "test", "mappings": []},
+        )
+
+        mat = EventMaterializer(events_dir, tmp_path / "local")
+        calls = []
+
+        class MockAdapter:
+            async def ingest_payload(self, payload):
+                calls.append(payload)
+                return {}
+
+        # First replay
+        asyncio.run(mat.replay_new_events(MockAdapter()))
+        assert len(calls) == 1
+
+        # Second replay — watermark should prevent re-processing
+        calls.clear()
+        asyncio.run(mat.replay_new_events(MockAdapter()))
+        assert len(calls) == 0
+
+    def test_replays_in_chronological_order(self, tmp_path):
+        import asyncio
+        from events.materializer import EventMaterializer
+
+        events_dir = tmp_path / "events"
+        # Write events from two users, interleaved timestamps
+        self._write_event_file(
+            events_dir, "b@test.com", "20260410T190000Z",
+            "ingest.completed", {"order": 2},
+        )
+        self._write_event_file(
+            events_dir, "a@test.com", "20260410T180000Z",
+            "ingest.completed", {"order": 1},
+        )
+        self._write_event_file(
+            events_dir, "a@test.com", "20260410T200000Z",
+            "ingest.completed", {"order": 3},
+        )
+
+        mat = EventMaterializer(events_dir, tmp_path / "local")
+        orders = []
+
+        class MockAdapter:
+            async def ingest_payload(self, payload):
+                orders.append(payload["order"])
+                return {}
+
+        asyncio.run(mat.replay_new_events(MockAdapter()))
+        assert orders == [1, 2, 3]
+
+    def test_link_commit_event_replay(self, tmp_path):
+        import asyncio
+        from events.materializer import EventMaterializer
+
+        events_dir = tmp_path / "events"
+        self._write_event_file(
+            events_dir, "a@test.com", "20260410T180000Z",
+            "link_commit.completed",
+            {"commit_hash": "abc123", "repo_path": "/tmp/repo"},
+        )
+
+        mat = EventMaterializer(events_dir, tmp_path / "local")
+        calls = []
+
+        class MockAdapter:
+            async def ingest_commit(self, commit_hash, repo_path):
+                calls.append((commit_hash, repo_path))
+                return {}
+
+        asyncio.run(mat.replay_new_events(MockAdapter()))
+        assert calls == [("abc123", "/tmp/repo")]
+
+    def test_extract_timestamp(self):
+        from events.materializer import EventMaterializer
+
+        assert EventMaterializer._extract_timestamp("20260410T180000Z-deadbeef.json") == "20260410T180000Z"
+        assert EventMaterializer._extract_timestamp("20260410T183022Z-a1b2c3d4.json") == "20260410T183022Z"
+
+
+# ── TeamWriteAdapter ─────────────────────────────────────────────────────
+
+
+class TestTeamWriteAdapter:
+    @pytest.fixture
+    def team_setup(self, tmp_path):
+        from events.writer import EventFileWriter
+        from events.materializer import EventMaterializer
+        from events.team_adapter import TeamWriteAdapter
+
+        events_dir = tmp_path / "events"
+        local_dir = tmp_path / "local"
+
+        writer = EventFileWriter(events_dir, "test@co.com")
+        materializer = EventMaterializer(events_dir, local_dir)
+
+        calls = {}
+
+        class MockInner:
+            async def connect(self):
+                calls["connect"] = True
+
+            async def ingest_payload(self, payload):
+                calls.setdefault("ingest_payload", []).append(payload)
+                return {"ingested": True}
+
+            async def ingest_commit(self, commit_hash, repo_path, drift_analyzer=None):
+                calls.setdefault("ingest_commit", []).append((commit_hash, repo_path))
+                return {"synced": True}
+
+            async def get_all_decisions(self, filter="all"):
+                return [{"id": "test"}]
+
+            async def search_by_query(self, query, max_results=10, min_confidence=0.5):
+                return []
+
+            async def get_decisions_for_file(self, file_path):
+                return []
+
+            async def get_undocumented_symbols(self, file_path):
+                return []
+
+            async def get_source_cursor(self, repo, source_type, source_scope="default"):
+                return None
+
+            async def upsert_source_cursor(self, **kwargs):
+                return {}
+
+        inner = MockInner()
+        adapter = TeamWriteAdapter(inner, writer, materializer)
+        return adapter, writer, calls
+
+    def test_ingest_writes_event_and_delegates(self, team_setup):
+        import asyncio
+
+        adapter, writer, calls = team_setup
+        payload = {"repo": "test", "mappings": []}
+
+        result = asyncio.run(adapter.ingest_payload(payload))
+
+        # Event file was written
+        event_files = list(writer.events_dir.glob("*/*.json"))
+        assert len(event_files) == 1
+
+        event = json.loads(event_files[0].read_text())
+        assert event["event_type"] == "ingest.completed"
+        assert event["payload"]["repo"] == "test"
+
+        # Inner adapter was called
+        assert calls["ingest_payload"] == [payload]
+        assert result == {"ingested": True}
+
+    def test_ingest_commit_writes_event_and_delegates(self, team_setup):
+        import asyncio
+
+        adapter, writer, calls = team_setup
+
+        result = asyncio.run(adapter.ingest_commit("abc123", "/tmp/repo"))
+
+        event_files = list(writer.events_dir.glob("*/*.json"))
+        assert len(event_files) == 1
+
+        event = json.loads(event_files[0].read_text())
+        assert event["event_type"] == "link_commit.completed"
+        assert event["payload"]["commit_hash"] == "abc123"
+
+        assert calls["ingest_commit"] == [("abc123", "/tmp/repo")]
+        assert result == {"synced": True}
+
+    def test_read_methods_delegate(self, team_setup):
+        import asyncio
+
+        adapter, _, _ = team_setup
+
+        decisions = asyncio.run(adapter.get_all_decisions())
+        assert decisions == [{"id": "test"}]
+
+    def test_no_event_for_source_cursor(self, team_setup):
+        import asyncio
+
+        adapter, writer, _ = team_setup
+
+        asyncio.run(adapter.upsert_source_cursor(
+            repo="test", source_type="transcript",
+        ))
+
+        event_files = list(writer.events_dir.glob("*/*.json"))
+        assert len(event_files) == 0
+
+
+# ── Config Detection ─────────────────────────────────────────────────────
+
+
+class TestConfigDetection:
+    def test_solo_when_no_config(self, tmp_path):
+        from adapters.ledger import _read_collaboration_mode
+
+        assert _read_collaboration_mode(str(tmp_path)) == "solo"
+
+    def test_solo_when_explicit(self, tmp_path):
+        from adapters.ledger import _read_collaboration_mode
+
+        config = tmp_path / ".bicameral" / "config.yaml"
+        config.parent.mkdir(parents=True)
+        config.write_text("mode: solo\n")
+
+        assert _read_collaboration_mode(str(tmp_path)) == "solo"
+
+    def test_team_when_configured(self, tmp_path):
+        from adapters.ledger import _read_collaboration_mode
+
+        config = tmp_path / ".bicameral" / "config.yaml"
+        config.parent.mkdir(parents=True)
+        config.write_text("mode: team\n")
+
+        assert _read_collaboration_mode(str(tmp_path)) == "team"
+
+    def test_team_with_quotes(self, tmp_path):
+        from adapters.ledger import _read_collaboration_mode
+
+        config = tmp_path / ".bicameral" / "config.yaml"
+        config.parent.mkdir(parents=True)
+        config.write_text('mode: "team"\n')
+
+        assert _read_collaboration_mode(str(tmp_path)) == "team"

--- a/tests/test_team_events.py
+++ b/tests/test_team_events.py
@@ -142,7 +142,7 @@ class TestEventMaterializer:
         assert len(calls) == 1
         assert calls[0][0] == "ingest"
 
-    def test_watermark_prevents_replay(self, tmp_path):
+    def test_watermark_prevents_replay_of_older_events(self, tmp_path):
         import asyncio
         from events.materializer import EventMaterializer
 
@@ -164,10 +164,16 @@ class TestEventMaterializer:
         asyncio.run(mat.replay_new_events(MockAdapter()))
         assert len(calls) == 1
 
-        # Second replay — watermark should prevent re-processing
+        # Second replay — same-second event re-applied (idempotent), but
+        # an older event added retroactively would be skipped
         calls.clear()
+        self._write_event_file(
+            events_dir, "b@test.com", "20260410T170000Z",
+            "ingest.completed", {"repo": "old", "mappings": []},
+        )
         asyncio.run(mat.replay_new_events(MockAdapter()))
-        assert len(calls) == 0
+        # Only the watermark-second event re-applied, not the older one
+        assert all(c["repo"] == "test" for c in calls)
 
     def test_replays_in_chronological_order(self, tmp_path):
         import asyncio


### PR DESCRIPTION
## Summary

- Adds cross-team decision sharing via append-only JSON event files committed to git
- **Dual-write adapter**: in team mode, every `ingest`/`link_commit` writes an event file to `.bicameral/events/{git-email}/` before updating the local DB
- **Watermark-based materializer**: on startup, replays peer events into the local ledger — incremental, only processes new events
- **Zero merge conflicts**: per-user directories + append-only files + UUID naming
- **Zero handler changes**: adapter factory swap is invisible to `server.py` and all handlers

### New files
| File | Purpose |
|---|---|
| `events/__init__.py` | Package marker |
| `events/models.py` | `EventEnvelope` Pydantic model |
| `events/writer.py` | `EventFileWriter` — atomic JSON writes to per-user dir |
| `events/materializer.py` | `EventMaterializer` — watermark + glob + replay |
| `events/team_adapter.py` | `TeamWriteAdapter` — composition wrapper |
| `tests/test_team_events.py` | 20 tests covering writer, materializer, adapter, config |

### Modified files
| File | Changes |
|---|---|
| `adapters/ledger.py` | `get_ledger()` reads `.bicameral/config.yaml`, returns `TeamWriteAdapter` when `mode: team` |
| `setup_wizard.py` | Solo/team mode selection, config.yaml creation, `.gitignore` handling |

## Test plan
- [x] 20 new unit tests passing (writer, materializer, team adapter, config detection)
- [x] Existing test suite unchanged (106 passing, pre-existing failures unaffected)
- [x] Manual: `bicameral-mcp setup` → select team mode → verify config.yaml + .gitignore
- [x] Manual: ingest in team mode → verify event file in `.bicameral/events/`
- [x] Manual: copy events from another user dir → restart → verify materialized

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added team collaboration mode for multi-user workflows alongside solo mode
  * Introduced configuration system to set and manage collaboration mode during setup
  * Event-sourced collaboration enabling team members to share and synchronize architectural decisions

* **Documentation**
  * Added collaboration modes guide with comparison table and configuration instructions
  * Enhanced local development setup documentation

<!-- end of auto-generated comment: release notes by coderabbit.ai -->