### PR TITLE
v0.4.8 — ingest → brief auto-chain + sync dedup guard

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,57 @@
 All notable changes to bicameral-mcp are tracked here. Format loosely follows
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
+## 0.4.8 — 2026-04-14 — Ingest → Brief Auto-Chain
+
+`bicameral.ingest` now automatically fires `bicameral.brief` on a topic
+derived from the payload and returns the brief embedded in
+`IngestResponse.brief`. Callers get divergence detection, drift signal, gap
+extraction, and suggested meeting questions in the same round-trip that
+produced the new decisions — no second tool call required. The killer
+feature: fresh-ingest contradiction alerts. If the new ingest adds a
+decision that conflicts with an existing one on the same symbol, the
+chained brief surfaces the divergence at the moment of creation instead
+of silently.
+
+### Added
+
+- **`IngestResponse.brief: BriefResponse | None`** — fused response field.
+  Populated when the payload has a derivable topic; `None` when it
+  doesn't (payload with only action_items, empty title, empty query).
+- **`_derive_brief_topic(payload)`** — picks topic via priority chain:
+  `payload.query` → longest raw decision description → `payload.title`
+  → empty. Reads raw `payload["decisions"][...]` to avoid the
+  `[Action:]` / `[Open Question]` prefixes that `_normalize_payload`
+  injects into `mapping.intent`. Word-boundary truncation at 200 chars.
+- **Within-call sync dedup guard** (`handlers/link_commit.py`) —
+  `_sync_cache_lookup` / `_store_sync_cache` / `invalidate_sync_cache`
+  short-circuit back-to-back `handle_link_commit("HEAD")` calls within
+  the same MCP invocation so auto-chains don't do N× backfill + drift
+  sweeps. Caches the **full** `LinkCommitResponse` so downstream
+  `sync_status` consumers see real `regions_updated` numbers, not
+  synthetic zeros. Re-reads live HEAD via `git rev-parse` on every
+  lookup so a mid-call commit bypasses the stale cache.
+- **`bicameral-ingest` skill step 5** — teaches the agent to present
+  `IngestResponse.brief` following the bicameral-brief presentation
+  rules (divergences first, drift candidates, decisions, gaps,
+  suggested_questions verbatim).
+
+### Fixed
+
+- **Pre-existing `bicameral.brief` double-sync** — `handle_brief` was
+  calling `link_commit(HEAD)` twice per invocation in v0.4.6 / v0.4.7
+  (once directly, once via its chained `handle_search_decisions`). The
+  v0.4.8 dedup guard collapses this to one sync. Brief gets faster on
+  every call, not just auto-chained ones.
+
+### Migration
+
+No schema changes. `IngestResponse.brief` is optional, so v0.4.7 clients
+ignore it. The sync dedup is transparent — callers can't tell a dedup
+hit from the original call except by the normalized
+`reason="already_synced"` string (which matches the ledger's own
+idempotency wording).
+
 ## 0.4.7 — 2026-04-14 — FC-3 Vocab Cache Similarity Gate
 
 Fixes witnessed cross-contamination where the vocab cache reused an unrelated

--- a/context.py
+++ b/context.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 import os
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 
 
 @dataclass(frozen=True)
@@ -17,6 +17,11 @@ class BicameralContext:
     drift_analyzer: object
     authoritative_ref: str = "main"
     authoritative_sha: str = ""
+    # v0.4.8: mutable cache for within-call sync dedup. Frozen-dataclass-safe
+    # because the reference stays pinned; only the dict's contents mutate.
+    # Keys: ``last_sync_sha`` (str). Cleared by any handler that mutates
+    # repo-state expectations before chaining downstream tools.
+    _sync_state: dict = field(default_factory=dict)
 
     @classmethod
     def from_env(cls) -> BicameralContext:

--- a/contracts.py
+++ b/contracts.py
@@ -210,6 +210,11 @@ class IngestResponse(BaseModel):
     stats: IngestStats
     ungrounded_intents: list[str]
     source_cursor: SourceCursorSummary | None = None
+    # v0.4.8: ingest auto-fires bicameral_brief on the derived topic and
+    # embeds the full brief response here. None when topic derivation yields
+    # nothing usable, or when the chained brief call fails (logged, not
+    # raised — ingest must not fail because post-phase brief had a hiccup).
+    brief: "BriefResponse | None" = None
 
 
 # ── Tool 6: /bicameral_brief — pre-meeting one-pager ────────────────
@@ -286,3 +291,8 @@ class ResetResponse(BaseModel):
     replay_plan: list[ResetReplayEntry] = []
     replay_errors: list[str] = []
     next_action: str                     # human-readable next step for the caller
+
+
+# v0.4.8: resolve the forward reference on IngestResponse.brief (BriefResponse
+# is defined further down in the file than IngestResponse).
+IngestResponse.model_rebuild()

--- a/handlers/ingest.py
+++ b/handlers/ingest.py
@@ -203,6 +203,64 @@ def _derive_last_source_ref(payload: dict) -> str:
     return refs[-1] if refs else str(payload.get("query", "")).strip()
 
 
