### PR TITLE
v0.4.12 — bicameral.preflight (proactive context surfacing)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,102 @@
 All notable changes to bicameral-mcp are tracked here. Format loosely follows
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
+## 0.4.12 — 2026-04-14 — Preflight (Proactive Context Surfacing)
+
+Adds `bicameral.preflight(topic)` — a proactive context-surfacing tool
+the agent calls BEFORE implementing code. Returns prior decisions,
+drifted regions, divergent decision pairs, and unresolved open
+questions linked to the topic, gated by the user's `guided_mode`
+setting. Closes the loop on the "tech debt accrues because developers
+make tiny architectural decisions without full insight" problem —
+bicameral now pushes the relevant context at the agent without
+waiting for an explicit query.
+
+### Added
+
+- **`bicameral.preflight(topic, participants?)`** — new MCP tool. Wraps
+  `bicameral.search` (and conditionally `bicameral.brief`) with a
+  Python-enforced gate that decides whether to surface based on
+  `ctx.guided_mode`:
+
+  - **Normal mode** (`guided_mode=false`, default) — *less intense*.
+    `fired=true` only when search matches contain **actionable signal**
+    (drift, ungrounded, divergence, open question). Plain matches are
+    silenced. Trust contract: surface only when there's something the
+    developer actually needs to know.
+  - **Guided mode** (`guided_mode=true`) — *standard*. `fired=true` on
+    any matches. Surface even on plain matches; the user opted into
+    the loud experience.
+
+  The gate logic lives in `handlers/preflight.py`, not in skill
+  markdown — enforced regardless of agent compliance.
+
+- **`PreflightResponse` contract** — populated when `fired=true`,
+  empty when `fired=false`. Carries `decisions`, `drift_candidates`,
+  `divergences`, `open_questions`, `action_hints` (with intensity
+  inherited from `guided_mode`), and `sources_chained` (which tools
+  the handler called: `["search"]` or `["search", "brief"]`).
+
+- **`bicameral-preflight` skill** at
+  `pilot/mcp/skills/bicameral-preflight/SKILL.md`. Auto-fires on
+  implementation verbs (`add`, `build`, `create`, `implement`,
+  `modify`, `refactor`, `update`, `fix`). Has an explicit "SKIP FOR"
+  list (read-only questions, doc-only edits, dependency updates,
+  typo fixes) so it doesn't fire on bare maintenance prompts.
+  Renders the `PreflightResponse` with a `(bicameral surfaced — ...)`
+  attribution prefix when `fired=true`. **Produces zero output when
+  `fired=false`** — the trust contract.
+
+- **Per-session topic dedup** in `ctx._sync_state["preflight_topics"]`.
+  Same topic preflight-checked within 5 minutes of the session is
+  silently skipped (`reason="recently_checked"`). Avoids the
+  "developer asks 4 follow-up questions about the same Stripe
+  webhook → preflight fires 4 times" annoyance.
+
+- **`BICAMERAL_PREFLIGHT_MUTE`** env var. One-line mute for the
+  current session. Truthy values (`1 / true / yes / on`) make
+  `handle_preflight` return `fired=false` with
+  `reason="preflight_disabled"` for every call.
+
+- **Brief chain** is conditional. The handler chains to
+  `bicameral.brief` when search has matches AND any match is drifted
+  or ungrounded — that's the cheap signal for "there's more to know."
+  In guided mode, the chain fires unconditionally (because the user
+  wants the full picture). When brief throws or returns empty, the
+  handler falls back to search-derived decisions and continues.
+
+### Robustness contract
+
+- **Fail open everywhere.** Search fails → `fired=false` silently.
+  Brief fails → fall back to search-only rendering. Topic invalid →
+  silent skip. Dedup hit → silent skip. Empty matches → silent skip.
+  Preflight is never a hard blocker on bicameral being unavailable.
+- **Honest empty path.** `fired=false` means the agent produces ZERO
+  output to the user about preflight. No "I checked and found
+  nothing" noise.
+- **Verbatim attribution.** Every cited decision in the rendered block
+  carries its `source_ref` so the user can trace it.
+- **Topic validation** is deterministic (≥4 chars, ≥2 non-stopword
+  content tokens, not a generic catch-all). Implementation verbs
+  (`implement`, `build`, etc.) are stopwords so "implement webhook"
+  fails validation but "implement Stripe webhook" passes.
+
+### Tests
+
+- 26 cases in `tests/test_v0412_preflight.py` covering: topic
+  validation, dedup hits + TTL expiry, env var mute, every fired /
+  not-fired path (no_matches, no_actionable_signal, topic_too_generic,
+  recently_checked, preflight_disabled, fired), normal-vs-guided mode
+  interaction (Q1=B), brief chain conditional firing (Q1=B), search
+  failure fail-open, brief failure fall-back.
+- Full v0.4.12 regression: 189 passed.
+
+### Migration
+
+No schema changes. New tool `bicameral.preflight` is additive — v0.4.11
+clients ignore it. The skill auto-fires only when Claude's skill matcher
+picks it up; users who haven't installed the skill see no change.
+
 ## 0.4.11 — 2026-04-14 — Latent Drift Fix (Range-Diff Sweep + Distinct Counters)
 
 Fixes a class of "invisible drift" where decisions silently went stale

--- a/contracts.py
+++ b/contracts.py
@@ -349,6 +349,62 @@ class ResetResponse(BaseModel):
     next_action: str                     # human-readable next step for the caller
 
 
