### PR TITLE
v0.4.11 — latent drift fix (range-diff sweep + distinct counters)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,69 @@
 All notable changes to bicameral-mcp are tracked here. Format loosely follows
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
+## 0.4.11 — 2026-04-14 — Latent Drift Fix (Range-Diff Sweep + Distinct Counters)
+
+Fixes a class of "invisible drift" where decisions silently went stale
+because `link_commit` only swept files in HEAD's own diff. After a
+gap of N commits without a bicameral invocation, drift introduced by
+intermediate commits stayed hidden until someone happened to re-edit
+the same files. Now `link_commit` sweeps every file touched between
+the last sync cursor and HEAD, so dark-period drift surfaces on the
+next call.
+
+### Fixed
+
+- **Latent drift via head-only sweep**. `ingest_commit` previously
+  enumerated changed files via `git show <head> --name-only`, which
+  only sees the head commit's own diff. Drift introduced by commits
+  N+1..N+5 was invisible if the user didn't run a bicameral tool
+  during that window, then ran one against commit N+5 whose own diff
+  didn't re-touch the drifted files. Fix: when the sync cursor lags
+  HEAD, run `git diff --name-only last_synced..HEAD` and sweep every
+  file in the range. New `sweep_scope` field on `LinkCommitResponse`
+  reports `head_only` (first sync, or fallback) vs `range_diff`
+  (default after first sync) vs `range_truncated` (range exceeded
+  cap; sweep was partial). Range cap defaults to 200 files; remainder
+  catches up on next sync.
+- **Inflated drift counters via per-(region, intent) counting**.
+  `decisions_drifted` and `decisions_reflected` previously incremented
+  once per `(region, intent)` pair that flipped — a decision with N
+  regions all flipping in the same sweep counted as N. Witnessed on
+  the Accountable demo where one Google Calendar decision flipped 4
+  regions and the counter reported `decisions_drifted=4` while only
+  1 distinct intent was actually drifted. Fix: dedupe by intent_id
+  via sets; counters now report the number of distinct decisions
+  whose status flipped, matching what users mentally expect from
+  "how many decisions just changed status."
+
+### Added
+
+- **`LinkCommitResponse.sweep_scope`** —
+  `Literal["head_only", "range_diff", "range_truncated"]`. Tells the
+  caller whether this sweep saw HEAD-only files or the full
+  last_synced..HEAD range. A "backlog sweep" after a dark period
+  reports `range_diff` with a large `range_size`, so a UI can frame
+  "47 decisions drifted" as "first scan after 6 weeks" instead of
+  "what the hell happened today."
+- **`LinkCommitResponse.range_size`** — number of files swept this
+  run. Zero for the `no_changes` and `already_synced` fast paths.
+- **`get_changed_files_in_range(base_sha, head_sha, repo_path)`** in
+  `ledger/status.py`. Runs `git diff --name-only base..head`. Returns
+  `None` (sentinel) when the diff fails (force-push, shallow clone,
+  unreachable base SHA) so the caller can fall back to head-only
+  scope without crashing.
+
+### Migration
+
+No schema changes. Existing `LinkCommitResponse` consumers see two
+new optional fields with sane defaults (`sweep_scope="head_only"`,
+`range_size=0`) — backward compatible. The semantic shift is in the
+counter values: deployments that scraped the old per-region counts
+will see smaller numbers in `decisions_drifted` /
+`decisions_reflected` because the same flip is now counted once per
+intent instead of once per region. The new behavior matches what the
+field name implies; the old behavior was a bug.
+
 ## 0.4.10 — 2026-04-14 — Guided Mode (Always-On Hints)
 
 Reframes v0.4.9's tester mode. **`action_hints` now fire whenever

--- a/contracts.py
+++ b/contracts.py
@@ -74,14 +74,35 @@ class DecisionMatch(BaseModel):
 
 
 class LinkCommitResponse(BaseModel):