+# ── v0.4.8: post-ingest brief auto-chain ────────────────────────────
+
+
+_BRIEF_TOPIC_MAX = 200
+
+
+def _word_truncate(text: str, limit: int) -> str:
+    """Truncate ``text`` to ``limit`` chars on a word boundary."""
+    if len(text) <= limit:
+        return text
+    clipped = text[:limit]
+    # Drop the trailing (possibly half-word) token if there's still a
+    # space somewhere earlier in the slice. Falls through to the raw
+    # clip when the slice is one giant token with no spaces.
+    if " " in clipped:
+        return clipped.rsplit(" ", 1)[0]
+    return clipped
+
+
+def _derive_brief_topic(payload: dict) -> str:
+    """Pick a topic string for the auto-fired ``handle_brief`` call.
+
+    Priority order:
+      1. ``payload.query`` if the caller supplied one — most accurate
+         signal of what they were asking about.
+      2. The single **longest** raw decision description from
+         ``payload.decisions``. We pick one (not a concatenation) because
+         multi-topic ingests otherwise blend unrelated content into one
+         BM25 query and brief returns a mess. Most ingests cluster around
+         one topic anyway; the longest decision is the richest anchor.
+         Raw ``decisions[]`` avoids the ``[Action:]`` / ``[Open Question]``
+         prefixes that ``_normalize_payload`` injects into ``mappings[].intent``.
+      3. ``payload.title`` as a last resort.
+      4. Empty string → caller skips the brief chain entirely.
+    """
+    query = str(payload.get("query") or "").strip()
+    if query:
+        return _word_truncate(query, _BRIEF_TOPIC_MAX)
+
+    decisions = payload.get("decisions") or []
+    decision_texts: list[str] = []
+    for d in decisions:
+        if not isinstance(d, dict):
+            continue
+        text = str(d.get("description") or d.get("title") or "").strip()
+        if text:
+            decision_texts.append(text)
+    if decision_texts:
+        longest = max(decision_texts, key=len)
+        return _word_truncate(longest, _BRIEF_TOPIC_MAX)
+
+    title = str(payload.get("title") or "").strip()
+    if title:
+        return _word_truncate(title, _BRIEF_TOPIC_MAX)
+
+    return ""
+
+
 async def handle_ingest(
     ctx,
     payload: dict,
@@ -306,14 +364,42 @@ async def handle_ingest(
             authoritative_ref, head_sha[:8], authoritative_ref, authoritative_ref,
         )
 
+    # v0.4.8: writes always invalidate the within-call sync cache. In the
+    # top-level ingest path this is a no-op (no cache exists yet this call),
+    # but the invariant "mutations clear cache" must hold symmetrically —
+    # otherwise a future chain that runs a read handler *before* ingest and
+    # then writes would leave a stale cache covering post-write reads.
+    try:
+        from handlers.link_commit import handle_link_commit, invalidate_sync_cache
+        invalidate_sync_cache(ctx)
+    except Exception:
+        pass
+
     result = await ledger.ingest_payload(payload, ctx=ctx)
 
     # Sync ledger to HEAD and re-ground any previously ungrounded intents
     try:
-        from handlers.link_commit import handle_link_commit
         await handle_link_commit(ctx, "HEAD")
     except Exception as exc:
         logger.warning("[ingest] post-ingest link_commit failed: %s", exc)
+
+    # v0.4.8: auto-fire bicameral_brief on a derived topic so the caller
+    # gets divergence / drift / gap / suggested_question signal in the
+    # same response as the ingest stats. Brief failures are logged and
+    # swallowed — they must not break the ingest itself.
+    brief_response = None
+    try:
+        brief_topic = _derive_brief_topic(payload)
+        if brief_topic:
+            from handlers.brief import handle_brief
+            brief_participants = payload.get("participants") or None
+            brief_response = await handle_brief(
+                ctx,
+                topic=brief_topic,
+                participants=brief_participants,
+            )
+    except Exception as exc:
+        logger.warning("[ingest] post-ingest brief chain failed: %s", exc)
 
     cursor_summary = None
     source_type = str(((payload.get("mappings") or [{}])[0].get("span") or {}).get("source_type", "manual"))
@@ -367,4 +453,5 @@ async def handle_ingest(
         ),
         ungrounded_intents=list(result.get("ungrounded_intents", [])),
         source_cursor=cursor_summary,
+        brief=brief_response,
     )

--- a/handlers/link_commit.py
+++ b/handlers/link_commit.py
@@ -70,7 +70,133 @@ async def _reground_ungrounded(ctx) -> int:
     return len(newly_grounded)
 
 
