### PR TITLE
test: tolerate v0.4.3 SKILL.md structure in step1 excerpt test

### DIFF
--- a/tests/test_extract_headless.py
+++ b/tests/test_extract_headless.py
@@ -39,13 +39,19 @@ def test_step1_excerpt_isolates_step1_from_real_skill_md():
     excerpt = _extract_step1_excerpt(md)
 
     assert "Extract candidate decisions" in excerpt
-    assert "Include" in excerpt
-    assert "Exclude" in excerpt
+    # Case-insensitive check: original SKILL.md used "Include"/"Exclude" as
+    # subsection headers; the v0.4.3 few-shot rewrite uses "INCLUDE"/"EXCLUDE".
+    # Both forms should be acceptable.
+    lower = excerpt.lower()
+    assert "include" in lower
+    assert "exclude" in lower
     # Step 2 header or its body should not be present
     assert "Validate relevance" not in excerpt
     # Hard size ceiling so a future SKILL.md rewrite can't silently include
-    # the entire file if header parsing breaks.
-    assert len(excerpt) < 4000, f"excerpt suspiciously long: {len(excerpt)} chars"
+    # the entire file if header parsing breaks. Bumped from 4000 → 8000 to
+    # accommodate the v0.4.3 few-shot variant which adds 6 worked examples
+    # to Step 1.
+    assert len(excerpt) < 8000, f"excerpt suspiciously long: {len(excerpt)} chars"
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
Quick follow-up after merging PR #5 on top of v0.4.3.

The `test_step1_excerpt_isolates_step1_from_real_skill_md` test was hard-coded against the previous SKILL.md structure and broke when the few-shot rewrite changed two things:

1. `Include`/`Exclude` subsection headers became uppercase `INCLUDE`/`EXCLUDE`
2. Step 1 grew from ~1.2KB → ~5.5KB after adding 6 worked examples

Fix:
- Case-insensitive include/exclude check
- Size ceiling bumped 4000 → 8000

The test's actual contract (Step 1 is isolated, Step 2 doesn't bleed in) is unchanged.

Suite goes from 70/71 → 71/71.