-    """Returned by /link_commit and embedded in /search_decisions + /detect_drift."""
+    """Returned by /link_commit and embedded in /search_decisions + /detect_drift.
+
+    v0.4.11 (latent drift fix):
+      - ``decisions_reflected`` and ``decisions_drifted`` count **distinct
+        intent_ids** that flipped this sweep, not (region, intent) pairs.
+        A decision with 5 regions all flipping to drifted now reports 1,
+        not 5. Matches user mental model.
+      - ``sweep_scope`` and ``range_size`` describe what the sweep covered.
+        ``head_only`` is the v0.4.10 behavior — only files in the HEAD
+        commit's own diff. ``range_diff`` is the v0.4.11 default — files
+        changed between ``last_synced_commit`` and HEAD. ``range_truncated``
+        means the range exceeded ``MAX_SWEEP_FILES`` (200) so we capped it
+        and only swept the first chunk; the remainder will catch up on
+        next sync.
+    """
     commit_hash: str
     synced: bool                      # False = new work done; True = fast-path
     reason: Literal["new_commit", "already_synced", "no_changes"]
     regions_updated: int = 0
-    decisions_reflected: int = 0     # pending → reflected this run
-    decisions_drifted: int = 0       # reflected → drifted this run
+    decisions_reflected: int = 0     # distinct intents that flipped to reflected
+    decisions_drifted: int = 0       # distinct intents that flipped to drifted
     undocumented_symbols: list[str] = []
+    # v0.4.11: sweep scope provenance.
+    sweep_scope: Literal[
+        "head_only",       # files in HEAD commit only (first sync, or fallback)
+        "range_diff",      # files in last_synced..HEAD range (default after first sync)
+        "range_truncated", # range exceeded MAX_SWEEP_FILES; capped
+    ] = "head_only"
+    range_size: int = 0              # number of files swept in this run
 
 
 class ActionHint(BaseModel):

--- a/handlers/link_commit.py
+++ b/handlers/link_commit.py
@@ -231,6 +231,8 @@ async def handle_link_commit(ctx, commit_hash: str = "HEAD") -> LinkCommitRespon
         decisions_reflected=result.get("decisions_reflected", 0),
         decisions_drifted=result.get("decisions_drifted", 0),
         undocumented_symbols=result.get("undocumented_symbols", []),
+        sweep_scope=result.get("sweep_scope", "head_only"),
+        range_size=result.get("range_size", 0),
     )
     _store_sync_cache(ctx, commit_hash, response)
     return response

--- a/ledger/adapter.py
+++ b/ledger/adapter.py
@@ -40,7 +40,20 @@ from .queries import (
     upsert_sync_state,
 )
 from .schema import init_schema, migrate
-from .status import compute_content_hash, derive_status, get_changed_files, resolve_head
+from .status import (
+    compute_content_hash,
+    derive_status,
+    get_changed_files,
+    get_changed_files_in_range,
+    resolve_head,
+)
+
+
+# v0.4.11: cap for range sweep. If the diff between last_synced and HEAD
+# spans more files than this, we sweep the first MAX_SWEEP_FILES and report
+# `sweep_scope="range_truncated"` so the caller knows the sweep was partial.
+# The next link_commit will pick up the remainder.
+_MAX_SWEEP_FILES = 200
 
 logger = logging.getLogger(__name__)
 
@@ -232,10 +245,55 @@ class SurrealDBLedgerAdapter:
                 "decisions_reflected": 0,
                 "decisions_drifted": 0,
                 "undocumented_symbols": [],
+                "sweep_scope": "head_only",
+                "range_size": 0,
             }
 