+def _read_current_head_sha(repo_path: str) -> str:
+    """Re-read HEAD via ``git rev-parse HEAD`` — single subprocess,
+    authoritative.
+
+    ``ctx.head_sha`` is captured at ``BicameralContext.from_env()`` time
+    and frozen, so it goes stale the instant any handler commits. The
+    dedup guard can't trust it — a fresh ``git rev-parse`` is the only
+    way to know whether a chained ``link_commit("HEAD")`` is asking to
+    sync the same commit the cache was populated against, or a newer
+    commit that must run a fresh sweep.
+    """
+    try:
+        import subprocess
+        result = subprocess.run(
+            ["git", "rev-parse", "HEAD"],
+            cwd=repo_path,
+            capture_output=True,
+            text=True,
+            check=True,
+            timeout=5,
+        )
+        return result.stdout.strip()
+    except Exception:
+        return ""
+
+
+def _sync_cache_lookup(ctx, commit_hash: str) -> LinkCommitResponse | None:
+    """Return a cached ``LinkCommitResponse`` if this SHA was already
+    synced within the current MCP call, else ``None``.
+
+    v0.4.8: auto-chained tool calls (e.g. ``ingest → brief``) both fire
+    ``handle_link_commit("HEAD")``. On the same unchanged HEAD that's
+    wasted work — second sweep re-reads the same refs and updates
+    nothing. This guard collapses the duplicate.
+
+    The **full real response** from the first sync is cached, so dedup
+    hits forward the same ``regions_updated`` / ``decisions_drifted`` /
+    ``decisions_reflected`` numbers that downstream handlers like
+    ``handle_search_decisions`` and ``handle_detect_drift`` surface in
+    their ``sync_status`` field. The caller-facing ``reason`` is
+    **normalized to ``"already_synced"``** on dedup hits so callers can
+    distinguish "ran fresh" from "skipped as idempotent" — matching the
+    ledger-level ``ingest_commit`` idempotency wording.
+
+    Eligibility:
+
+    - ``commit_hash == "HEAD"`` → re-reads HEAD via ``git rev-parse``
+      to detect a moved HEAD. Skips dedup when the live SHA differs
+      from the cached SHA (the repo advanced between calls, we must
+      re-sync fresh).
+    - Explicit SHA equal to ``last_sync_sha`` → always hits cache.
+    - Any other explicit SHA → always runs (may be paging history).
+
+    Cleared on any mutation via ``invalidate_sync_cache(ctx)``.
+    """
+    sync_state = getattr(ctx, "_sync_state", None)
+    if not isinstance(sync_state, dict):
+        return None
+    cached_sha = sync_state.get("last_sync_sha")
+    cached_response = sync_state.get("last_sync_response")
+    if not cached_sha or not isinstance(cached_response, LinkCommitResponse):
+        return None
+
+    hit = False
+    if commit_hash in ("HEAD", ""):
+        live_head = _read_current_head_sha(getattr(ctx, "repo_path", "") or ".")
+        if live_head and live_head == cached_sha:
+            hit = True
+    elif commit_hash == cached_sha:
+        hit = True
+
+    if not hit:
+        return None
+
+    # Normalize reason to match the ledger's own idempotency wording.
+    # Every other field (regions_updated, decisions_drifted, etc.) stays
+    # verbatim from the first-call response so downstream ``sync_status``
+    # consumers see real numbers (B23).
+    return cached_response.model_copy(update={"reason": "already_synced"})
+
+
+def _store_sync_cache(ctx, commit_hash: str, response: LinkCommitResponse) -> None:
+    """Record the real response from a successful sync so subsequent
+    ``handle_link_commit`` calls in the same MCP call can short-circuit.
+
+    For ``commit_hash == "HEAD"`` we persist the **live** ``git rev-parse
+    HEAD`` result, not ``ctx.head_sha`` (which is captured at ctx
+    creation time and can go stale mid-call).
+    """
+    sync_state = getattr(ctx, "_sync_state", None)
+    if not isinstance(sync_state, dict):
+        return
+    if commit_hash in ("HEAD", ""):
+        live_head = _read_current_head_sha(getattr(ctx, "repo_path", "") or ".")
+        if not live_head:
+            return
+        sync_state["last_sync_sha"] = live_head
+    else:
+        sync_state["last_sync_sha"] = commit_hash
+    sync_state["last_sync_response"] = response
+
+
+def invalidate_sync_cache(ctx) -> None:
+    """Clear the within-call sync cache. Call before any write that would
+    invalidate a prior sync's view of repo state (ingest_payload, update,
+    reset, or any flow that mutates the ledger). Callers must hold the
+    invariant: writes clear cache → next read runs a fresh sync.
+    """
+    sync_state = getattr(ctx, "_sync_state", None)
+    if isinstance(sync_state, dict):
+        sync_state.pop("last_sync_sha", None)
+        sync_state.pop("last_sync_response", None)
+
+
 async def handle_link_commit(ctx, commit_hash: str = "HEAD") -> LinkCommitResponse:
+    # v0.4.8: short-circuit if we've already synced this SHA within this
+    # MCP call. Returns the FULL cached response from the first sync so
+    # downstream consumers (search/drift's ``sync_status``) see real
+    # region counts, not synthetic zeros.
+    cached = _sync_cache_lookup(ctx, commit_hash)
+    if cached is not None:
+        logger.debug(
+            "[link_commit] sync dedup: %s already synced in this call",
+            commit_hash,
+        )
+        return cached
+
     # Self-heal legacy regions with empty content_hash from pre-v0.4.5
     # ingests. Scoped to ctx.repo_path so multi-repo SurrealDB instances
     # stay isolated; no-op once every region in this repo has a baseline.
@@ -97,7 +223,7 @@ async def handle_link_commit(ctx, commit_hash: str = "HEAD") -> LinkCommitRespon
 
     await _reground_ungrounded(ctx)
 
-    return LinkCommitResponse(
+    response = LinkCommitResponse(
         commit_hash=result["commit_hash"],
         synced=result["synced"],
         reason=result["reason"],
@@ -106,3 +232,5 @@ async def handle_link_commit(ctx, commit_hash: str = "HEAD") -> LinkCommitRespon
         decisions_drifted=result.get("decisions_drifted", 0),
         undocumented_symbols=result.get("undocumented_symbols", []),
     )
+    _store_sync_cache(ctx, commit_hash, response)
+    return response

--- a/handlers/reset.py
+++ b/handlers/reset.py
@@ -83,6 +83,15 @@ async def handle_reset(
         )
 
     # Destructive path — wipe the ledger scoped to this repo.
+    # v0.4.8: invalidate the within-call sync cache so any future chained
+    # handler in this same MCP call (e.g. future tester-mode hint chains)
+    # doesn't read stale decision state from before the wipe.
+    try:
+        from handlers.link_commit import invalidate_sync_cache
+        invalidate_sync_cache(ctx)
+    except Exception:
+        pass
+
     replay_errors: list[str] = []
     try:
         await _wipe_all(ledger, ctx.repo_path)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "bicameral-mcp"
-version = "0.4.7"
+version = "0.4.8"
 description = "Decision ledger MCP server — ingests meeting transcripts, maps decisions to code, tracks drift"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/skills/bicameral-ingest/SKILL.md
+++ b/skills/bicameral-ingest/SKILL.md
@@ -75,6 +75,36 @@ Show the user:
 - How many were ingested, how many mapped to code, how many are ungrounded
 - If decisions were dropped, briefly list what was excluded and why (e.g., "Dropped 3 strategic/market decisions")
 
+### 5. Present the auto-fired brief (v0.4.8+)
+
+`bicameral.ingest` auto-fires `bicameral.brief` on a topic derived from the
+payload and returns the brief inside ``IngestResponse.brief``. **When
+``brief`` is non-null, present it immediately after the ingest summary
+using the bicameral-brief presentation rules.** In particular:
+
+- **Lead with divergences** (`brief.divergences`) whenever non-empty. The
+  fresh ingest may have just introduced a decision that contradicts an
+  existing one on the same symbol — that's the single highest-stakes
+  signal bicameral can carry, and the whole reason the brief auto-fires
+  after ingest. Surface each divergence as a bold warning with the
+  symbol, file path, and summary line.
+- Then `brief.drift_candidates`, then `brief.decisions` (grouped by status,
+  skipping duplicates that already appear in drift_candidates), then
+  `brief.gaps`, then `brief.suggested_questions` **verbatim**.
+- Skip any bucket that's empty. If every bucket is empty, say so plainly —
+  it means the fresh ingest didn't touch any prior decisions and no
+  divergences exist. That itself is useful information.
+- **Never** paraphrase `suggested_questions`. They're templated to be
+  neutral-voice; paraphrasing reintroduces the "me vs you" framing the
+  tool exists to remove.
+
+The full presentation contract lives in `skills/bicameral-brief/SKILL.md`
+and is the canonical reference — this step just cross-links it.
+
+When `brief` is `null` (e.g. the payload had no derivable topic or the
+chained brief call failed), skip this step silently. The ingest summary
+from step 4 is sufficient on its own.
+
 ## Arguments
 
 $ARGUMENTS — the transcript text, file path, or description of what to ingest

--- a/tests/test_v048_ingest_brief_chain.py
+++ b/tests/test_v048_ingest_brief_chain.py
@@ -1,0 +1,289 @@
+"""v0.4.8 — ingest → brief auto-chain regression tests.
+
+After a successful ``bicameral.ingest`` call, the handler derives a
+topic from the payload and auto-fires ``handle_brief`` on it. The
+brief response is returned embedded in ``IngestResponse.brief`` so
+callers can surface divergences, drift candidates, and suggested
+questions in the same round-trip that produced the new decisions.
+
+These tests lock in:
+
+  1. Topic derivation priority (query → longest decision → title → "")
+  2. ``IngestResponse.brief`` is populated when the payload has a
+     derivable topic
+  3. ``IngestResponse.brief`` is ``None`` when the topic is empty
+  4. Fresh decisions are visible in the chained brief's matches
+  5. Brief-chain failure doesn't fail the ingest (the brief field is
+     set to None and the ingest still returns a valid response)
+"""
+
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+from textwrap import dedent
+from unittest.mock import patch
+
+import pytest
+
+from adapters.ledger import get_ledger, reset_ledger_singleton
+from context import BicameralContext
+from handlers.ingest import _derive_brief_topic, _word_truncate, handle_ingest
+
+
+# ── Pure helpers ────────────────────────────────────────────────────
+
+
+def test_word_truncate_under_limit_returns_unchanged():
+    assert _word_truncate("hello world", 20) == "hello world"
+
+
+def test_word_truncate_drops_half_word():
+    # 20 chars: "the quick brown fox "
+    # clipped at 18: "the quick brown fo" → rsplit → "the quick brown"
+    out = _word_truncate("the quick brown fox jumps", 18)
+    assert out == "the quick brown"
+
+
+def test_word_truncate_single_long_token_raw_clip():
+    # No space in the slice → fall back to raw slice
+    out = _word_truncate("supercalifragilisticexpialidocious", 10)
+    assert out == "supercalif"
+
+
+def test_derive_topic_prefers_query():
+    payload = {
+        "query": "rate limiting strategy",
+        "decisions": [{"description": "unrelated long decision text"}],
+    }
+    assert _derive_brief_topic(payload) == "rate limiting strategy"
+
+
+def test_derive_topic_longest_decision():
+    payload = {
+        "query": "",
+        "decisions": [
+            {"description": "short"},
+            {"description": "this is the longest description by a wide margin"},
+            {"description": "medium length"},
+        ],
+    }
+    assert (
+        _derive_brief_topic(payload)
+        == "this is the longest description by a wide margin"
+    )
+
+
+def test_derive_topic_skips_action_item_prefix():
+    """Action items get prefixed with '[Action: owner]' during normalization.
+    The topic deriver reads raw payload.decisions, so it never sees the
+    prefix — confirmed here by absence of a decisions field entirely.
+    """
+    payload = {
+        "query": "",
+        "decisions": [],  # only action_items in a real payload
+        "title": "fallback title works",
+    }
+    assert _derive_brief_topic(payload) == "fallback title works"
+
+
+def test_derive_topic_returns_empty_when_nothing_usable():
+    assert _derive_brief_topic({}) == ""
+    assert _derive_brief_topic({"query": "", "decisions": [], "title": ""}) == ""
+
+
+def test_derive_topic_uses_title_field_on_decision():
+    payload = {
+        "decisions": [
+            {"title": "auth rewrite", "description": ""},
+        ],
+    }
+    assert _derive_brief_topic(payload) == "auth rewrite"
+
+
+def test_derive_topic_word_boundary_on_200_cap():
+    long_desc = " ".join(["rate"] * 80)  # ~400 chars, word-separated
+    payload = {"decisions": [{"description": long_desc}]}
+    topic = _derive_brief_topic(payload)
+    assert len(topic) <= 200
+    assert not topic.endswith(" ")
+    # Must not end mid-word — each word is "rate", so truncation has to
+    # land on a word boundary.
+    assert all(tok == "rate" for tok in topic.split())
+
+
+# ── End-to-end chain test ───────────────────────────────────────────
+
+
+def _git(cwd: Path, *args: str) -> str:
+    return subprocess.run(
+        ["git", *args],
+        cwd=cwd,
+        capture_output=True,
+        text=True,
+        check=True,
+    ).stdout.strip()
+
+
+def _seed_repo(repo_root: Path, body: str) -> None:
+    repo_root.mkdir(parents=True, exist_ok=True)
+    _git(repo_root, "init", "-q", "-b", "main")
+    _git(repo_root, "config", "user.email", "t@e.com")
+    _git(repo_root, "config", "user.name", "t")
+    (repo_root / "pricing.py").write_text(dedent(body).strip() + "\n")
+    _git(repo_root, "add", ".")
+    _git(
+        repo_root,
+        "-c", "commit.gpgsign=false",
+        "commit", "-q", "-m", "seed",
+    )
+
+
+@pytest.fixture
+def _isolated_ledger(monkeypatch, tmp_path):
+    monkeypatch.setenv("USE_REAL_LEDGER", "1")
+    monkeypatch.setenv("SURREAL_URL", "memory://")
+    repo_root = tmp_path / "repo"
+    _seed_repo(
+        repo_root,
+        """
+        def calculate_discount(order_total):
+            if order_total >= 100:
+                return order_total * 0.10
+            return 0
+        """,
+    )
+    monkeypatch.setenv("REPO_PATH", str(repo_root))
+    monkeypatch.setenv("BICAMERAL_AUTHORITATIVE_REF", "main")
+    monkeypatch.chdir(repo_root)
+    reset_ledger_singleton()
+    yield repo_root
+    reset_ledger_singleton()
+
+
+def _payload_with_decision(repo: str, description: str) -> dict:
+    """Minimal payload with pre-resolved code regions so we skip the
+    grounding BM25 path and stay laser-focused on the chain wiring.
+    """
+    return {
+        "query": description,
+        "repo": repo,
+        "mappings": [
+            {
+                "span": {
+                    "span_id": "chain-0",
+                    "source_type": "transcript",
+                    "text": description,
+                    "source_ref": "v048-chain-test",
+                },
+                "intent": description,
+                "symbols": ["calculate_discount"],
+                "code_regions": [
+                    {
+                        "file_path": "pricing.py",
+                        "symbol": "calculate_discount",
+                        "type": "function",
+                        "start_line": 1,
+                        "end_line": 4,
+                        "purpose": "pricing rule",
+                    }
+                ],
+                "dependency_edges": [],
+            }
+        ],
+    }
+
+
+class _Ctx:
+    """Wrap BicameralContext.from_env() and expose it uniformly."""
+    @staticmethod
+    def fresh() -> BicameralContext:
+        return BicameralContext.from_env()
+
+
+@pytest.mark.phase2
+@pytest.mark.asyncio
+async def test_ingest_populates_brief_field(_isolated_ledger):
+    """A successful ingest with a derivable topic must return
+    ``IngestResponse.brief`` as a non-null ``BriefResponse``.
+    """
+    ledger = get_ledger()
+    await ledger.connect()
+
+    ctx = _Ctx.fresh()
+    payload = _payload_with_decision(
+        repo=str(_isolated_ledger),
+        description="Apply 10% discount on orders of $100 or more",
+    )
+
+    response = await handle_ingest(ctx, payload)
+
+    assert response.brief is not None, (
+        "IngestResponse.brief must be populated when the payload has a "
+        "derivable topic; got None"
+    )
+    assert response.brief.topic.strip() != ""
+    # The chained brief ran against the fresh ingest — should see at
+    # least the just-ingested decision in its decisions list.
+    assert len(response.brief.decisions) >= 1, (
+        f"Chained brief should see at least the fresh decision, "
+        f"got {len(response.brief.decisions)} matches"
+    )
+
+
+@pytest.mark.phase2
+@pytest.mark.asyncio
+async def test_ingest_skips_brief_when_topic_empty(_isolated_ledger):
+    """When the payload has no query, no decisions, and no title, the
+    auto-chain skips brief entirely. ``IngestResponse.brief`` is ``None``.
+    """
+    ledger = get_ledger()
+    await ledger.connect()
+
+    ctx = _Ctx.fresh()
+    # Manually build a payload with only an action_item (produces a
+    # mapping but no raw decisions, no query, no title).
+    payload = {
+        "repo": str(_isolated_ledger),
+        "action_items": [
+            {"action": "write unit tests", "owner": ""},
+        ],
+    }
+
+    response = await handle_ingest(ctx, payload)
+
+    assert response.brief is None, (
+        "IngestResponse.brief must be None when the payload has no "
+        "derivable topic; got a BriefResponse"
+    )
+
+
+@pytest.mark.phase2
+@pytest.mark.asyncio
+async def test_brief_chain_failure_doesnt_fail_ingest(_isolated_ledger):
+    """If the chained ``handle_brief`` raises, the ingest itself must
+    still return a valid IngestResponse with ``brief=None``.
+    """
+    ledger = get_ledger()
+    await ledger.connect()
+
+    ctx = _Ctx.fresh()
+    payload = _payload_with_decision(
+        repo=str(_isolated_ledger),
+        description="Apply 10% discount on orders of $100 or more",
+    )
+
+    # Force brief to blow up on entry.
+    async def _boom(*args, **kwargs):
+        raise RuntimeError("simulated brief crash")
+
+    with patch("handlers.brief.handle_brief", side_effect=_boom):
+        response = await handle_ingest(ctx, payload)
+
+    assert response.ingested is True, (
+        "Ingest must still report ingested=True when the brief chain "
+        "crashes — brief is a post-phase, never load-bearing"
+    )
+    assert response.brief is None, (
+        "On brief chain failure, IngestResponse.brief must be None"
+    )

--- a/tests/test_v048_sync_dedup.py
+++ b/tests/test_v048_sync_dedup.py
@@ -1,0 +1,230 @@
+"""v0.4.8 — within-call sync dedup guard regression tests.
+
+The dedup guard lives in ``handlers/link_commit.py``:
+``_sync_cache_lookup`` / ``_store_sync_cache`` / ``invalidate_sync_cache``.
+It short-circuits back-to-back ``handle_link_commit("HEAD")`` calls
+within the same MCP invocation so auto-chains like ``ingest → brief``
+don't do N× backfill + drift sweeps on the same unchanged HEAD.
+
+These tests lock in the contract:
+
+  1. Second call on unchanged HEAD returns ``reason="already_synced"``
+     with the **same** ``regions_updated`` / ``decisions_drifted`` /
+     ``decisions_reflected`` numbers as the first real call (B23:
+     cached response, not synthetic zeros).
+  2. After ``invalidate_sync_cache(ctx)``, the next call re-runs
+     fresh — reason is NOT ``"already_synced"``.
+  3. When HEAD advances between calls (real commit), the dedup
+     skips the cache and re-runs a fresh sweep — proving the
+     live ``git rev-parse HEAD`` check does its job.
+"""
+
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+from textwrap import dedent
+
+import pytest
+
+from adapters.ledger import get_ledger, reset_ledger_singleton
+from context import BicameralContext
+from handlers.link_commit import (
+    handle_link_commit,
+    invalidate_sync_cache,
+)
+
+
+def _git(cwd: Path, *args: str) -> str:
+    result = subprocess.run(
+        ["git", *args],
+        cwd=cwd,
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+    return result.stdout.strip()
+
+
+def _seed_repo(repo_root: Path, body: str) -> None:
+    repo_root.mkdir(parents=True, exist_ok=True)
+    _git(repo_root, "init", "-q", "-b", "main")
+    _git(repo_root, "config", "user.email", "t@e.com")
+    _git(repo_root, "config", "user.name", "t")
+    (repo_root / "pricing.py").write_text(dedent(body).strip() + "\n")
+    _git(repo_root, "add", ".")
+    _git(
+        repo_root,
+        "-c", "commit.gpgsign=false",
+        "commit", "-q", "-m", "seed",
+    )
+
+
+def _commit_edit(repo_root: Path, new_body: str, message: str) -> None:
+    (repo_root / "pricing.py").write_text(dedent(new_body).strip() + "\n")
+    _git(repo_root, "add", "pricing.py")
+    _git(
+        repo_root,
+        "-c", "commit.gpgsign=false",
+        "commit", "-q", "-m", message,
+    )
+
+
+@pytest.fixture
+def _isolated_ledger(monkeypatch, tmp_path):
+    monkeypatch.setenv("USE_REAL_LEDGER", "1")
+    monkeypatch.setenv("SURREAL_URL", "memory://")
+    repo_root = tmp_path / "repo"
+    _seed_repo(
+        repo_root,
+        """
+        def calculate_discount(order_total):
+            if order_total >= 100:
+                return order_total * 0.10
+            return 0
+        """,
+    )
+    monkeypatch.setenv("REPO_PATH", str(repo_root))
+    monkeypatch.setenv("BICAMERAL_AUTHORITATIVE_REF", "main")
+    monkeypatch.chdir(repo_root)
+    reset_ledger_singleton()
+    yield repo_root
+    reset_ledger_singleton()
+
+
+def _ctx() -> BicameralContext:
+    return BicameralContext.from_env()
+
+
+# ── Contract tests ──────────────────────────────────────────────────
+
+
+@pytest.mark.phase2
+@pytest.mark.asyncio
+async def test_dedup_second_call_normalizes_reason(_isolated_ledger):
+    """Second link_commit(HEAD) on unchanged HEAD must report
+    ``reason == 'already_synced'`` so callers can distinguish a dedup
+    hit from a fresh sync.
+    """
+    ledger = get_ledger()
+    await ledger.connect()
+
+    ctx = _ctx()
+    r1 = await handle_link_commit(ctx, "HEAD")
+    r2 = await handle_link_commit(ctx, "HEAD")
+
+    assert r2.reason == "already_synced", (
+        f"Dedup hit must normalize reason to 'already_synced', "
+        f"got {r2.reason!r}"
+    )
+    # Cached fields should match the first call's real values (B23).
+    assert r2.commit_hash == r1.commit_hash
+    assert r2.regions_updated == r1.regions_updated
+    assert r2.decisions_reflected == r1.decisions_reflected
+    assert r2.decisions_drifted == r1.decisions_drifted
+
+
+@pytest.mark.phase2
+@pytest.mark.asyncio
+async def test_invalidate_forces_fresh_sync(_isolated_ledger, monkeypatch):
+    """After ``invalidate_sync_cache(ctx)``, the next link_commit must
+    actually call the ledger's ``ingest_commit`` again instead of
+    short-circuiting. We prove the dedup was cleared by counting real
+    ``ingest_commit`` invocations — not by the ``reason`` field, which
+    the ledger's own sync_state cursor also reports as "already_synced"
+    when the SHA hasn't changed (orthogonal layer).
+    """
+    ledger = get_ledger()
+    await ledger.connect()
+
+    # Spy on ingest_commit so we can count real calls.
+    original_ingest_commit = ledger.ingest_commit
+    call_count = {"n": 0}
+
+    async def _counting_ingest_commit(*args, **kwargs):
+        call_count["n"] += 1
+        return await original_ingest_commit(*args, **kwargs)
+
+    monkeypatch.setattr(ledger, "ingest_commit", _counting_ingest_commit)
+
+    ctx = _ctx()
+    await handle_link_commit(ctx, "HEAD")
+    assert call_count["n"] == 1, (
+        f"First call should hit the ledger once, got {call_count['n']}"
+    )
+
+    # Second call WITHOUT invalidate — dedup short-circuits, no ledger hit.
+    await handle_link_commit(ctx, "HEAD")
+    assert call_count["n"] == 1, (
+        f"Second call without invalidate must dedup — ledger should NOT "
+        f"have been re-hit. ingest_commit call count = {call_count['n']}"
+    )
+
+    # Third call AFTER invalidate — must re-hit the ledger.
+    invalidate_sync_cache(ctx)
+    await handle_link_commit(ctx, "HEAD")
+    assert call_count["n"] == 2, (
+        f"After invalidate_sync_cache, next link_commit must re-run "
+        f"ingest_commit. Got call count = {call_count['n']} (expected 2)"
+    )
+
+
+@pytest.mark.phase2
+@pytest.mark.asyncio
+async def test_head_advance_bypasses_dedup(_isolated_ledger):
+    """If HEAD moves between calls, the dedup guard must detect the
+    new SHA via live ``git rev-parse`` and run a fresh sync instead
+    of returning the stale cache.
+    """
+    repo_root = _isolated_ledger
+    ledger = get_ledger()
+    await ledger.connect()
+
+    ctx = _ctx()
+    r1 = await handle_link_commit(ctx, "HEAD")
+
+    # Advance HEAD with a real git commit.
+    _commit_edit(
+        repo_root,
+        """
+        def calculate_discount(order_total):
+            # Totally different implementation.
+            return 0
+        """,
+        "rewrite pricing",
+    )
+
+    r2 = await handle_link_commit(ctx, "HEAD")
+
+    assert r2.reason != "already_synced", (
+        f"HEAD advanced; dedup must NOT fire. Got reason={r2.reason!r}. "
+        f"This means ctx.head_sha is stale and _sync_cache_lookup is "
+        f"trusting it instead of re-reading git HEAD."
+    )
+    assert r2.commit_hash != r1.commit_hash, (
+        f"New HEAD SHA should differ from old. r1={r1.commit_hash!r}, "
+        f"r2={r2.commit_hash!r}"
+    )
+
+
+@pytest.mark.phase2
+@pytest.mark.asyncio
+async def test_explicit_sha_dedup(_isolated_ledger):
+    """Two back-to-back link_commit calls with the same explicit SHA
+    must dedup the second one too.
+    """
+    ledger = get_ledger()
+    await ledger.connect()
+
+    ctx = _ctx()
+    # Use the repo's current HEAD SHA explicitly (not "HEAD" string).
+    head_sha = _git(_isolated_ledger, "rev-parse", "HEAD")
+
+    r1 = await handle_link_commit(ctx, head_sha)
+    r2 = await handle_link_commit(ctx, head_sha)
+
+    assert r2.reason == "already_synced", (
+        f"Second call with same explicit SHA should dedup — "
+        f"got reason={r2.reason!r}"
+    )
+    assert r2.commit_hash == r1.commit_hash


### PR DESCRIPTION
## Summary

- **Ingest → brief auto-chain.** `bicameral.ingest` now derives a topic from the payload and fires `bicameral.brief` as a post-phase, embedding the full brief in `IngestResponse.brief`. Callers get divergences, drift signal, gap extraction, and suggested meeting questions in the same round-trip that produced the new decisions.
- **Killer use case**: fresh-ingest contradiction alerts. If the new ingest adds a decision that conflicts with an existing one on the same symbol, the chained brief surfaces the divergence at the moment of creation instead of silently.
- **Within-call sync dedup guard.** `_sync_cache_lookup` / `_store_sync_cache` / `invalidate_sync_cache` short-circuit back-to-back `handle_link_commit("HEAD")` calls within the same MCP invocation. Re-reads live HEAD via `git rev-parse` on every lookup so a mid-call commit bypasses the stale cache.
- **Bonus fix**: the pre-existing `bicameral.brief` double-sync (v0.4.6+) is collapsed as a side effect. Brief gets faster on every call, not just auto-chained ones.

Phase 1 of v0.4.8. Phase 2 (tester mode + \`ActionHint\`) is scoped but unshipped.

See \`thoughts/shared/plans/2026-04-14-v0.4.8-flow-walkthrough.md\` in the parent repo for full skill → tool flow diagrams and the bug hunt (B1/B6/B7/B8/B10/B11/B19/B23).

## Test plan

- [x] 16 new cases in \`tests/test_v048_ingest_brief_chain.py\` + \`tests/test_v048_sync_dedup.py\`
- [x] Topic derivation priority, word-boundary truncation, fused population, failure isolation
- [x] Dedup hit semantics + invalidation via spy-counted \`ingest_commit\` calls
- [x] Live-HEAD re-read on advanced commits
- [x] Full v0.4.8 regression sweep: **122 passed** (106 pre-existing + 16 new)
- [ ] Manual: re-ingest the Accountable Stripe payment-link transcript, confirm \`IngestResponse.brief\` surfaces divergences

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Ingest operations now automatically trigger and include brief analysis based on the ingested payload
  * Added sync deduplication to prevent redundant repository checks within a single operation

* **Bug Fixes**
  * Resolved double-sync issue occurring during brief workflows

* **Documentation**
  * Updated guidance on presenting auto-generated briefs following ingest operations

<!-- end of auto-generated comment: release notes by coderabbit.ai -->