### PR TITLE
fix: Stage 1 symbol ranking by fuzzy score — MRR@3 0.39→0.58 

### DIFF
--- a/adapters/code_locator.py
+++ b/adapters/code_locator.py
@@ -212,11 +212,14 @@ class RealCodeLocatorAdapter:
         #      collapses to BM25-only.
         #   2. Rank symbols within each qualifying file (relevant ones
         #      come first).
-        matched_ids: set[int] = set()
+        matched_scores: dict[int, float] = {}
         if tokens:
             try:
                 validated = self._validate_with_threshold(tokens, fuzzy_threshold)
-                matched_ids = {v["symbol_id"] for v in validated if v.get("symbol_id")}
+                for v in validated:
+                    sid = v.get("symbol_id")
+                    if sid:
+                        matched_scores[sid] = max(matched_scores.get(sid, 0), v["match_score"])
             except Exception as exc:
                 logger.debug("[ground] fuzzy validate failed for '%s': %s", description[:60], exc)
 
@@ -225,9 +228,11 @@ class RealCodeLocatorAdapter:
                 try:
                     rows = db.lookup_by_name(name)
                     for row in rows:
-                        matched_ids.add(row["id"])
+                        matched_scores[row["id"]] = max(matched_scores.get(row["id"], 0), 100.0)
                 except Exception as exc:
                     logger.debug("[ground] symbol name lookup failed for '%s': %s", name, exc)
+
+        matched_ids = set(matched_scores)
 
         # Stage 1: multi-file fused retrieval (FC-2 fix, v0.4.6).
         # Previously this stage took only the top-1 BM25 hit via next(),
@@ -273,7 +278,7 @@ class RealCodeLocatorAdapter:
                     relevant_ids = matched_ids & file_symbol_ids
                     ranked = sorted(
                         file_symbols,
-                        key=lambda r: (r["id"] not in relevant_ids, r["start_line"]),
+                        key=lambda r: (r["id"] not in relevant_ids, -matched_scores.get(r["id"], 0)),
                     )
                     for row in ranked[:per_file_budget]:
                         code_regions.append({
@@ -294,8 +299,9 @@ class RealCodeLocatorAdapter:
         # Unchanged from v0.4.5 semantics.
         if not code_regions and matched_ids:
             try:
+                score_ranked_ids = sorted(matched_scores, key=matched_scores.get, reverse=True)
                 code_regions = self._regions_from_symbol_ids(
-                    sorted(matched_ids)[:max_symbols], db, description,
+                    score_ranked_ids[:max_symbols], db, description,
                 )
             except Exception as exc:
                 logger.warning("[ground] fuzzy fallback failed: %s", exc)


### PR DESCRIPTION
## Summary                                                                                                                                                           
  - Stage 1 file→symbol expansion was ranking symbols by `start_line` (insertion order) instead of fuzzy relevance score, causing the grounding pipeline to select     
  wrong symbols from correct files                                                                                                                                     
  - Preserve `match_score` from `validate_symbols` as a `dict[int, float]` and use it as the within-file sort key instead of line number                               
  - Stage 2 fallback also fixed: sorts by score descending instead of rowid                                                                                            
                                                                                                                                                                       
  ## Results                                                                                                                                                           
  | Repo | MRR@3 Before | MRR@3 After |                                                                                                                                
  |------|-------------|-------------|                                                                                                                                 
  | medusa | ~0.39 | 0.458 |                                
  | saleor | ~0.39 | 0.773 |
  | vendure | ~0.39 | 0.500 |                                                                                                                                          
  | **Aggregate** | **0.392** | **0.577** |                                                                                                                            
                                                                                                                                                                       
  Rank overflow (relevant symbol exists but ranked beyond top-3): **0** across all repos.                                                                              
                                                                                                                                                                       
  ## Test plan                                                                                                                                                         
  - [x] 29/29 unit tests pass (phase1, phase3, coverage_loop)                                                                                                          
  - [x] Eval harness: aggregate MRR@3 0.392 → 0.577 (+47%)   
  - [x] No regressions in hit rate or grounding rate

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Enhanced symbol relevance scoring and ranking mechanism within the code locator functionality to improve how matching symbols are prioritized and resolved.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->