-        # Get changed files from this commit
-        changed_files = get_changed_files(commit_hash, repo_path)
+        # v0.4.11: determine sweep scope. The pre-v0.4.11 behavior was always
+        # head-only (`git show HEAD --name-only`), which missed every file
+        # drifted between last_synced and HEAD. Now the default is range_diff
+        # — sweep every file touched since the cursor — falling back to
+        # head_only when there's no cursor or the range is unreachable.
+        last_synced = (state or {}).get("last_synced_commit", "") or ""
+        sweep_scope: str = "head_only"
+        changed_files: list[str] = []
+
+        if last_synced and last_synced != commit_hash:
+            range_files = get_changed_files_in_range(
+                last_synced, commit_hash, repo_path,
+            )
+            if range_files is None:
+                # Range unreachable (force-push, shallow clone, rebase
+                # discarded the base). Fall back to head-only — partial
+                # but better than crashing. The next sync after a real
+                # commit will recover.
+                logger.warning(
+                    "[link_commit] range %s..%s unreachable, falling "
+                    "back to head-only sweep",
+                    last_synced[:8], commit_hash[:8],
+                )
+                changed_files = get_changed_files(commit_hash, repo_path)
+                sweep_scope = "head_only"
+            else:
+                changed_files = range_files
+                sweep_scope = "range_diff"
+                if len(changed_files) > _MAX_SWEEP_FILES:
+                    logger.warning(
+                        "[link_commit] range sweep capped at %d files "
+                        "(would have swept %d). Remainder will catch up "
+                        "on next sync.",
+                        _MAX_SWEEP_FILES, len(changed_files),
+                    )
+                    changed_files = changed_files[:_MAX_SWEEP_FILES]
+                    sweep_scope = "range_truncated"
+        else:
+            # First-ever sync (no cursor) OR same SHA as cursor.
+            # Head-only is the right scope here.
+            changed_files = get_changed_files(commit_hash, repo_path)
+            sweep_scope = "head_only"
+
+        range_size = len(changed_files)
+
         if not changed_files:
             # Only advance the sync cursor on authoritative refs — pollution guard
             if is_authoritative:
@@ -248,14 +306,20 @@ class SurrealDBLedgerAdapter:
                 "decisions_reflected": 0,
                 "decisions_drifted": 0,
                 "undocumented_symbols": [],
+                "sweep_scope": sweep_scope,
+                "range_size": 0,
             }
 
         # Find all code_regions for changed files
         regions = await get_regions_for_files(self._client, changed_files)
 
         regions_updated = 0
-        decisions_reflected = 0
-        decisions_drifted = 0
+        # v0.4.11: track distinct intent_ids that flipped, not (region, intent)
+        # pairs. A decision with N regions all flipping in the same sweep
+        # used to inflate the counter N times — now it's counted once. Matches
+        # what users expect from "how many decisions just changed status."
+        flipped_to_reflected: set[str] = set()
+        flipped_to_drifted: set[str] = set()
         undocumented_symbols: list[str] = []
 
         for region in regions:
@@ -318,10 +382,13 @@ class SurrealDBLedgerAdapter:
                 old_status = intent.get("status", "ungrounded")
                 if is_authoritative:
                     await update_intent_status(self._client, intent_id, new_status)
+                # v0.4.11: dedupe by intent_id. A decision with multiple
+                # regions all flipping in the same sweep is one flipped
+                # decision, not N. Sets collapse the duplicates.
                 if new_status == "reflected" and old_status != "reflected":
-                    decisions_reflected += 1
+                    flipped_to_reflected.add(intent_id)
                 elif new_status == "drifted" and old_status != "drifted":
-                    decisions_drifted += 1
+                    flipped_to_drifted.add(intent_id)
 
             # Flag as undocumented if no intents mapped
             intents = [i for i in (region.get("intents") or []) if i is not None]
@@ -339,9 +406,11 @@ class SurrealDBLedgerAdapter:
             "commit_hash": commit_hash,
             "reason": "new_commit",
             "regions_updated": regions_updated,
-            "decisions_reflected": decisions_reflected,
-            "decisions_drifted": decisions_drifted,
+            "decisions_reflected": len(flipped_to_reflected),
+            "decisions_drifted": len(flipped_to_drifted),
             "undocumented_symbols": list(set(undocumented_symbols)),