+# ── Tool 9: /bicameral_preflight — proactive context surfacing (v0.4.12) ──
+
+
+class PreflightResponse(BaseModel):
+    """Response envelope for bicameral_preflight(topic).
+
+    The handler runs ``bicameral.search`` (and optionally ``bicameral.brief``)
+    against the topic and returns a gated decision: should the agent
+    surface this context to the user, or proceed silently?
+
+    Gating logic depends on ``ctx.guided_mode``:
+
+    - **Normal mode** (``guided_mode=False``): less intense. ``fired=True``
+      only when search matches contain **actionable signal** — at least one
+      drifted match, ungrounded match, divergent pair, or open question.
+      Plain matches (all reflected, no drift, no questions) → ``fired=False``.
+      Trust contract: surface only when there's something the developer
+      actually needs to know.
+
+    - **Guided mode** (``guided_mode=True``): standard. ``fired=True`` when
+      search returns any matches at all. Surface even on plain matches —
+      the user opted into the loud experience.
+
+    Always-true gates:
+
+    - Topic must validate (≥4 chars, ≥2 non-stopword content tokens, not
+      a generic catch-all). Failed validation → ``fired=False`` with
+      ``reason="topic_too_generic"``.
+    - Per-session dedup: if the same topic was preflight-checked within
+      the last 5 minutes of this MCP server session, ``fired=False`` with
+      ``reason="recently_checked"``.
+
+    On ``fired=False``, the agent produces NO OUTPUT to the user — that's
+    the trust contract. The empty path is silent.
+    """
+    topic: str                           # the topic that was preflight-checked
+    fired: bool                          # True = render output, False = silent skip
+    reason: Literal[
+        "fired",                         # gates passed, render the response
+        "no_matches",                    # search returned nothing
+        "no_actionable_signal",          # normal mode + no drift/divergence/etc
+        "topic_too_generic",             # topic failed deterministic validation
+        "recently_checked",              # per-session dedup hit
+        "guided_mode_off",               # ctx.guided_mode is False AND nothing actionable
+        "preflight_disabled",            # explicit env override mute
+    ]
+    guided_mode: bool                    # echo the flag for caller visibility
+    # Populated when fired=True. Empty when fired=False.
+    decisions: list[BriefDecision] = []
+    drift_candidates: list[BriefDecision] = []
+    divergences: list[BriefDivergence] = []
+    open_questions: list[BriefGap] = []
+    action_hints: list[ActionHint] = []
+    sources_chained: list[str] = []      # which tools were called: ["search"], ["search", "brief"]
+
+
 # v0.4.8: resolve the forward reference on IngestResponse.brief (BriefResponse
 # is defined further down in the file than IngestResponse).
 IngestResponse.model_rebuild()

