### PR TITLE
v0.4.9 — tester mode + search status fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,66 @@
 All notable changes to bicameral-mcp are tracked here. Format loosely follows
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
+## 0.4.9 — 2026-04-14 — Tester Mode + Search Status Fix
+
+Phase 2 of v0.4.8. Adds an opt-in **tester mode** that makes
+`bicameral.search` and `bicameral.brief` responses emit **blocking
+action hints** the agent must address before any write operation.
+Hints surface drifted decisions, ungrounded decisions, divergent
+decision pairs, and unresolved open questions linked to the query
+scope. For onboarding, demos, and skill evaluation flows where you
+want bicameral to push signal at the agent instead of waiting for
+the agent to ask.
+
+### Added
+
+- **`BicameralContext.tester_mode: bool`** — parsed from
+  `BICAMERAL_TESTER_MODE` env var at context construction. Accepts
+  `1 / true / yes / on` (case-insensitive). Off by default.
+- **`ActionHint`** — Pydantic model in `contracts.py`. Four kinds:
+  - `review_drift` — drifted decisions in the match set
+  - `ground_decision` — ungrounded decisions in the match set
+  - `resolve_divergence` — two non-superseded decisions contradict on
+    the same symbol (brief only)
+  - `answer_open_questions` — open-question-shaped gaps in scope
+    (brief only)
+  Each hint has `kind`, `message`, `blocking: bool`, and `refs`.
+- **`SearchDecisionsResponse.action_hints` + `BriefResponse.action_hints`**
+  — optional list fields. Empty when `tester_mode=False`, so regular
+  mode is byte-identical to v0.4.8 except for the new empty field.
+- **`handlers/action_hints.py`** — pure post-compute hint generators.
+  Zero extra DB roundtrips; inspect already-computed response objects
+  and emit hints derived from their contents.
+- **`bicameral-tester` skill** — new top-level skill doc explaining
+  when to enable tester mode, what the blocking contract is, how to
+  debug hints that don't fire.
+- **`bicameral-search` + `bicameral-brief` SKILL.md** — new "Tester
+  Mode Contract" sections teaching the agent to address blocking hints
+  before any write.
+
+### Fixed
+
+- **Pre-existing search status bug** — `handle_search_decisions` was
+  reading `status` from `raw_regions[0]` but `code_region` rows don't
+  carry a status field (it's on the intent node). Every search match
+  had been silently reported as `pending` regardless of real state,
+  masking drifted decisions from callers. Now reads intent-level
+  `status` from the `search_by_bm25` row, which already selects it.
+  This is load-bearing for Phase 2: without the fix, the
+  `review_drift` hint generator couldn't fire because no match ever
+  looked drifted to it. Surfaced during the Accountable drift demo
+  walkthrough (see `thoughts/shared/plans/2026-04-14-accountable-drift-demo.md`).
+
+### Migration
+
+No schema changes. `action_hints` is an optional list defaulting to
+`[]`, so v0.4.8 clients ignore it. Tester mode is off by default —
+existing deployments are byte-identical in non-tester mode. The search
+status bug fix is backward-compatible: reflected / drifted decisions
+that were silently misreported as pending now show the correct status.
+This may change downstream UI grouping ("why is this now drifted?") —
+the answer is it was ALWAYS drifted, v0.4.9 just stopped hiding it.
+
 ## 0.4.8 — 2026-04-14 — Ingest → Brief Auto-Chain
 
 `bicameral.ingest` now automatically fires `bicameral.brief` on a topic

--- a/context.py
+++ b/context.py
@@ -6,6 +6,9 @@ import os
 from dataclasses import dataclass, field
 
 
+_TESTER_MODE_TRUTHY = frozenset({"1", "true", "yes", "on"})
+
+
 @dataclass(frozen=True)
 class BicameralContext:
     """Created once per MCP tool call. All services see the same commit."""
@@ -17,6 +20,11 @@ class BicameralContext:
     drift_analyzer: object
     authoritative_ref: str = "main"
     authoritative_sha: str = ""
+    # v0.4.9 (Phase 2): tester mode enables blocking action_hints on
+    # search/brief responses so agents must address drifted decisions,
+    # unresolved open questions, and divergences before making code
+    # changes. Off by default — opt-in via BICAMERAL_TESTER_MODE env var.
+    tester_mode: bool = False
     # v0.4.8: mutable cache for within-call sync dedup. Frozen-dataclass-safe
     # because the reference stays pinned; only the dict's contents mutate.
     # Keys: ``last_sync_sha`` (str). Cleared by any handler that mutates
@@ -33,6 +41,10 @@ class BicameralContext:
         state = get_repo_index_state(repo_path)
         authoritative_ref = detect_authoritative_ref(repo_path)
         authoritative_sha = resolve_ref_sha(repo_path, authoritative_ref) or ""
+        tester_mode = (
+            os.getenv("BICAMERAL_TESTER_MODE", "").strip().lower()
+            in _TESTER_MODE_TRUTHY
+        )
 
         return cls(
             repo_path=repo_path,
@@ -42,4 +54,5 @@ class BicameralContext:
             drift_analyzer=get_drift_analyzer(),
             authoritative_ref=authoritative_ref,
             authoritative_sha=authoritative_sha,
+            tester_mode=tester_mode,
         )

--- a/contracts.py
+++ b/contracts.py
@@ -84,12 +84,45 @@ class LinkCommitResponse(BaseModel):
     undocumented_symbols: list[str] = []
 
 
+class ActionHint(BaseModel):
+    """v0.4.9 (Phase 2): tester-mode directive appended to search/brief
+    responses. Blocking hints MUST be addressed by the agent before any
+    write operation (file edits, commits, PRs, bicameral_ingest). Skill
+    contracts enforce this — the wire protocol itself is advisory.
+
+    Kinds:
+      - ``answer_open_questions`` — matched decisions have unresolved
+        open questions the agent should resolve with the user first.
+      - ``review_drift`` — at least one matched decision is drifted.
+        Surface the drifted region before editing anywhere near it.
+      - ``resolve_divergence`` — two non-superseded decisions contradict
+        on the same symbol. Human resolution required.
+      - ``ground_decision`` — a matched decision has no code regions.
+        Call ``bicameral_ingest`` on the referenced intent with fresh
+        grounding before acting on it.
+
+    Empty when ``ctx.tester_mode`` is False (default), so regular-mode
+    responses are byte-identical to v0.4.8.
+    """
+    kind: Literal[
+        "answer_open_questions",
+        "review_drift",
+        "resolve_divergence",
+        "ground_decision",
+    ]
+    message: str                    # 1-sentence directive, agent-facing
+    blocking: bool                  # True = skill contract forbids writes until addressed
+    refs: list[str] = []            # kind-specific refs (intent_ids, file paths, question texts)
+
+
 class SearchDecisionsResponse(BaseModel):
     query: str
     sync_status: LinkCommitResponse  # result of auto-triggered link_commit
     matches: list[DecisionMatch]
     ungrounded_count: int            # matches with no code region
     suggested_review: list[str]      # intent_ids of drifted/pending to review first
+    # v0.4.9 (Phase 2): populated only when ctx.tester_mode is True.
+    action_hints: list[ActionHint] = []
 
 
 # ── Tool 3: /detect_drift ────────────────────────────────────────────
@@ -269,6 +302,8 @@ class BriefResponse(BaseModel):
     divergences: list[BriefDivergence] = []     # Branch Problem Instance 4 detector output
     gaps: list[BriefGap] = []
     suggested_questions: list[BriefQuestion] = []
+    # v0.4.9 (Phase 2): populated only when ctx.tester_mode is True.
+    action_hints: list[ActionHint] = []
 
 
 # ── Tool 7: /bicameral_reset — fail-safe recovery ───────────────────

--- a/handlers/action_hints.py
+++ b/handlers/action_hints.py
@@ -1,0 +1,160 @@
+"""v0.4.9 (Phase 2) — tester mode action hint generators.
+
+When ``ctx.tester_mode`` is True, search and brief responses are
+augmented with ``ActionHint`` objects that tell the agent what MUST
+be addressed before any write operation. The generators are pure,
+post-compute, zero extra DB calls — they inspect the already-computed
+response object and emit hints derived from its contents.
+
+Design anchors:
+  - **Zero DB roundtrips.** Hint generation runs after the handler has
+    already paid its query cost. If a generator needs data that isn't
+    already on the response, it doesn't fire. This keeps tester mode
+    free-at-cost for the server.
+  - **Hints are advisory at the wire, blocking at the skill.** MCP
+    can't force the agent to do anything. We set ``blocking=True``
+    and rely on the ``bicameral-tester`` skill contract to teach the
+    agent to stop until each blocking hint is resolved.
+  - **No LLM here.** All heuristics are deterministic. Matches the
+    ``handlers/brief.py`` invariant from v0.4.6.
+"""
+
+from __future__ import annotations
+
+from contracts import (
+    ActionHint,
+    BriefResponse,
+    SearchDecisionsResponse,
+)
+
+
+# ── Generators ──────────────────────────────────────────────────────
+
+
+def generate_hints_for_search(
+    response: SearchDecisionsResponse,
+    tester_mode: bool,
+) -> list[ActionHint]:
+    """Inspect a ``SearchDecisionsResponse`` and emit blocking hints.
+
+    Fires:
+      - ``review_drift`` when any matched decision has status=drifted.
+        Refs: the drifted decisions' intent_ids.
+      - ``ground_decision`` when the response has ungrounded matches
+        (already surfaced via ``suggested_review`` but we promote it
+        to a blocking hint so the agent can't quietly ignore it).
+
+    Returns [] when ``tester_mode`` is False.
+    """
+    if not tester_mode:
+        return []
+
+    hints: list[ActionHint] = []
+
+    drifted = [m for m in response.matches if m.status == "drifted"]
+    if drifted:
+        files = sorted({
+            r.file_path
+            for m in drifted
+            for r in m.code_regions
+            if r.file_path
+        })
+        hints.append(ActionHint(
+            kind="review_drift",
+            message=(
+                f"{len(drifted)} matched decision(s) have drifted — the "
+                f"current code no longer reflects what was decided. "
+                f"Review the drifted regions and confirm the code still "
+                f"matches stored intent BEFORE making changes."
+            ),
+            blocking=True,
+            refs=[m.intent_id for m in drifted] + files,
+        ))
+
+    ungrounded = [m for m in response.matches if m.status == "ungrounded"]
+    if ungrounded:
+        hints.append(ActionHint(
+            kind="ground_decision",
+            message=(
+                f"{len(ungrounded)} matched decision(s) are recorded but "
+                f"have no code grounding yet. Before implementing, confirm "
+                f"with the user what should exist — or call "
+                f"bicameral_ingest with a refreshed payload to ground them."
+            ),
+            blocking=True,
+            refs=[m.intent_id for m in ungrounded],
+        ))
+
+    return hints
+
+
+def generate_hints_for_brief(
+    response: BriefResponse,
+    tester_mode: bool,
+) -> list[ActionHint]:
+    """Inspect a ``BriefResponse`` and emit blocking hints.
+
+    Fires:
+      - ``resolve_divergence`` when ``response.divergences`` is non-empty.
+        Highest-stakes signal — the brief already leads with it, but
+        the hint makes it blocking.
+      - ``answer_open_questions`` when ``response.gaps`` contains
+        open_question-shaped entries. Refs: the gap description texts.
+      - ``review_drift`` when ``response.drift_candidates`` is non-empty
+        (subset of matched decisions with status=drifted).
+
+    Returns [] when ``tester_mode`` is False.
+    """
+    if not tester_mode:
+        return []
+
+    hints: list[ActionHint] = []
+
+    if response.divergences:
+        refs = [
+            f"{d.symbol} ({d.file_path})"
+            for d in response.divergences
+        ]
+        hints.append(ActionHint(
+            kind="resolve_divergence",
+            message=(
+                f"{len(response.divergences)} divergent decision pair(s) "
+                f"detected on the same symbol. Two non-superseded decisions "
+                f"contradict each other — pick which wins with the user "
+                f"and mark the loser superseded via bicameral_update BEFORE "
+                f"any code change."
+            ),
+            blocking=True,
+            refs=refs,
+        ))
+
+    if response.drift_candidates:
+        hints.append(ActionHint(
+            kind="review_drift",
+            message=(
+                f"{len(response.drift_candidates)} decision(s) in scope have "
+                f"drifted — the code no longer reflects intent. Surface each "
+                f"drifted region to the user before editing near it."
+            ),
+            blocking=True,
+            refs=[d.intent_id for d in response.drift_candidates],
+        ))
+
+    open_q_gaps = [
+        g for g in response.gaps
+        if "open-question" in g.hint or "open question" in g.hint
+    ]
+    if open_q_gaps:
+        hints.append(ActionHint(
+            kind="answer_open_questions",
+            message=(
+                f"{len(open_q_gaps)} unanswered open question(s) linked to "
+                f"this topic. Surface them to the user and resolve them "
+                f"with a follow-up bicameral_ingest BEFORE implementing "
+                f"any related code."
+            ),
+            blocking=True,
+            refs=[g.description[:140] for g in open_q_gaps],
+        ))
+
+    return hints

--- a/handlers/brief.py
+++ b/handlers/brief.py
@@ -34,6 +34,7 @@ from contracts import (
     DecisionMatch,
     SearchDecisionsResponse,
 )
+from handlers.action_hints import generate_hints_for_brief
 from handlers.link_commit import handle_link_commit
 from handlers.search_decisions import handle_search_decisions
 from ledger.status import resolve_head
@@ -315,7 +316,7 @@ async def handle_brief(
     # 5. Assemble response
     ref = resolve_head(ctx.repo_path) or "HEAD"
 
-    return BriefResponse(
+    response = BriefResponse(
         topic=topic,
         participants=participants or [],
         as_of=datetime.now(timezone.utc).isoformat(),
@@ -326,3 +327,7 @@ async def handle_brief(
         gaps=gaps,
         suggested_questions=questions,
     )
+    response.action_hints = generate_hints_for_brief(
+        response, tester_mode=getattr(ctx, "tester_mode", False),
+    )
+    return response

--- a/handlers/search_decisions.py
+++ b/handlers/search_decisions.py
@@ -7,6 +7,7 @@ in the same area with their status. Auto-triggers link_commit(HEAD) first.
 from __future__ import annotations
 
 from contracts import CodeRegionSummary, DecisionMatch, LinkCommitResponse, SearchDecisionsResponse
+from handlers.action_hints import generate_hints_for_search
 from handlers.link_commit import handle_link_commit
 
 
@@ -34,11 +35,20 @@ async def handle_search_decisions(
             for r in m.get("code_regions", [])
         ]
 
-        if not regions:
+        # v0.4.9: trust the intent-level ``status`` that ``search_by_bm25``
+        # selects off the intent node. Previously this handler looked for
+        # ``status`` on raw_regions[0] — but code_region rows don't carry
+        # status (it's an intent property), so the lookup silently returned
+        # the ``"pending"`` default for every match regardless of real
+        # state. That masked drifted decisions from callers and (Phase 2)
+        # broke the ``review_drift`` action_hint generator.
+        intent_status = str(m.get("status") or "").strip()
+        if intent_status in ("reflected", "drifted", "pending", "ungrounded"):
+            status = intent_status
+        elif not regions:
             status = "ungrounded"
         else:
-            raw_regions = m.get("code_regions", [])
-            status = raw_regions[0].get("status", "pending") if raw_regions else "pending"
+            status = "pending"
 
         if status in ("drifted", "pending"):
             suggested_review.append(m["intent_id"])
@@ -56,10 +66,14 @@ async def handle_search_decisions(
 
     ungrounded_count = sum(1 for m in matches if m.status == "ungrounded")
 
-    return SearchDecisionsResponse(
+    response = SearchDecisionsResponse(
         query=query,
         sync_status=sync_status,
         matches=matches,
         ungrounded_count=ungrounded_count,
         suggested_review=suggested_review,
     )
+    response.action_hints = generate_hints_for_search(
+        response, tester_mode=getattr(ctx, "tester_mode", False),
+    )
+    return response

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "bicameral-mcp"
-version = "0.4.8"
+version = "0.4.9"
 description = "Decision ledger MCP server — ingests meeting transcripts, maps decisions to code, tracks drift"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/skills/bicameral-brief/SKILL.md
+++ b/skills/bicameral-brief/SKILL.md
@@ -116,3 +116,23 @@ owns, try briefing on that instead — e.g.
 2. **Suggested questions verbatim.** The phrasings are templated to be neutral-voice; paraphrasing them reintroduces the "me vs you" framing the tool exists to remove.
 3. **No LLM summarization in v0.4.6.** The heuristics under the hood are deterministic. Don't layer your own LLM interpretation on top of the response — present it as-is and let the user ask follow-up questions.
 4. **Short is better than comprehensive.** If the brief response has 30 decisions, show the top 10 by status severity (drifted → reflected → pending → ungrounded) and note the full count.
+
+## Tester Mode Contract (v0.4.9+)
+
+When the server runs with `BICAMERAL_TESTER_MODE=1`, the response
+includes an `action_hints` list. **Hints with `blocking: true` MUST be
+addressed before any write operation** (file edits, commits, PRs,
+`bicameral_ingest`). Kinds that can fire on brief responses:
+
+- **`resolve_divergence`** — two non-superseded decisions contradict
+  each other on the same symbol. Highest-stakes signal. Show both
+  decisions to the user, let them pick which wins, then mark the loser
+  superseded via `bicameral_update`.
+- **`review_drift`** — one or more decisions in scope have drifted.
+  Surface each drifted region before editing near it.
+- **`answer_open_questions`** — gap extraction found open questions
+  linked to this topic. Surface them to the user and resolve them with
+  a follow-up `bicameral_ingest` before implementing any related code.
+
+When `action_hints` is empty, present the brief normally. Never
+paraphrase a hint's `message` field — surface it verbatim.

--- a/skills/bicameral-search/SKILL.md
+++ b/skills/bicameral-search/SKILL.md
@@ -28,6 +28,31 @@ Pre-flight check before coding — surface past decisions relevant to what you'r
 
 $ARGUMENTS — the feature, task, or area to search for prior decisions about
 
+## Tester Mode Contract (v0.4.9+)
+
+When the server runs with `BICAMERAL_TESTER_MODE=1`, the response
+includes an `action_hints` list. **Hints with `blocking: true` MUST be
+addressed before any write operation** (file edits, commits, PRs,
+`bicameral_ingest`). Kinds that can fire on search responses:
+
+- **`review_drift`** — one or more matched decisions are drifted. The
+  recorded intent no longer matches the current code. Surface the
+  drifted files to the user and confirm the code still reflects intent
+  BEFORE making changes near them. Refs list includes the drifted
+  `intent_id`s and the file paths they touch.
+- **`ground_decision`** — one or more matched decisions have no code
+  grounding yet. Before implementing something described by an
+  ungrounded decision, confirm with the user what should exist, then
+  call `bicameral_ingest` with a refreshed payload to ground them.
+
+When `action_hints` is empty (the default in non-tester mode), proceed
+normally. Empty is not an error — it means the server is in regular
+mode or none of the matches triggered any hint.
+
+Never paraphrase a hint's `message` field to the user — surface it
+verbatim so the tester can observe exactly what the server is
+signaling.
+
 ## Example
 
 User: "/bicameral:search rate limiting"

--- a/skills/bicameral-tester/SKILL.md
+++ b/skills/bicameral-tester/SKILL.md
@@ -1,0 +1,125 @@
+---
+name: bicameral-tester
+description: Strict-enforcement mode for onboarding, demos, and skill evaluation. When BICAMERAL_TESTER_MODE=1 is set on the MCP server, bicameral.search and bicameral.brief responses include blocking action_hints the agent MUST address before any write operation. This skill explains when to enable it, what the contract is, and how to debug it.
+---
+
+# Bicameral Tester Mode
+
+Tester mode is an opt-in strict-enforcement layer on top of
+`bicameral.search` and `bicameral.brief`. It makes bicameral **push**
+signal at the agent instead of waiting for the agent to ask — on every
+query, the server appends `action_hints` that describe what MUST be
+addressed before any code change.
+
+**The flag is off by default.** When off, responses are byte-identical
+to v0.4.8 except for the new empty `action_hints: []` field. Enable it
+for onboarding flows, demo runs, skill evaluation, and any session
+where you want the tools to be loud instead of quiet.
+
+## When to enable
+
+- **Onboarding a new user** to a repo with an existing bicameral ledger
+  — tester mode makes the first few queries surface drift, divergences,
+  and unresolved questions the user needs to know about before editing
+  any related code.
+- **Demos** where you want the audience to see bicameral doing
+  adversarial-audit work, not just retrieval.
+- **Skill evaluation** (M1 / Silong's eval harness) — tester mode
+  produces structured hint objects that are easier to score than
+  free-text agent outputs.
+- **Your first few sessions in a new codebase** — a safety net against
+  editing near drifted regions without realizing.
+
+## How to enable
+
+Set the env var on the MCP server process before it starts:
+
+```bash
+BICAMERAL_TESTER_MODE=1
+# or: true, yes, on (case-insensitive)
+```
+
+Any other value (including empty, `0`, `false`) means off. The flag is
+read at `BicameralContext.from_env()` time, which runs once per MCP
+tool call — so changes take effect on the next tool invocation, no
+server restart needed if you set the env var in the parent shell.
+
+## What fires
+
+### On `bicameral.search` responses:
+
+- **`review_drift`** — at least one matched decision has status
+  `drifted`. The recorded intent no longer matches the current code.
+  Refs: the drifted intent_ids + the file paths their regions touch.
+- **`ground_decision`** — at least one matched decision has no code
+  grounding (status `ungrounded`). Refs: the ungrounded intent_ids.
+
+### On `bicameral.brief` responses:
+
+- **`resolve_divergence`** — two non-superseded decisions contradict
+  on the same symbol. Refs: `symbol (file_path)` strings.
+- **`review_drift`** — at least one decision in scope is drifted.
+  Refs: drifted intent_ids.
+- **`answer_open_questions`** — gap extraction found
+  open-question-shaped decisions in scope. Refs: truncated gap
+  descriptions.
+
+Each hint has `blocking: true` and a human-readable `message` field.
+**Never paraphrase the message** — surface it verbatim so testers can
+observe exactly what the server signaled.
+
+## The blocking contract
+
+When a tester-mode response includes `action_hints` with
+`blocking: true`, the agent MUST:
+
+1. Surface each hint's `message` to the user verbatim, along with the
+   relevant refs (drifted files, divergent symbols, open questions).
+2. **Pause before any write operation** (file edit, commit, PR,
+   `bicameral_ingest`) until the user acknowledges the hint and either
+   resolves it or explicitly tells the agent to proceed anyway.
+3. If the user chooses to proceed despite a blocking hint, record the
+   decision — "user acknowledged X and chose to proceed" — so the
+   override is visible in transcripts.
+
+**MCP cannot actually force this** — the wire protocol is advisory.
+Enforcement lives in this skill contract. A skill-following agent is
+expected to stop at blocking hints; a non-compliant agent can ignore
+them. If adoption telemetry shows hint-ignore rates are high, v0.5.x
+may add server-side refusal (e.g. `ingest_payload` refuses inputs when
+blocking hints are outstanding for related decisions).
+
+## When NOT to enable
+
+- **Production adoption of a mature ledger** — tester mode is loud and
+  optimized for discovery. Once the user knows the ledger and trusts
+  the grounding, tester mode becomes noise. Turn it off for daily
+  workflow once the first session or two are past.
+- **Automated ingest flows** — the auto-fired `bicameral.brief` from
+  `bicameral.ingest` (v0.4.8+) already surfaces divergences and gaps
+  through the fused `IngestResponse.brief` field. Tester mode adds the
+  blocking wrapper; if your ingest is headless (no user to pause for)
+  the hints have nowhere to go.
+
+## Debugging
+
+If hints aren't firing when you expect them to:
+
+1. **Check `ctx.tester_mode`** — print it in a handler to confirm the
+   env var parsed correctly. Only `1 / true / yes / on` (case-insensitive)
+   enable it; anything else is off.
+2. **Check the `status` field on matches.** The
+   `review_drift` search hint fires only when at least one match has
+   `status == "drifted"`. In v0.4.8 and earlier, `handle_search_decisions`
+   had a bug where every match was reported as `pending` regardless of
+   real state (read `status` from the wrong table). v0.4.9 fixes this —
+   make sure you're running v0.4.9+.
+3. **Check the ledger actually has drifted state.** A decision only
+   becomes drifted after `handle_link_commit` detects a content_hash
+   mismatch against a grounded region's stored baseline. If no commit
+   has introduced drift, there's nothing for the hint to fire on.
+4. **Check the pollution guard.** Drift status is only persisted when
+   `HEAD == authoritative_ref` (the v0.4.6 pollution guard). On a
+   feature branch, drift is detected but not persisted — the next
+   search will still see `reflected`. Override via
+   `BICAMERAL_AUTHORITATIVE_REF=<your-branch>` for local experiments.

--- a/tests/test_v049_tester_mode.py
+++ b/tests/test_v049_tester_mode.py
@@ -1,0 +1,326 @@
+"""v0.4.9 Phase 2 — tester mode action hint regression tests.
+
+Two layers:
+
+  1. **Pure-function tests** for the hint generators
+     (``generate_hints_for_search`` + ``generate_hints_for_brief``).
+     These exercise every hint kind: review_drift, ground_decision,
+     resolve_divergence, answer_open_questions. Synchronous, IO-free.
+
+  2. **Context flag test** — verify ``BICAMERAL_TESTER_MODE`` env var
+     parses correctly into ``BicameralContext.tester_mode``.
+
+  3. **Backward-compat test** — when ``tester_mode=False`` (default),
+     responses must be byte-identical to v0.4.8 except for the new
+     empty ``action_hints=[]`` field. No hint should ever fire.
+"""
+
+from __future__ import annotations
+
+import os
+
+import pytest
+
+from contracts import (
+    ActionHint,
+    BriefDecision,
+    BriefDivergence,
+    BriefGap,
+    BriefResponse,
+    CodeRegionSummary,
+    DecisionMatch,
+    LinkCommitResponse,
+    SearchDecisionsResponse,
+)
+from handlers.action_hints import (
+    generate_hints_for_brief,
+    generate_hints_for_search,
+)
+
+
+# ── Helper factories ────────────────────────────────────────────────
+
+
+def _match(
+    *,
+    intent_id: str = "intent:1",
+    description: str = "test decision",
+    status: str = "reflected",
+    file_path: str = "src/foo.ts",
+    symbol: str = "foo",
+) -> DecisionMatch:
+    return DecisionMatch(
+        intent_id=intent_id,
+        description=description,
+        status=status,  # type: ignore[arg-type]
+        confidence=0.9,
+        source_ref="test-ref",
+        code_regions=[
+            CodeRegionSummary(
+                file_path=file_path,
+                symbol=symbol,
+                lines=(10, 30),
+                purpose="",
+            )
+        ],
+    )
+
+
+def _search_response(matches: list[DecisionMatch]) -> SearchDecisionsResponse:
+    return SearchDecisionsResponse(
+        query="test",
+        sync_status=LinkCommitResponse(
+            commit_hash="abc123",
+            synced=True,
+            reason="new_commit",
+            regions_updated=0,
+            decisions_reflected=0,
+            decisions_drifted=0,
+            undocumented_symbols=[],
+        ),
+        matches=matches,
+        ungrounded_count=sum(1 for m in matches if m.status == "ungrounded"),
+        suggested_review=[m.intent_id for m in matches if m.status in ("drifted", "pending")],
+    )
+
+
+def _brief_decision(
+    intent_id: str = "intent:1",
+    description: str = "test",
+    status: str = "reflected",
+) -> BriefDecision:
+    return BriefDecision(
+        intent_id=intent_id,
+        description=description,
+        status=status,  # type: ignore[arg-type]
+        source_ref="test-ref",
+        code_regions=[],
+        severity_tier=1,
+    )
+
+
+def _brief_response(
+    *,
+    decisions: list[BriefDecision] | None = None,
+    drift_candidates: list[BriefDecision] | None = None,
+    divergences: list[BriefDivergence] | None = None,
+    gaps: list[BriefGap] | None = None,
+) -> BriefResponse:
+    return BriefResponse(
+        topic="test",
+        as_of="2026-04-14T00:00:00Z",
+        ref="HEAD",
+        decisions=decisions or [],
+        drift_candidates=drift_candidates or [],
+        divergences=divergences or [],
+        gaps=gaps or [],
+        suggested_questions=[],
+    )
+
+
+# ── generate_hints_for_search ──────────────────────────────────────
+
+
+def test_search_no_hints_when_tester_mode_off():
+    response = _search_response([
+        _match(status="drifted"),
+        _match(status="ungrounded"),
+    ])
+    hints = generate_hints_for_search(response, tester_mode=False)
+    assert hints == []
+
+
+def test_search_empty_matches_produces_no_hints():
+    response = _search_response([])
+    hints = generate_hints_for_search(response, tester_mode=True)
+    assert hints == []
+
+
+def test_search_drifted_match_fires_review_drift():
+    response = _search_response([
+        _match(intent_id="intent:1", status="drifted", file_path="src/a.ts"),
+        _match(intent_id="intent:2", status="drifted", file_path="src/b.ts"),
+        _match(intent_id="intent:3", status="reflected"),
+    ])
+    hints = generate_hints_for_search(response, tester_mode=True)
+    review = [h for h in hints if h.kind == "review_drift"]
+    assert len(review) == 1
+    hint = review[0]
+    assert hint.blocking is True
+    assert "2 matched decision(s) have drifted" in hint.message
+    # Refs include the drifted intent_ids and the files they touch
+    assert "intent:1" in hint.refs
+    assert "intent:2" in hint.refs
+    assert "src/a.ts" in hint.refs
+    assert "src/b.ts" in hint.refs
+
+
+def test_search_ungrounded_match_fires_ground_decision():
+    response = _search_response([
+        _match(intent_id="intent:1", status="ungrounded"),
+    ])
+    # Ungrounded match — DecisionMatch still needs at least one region for
+    # the helper. Fabricate one with "ungrounded" semantic directly.
+    response.matches[0].code_regions = []
+    hints = generate_hints_for_search(response, tester_mode=True)
+    ground = [h for h in hints if h.kind == "ground_decision"]
+    assert len(ground) == 1
+    assert ground[0].blocking is True
+    assert "intent:1" in ground[0].refs
+
+
+def test_search_fires_both_review_and_ground_when_mixed():
+    response = _search_response([
+        _match(intent_id="intent:1", status="drifted"),
+        _match(intent_id="intent:2", status="ungrounded"),
+        _match(intent_id="intent:3", status="reflected"),
+    ])
+    hints = generate_hints_for_search(response, tester_mode=True)
+    kinds = {h.kind for h in hints}
+    assert "review_drift" in kinds
+    assert "ground_decision" in kinds
+
+
+def test_search_all_reflected_fires_no_hints():
+    response = _search_response([
+        _match(intent_id="intent:1", status="reflected"),
+        _match(intent_id="intent:2", status="reflected"),
+    ])
+    hints = generate_hints_for_search(response, tester_mode=True)
+    assert hints == []
+
+
+# ── generate_hints_for_brief ───────────────────────────────────────
+
+
+def test_brief_no_hints_when_tester_mode_off():
+    response = _brief_response(
+        drift_candidates=[_brief_decision(status="drifted")],
+    )
+    hints = generate_hints_for_brief(response, tester_mode=False)
+    assert hints == []
+
+
+def test_brief_divergence_fires_resolve_divergence():
+    divergence = BriefDivergence(
+        symbol="SessionCache",
+        file_path="src/session.ts",
+        conflicting_decisions=[
+            _brief_decision(intent_id="a", description="Use Redis"),
+            _brief_decision(intent_id="b", description="Use local memory"),
+        ],
+        summary="2 decisions contradict",
+    )
+    response = _brief_response(divergences=[divergence])
+    hints = generate_hints_for_brief(response, tester_mode=True)
+    divergent = [h for h in hints if h.kind == "resolve_divergence"]
+    assert len(divergent) == 1
+    h = divergent[0]
+    assert h.blocking is True
+    assert "1 divergent decision pair(s)" in h.message
+    assert any("SessionCache" in ref for ref in h.refs)
+
+
+def test_brief_drift_candidates_fire_review_drift():
+    response = _brief_response(
+        drift_candidates=[
+            _brief_decision(intent_id="a", status="drifted"),
+            _brief_decision(intent_id="b", status="drifted"),
+        ],
+    )
+    hints = generate_hints_for_brief(response, tester_mode=True)
+    review = [h for h in hints if h.kind == "review_drift"]
+    assert len(review) == 1
+    assert "2 decision(s) in scope have drifted" in review[0].message
+    assert review[0].refs == ["a", "b"]
+
+
+def test_brief_open_question_gap_fires_answer_open_questions():
+    response = _brief_response(
+        gaps=[
+            BriefGap(
+                description="RSVP sync direction — bidirectional or one-way?",
+                hint="open-question phrasing (vs/or/tbd/?)",
+            ),
+            BriefGap(
+                description="unrelated gap",
+                hint="missing acceptance criteria",  # not open-question
+            ),
+        ],
+    )
+    hints = generate_hints_for_brief(response, tester_mode=True)
+    open_q = [h for h in hints if h.kind == "answer_open_questions"]
+    assert len(open_q) == 1
+    assert "1 unanswered open question(s)" in open_q[0].message
+    # Only the open-question gap's description is in refs, not the other
+    assert len(open_q[0].refs) == 1
+    assert "RSVP sync" in open_q[0].refs[0]
+
+
+def test_brief_fires_all_three_hint_kinds_when_everything_present():
+    response = _brief_response(
+        drift_candidates=[_brief_decision(intent_id="a", status="drifted")],
+        divergences=[
+            BriefDivergence(
+                symbol="X",
+                file_path="src/x.ts",
+                conflicting_decisions=[_brief_decision(), _brief_decision()],
+                summary="conflict",
+            )
+        ],
+        gaps=[
+            BriefGap(
+                description="open q",
+                hint="open-question phrasing",
+            ),
+        ],
+    )
+    hints = generate_hints_for_brief(response, tester_mode=True)
+    kinds = {h.kind for h in hints}
+    assert kinds == {"resolve_divergence", "review_drift", "answer_open_questions"}
+    # All three should be blocking
+    assert all(h.blocking for h in hints)
+
+
+def test_brief_empty_response_produces_no_hints():
+    response = _brief_response()
+    hints = generate_hints_for_brief(response, tester_mode=True)
+    assert hints == []
+
+
+# ── Backward compat ─────────────────────────────────────────────────
+
+
+def test_action_hints_default_to_empty_list():
+    """Backward compat: v0.4.8 callers that don't set action_hints must
+    see an empty list, not None."""
+    response = _search_response([_match()])
+    assert response.action_hints == []
+
+    brief = _brief_response()
+    assert brief.action_hints == []
+
+
+# ── Context flag parsing ────────────────────────────────────────────
+
+
+@pytest.mark.parametrize("env_val,expected", [
+    ("1", True),
+    ("true", True),
+    ("True", True),
+    ("TRUE", True),
+    ("yes", True),
+    ("on", True),
+    ("0", False),
+    ("false", False),
+    ("", False),
+    ("no", False),
+    ("maybe", False),
+])
+def test_tester_mode_env_parse(env_val: str, expected: bool, monkeypatch):
+    """BICAMERAL_TESTER_MODE accepts a specific set of truthy values."""
+    from context import _TESTER_MODE_TRUTHY
+    # The env-parse logic lives in BicameralContext.from_env(). Testing
+    # the helper set directly here instead of round-tripping through
+    # from_env() to avoid needing a real ledger/code_graph.
+    assert (env_val.strip().lower() in _TESTER_MODE_TRUTHY) == expected


### PR DESCRIPTION
## Summary

Phase 2 of the v0.4.8 "Second Moment" bucket. Adds an opt-in **tester mode** (`BICAMERAL_TESTER_MODE=1`) that makes `bicameral.search` and `bicameral.brief` emit **blocking `action_hints`** the agent must address before any write operation. For onboarding, demos, and skill evaluation flows.

**Four hint kinds**:
- `review_drift` (search + brief) — drifted decisions in scope
- `ground_decision` (search) — ungrounded matches
- `resolve_divergence` (brief) — contradictory decisions on same symbol
- `answer_open_questions` (brief) — open-question gaps

Regular mode (`tester_mode=False`, default) is byte-identical to v0.4.8 except for the new empty `action_hints=[]` field.

**Bug fix (load-bearing)**: `handle_search_decisions` was reading `status` from `raw_regions[0]` but `code_region` rows don't carry a status field — it's an intent property. Every match had been silently reported as `pending` regardless of real state, masking drifted decisions from callers. Now reads intent-level status from the `search_by_bm25` row.

Surfaced during an end-to-end drift demo on Accountable — see the full walkthrough in the parent repo: `thoughts/shared/plans/2026-04-14-accountable-drift-demo.md`.

## Test plan

- [x] 24 new cases in `tests/test_v049_tester_mode.py` covering every hint kind (fires / doesn't fire), both generators, backward compat, tester_mode env parse
- [x] Full v0.4.9 regression: **146 passed** in 12s
- [x] Manual: verified on Accountable ledger — `tester_mode=OFF` returns empty hints; `tester_mode=ON` fires `review_drift` with refs to the edited file, `brief` fires same hint via its own generator
- [x] Skill contracts updated: `bicameral-search`, `bicameral-brief`, new top-level `bicameral-tester`

🤖 Generated with [Claude Code](https://claude.com/claude-code)