### PR TITLE
fix: compound token extraction for grounding recall (9%→14%)

### DIFF
--- a/adapters/code_locator.py
+++ b/adapters/code_locator.py
@@ -157,6 +157,9 @@ class RealCodeLocatorAdapter:
         "like", "make", "made", "use", "used", "using", "after", "before",
     })
 
+    _COMPOUND_RE = re.compile(r"[A-Za-z]\w*(?:[_.][A-Za-z]\w*)+")
+
+
     def _regions_from_symbol_ids(self, symbol_ids: list[int], db, description: str) -> list[dict]:
         """Resolve a list of symbol IDs to code_region dicts."""
         regions = []
@@ -199,10 +202,12 @@ class RealCodeLocatorAdapter:
         if hits is None:
             hits = []
 
-        tokens = [
+        compounds = [c for c in self._COMPOUND_RE.findall(description) if len(c) >= 4]
+        word_tokens = [
             w for w in re.findall(r"[a-zA-Z]{4,}", description)
             if w.lower() not in self._STOP_WORDS
         ]
+        tokens = compounds + word_tokens
 
         # Pre-compute fuzzy-validated symbol IDs once. These serve two
         # purposes below:


### PR DESCRIPTION
## Summary                                                                                                                                                           
  - The tokenizer in `_ground_single` used `re.findall(r"[a-zA-Z]{4,}")` which stripped underscores and dots, destroying compound identifiers (`decrease_stock` →
  `["decrease", "stock"]`) before they reached `validate_symbols`                                                                                                
  - Added `_COMPOUND_RE` regex to extract snake_case and dotted.name identifiers intact, prepended to the token list before word-level tokens                          
  - 6 lines changed in one file (`adapters/code_locator.py`)                                                                                 
                                                                                                                                                                       
  ## Results                                                                                                                                                           
  | Metric | Before | After |                                                                                                                                          
  |--------|--------|-------|                                                                                                                                          
  | Recall | 9.3% | **13.9%** (+50%) |                                                                                                                                 
  | MRR@3 | 0.577 | **0.592** (held) |
  | Saleor recall | 13.6% | **27.3%** (2x) |                                                                                                                           
                                                                                                                                                                       
  Key wins: `decrease_stock`, `update_order_status`, `transaction.atomic` now match their exact symbols instead of generic fragments like `Stock` or `Order`.          
                                                                                                                                                                       
  ## Test plan                                                                                                                                                         
  - [x] 29/29 unit tests pass                                                                                                                                          
  - [x] Eval harness: recall 9.3% → 13.9%, MRR@3 held at 0.59
  - [x] No regressions in hit rate or grounding rate                                                                                                                   
                                                                                                                                                                       
  PR 2: Parent Repo (bicameral)                                                                                                                                        
                                                                                                                                                                       
  Title: mcp: bump submodule — compound token recall fix    
                                                                                                                                                                       
  Body:                                                     
  ## Summary
  - Bumps pilot/mcp submodule to include compound token extraction fix
  - See BicameralAI/bicameral-mcp#<PR_NUMBER> for details

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Enhanced code location detection to better recognize compound identifiers (such as names with underscores and dots), improving search and navigation accuracy.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->