--- a/handlers/preflight.py
+++ b/handlers/preflight.py
@@ -1,0 +1,322 @@
+"""Handler for /bicameral_preflight MCP tool (v0.4.12).
+
+Proactive context surfacing: agents call this BEFORE implementing
+code to get a gated context block. The handler:
+
+  1. Validates the topic deterministically (≥4 chars, ≥2 content tokens,
+     not a generic catch-all). Failed validation → fired=False.
+  2. Checks per-session dedup — if the same topic was preflight-checked
+     within the last 5 minutes, fired=False.
+  3. Calls ``handle_search_decisions(topic)`` internally.
+  4. Empty matches → fired=False with reason=no_matches.
+  5. **Gating**:
+     - guided_mode=False (normal): fired=True only when matches contain
+       drift, ungrounded decisions, or (after brief chain) divergences /
+       open questions. "Less intense" — silent on plain matches.
+     - guided_mode=True (standard): fired=True on any matches.
+  6. Conditionally chains to ``handle_brief(topic)`` when matches contain
+     drift or ungrounded status — that's where divergences and gaps live.
+  7. Returns a ``PreflightResponse`` with everything composed.
+
+The gate logic lives in Python (here), not in the skill markdown, so
+it's enforced regardless of agent compliance. The skill is a thin
+wrapper that calls this tool and renders the response when fired=True.
+
+Trust contract: ``fired=False`` means the agent produces ZERO OUTPUT to
+the user. No "I checked and found nothing" noise. The empty path is
+silent.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import time
+from datetime import datetime, timezone
+
+from contracts import (
+    ActionHint,
+    BriefDecision,
+    BriefDivergence,
+    BriefGap,
+    PreflightResponse,
+)
+from handlers.brief import handle_brief, _to_brief_decision
+from handlers.search_decisions import handle_search_decisions
+
+logger = logging.getLogger(__name__)
+
+
+# v0.4.12: dedup TTL — same topic preflight-checked within this many
+# seconds in the current MCP server session is silently skipped. Avoids
+# the "developer asks 4 follow-up questions about Stripe webhook,
+# preflight fires 4 times" annoyance. 5 minutes is long enough to cover
+# a back-and-forth conversation, short enough that the next implementation
+# session gets fresh context.
+_DEDUP_TTL_SECONDS = 300
+
+_GENERIC_TOPICS = frozenset({
+    "code", "project", "everything", "anything", "stuff",
+    "thing", "things", "feature", "features", "system",
+    "module", "function", "method",
+})
+
+_STOPWORDS = frozenset({
+    "the", "and", "for", "that", "this", "with", "are", "from", "have",
+    "will", "when", "then", "been", "also", "into", "about", "should",
+    "must", "need", "each", "they", "their", "there", "which", "where",
+    "what", "than", "some", "more", "such", "only", "very", "just",
+    "like", "make", "made", "use", "used", "using", "after", "before",
+    "over", "under", "between", "through", "against", "implement",
+    "build", "create", "modify", "refactor", "update", "change", "fix",
+    "edit", "remove", "delete",
+})
+
+
+def _content_tokens(text: str) -> set[str]:
+    """Lowercase non-stopword 4+ char tokens. Reuses the FC-3 tokenizer
+    shape but with implementation verbs added to the stopword set so
+    'implement Stripe webhook' yields ['stripe', 'webhook']."""
+    import re
+    raw = re.findall(r"[A-Za-z]{4,}", text or "")
+    return {t.lower() for t in raw if t.lower() not in _STOPWORDS}
+
+
+def _validate_topic(topic: str) -> bool:
+    """Deterministic guard: topic must be non-trivial enough that BM25
+    has a chance of finding meaningful matches.
+
+    Returns False when:
+    - Topic is empty or shorter than 4 chars
+    - Topic has fewer than 2 content tokens after stopword/length filtering
+    - Topic is a generic catch-all single word
+    """
+    if not topic or len(topic.strip()) < 4:
+        return False
+    normalized = topic.strip().lower()
+    if normalized in _GENERIC_TOPICS:
+        return False
+    tokens = _content_tokens(topic)
+    if len(tokens) < 2:
+        return False
+    return True
+
+
+def _dedup_key_for(topic: str) -> str:
+    """Normalize topic for dedup key — case-insensitive, content-tokens
+    only, sorted. Catches phrasings like 'Stripe webhook' and
+    'webhook stripe' as the same topic."""
+    return " ".join(sorted(_content_tokens(topic)))
+
+
+def _check_dedup(ctx, topic: str) -> bool:
+    """Return True when this topic was already preflight-checked within
+    ``_DEDUP_TTL_SECONDS``. Marks the topic as checked at current time
+    when not deduped (so repeat fires within the window are silenced).
+    """
+    sync_state = getattr(ctx, "_sync_state", None)
+    if not isinstance(sync_state, dict):
+        return False
+    topics: dict[str, float] = sync_state.setdefault("preflight_topics", {})
+    key = _dedup_key_for(topic)
+    if not key:
+        return False
+    now = time.time()
+    last = topics.get(key, 0.0)
+    if now - last < _DEDUP_TTL_SECONDS:
+        return True
+    topics[key] = now
+    return False
+
+
+def _has_actionable_signal_in_search(matches: list) -> bool:
+    """Normal mode trust gate: surface only when there's something the
+    developer actually needs to know. Drifted decisions count, ungrounded
+    decisions count. Plain reflected matches don't.
+    """
+    return any(
+        m.status in ("drifted", "ungrounded")
+        for m in matches
+    )
+
+
+def _has_actionable_signal_in_brief(brief_response) -> bool:
+    """Brief-level signal: divergences or open-question gaps. Drift is
+    already covered by the search-level gate.
+    """
+    if brief_response.divergences:
+        return True
+    if any(
+        ("open-question" in g.hint or "open question" in g.hint)
+        for g in brief_response.gaps
+    ):
+        return True
+    return False
+
+
+def _extract_open_questions(brief_response) -> list[BriefGap]:
+    return [
+        g for g in brief_response.gaps
+        if "open-question" in g.hint or "open question" in g.hint
+    ]
+
+
+async def handle_preflight(
+    ctx,
+    topic: str,
+    participants: list[str] | None = None,
+) -> PreflightResponse:
+    """Pre-flight context check. Gates output by ``ctx.guided_mode``."""
+    guided_mode = bool(getattr(ctx, "guided_mode", False))
+
+    # Explicit mute via env var — one-line off-switch for the session.
+    if os.getenv("BICAMERAL_PREFLIGHT_MUTE", "").strip().lower() in (
+        "1", "true", "yes", "on",
+    ):
+        return PreflightResponse(
+            topic=topic,
+            fired=False,
+            reason="preflight_disabled",
+            guided_mode=guided_mode,
+        )
+
+    # Topic validation — deterministic guard. Failed validation =
+    # silent skip, no preflight call.
+    if not _validate_topic(topic):
+        logger.debug("[preflight] topic failed validation: %r", topic[:60])
+        return PreflightResponse(
+            topic=topic,
+            fired=False,
+            reason="topic_too_generic",
+            guided_mode=guided_mode,
+        )
+
+    # Per-session dedup — same topic within 5 min is silenced.
+    if _check_dedup(ctx, topic):
+        logger.debug("[preflight] dedup hit for topic: %r", topic[:60])
+        return PreflightResponse(
+            topic=topic,
+            fired=False,
+            reason="recently_checked",
+            guided_mode=guided_mode,
+        )
+
+    sources_chained: list[str] = []
+
+    # Step 1 — call search. Cheap, single ledger query.
+    try:
+        search_resp = await handle_search_decisions(
+            ctx,
+            query=topic,
+            max_results=10,
+            min_confidence=0.4,
+        )
+        sources_chained.append("search")
+    except Exception as exc:
+        # Fail open — preflight never blocks on bicameral being unavailable.
+        logger.warning("[preflight] search failed, fail-open: %s", exc)
+        return PreflightResponse(
+            topic=topic,
+            fired=False,
+            reason="no_matches",
+            guided_mode=guided_mode,
+        )
+
+    if not search_resp.matches:
+        return PreflightResponse(
+            topic=topic,
+            fired=False,
+            reason="no_matches",
+            guided_mode=guided_mode,
+            sources_chained=sources_chained,
+        )
+
+    # Search-level gate: in normal mode, require actionable signal in
+    # the search response itself. Plain reflected matches are silenced.
+    search_actionable = _has_actionable_signal_in_search(search_resp.matches)
+
+    # Step 2 — conditionally chain to brief. Brief is the source of truth
+    # for divergences and open-question gaps. We chain when the search
+    # already shows signal (drift/ungrounded), or when guided mode wants
+    # the full picture even on plain matches.
+    chain_brief = search_actionable or guided_mode
+    brief_resp = None
+    if chain_brief:
+        try:
+            brief_resp = await handle_brief(
+                ctx, topic=topic, participants=participants,
+            )
+            sources_chained.append("brief")
+        except Exception as exc:
+            logger.warning("[preflight] brief chain failed, continuing: %s", exc)
+            brief_resp = None
+
+    brief_actionable = bool(brief_resp) and _has_actionable_signal_in_brief(brief_resp)
+
+    # Final gate decision: in normal mode, fired=True only when at least
+    # one of search or brief turned up actionable signal. In guided mode,
+    # fired=True on any matches at all.
+    if guided_mode:
+        fired = True
+        reason = "fired"
+    else:
+        if search_actionable or brief_actionable:
+            fired = True
+            reason = "fired"
+        else:
+            fired = False
+            reason = "no_actionable_signal"
+
+    if not fired:
+        return PreflightResponse(
+            topic=topic,
+            fired=False,
+            reason=reason,  # type: ignore[arg-type]
+            guided_mode=guided_mode,
+            sources_chained=sources_chained,
+        )
+
+    # Compose the populated response. Brief is the richer view (it has
+    # severity_tier, drift_evidence, divergences, gaps), but it can
+    # return empty in pathological cases. Fall back to search-derived
+    # values when brief didn't surface anything useful.
+    brief_has_decisions = (
+        brief_resp is not None and len(brief_resp.decisions) > 0
+    )
+    if brief_has_decisions:
+        decisions = brief_resp.decisions
+        drift_candidates = brief_resp.drift_candidates
+    else:
+        decisions = [_to_brief_decision(m) for m in search_resp.matches]
+        drift_candidates = [
+            _to_brief_decision(m)
+            for m in search_resp.matches
+            if m.status == "drifted"
+        ]
+
+    # Divergences and open questions can only come from brief (search
+    # doesn't compute them). When brief was skipped or empty, they're
+    # naturally empty here.
+    divergences = brief_resp.divergences if brief_resp is not None else []
+    open_questions = _extract_open_questions(brief_resp) if brief_resp is not None else []
+
+    # Action hints come from whichever response carries more signal.
+    # Brief's hint set is a superset of search's when brief was chained,
+    # so prefer brief when it has anything; otherwise use search's hints.
+    if brief_resp is not None and brief_resp.action_hints:
+        action_hints = brief_resp.action_hints
+    else:
+        action_hints = search_resp.action_hints
+
+    return PreflightResponse(
+        topic=topic,
+        fired=True,
+        reason="fired",  # type: ignore[arg-type]
+        guided_mode=guided_mode,
+        decisions=decisions,
+        drift_candidates=drift_candidates,
+        divergences=divergences,
+        open_questions=open_questions,
+        action_hints=action_hints,
+        sources_chained=sources_chained,
+    )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "bicameral-mcp"
-version = "0.4.11"
+version = "0.4.12"
 description = "Decision ledger MCP server — ingests meeting transcripts, maps decisions to code, tracks drift"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/server.py
+++ b/server.py
@@ -37,6 +37,7 @@ from handlers.decision_status import handle_decision_status
 from handlers.detect_drift import handle_detect_drift
 from handlers.ingest import handle_ingest
 from handlers.link_commit import handle_link_commit
+from handlers.preflight import handle_preflight
 from handlers.reset import handle_reset
 from handlers.search_decisions import handle_search_decisions
 from handlers.update import get_update_notice, handle_update
@@ -276,6 +277,42 @@ async def list_tools() -> list[Tool]:
                 },
             },
         ),
+        Tool(
+            name="bicameral.preflight",
+            description=(
+                "Proactive context surfacing — call BEFORE implementing, building, modifying, "
+                "refactoring, or adding any code that touches a tracked feature area. Returns "
+                "prior decisions, drifted regions, divergent decision pairs, and unresolved open "
+                "questions linked to the topic, gated by the user's guided_mode setting. "
+                "In normal mode, fires only when there's actionable signal (drift, ungrounded, "
+                "divergence, open question). In guided mode, fires on any matches. "
+                "When fired=false, the agent MUST produce no output and proceed silently — "
+                "that's the trust contract. When fired=true, render the surfaced context with "
+                "a '(bicameral surfaced)' attribution before continuing with the implementation. "
+                "Slash alias: /bicameral:preflight"
+            ),
+            inputSchema={
+                "type": "object",
+                "properties": {
+                    "topic": {
+                        "type": "string",
+                        "description": (
+                            "1-line topic capturing the feature area the user is about to "
+                            "implement. Extract from the user's prompt — e.g. 'Stripe webhook "
+                            "payment_intent succeeded' or 'rate limiting middleware sliding window'. "
+                            "Must be ≥4 chars and contain ≥2 non-stopword content tokens, otherwise "
+                            "the handler returns fired=false."
+                        ),
+                    },
+                    "participants": {
+                        "type": "array",
+                        "items": {"type": "string"},
+                        "description": "Optional list of teammates the user mentioned — used by the chained brief call",
+                    },
+                },
+                "required": ["topic"],
+            },
+        ),
         # ── Code locator tools (MCP-native) ──────────────────────────
         Tool(
             name="validate_symbols",
@@ -414,6 +451,12 @@ async def call_tool(name: str, arguments: dict) -> list[TextContent]:
             ctx,
             confirm=arguments.get("confirm", False),
             replay=arguments.get("replay", True),
+        )
+    elif name in ("bicameral.preflight", "preflight"):
+        result = await handle_preflight(
+            ctx,
+            topic=arguments["topic"],
+            participants=arguments.get("participants") or None,
         )
     # ── Code locator tools ────────────────────────────────────────
     elif name == "validate_symbols":

--- a/skills/bicameral-preflight/SKILL.md
+++ b/skills/bicameral-preflight/SKILL.md
@@ -1,0 +1,271 @@
+---
+name: bicameral-preflight
+description: Pre-flight context check BEFORE implementing code. Auto-fires on implementation requests using verbs like "add", "build", "create", "implement", "modify", "refactor", "update", "fix", or any prompt asking Claude to write or change source code. Surfaces prior decisions, drifted regions, divergences, and open questions linked to the feature area BEFORE Claude starts writing. Silent if no relevant context exists. SKIP FOR — read-only questions, debugging without code changes, documentation-only edits, simple typo fixes, dependency updates.
+---
+
+# Bicameral Preflight
+
+The proactive context-surfacing skill. Bicameral notices when you're
+about to implement something and pushes the relevant prior decisions,
+drift, and open questions at you BEFORE Claude writes any code.
+
+**The wow moment**: developer says *"add a Stripe webhook handler for
+payment_intent.succeeded"* — without being asked, bicameral chimes in
+with idempotency decisions from a sprint review, the drifted timestamp
+handling from PR #287, and the unresolved deduplication question from
+last week's Slack thread. The implementation that follows is informed
+by all of it.
+
+**The trust contract**: when there's nothing relevant to surface, this
+skill produces ZERO output. No "I checked and found nothing" noise.
+The empty path is silent.
+
+## When to fire
+
+Auto-fire on prompts that ask Claude to write, modify, or refactor
+code:
+
+- *"add a Stripe webhook handler for payment_intent.succeeded"*
+- *"refactor the rate limiting middleware to use sliding window"*
+- *"build a notification system for retention nudges"*
+- *"implement OAuth callback for Google Calendar"*
+- *"modify the discount calculation to handle cents"*
+- *"create a migration to add the audit_log table"*
+- *"continue what we started yesterday on the email queue"* (use
+  conversation context to extract the topic)
+
+## When NOT to fire
+
+The "SKIP FOR" list in the description is load-bearing. Do NOT fire on:
+
+- *"how does the rate limiter work?"* (read-only question)
+- *"why is this test failing?"* (debugging, no code change yet)
+- *"fix the typo in the README"* (doc-only edit)
+- *"bump lodash to 4.17.21"* (dependency update, no semantic change)
+- *"what does this function do?"* (explanation, not implementation)
+
+If the user is asking you to SHOW or EXPLAIN, not BUILD or CHANGE,
+preflight does not fire.
+
+## Steps
+
+### 1. Extract a 1-line topic
+
+Before calling the tool, extract a topic string from the user's
+prompt. The topic should capture the feature area in 4-12 words. Use
+conversation context if the prompt is indirect.
+
+Examples:
+
+| User prompt | Extracted topic |
+|---|---|
+| "Add Stripe webhook handler for payment_intent.succeeded" | `Stripe webhook payment_intent succeeded` |
+| "Refactor the rate limiting middleware to use sliding window" | `rate limiting middleware sliding window` |
+| "Continue what we started yesterday on the email queue" | `email queue retention nudge` *(infer from prior turn)* |
+| "Build the audit log feature Brian asked for" | `audit log feature` (with `participants=["Brian"]`) |
+
+The handler validates the topic deterministically (≥4 chars, ≥2
+non-stopword content tokens, not a generic catch-all). If your topic
+fails validation, the handler returns `fired=false` with
+`reason="topic_too_generic"` — that's the silent skip path. Don't
+worry about getting validation perfect; the handler is forgiving on
+the happy path.
+
+### 2. Call `bicameral.preflight`
+
+```
+bicameral.preflight(
+  topic="<the 1-line topic>",
+  participants=[<names if user mentioned specific people>],  # optional
+)
+```
+
+The handler runs `bicameral.search` internally, gates on the user's
+`guided_mode` setting, conditionally chains to `bicameral.brief`, and
+returns a `PreflightResponse` with a `fired: bool` field.
+
+### 3. Decide whether to render
+
+Look at `response.fired`:
+
+- **`fired == false`** → produce **NO OUTPUT** about the preflight.
+  Do not say "I checked bicameral and found nothing." Do not say "no
+  relevant context." Just proceed silently with the user's original
+  request. The reason field tells you why (no_matches,
+  no_actionable_signal, topic_too_generic, recently_checked,
+  preflight_disabled) — useful for debugging, never user-facing.
+
+- **`fired == true`** → render the surfaced block (next step) BEFORE
+  doing any code work.
+
+### 4. Render the surfaced block
+
+When `fired=true`, surface the response using this exact format. Lead
+with the `(bicameral surfaced)` attribution line.
+
+```
+(bicameral surfaced — checking <topic> context before implementing)
+
+📌 N prior decisions in scope:
+  ✓ <decision description>
+    <file_path>:<symbol>:<lines>
+    Source: <source_ref> · <source_type>
+
+  ✓ <next decision...>
+
+  ⚠ DRIFTED: <decision description>
+    <file_path>:<symbol>:<lines>
+    Source: <source_ref>
+    Drift evidence: <drift_evidence verbatim>
+
+⚠ N divergent decision pair(s) — pick a winner before continuing:
+  • <symbol> (<file_path>): <summary>
+
+⚠ N unresolved open question(s):
+  • <description>
+    Source: <source_ref>
+```
+
+Then, if `response.action_hints` is non-empty, render each hint
+verbatim — never paraphrase the `message` field.
+
+After the surfaced block, **continue with the user's original request**.
+A one-line forward narration helps:
+
+> "Proceeding with implementation; pulling the Redis SETNX pattern
+> from idempotency.ts. I'll flag the event.id deduplication question
+> for you to answer before I commit."
+
+### 5. Honor blocking hints (guided mode only)
+
+If any hint has `blocking: true`, you MUST stop after the surfaced
+block and wait for user acknowledgment before doing any write
+operation (file edit, commit, PR, `bicameral_ingest`). Surface the
+hint's `message` verbatim and ask the user to either resolve it or
+explicitly tell you to proceed.
+
+In normal mode (non-guided), hints have `blocking: false` and you can
+proceed after surfacing them. The user opted into the looser
+interaction at setup time.
+
+## Examples
+
+### Hit — guided mode, drift + divergence found
+
+**User**: "Add a Stripe webhook handler for payment_intent.succeeded"
+
+**Topic extracted**: `Stripe webhook payment_intent succeeded`
+
+**Tool call**: `bicameral.preflight(topic="Stripe webhook payment_intent succeeded")`
+
+**Response** (fired=true, guided_mode=true):
+
+```
+(bicameral surfaced — checking Stripe webhook payment_intent succeeded
+context before implementing)
+
+📌 3 prior decisions in scope:
+
+  ✓ Idempotency via Redis SETNX with 24h TTL
+    src/middleware/idempotency.ts:checkIdempotencyKey:42-67
+    Source: Sprint 14 architecture review · Ian, 2026-03-12
+
+  ✓ Retry failed webhooks with exponential backoff (max 5 attempts)
+    src/queue/webhook-retry.ts:scheduleRetry:18-45
+    Source: PR #261 review · Brian, 2026-03-22
+
+  ⚠ DRIFTED: Trust Stripe event.created timestamp, not server time
+    src/handlers/webhook.ts:processEvent:80-92
+    Source: arch review 2026-03-15
+    Drift evidence: switched from event.created to Date.now() in PR #287
+
+⚠ 1 unresolved open question:
+  • "Should we deduplicate by event.id or by (account_id, event.id)?"
+    Source: Slack #payments 2026-03-20
+
+⚠ BLOCKING (guided mode): 1 matched decision(s) have drifted — review
+the drifted regions and confirm the code still matches stored intent
+BEFORE making changes.
+
+I need you to resolve before I proceed:
+1. Was the switch to Date.now() in PR #287 intentional, or should I
+   revert to event.created?
+2. Which deduplication key should I use — event.id or
+   (account_id, event.id)?
+```
+
+(Then waits for user acknowledgment.)
+
+### Miss — silent skip
+
+**User**: "Fix the typo in the README"
+
+**Topic extracted**: `typo README` (or skipped entirely if you decide
+this is doc-only)
+
+**Tool call**: skipped, OR `bicameral.preflight(topic="typo README")`
+
+**Response** (fired=false, reason=topic_too_generic OR no_matches):
+
+```
+[no output about preflight at all]
+```
+
+Then continue with the typo fix. The user should not see any preflight
+output for prompts that don't match anything.
+
+### Hit — normal mode, advisory only
+
+**User**: "Refactor the discount calculation to handle cents"
+
+**Response** (fired=true, guided_mode=false):
+
+```
+(bicameral surfaced — checking discount calculation cents context
+before implementing)
+
+📌 1 prior decision in scope:
+  ⚠ DRIFTED: Apply 10% discount on orders >= $100
+    src/pricing/discount.py:calculate_discount:42-67
+    Source: Sprint 14 planning · Ian, 2026-03-12
+    Drift evidence: threshold raised 100 → 500, rate lowered 10% → 5%
+
+Note: the discount logic is currently drifted from the original
+intent. Worth confirming with Ian before changing it again. Proceeding
+with the refactor — let me know if you want me to align it back to
+the original 10% / $100 baseline or keep the current 5% / $500
+behavior.
+```
+
+(Continues with the refactor — no blocking pause in normal mode.)
+
+## Rules
+
+1. **Honest empty path.** When `fired=false`, produce NO output about
+   preflight. Silent skip. Period.
+2. **Verbatim attribution.** Every cited decision includes its
+   `source_ref` so the user can trace it.
+3. **Never paraphrase hint messages.** Surface them as-is. The
+   message tone (advisory vs imperative) is calibrated by guided mode
+   and the user can read intent from it directly.
+4. **Topic from prompt + context.** If the user's prompt is indirect
+   ("continue what we started yesterday"), use the prior conversation
+   to extract a meaningful topic. Don't pass the raw prompt verbatim.
+5. **Forward narration after surfacing.** Tell the user what you're
+   about to do with the surfaced context, not just what you found.
+   "Proceeding with X; pulling pattern from Y; will flag Z for you to
+   answer before commit."
+6. **Skip the SKIP-FOR list.** Read-only, doc-only, and dependency-
+   only prompts do not need preflight. Don't fire on them.
+
+## How to disable
+
+If preflight is too noisy for the current session, the user can set
+`BICAMERAL_PREFLIGHT_MUTE=1` on the MCP server process to silence it
+for one session. The handler will return `fired=false` with
+`reason="preflight_disabled"` for every call.
+
+For a permanent off-switch, edit `.bicameral/config.yaml` and remove
+the preflight skill from the agent's skill set, OR set
+`guided: false` (which dials preflight back to "actionable signal
+only" — silent on plain matches).

--- a/tests/test_v0412_preflight.py
+++ b/tests/test_v0412_preflight.py
@@ -1,0 +1,440 @@
+"""v0.4.12 — bicameral.preflight regression tests.
+
+Covers:
+
+  1. Pure-function tests for the helpers (_validate_topic, _content_tokens,
+     _has_actionable_signal_in_search, _check_dedup) — synchronous, IO-free.
+
+  2. Handler tests with mocked search/brief responses — cover every
+     fired/not-fired path:
+       - topic_too_generic (validation failure)
+       - recently_checked (dedup hit)
+       - preflight_disabled (env var mute)
+       - no_matches (empty search response)
+       - no_actionable_signal (normal mode + plain matches only)
+       - fired (normal mode + drift)
+       - fired (guided mode + plain matches)
+
+  3. Mode interaction: normal mode SHOULD NOT fire on plain matches;
+     guided mode SHOULD fire on the same plain matches.
+
+  4. Brief chain: triggers when search has actionable signal, OR when
+     guided_mode=True. Doesn't fire otherwise.
+"""
+
+from __future__ import annotations
+
+import time
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from contracts import (
+    BriefDecision,
+    BriefDivergence,
+    BriefGap,
+    BriefResponse,
+    CodeRegionSummary,
+    DecisionMatch,
+    LinkCommitResponse,
+    PreflightResponse,
+    SearchDecisionsResponse,
+)
+from handlers.preflight import (
+    _check_dedup,
+    _content_tokens,
+    _dedup_key_for,
+    _has_actionable_signal_in_brief,
+    _has_actionable_signal_in_search,
+    _validate_topic,
+    handle_preflight,
+)
+
+
+# ── Pure helpers ────────────────────────────────────────────────────
+
+
+def test_validate_topic_accepts_real_topic():
+    assert _validate_topic("Stripe webhook payment_intent succeeded")
+    assert _validate_topic("rate limiting middleware sliding window")
+    assert _validate_topic("Google Calendar OAuth callback flow")
+
+
+def test_validate_topic_rejects_too_short():
+    assert not _validate_topic("")
+    assert not _validate_topic("foo")
+    assert not _validate_topic("ab")
+
+
+def test_validate_topic_rejects_single_token():
+    assert not _validate_topic("webhook")
+    assert not _validate_topic("authorization")
+
+
+def test_validate_topic_rejects_generic_catchall():
+    assert not _validate_topic("project")
+    assert not _validate_topic("code")
+    assert not _validate_topic("everything")
+    assert not _validate_topic("system")
+
+
+def test_validate_topic_strips_implementation_verbs():
+    """Implementation verbs are in the stopword set so they don't
+    count toward the 2-content-token requirement."""
+    # "implement webhook" — only 'webhook' is content. Should fail.
+    assert not _validate_topic("implement webhook")
+    # "implement Stripe webhook" — 2 content tokens. Should pass.
+    assert _validate_topic("implement Stripe webhook")
+
+
+def test_dedup_key_normalizes_word_order():
+    """'Stripe webhook' and 'webhook stripe' should dedup as same topic."""
+    assert _dedup_key_for("Stripe webhook payment") == _dedup_key_for(
+        "payment webhook Stripe"
+    )
+
+
+def test_check_dedup_marks_then_hits():
+    ctx = SimpleNamespace(_sync_state={})
+    # First call — no entry, should not dedup, should mark
+    assert _check_dedup(ctx, "Stripe webhook payment") is False
+    # Second call — entry is fresh, should dedup
+    assert _check_dedup(ctx, "Stripe webhook payment") is True
+    # Different topic — should not dedup
+    assert _check_dedup(ctx, "rate limiting middleware") is False
+
+
+def test_check_dedup_expires_after_ttl(monkeypatch):
+    ctx = SimpleNamespace(_sync_state={})
+    now = [1000.0]
+
+    def fake_time():
+        return now[0]
+
+    monkeypatch.setattr("handlers.preflight.time.time", fake_time)
+    _check_dedup(ctx, "Stripe webhook payment")
+    # Same instant — dedup hits
+    assert _check_dedup(ctx, "Stripe webhook payment") is True
+    # 6 minutes later — TTL expired (300s), should NOT dedup
+    now[0] += 360
+    assert _check_dedup(ctx, "Stripe webhook payment") is False
+
+
+def test_actionable_signal_in_search_drifted():
+    matches = [
+        SimpleNamespace(status="reflected"),
+        SimpleNamespace(status="drifted"),
+    ]
+    assert _has_actionable_signal_in_search(matches) is True
+
+
+def test_actionable_signal_in_search_ungrounded():
+    matches = [SimpleNamespace(status="ungrounded")]
+    assert _has_actionable_signal_in_search(matches) is True
+
+
+def test_actionable_signal_in_search_only_reflected():
+    matches = [SimpleNamespace(status="reflected"), SimpleNamespace(status="reflected")]
+    assert _has_actionable_signal_in_search(matches) is False
+
+
+def test_actionable_signal_in_brief_divergence():
+    brief = SimpleNamespace(
+        divergences=[SimpleNamespace()],
+        gaps=[],
+    )
+    assert _has_actionable_signal_in_brief(brief) is True
+
+
+def test_actionable_signal_in_brief_open_question_gap():
+    brief = SimpleNamespace(
+        divergences=[],
+        gaps=[SimpleNamespace(hint="open-question phrasing")],
+    )
+    assert _has_actionable_signal_in_brief(brief) is True
+
+
+def test_actionable_signal_in_brief_plain():
+    brief = SimpleNamespace(
+        divergences=[],
+        gaps=[SimpleNamespace(hint="missing acceptance criteria")],
+    )
+    assert _has_actionable_signal_in_brief(brief) is False
+
+
+# ── Handler tests with mocked search/brief ──────────────────────────
+
+
+def _ctx(guided: bool = False, sync_state: dict | None = None):
+    return SimpleNamespace(
+        guided_mode=guided,
+        _sync_state=sync_state if sync_state is not None else {},
+        repo_path="/tmp/test-repo",
+    )
+
+
+def _empty_search_response() -> SearchDecisionsResponse:
+    return SearchDecisionsResponse(
+        query="test",
+        sync_status=LinkCommitResponse(
+            commit_hash="abc", synced=True, reason="new_commit",
+        ),
+        matches=[],
+        ungrounded_count=0,
+        suggested_review=[],
+    )
+
+
+def _search_response_with(matches: list[DecisionMatch]) -> SearchDecisionsResponse:
+    return SearchDecisionsResponse(
+        query="test",
+        sync_status=LinkCommitResponse(
+            commit_hash="abc", synced=True, reason="new_commit",
+        ),
+        matches=matches,
+        ungrounded_count=sum(1 for m in matches if m.status == "ungrounded"),
+        suggested_review=[m.intent_id for m in matches if m.status in ("drifted", "pending")],
+    )
+
+
+def _match(intent_id: str, status: str = "reflected", file_path: str = "src/foo.ts") -> DecisionMatch:
+    return DecisionMatch(
+        intent_id=intent_id,
+        description=f"decision {intent_id}",
+        status=status,  # type: ignore[arg-type]
+        confidence=0.9,
+        source_ref="test-ref",
+        code_regions=[
+            CodeRegionSummary(
+                file_path=file_path, symbol="foo", lines=(1, 10), purpose="",
+            )
+        ],
+    )
+
+
+def _empty_brief() -> BriefResponse:
+    return BriefResponse(
+        topic="test",
+        as_of="2026-04-14T00:00:00Z",
+        ref="HEAD",
+    )
+
+
+def _brief_with(
+    divergences: list[BriefDivergence] | None = None,
+    open_qs: list[str] | None = None,
+    drift_candidates: list[BriefDecision] | None = None,
+) -> BriefResponse:
+    return BriefResponse(
+        topic="test",
+        as_of="2026-04-14T00:00:00Z",
+        ref="HEAD",
+        divergences=divergences or [],
+        gaps=[
+            BriefGap(description=q, hint="open-question phrasing")
+            for q in (open_qs or [])
+        ],
+        drift_candidates=drift_candidates or [],
+    )
+
+
+@pytest.mark.asyncio
+async def test_topic_too_generic_returns_silent_skip():
+    ctx = _ctx()
+    r = await handle_preflight(ctx, topic="project")
+    assert r.fired is False
+    assert r.reason == "topic_too_generic"
+    assert r.decisions == []
+
+
+@pytest.mark.asyncio
+async def test_dedup_hit_returns_silent_skip():
+    ctx = _ctx()
+    # Mock search to make sure it's NOT called on the second invocation
+    with patch("handlers.preflight.handle_search_decisions") as mock_search:
+        mock_search.return_value = _empty_search_response()
+        r1 = await handle_preflight(ctx, topic="Stripe webhook payment")
+        assert mock_search.call_count == 1
+        r2 = await handle_preflight(ctx, topic="Stripe webhook payment")
+        # Second call hit dedup — search should NOT have been called again
+        assert mock_search.call_count == 1
+        assert r2.fired is False
+        assert r2.reason == "recently_checked"
+
+
+@pytest.mark.asyncio
+async def test_env_mute_returns_silent_skip(monkeypatch):
+    monkeypatch.setenv("BICAMERAL_PREFLIGHT_MUTE", "1")
+    ctx = _ctx()
+    r = await handle_preflight(ctx, topic="Stripe webhook payment")
+    assert r.fired is False
+    assert r.reason == "preflight_disabled"
+
+
+@pytest.mark.asyncio
+async def test_no_matches_returns_silent_skip():
+    ctx = _ctx()
+    with patch(
+        "handlers.preflight.handle_search_decisions",
+        new=AsyncMock(return_value=_empty_search_response()),
+    ):
+        r = await handle_preflight(ctx, topic="Stripe webhook payment")
+    assert r.fired is False
+    assert r.reason == "no_matches"
+    assert "search" in r.sources_chained
+
+
+@pytest.mark.asyncio
+async def test_normal_mode_silent_on_plain_matches_only():
+    """Q1=B + 'less intense than standard': normal mode is silent when
+    the only matches are reflected with no drift, no divergences, no
+    open questions."""
+    ctx = _ctx(guided=False)
+    search = _search_response_with([
+        _match("intent:1", status="reflected"),
+        _match("intent:2", status="reflected"),
+    ])
+    with patch(
+        "handlers.preflight.handle_search_decisions",
+        new=AsyncMock(return_value=search),
+    ), patch(
+        "handlers.preflight.handle_brief",
+        new=AsyncMock(return_value=_empty_brief()),
+    ):
+        r = await handle_preflight(ctx, topic="Stripe webhook payment")
+    assert r.fired is False
+    assert r.reason == "no_actionable_signal"
+
+
+@pytest.mark.asyncio
+async def test_guided_mode_fires_on_plain_matches():
+    """Standard intensity: guided mode fires whenever there are matches,
+    even without actionable signal."""
+    ctx = _ctx(guided=True)
+    search = _search_response_with([
+        _match("intent:1", status="reflected"),
+    ])
+    with patch(
+        "handlers.preflight.handle_search_decisions",
+        new=AsyncMock(return_value=search),
+    ), patch(
+        "handlers.preflight.handle_brief",
+        new=AsyncMock(return_value=_empty_brief()),
+    ):
+        r = await handle_preflight(ctx, topic="Stripe webhook payment")
+    assert r.fired is True
+    assert r.reason == "fired"
+    assert len(r.decisions) >= 1
+
+
+@pytest.mark.asyncio
+async def test_normal_mode_fires_on_drifted_match():
+    """Even in normal mode, a drifted match is enough to fire."""
+    ctx = _ctx(guided=False)
+    search = _search_response_with([
+        _match("intent:1", status="drifted"),
+    ])
+    with patch(
+        "handlers.preflight.handle_search_decisions",
+        new=AsyncMock(return_value=search),
+    ), patch(
+        "handlers.preflight.handle_brief",
+        new=AsyncMock(return_value=_empty_brief()),
+    ):
+        r = await handle_preflight(ctx, topic="Stripe webhook payment")
+    assert r.fired is True
+    assert r.reason == "fired"
+    assert len(r.drift_candidates) >= 1
+
+
+@pytest.mark.asyncio
+async def test_brief_chain_fires_when_search_has_drift():
+    """Q1=B: brief chain fires when search returns drift, regardless of mode."""
+    ctx = _ctx(guided=False)
+    search = _search_response_with([_match("intent:1", status="drifted")])
+    brief = _brief_with(open_qs=["Should we use Redis or local memory?"])
+    with patch(
+        "handlers.preflight.handle_search_decisions",
+        new=AsyncMock(return_value=search),
+    ), patch(
+        "handlers.preflight.handle_brief",
+        new=AsyncMock(return_value=brief),
+    ) as mock_brief:
+        r = await handle_preflight(ctx, topic="Stripe webhook payment")
+    assert mock_brief.called
+    assert "brief" in r.sources_chained
+    assert r.fired is True
+    assert len(r.open_questions) == 1
+
+
+@pytest.mark.asyncio
+async def test_brief_chain_skipped_when_search_has_only_plain_matches_in_normal_mode():
+    """Q1=B inverse: brief chain does NOT fire on plain matches in
+    normal mode (would be wasted work; the gate would still produce
+    fired=false)."""
+    ctx = _ctx(guided=False)
+    search = _search_response_with([_match("intent:1", status="reflected")])
+    with patch(
+        "handlers.preflight.handle_search_decisions",
+        new=AsyncMock(return_value=search),
+    ), patch(
+        "handlers.preflight.handle_brief",
+        new=AsyncMock(return_value=_empty_brief()),
+    ) as mock_brief:
+        r = await handle_preflight(ctx, topic="Stripe webhook payment")
+    assert not mock_brief.called
+    assert r.fired is False
+
+
+@pytest.mark.asyncio
+async def test_brief_chain_fires_in_guided_mode_even_on_plain_matches():
+    """Q1=B: in guided mode, brief chains even on plain matches because
+    the user opted into the loud experience."""
+    ctx = _ctx(guided=True)
+    search = _search_response_with([_match("intent:1", status="reflected")])
+    with patch(
+        "handlers.preflight.handle_search_decisions",
+        new=AsyncMock(return_value=search),
+    ), patch(
+        "handlers.preflight.handle_brief",
+        new=AsyncMock(return_value=_empty_brief()),
+    ) as mock_brief:
+        r = await handle_preflight(ctx, topic="Stripe webhook payment")
+    assert mock_brief.called
+    assert "brief" in r.sources_chained
+
+
+@pytest.mark.asyncio
+async def test_search_failure_fails_open():
+    """Robustness: if search throws, preflight returns fired=false
+    silently — never blocks on bicameral being unavailable."""
+    ctx = _ctx()
+    async def _boom(*a, **kw):
+        raise RuntimeError("ledger down")
+    with patch("handlers.preflight.handle_search_decisions", side_effect=_boom):
+        r = await handle_preflight(ctx, topic="Stripe webhook payment")
+    assert r.fired is False
+    assert r.reason == "no_matches"
+
+
+@pytest.mark.asyncio
+async def test_brief_failure_continues_with_search_only():
+    """Robustness: if brief throws, preflight falls back to search-only
+    rendering instead of failing the whole call."""
+    ctx = _ctx(guided=False)
+    search = _search_response_with([_match("intent:1", status="drifted")])
+    async def _boom(*a, **kw):
+        raise RuntimeError("brief crashed")
+    with patch(
+        "handlers.preflight.handle_search_decisions",
+        new=AsyncMock(return_value=search),
+    ), patch("handlers.preflight.handle_brief", side_effect=_boom):
+        r = await handle_preflight(ctx, topic="Stripe webhook payment")
+    # Should still fire because search alone has actionable signal
+    assert r.fired is True
+    assert r.reason == "fired"
+    assert "search" in r.sources_chained
+    # Brief in sources_chained means it was attempted; on failure it
+    # should NOT be in sources_chained
+    assert "brief" not in r.sources_chained


### PR DESCRIPTION
## Summary

Adds \`bicameral.preflight(topic)\` — a new MCP tool that the agent calls BEFORE implementing code to get a gated context block. Closes the loop on the "tech debt accrues because developers make tiny architectural decisions without full insight into product context" problem — bicameral now pushes context at the agent without waiting for an explicit query.

**The wow moment**: developer says *"add a Stripe webhook handler for payment_intent.succeeded"* → without being asked, bicameral surfaces the idempotency decision from a prior arch review, the drifted timestamp handling from PR #287, and the unresolved deduplication question from last week's Slack thread. The implementation that follows is informed by all of it.

**The trust contract**: when there's nothing relevant, preflight produces ZERO output. Honest empty path. No "I checked and found nothing" noise.

## Architecture

- **New tool** \`bicameral.preflight(topic, participants?)\` with Python-enforced gate logic in \`handlers/preflight.py\`. The gate decides \`fired: true | false\` based on \`ctx.guided_mode\`:
  - **Normal** (default): \`fired=true\` only on actionable signal (drift / ungrounded / divergence / open question)
  - **Guided**: \`fired=true\` on any matches
- **New skill** \`bicameral-preflight\` auto-fires on implementation verbs with explicit SKIP FOR list
- **Conditional brief chain** (Q1=B): when search has drift/ungrounded, OR always in guided mode
- **Topic extraction** (Q2=C): agent extracts via LLM, deterministic validator gates bad inputs
- **Per-session dedup**: same topic within 5 min is silenced
- **Env mute**: \`BICAMERAL_PREFLIGHT_MUTE=1\` for one-line off-switch
- **Reuses guided_mode** from v0.4.10 — no new setup wizard prompt

## Test plan

- [x] 26 cases in \`tests/test_v0412_preflight.py\` covering topic validation, dedup hits + TTL expiry, env mute, every fired/not-fired path, normal-vs-guided mode, brief chain conditional firing, fail-open robustness
- [x] Full v0.4.12 regression: **189 passed** in 14s
- [ ] Manual: dogfood the skill on Accountable with a real implementation prompt

🤖 Generated with [Claude Code](https://claude.com/claude-code)