+            "sweep_scope": sweep_scope,
+            "range_size": range_size,
         }
 
     async def backfill_empty_hashes(

--- a/ledger/status.py
+++ b/ledger/status.py
@@ -212,6 +212,50 @@ def get_changed_files(commit_hash: str, repo_path: str) -> list[str]:
         return []
 
 
+def get_changed_files_in_range(
+    base_sha: str,
+    head_sha: str,
+    repo_path: str,
+) -> list[str] | None:
+    """Return files touched between ``base_sha`` and ``head_sha``.
+
+    v0.4.11 (latent drift fix): when ``link_commit`` runs after a gap of
+    multiple commits since the last sync, sweeping only ``HEAD --name-only``
+    misses every file drifted by intermediate commits. This helper runs
+    ``git diff --name-only base..head`` to enumerate the full set of files
+    touched across the gap, so the drift sweep covers everything that
+    needs re-checking.
+
+    Returns:
+        - ``list[str]`` of changed file paths (possibly empty when the
+          two refs touch no different files)
+        - ``None`` when the diff failed (force-push, shallow clone,
+          unreachable base SHA, etc.) — caller should fall back to
+          ``get_changed_files(head_sha, repo_path)`` for head-only scope.
+
+    The ``None`` sentinel matters: empty list means "ran successfully,
+    no files differ" while ``None`` means "the range is unreachable."
+    """
+    try:
+        result = subprocess.run(
+            ["git", "diff", "--name-only", f"{base_sha}..{head_sha}"],
+            cwd=Path(repo_path).resolve(),
+            capture_output=True,
+            text=True,
+            timeout=30,
+        )
+        if result.returncode != 0:
+            logger.warning(
+                "[status] git diff %s..%s failed: %s",
+                base_sha[:8], head_sha[:8], result.stderr[:200],
+            )
+            return None
+        return [f.strip() for f in result.stdout.strip().splitlines() if f.strip()]
+    except (subprocess.TimeoutExpired, FileNotFoundError) as e:
+        logger.warning("[status] git diff range error: %s", e)
+        return None
+
+
 def resolve_head(repo_path: str) -> str | None:
     """Return current HEAD SHA."""
     try:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "bicameral-mcp"
-version = "0.4.10"
+version = "0.4.11"
 description = "Decision ledger MCP server — ingests meeting transcripts, maps decisions to code, tracks drift"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/tests/test_v0411_latent_drift.py
+++ b/tests/test_v0411_latent_drift.py
@@ -1,0 +1,398 @@
+"""v0.4.11 latent drift fix — regression tests.
+
+Two layers:
+
+  1. **Range-diff sweep** — when ``last_synced_commit`` lags HEAD by N
+     commits, ``handle_link_commit`` now sweeps every file touched in
+     that range, not just HEAD's own diff. Catches drift introduced
+     in commits between syncs.
+
+  2. **Distinct intent counters** — ``decisions_drifted`` and
+     ``decisions_reflected`` now count distinct intent_ids that
+     flipped, not (region, intent) pairs. A decision with N regions
+     all flipping in the same sweep counts as 1, not N.
+
+Also covers the new response fields (``sweep_scope``, ``range_size``)
+and the fall-back logic when a range is unreachable (force-push,
+shallow clone).
+"""
+
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+from textwrap import dedent
+
+import pytest
+
+from adapters.ledger import get_ledger, reset_ledger_singleton
+from context import BicameralContext
+from handlers.link_commit import handle_link_commit
+from ledger.status import get_changed_files, get_changed_files_in_range
+
+
+# ── Helpers ─────────────────────────────────────────────────────────
+
+
+def _git(cwd: Path, *args: str) -> str:
+    return subprocess.run(
+        ["git", *args],
+        cwd=cwd,
+        capture_output=True,
+        text=True,
+        check=True,
+    ).stdout.strip()
+
+
+def _seed_repo(repo_root: Path) -> str:
+    repo_root.mkdir(parents=True, exist_ok=True)
+    _git(repo_root, "init", "-q", "-b", "main")
+    _git(repo_root, "config", "user.email", "t@e.com")
+    _git(repo_root, "config", "user.name", "t")
+    (repo_root / "pricing.py").write_text(dedent("""
+        def calculate_discount(order_total):
+            if order_total >= 100:
+                return order_total * 0.10
+            return 0
+    """).strip() + "\n")
+    (repo_root / "auth.py").write_text(dedent("""
+        def validate_token(token):
+            if not token:
+                return False
+            return len(token) > 10
+    """).strip() + "\n")
+    _git(repo_root, "add", ".")
+    _git(repo_root, "-c", "commit.gpgsign=false", "commit", "-q", "-m", "seed")
+    return _git(repo_root, "rev-parse", "HEAD")
+
+
+def _commit_edit(repo_root: Path, file: str, body: str, message: str) -> str:
+    (repo_root / file).write_text(dedent(body).strip() + "\n")
+    _git(repo_root, "add", file)
+    _git(repo_root, "-c", "commit.gpgsign=false", "commit", "-q", "-m", message)
+    return _git(repo_root, "rev-parse", "HEAD")
+
+
+@pytest.fixture
+def _isolated_ledger(monkeypatch, tmp_path):
+    monkeypatch.setenv("USE_REAL_LEDGER", "1")
+    monkeypatch.setenv("SURREAL_URL", "memory://")
+    repo_root = tmp_path / "repo"
+    _seed_repo(repo_root)
+    monkeypatch.setenv("REPO_PATH", str(repo_root))
+    monkeypatch.setenv("BICAMERAL_AUTHORITATIVE_REF", "main")
+    monkeypatch.chdir(repo_root)
+    reset_ledger_singleton()
+    yield repo_root
+    reset_ledger_singleton()
+
+
+def _ctx() -> BicameralContext:
+    return BicameralContext.from_env()
+
+
+# ── get_changed_files_in_range — pure helper ──────────────────────
+
+
+def test_range_diff_returns_files_touched_in_range(tmp_path):
+    repo = tmp_path / "repo"
+    base_sha = _seed_repo(repo)
+    sha2 = _commit_edit(repo, "pricing.py", "x = 1", "edit pricing")
+    sha3 = _commit_edit(repo, "auth.py", "y = 2", "edit auth")
+
+    files = get_changed_files_in_range(base_sha, sha3, str(repo))
+    assert files is not None
+    assert set(files) == {"pricing.py", "auth.py"}
+
+
+def test_range_diff_empty_when_same_sha(tmp_path):
+    repo = tmp_path / "repo"
+    sha = _seed_repo(repo)
+    files = get_changed_files_in_range(sha, sha, str(repo))
+    assert files == []
+
+
+def test_range_diff_returns_none_on_unreachable_ref(tmp_path):
+    repo = tmp_path / "repo"
+    sha = _seed_repo(repo)
+    # Garbage SHA that doesn't exist in this repo
+    bogus = "deadbeef" + "0" * 32
+    files = get_changed_files_in_range(bogus, sha, str(repo))
+    assert files is None
+
+
+def test_get_changed_files_unchanged_for_single_commit(tmp_path):
+    """The pre-v0.4.11 head-only helper still works for fresh-repo
+    bootstraps."""
+    repo = tmp_path / "repo"
+    sha = _seed_repo(repo)
+    files = get_changed_files(sha, str(repo))
+    assert set(files) == {"pricing.py", "auth.py"}
+
+
+# ── handle_link_commit — sweep_scope semantics ─────────────────────
+
+
+@pytest.mark.phase2
+@pytest.mark.asyncio
+async def test_first_sync_uses_head_only_scope(_isolated_ledger):
+    """No cursor exists yet, so the first sync falls back to head-only."""
+    ledger = get_ledger()
+    await ledger.connect()
+
+    ctx = _ctx()
+    r = await handle_link_commit(ctx, "HEAD")
+
+    assert r.sweep_scope == "head_only"
+    assert r.range_size == 2  # pricing.py + auth.py from seed commit
+
+
+@pytest.mark.phase2
+@pytest.mark.asyncio
+async def test_second_sync_after_gap_uses_range_diff(_isolated_ledger):
+    """After the first sync stamps the cursor, a subsequent sync
+    against an advanced HEAD should use range_diff and find every
+    file touched between cursor and HEAD — including files NOT in
+    the head commit's own diff.
+    """
+    repo_root = _isolated_ledger
+    ledger = get_ledger()
+    await ledger.connect()
+
+    # Sync #1 — stamps the cursor at the seed commit
+    ctx1 = _ctx()
+    r1 = await handle_link_commit(ctx1, "HEAD")
+    assert r1.sweep_scope == "head_only"
+    seed_sha = r1.commit_hash
+
+    # Two commits, two different files
+    sha2 = _commit_edit(
+        repo_root, "pricing.py",
+        "def calculate_discount(t):\n    return t * 0.5",
+        "rewrite pricing",
+    )
+    sha3 = _commit_edit(
+        repo_root, "auth.py",
+        "def validate_token(t):\n    return False",
+        "rewrite auth",
+    )
+    assert sha3 != sha2 != seed_sha
+
+    # Sync #2 — should diff seed..HEAD and pick up BOTH files,
+    # not just auth.py (which is the head commit's own diff).
+    # Fresh ctx so the in-call sync cache is empty.
+    # Fresh ctx (empty within-call sync cache) but same ledger instance
+    # so the cursor stamped by sync #1 persists across this call.
+    ctx2 = _ctx()
+    r2 = await handle_link_commit(ctx2, "HEAD")
+
+    assert r2.sweep_scope == "range_diff", (
+        f"Expected range_diff after gap, got {r2.sweep_scope}"
+    )
+    assert r2.range_size >= 2, (
+        f"Expected range sweep to cover both pricing.py + auth.py "
+        f"(range_size>=2), got range_size={r2.range_size}"
+    )
+
+
+@pytest.mark.phase2
+@pytest.mark.asyncio
+async def test_pre_v0411_head_only_would_have_missed_intermediate_drift(
+    _isolated_ledger,
+):
+    """Latent drift demonstration: with the OLD head-only behavior,
+    a commit that drifts pricing.py followed by an unrelated commit
+    that touches README.md would have left the pricing drift invisible
+    until pricing.py was edited again. v0.4.11's range_diff catches
+    it on the next link_commit.
+    """
+    repo_root = _isolated_ledger
+    ledger = get_ledger()
+    await ledger.connect()
+
+    # Sync #1 stamps cursor
+    ctx1 = _ctx()
+    await handle_link_commit(ctx1, "HEAD")
+
+    # Drift commit
+    _commit_edit(
+        repo_root, "pricing.py",
+        "def calculate_discount(t):\n    return t * 999",  # nonsense
+        "drift pricing",
+    )
+    # Unrelated subsequent commit
+    (repo_root / "README.md").write_text("# repo\n")
+    _git(repo_root, "add", "README.md")
+    _git(repo_root, "-c", "commit.gpgsign=false", "commit", "-q", "-m", "add readme")
+
+    # Fresh ctx; same ledger so cursor persists.
+    ctx2 = _ctx()
+    r2 = await handle_link_commit(ctx2, "HEAD")
+
+    # Range should include pricing.py + README.md, NOT just README.md
+    assert r2.sweep_scope == "range_diff"
+    assert r2.range_size >= 2
+
+
+@pytest.mark.phase2
+@pytest.mark.asyncio
+async def test_sync_to_same_sha_fast_paths_with_head_only_scope(_isolated_ledger):
+    """Calling link_commit twice on the same SHA: second hits the
+    fast-path and returns sweep_scope='head_only' (no work done,
+    cursor unchanged)."""
+    ledger = get_ledger()
+    await ledger.connect()
+    ctx = _ctx()
+    await handle_link_commit(ctx, "HEAD")
+
+    # Fresh ctx (clears v0.4.8 within-call dedup cache) but same ledger
+    # so the cursor persists; second call should hit the ledger-level
+    # idempotency fast-path.
+    ctx2 = _ctx()
+    r2 = await handle_link_commit(ctx2, "HEAD")
+
+    # Fast-path returns "already_synced" + head_only scope, range_size=0
+    assert r2.reason == "already_synced"
+    assert r2.sweep_scope == "head_only"
+    assert r2.range_size == 0
+
+
+@pytest.mark.phase2
+@pytest.mark.asyncio
+async def test_unreachable_base_sha_falls_back_to_head_only(
+    _isolated_ledger, monkeypatch,
+):
+    """If ``last_synced_commit`` is unreachable (force-push, shallow
+    clone), the range diff returns None and we fall back to head-only.
+    The sync still completes — we just lose the intermediate-commit
+    coverage for one cycle.
+    """
+    repo_root = _isolated_ledger
+    ledger = get_ledger()
+    await ledger.connect()
+
+    # Inject a bogus cursor by patching get_sync_state to return a
+    # SHA that doesn't exist in the repo.
+    from ledger import adapter as adapter_mod
+    bogus = "deadbeef" + "0" * 32
+
+    real_get_sync_state = adapter_mod.get_sync_state
+
+    async def _bogus_get_sync_state(client, repo_path):
+        return {"last_synced_commit": bogus}
+
+    monkeypatch.setattr(adapter_mod, "get_sync_state", _bogus_get_sync_state)
+
+    ctx = _ctx()
+    r = await handle_link_commit(ctx, "HEAD")
+
+    # Should fall back to head_only, NOT crash
+    assert r.sweep_scope == "head_only"
+    assert r.range_size >= 1
+
+
+# ── Distinct intent counters ───────────────────────────────────────
+
+
+def test_link_commit_response_contract_has_new_fields():
+    """LinkCommitResponse v0.4.11 contract has sweep_scope + range_size."""
+    from contracts import LinkCommitResponse
+    fields = LinkCommitResponse.model_fields
+    assert "sweep_scope" in fields
+    assert "range_size" in fields
+    # Defaults: head_only / 0 — backward compat for callers that don't set them
+    inst = LinkCommitResponse(
+        commit_hash="abc", synced=True, reason="new_commit",
+    )
+    assert inst.sweep_scope == "head_only"
+    assert inst.range_size == 0
+
+
+@pytest.mark.phase2
+@pytest.mark.asyncio
+async def test_distinct_intents_when_one_decision_has_multiple_drifted_regions(
+    _isolated_ledger,
+):
+    """A decision with multiple regions, all flipping to drifted in the
+    same sweep, should report decisions_drifted=1 (not N).
+
+    Set up: ingest one decision that maps to TWO regions in the same
+    file. Edit BOTH regions. Run link_commit. Counter should show 1.
+    """
+    repo_root = _isolated_ledger
+    ledger = get_ledger()
+    await ledger.connect()
+
+    # Append a second function so we have two regions in pricing.py
+    (repo_root / "pricing.py").write_text(dedent("""
+        def calculate_discount(order_total):
+            if order_total >= 100:
+                return order_total * 0.10
+            return 0
+
+
+        def calculate_tax(order_total):
+            return order_total * 0.08
+    """).strip() + "\n")
+    _git(repo_root, "add", "pricing.py")
+    _git(repo_root, "-c", "commit.gpgsign=false", "commit", "-q", "-m", "add tax")
+
+    payload = {
+        "query": "Apply 10% discount and 8% tax on orders",
+        "repo": str(repo_root),
+        "mappings": [
+            {
+                "span": {
+                    "span_id": "p1-0",
+                    "source_type": "transcript",
+                    "text": "Apply 10% discount and 8% tax on orders",
+                    "source_ref": "v0411-test",
+                },
+                "intent": "Apply 10% discount and 8% tax on orders",
+                "symbols": ["calculate_discount", "calculate_tax"],
+                "code_regions": [
+                    {
+                        "file_path": "pricing.py",
+                        "symbol": "calculate_discount",
+                        "type": "function",
+                        "start_line": 1,
+                        "end_line": 4,
+                    },
+                    {
+                        "file_path": "pricing.py",
+                        "symbol": "calculate_tax",
+                        "type": "function",
+                        "start_line": 7,
+                        "end_line": 8,
+                    },
+                ],
+            }
+        ],
+    }
+    await ledger.ingest_payload(payload)
+
+    # First sync — stamp baselines for both regions
+    ctx = _ctx()
+    await handle_link_commit(ctx, "HEAD")
+
+    # Now drift BOTH regions in one commit
+    (repo_root / "pricing.py").write_text(dedent("""
+        def calculate_discount(order_total):
+            return order_total * 999  # nonsense
+
+
+        def calculate_tax(order_total):
+            return order_total * 999  # nonsense
+    """).strip() + "\n")
+    _git(repo_root, "add", "pricing.py")
+    _git(repo_root, "-c", "commit.gpgsign=false", "commit", "-q", "-m", "drift both")
+
+    # Fresh ctx; same ledger so the prior baselines + cursor persist.
+    ctx2 = _ctx()
+    r2 = await handle_link_commit(ctx2, "HEAD")
+
+    assert r2.decisions_drifted == 1, (
+        f"One intent maps to two drifted regions; counter must show 1 "
+        f"distinct decision flipped, got {r2.decisions_drifted}. "
+        f"This is the v0.4.11 dedup-by-intent_id fix."
+    )


### PR DESCRIPTION
## Summary

Fixes a class of "invisible drift" where decisions silently went stale because \`link_commit\` only swept files in HEAD's own diff. After a gap of N commits without a bicameral invocation, drift introduced by intermediate commits stayed hidden until someone happened to re-edit the same files.

**Two changes:**

1. **Range-diff sweep.** \`ingest_commit\` now diffs \`last_synced..HEAD\` via \`git diff --name-only\` and sweeps every file in the range. New \`sweep_scope\` field on \`LinkCommitResponse\` reports \`head_only\` (first sync, or fallback) vs \`range_diff\` (default after first sync) vs \`range_truncated\` (range exceeded 200-file cap). Falls back to head-only when the base SHA is unreachable. New \`range_size\` field reports how many files were swept.

2. **Distinct intent counters.** \`decisions_drifted\` and \`decisions_reflected\` now count distinct intent_ids that flipped, not (region, intent) pairs. Witnessed on the Accountable demo where one Google Calendar decision flipped 4 regions and the old counter reported \`decisions_drifted=4\` while only 1 distinct intent was actually drifted.

Both changes were teed up in conversation after the Phase 2 drift demo on Accountable surfaced the per-region count discrepancy and the latent-drift mental model.

## Test plan

- [x] 11 cases in \`tests/test_v0411_latent_drift.py\` covering:
  - \`get_changed_files_in_range\` helper (in-range, empty range, unreachable base)
  - \`sweep_scope\` semantics (first sync = head_only, second sync after gap = range_diff, fast-path = head_only with size 0, unreachable cursor = head_only fallback)
  - Distinct intent counter dedup (one decision with N drifted regions = 1 in counter)
- [x] Full v0.4.11 regression: **163 passed** in 14s
- [ ] Manual: run on Accountable to verify latent drift surfaces correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced commit synchronization now scans the full range from last sync to current HEAD, surfacing drift previously undetected during gaps
  * Added response metadata reporting scan scope and file count swept

* **Bug Fixes**
  * Fixed overcounting of drift and reflection metrics by deduplicating based on intent rather than individual region changes

* **Tests**
  * Added comprehensive regression test suite validating latent drift detection and range-diff functionality

<!-- end of auto-generated comment: release notes by coderabbit.ai -->