### PR TITLE
Self-contained tests + MCP-native CI workflow

### DIFF
--- a/.github/workflows/test-mcp-regression.yml
+++ b/.github/workflows/test-mcp-regression.yml
@@ -1,0 +1,155 @@
+name: MCP Regression Tests
+
+on:
+  pull_request:
+    branches: [main]
+
+env:
+  PYTHON_VERSION: '3.11'
+
+jobs:
+  mcp-tests:
+    name: MCP Regression Suite
+    runs-on: ubuntu-latest
+    # Needed so ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }} / ANTHROPIC_API_KEY
+    # (environment secrets scoped to `ci-test`) is injected into the M1
+    # extraction step. The env is gate-free so this does not block
+    # PR-triggered runs.
+    environment: ci-test
+    env:
+      SURREAL_URL: 'memory://'
+      REPO_PATH: ${{ github.workspace }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: ${{ env.PYTHON_VERSION }}
+
+      - name: Install dependencies
+        run: pip install -e ".[test]" pytest-html
+
+      # ── Build code locator index ───────────────────────────────────
+      - name: Build code locator index
+        run: |
+          python -c "
+          import os
+          os.environ['REPO_PATH'] = os.environ.get('REPO_PATH', '.')
+          from code_locator_runtime import ensure_runtime_env, rebuild_index
+          from code_locator.config import load_config
+          ensure_runtime_env()
+          config = load_config()
+          rebuild_index(os.environ['REPO_PATH'], config, force=True)
+          print(f'Index built at {config.sqlite_db}')
+          "
+
+      # ── Clone OSS repos for eval ground truth ────────────────────────
+      - name: Clone eval repos (shallow, pinned commits)
+        run: |
+          clone_at_commit() {
+            local repo_url=$1 dest=$2 commit=$3
+            mkdir -p "$dest"
+            cd "$dest"
+            git init -q
+            git remote add origin "$repo_url"
+            git fetch --depth 1 origin "$commit"
+            git checkout FETCH_HEAD
+            cd -
+          }
+          mkdir -p test-results/.repos
+          clone_at_commit https://github.com/medusajs/medusa test-results/.repos/medusa dbff8196af90042829a5b8fd06adb27d7b8b5df3
+          clone_at_commit https://github.com/saleor/saleor test-results/.repos/saleor 88eee1d6b9589523ce5bd6955db8ec8a775decde
+          clone_at_commit https://github.com/vendure-ecommerce/vendure test-results/.repos/vendure e63387aa9e8ac44bbc72896ef9143265e3403948
+
+      # ── Run all phases in a single pytest invocation ───────────────
+      - name: Run MCP regression tests
+        run: >
+          pytest
+          tests/test_phase1_code_locator.py
+          tests/test_phase2_ledger.py
+          tests/test_phase3_integration.py
+          -v --tb=short
+          --junitxml=test-results/results.xml
+          --html=test-results/report.html --self-contained-html
+
+      # ── Retrieval quality regression gate ─────────────────────────
+      # Threshold recalibrated 2026-04-14: v0.4.6 changed _ground_single
+      # to re-run search_code with regex-token graph seeds, which improved
+      # multi-region grounding (FC-2 fix) but degraded description-mode MRR
+      # from 0.66 to ~0.19 because NL tokens fuzzy-match wrong symbols.
+      # Threshold lowered from 0.55 to 0.10 until F1 (LLM symbol seeding)
+      # restores seed quality. Variance raised to 0.25 for same reason.
+      - name: RAG eval regression gate (description mode — matches ingest path)
+        run: >
+          python tests/eval_code_locator.py
+          --multi-repo '{"medusa": "test-results/.repos/medusa", "saleor": "test-results/.repos/saleor", "vendure": "test-results/.repos/vendure"}'
+          --top-k 3 --use-description --min-mrr 0.10 --max-repo-variance 0.25
+          -o test-results/eval-regression.json
+
+      # ── Diagnostic: report ANTHROPIC_API_KEY visibility ───────────
+      # GitHub masks secret values in logs, but we can safely report
+      # (a) whether the secret-expression evaluates to non-empty and
+      # (b) the length of the resolved value. Lets us distinguish
+      # "secret is not set" from "secret is set to empty string" from
+      # "secret is set correctly" without ever exposing the key.
+      - name: M1 secret visibility probe
+        run: |
+          set +e
+          if [ -n "${ANTHROPIC_API_KEY}" ]; then
+            echo "ANTHROPIC_API_KEY: present (length=${#ANTHROPIC_API_KEY})"
+          else
+            echo "ANTHROPIC_API_KEY: EMPTY or UNSET"
+            echo "  secret expression non-empty: ${{ secrets.ANTHROPIC_API_KEY != '' }}"
+          fi
+        env:
+          ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+
+      # ── M1 decision relevance: adversarial corpus (warn-only) ────
+      # Runs the current .claude/skills/bicameral-ingest/SKILL.md through
+      # the headless Anthropic extraction driver against the 5 adversarial
+      # transcripts (tests/fixtures/transcripts/adv-*.md), then scores
+      # extraction P/R/F1 against the committed Opus ground truth via
+      # Haiku LLM-as-judge. Phase 5 skill-spec branches use this step
+      # to compare adversarial deltas across SKILL.md variants.
+      #
+      # The "adversarial" key in --multi-repo aliases to the medusa clone
+      # purely so the grounding pipeline has *some* indexed code to run
+      # against; adversarial transcripts measure extraction quality, not
+      # grounding against any specific codebase.
+      #
+      # Auth: ANTHROPIC_API_KEY (ci-test environment secret) sent as
+      # the x-api-key header. Warn-only — a missing/rotated key surfaces
+      # as a red "M1 adversarial" step in the job without failing the
+      # whole build, so the rest of the regression suite still reports.
+      - name: M1 adversarial corpus eval (warn-only)
+        continue-on-error: true
+        env:
+          ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+          M1_EVAL_MODEL: claude-haiku-4-5-20251001
+        run: >
+          python tests/eval_decision_relevance.py
+          --multi-repo '{"adversarial": "test-results/.repos/medusa"}'
+          --skill-variant from-skill-md
+          -o test-results/m1-adversarial.json
+
+      # ── Generate rich E2E report from artifacts ────────────────────
+      - name: Generate E2E report
+        if: always()
+        run: python tests/generate_e2e_report.py
+
+      # ── Generate step summary from JUnit XML ───────────────────────
+      - name: Test Summary
+        uses: test-summary/action@v2
+        if: always()
+        with:
+          paths: test-results/results.xml
+          show: fail, skip
+
+      # ── Upload artifacts for qualitative review ────────────────────
+      - name: Upload test results
+        uses: actions/upload-artifact@v4
+        if: always()
+        with:
+          name: mcp-test-results
+          path: test-results/
+          retention-days: 30

--- a/tests/README.md
+++ b/tests/README.md
@@ -5,7 +5,6 @@ Tests are gated by phase. Each phase gate is an env var. Run only what's impleme
 ## Running tests
 
 ```bash
-cd pilot/mcp
 source .venv/bin/activate  # or: python -m pytest directly via .venv/bin/pytest
 
 # Packaging / startup smoke

--- a/tests/_extract_headless.py
+++ b/tests/_extract_headless.py
@@ -31,11 +31,11 @@ from typing import Any
 
 import httpx
 
-# The canonical bicameral-ingest skill lives inside the MCP submodule
-# (tracked at pilot/mcp/.claude/skills/bicameral-ingest/SKILL.md). We
-# resolve it relative to this file so CI and local dev agree without any
-# env-var dance. Phase 5 skill-spec A/B branches edit this exact file.
-MCP_ROOT = Path(__file__).resolve().parents[1]  # pilot/mcp
+# The canonical bicameral-ingest skill lives at
+# .claude/skills/bicameral-ingest/SKILL.md. We resolve it relative to
+# this file so CI and local dev agree without any env-var dance. Phase 5
+# skill-spec A/B branches edit this exact file.
+MCP_ROOT = Path(__file__).resolve().parents[1]
 SKILL_MD_PATH = MCP_ROOT / ".claude" / "skills" / "bicameral-ingest" / "SKILL.md"
 CACHE_DIR = Path(__file__).resolve().parent / ".extract-cache"
 

--- a/tests/_extraction_metrics.py
+++ b/tests/_extraction_metrics.py
@@ -16,9 +16,9 @@ and rapidfuzz otherwise.
 
 Fixture format (one JSON file per transcript):
 
-    pilot/mcp/tests/fixtures/extraction/<source_ref>.json
+    tests/fixtures/extraction/<source_ref>.json
     {
-      "source_ref": "medusa-payment-timeout",
+      "source_ref": "adv-strat-fake",
       "generated_by": "claude-opus-4-6-20251015",
       "generated_at": "2026-04-13T22:30:00Z",
       "decisions": [ {"description": "..."}, ... ],

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -58,8 +58,8 @@ def _default_authoritative_ref_to_current_branch(monkeypatch):
 
 @pytest.fixture
 def repo_path() -> str:
-    """Repo root. Defaults to the bicameral repo itself for Phase 1+ tests."""
-    return os.getenv("REPO_PATH", str(os.path.abspath(os.path.join(os.path.dirname(__file__), "../../.."))))
+    """Repo root. Defaults to the MCP repo itself for Phase 1+ tests."""
+    return os.getenv("REPO_PATH", str(os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))))
 
 
 @pytest.fixture
@@ -114,7 +114,7 @@ def minimal_payload() -> dict:
                 "symbols": ["test_function"],
                 "code_regions": [
                     {
-                        "file_path": "pilot/mcp/server.py",
+                        "file_path": "server.py",
                         "symbol": "test_function",
                         "type": "function",
                         "start_line": 1,

--- a/tests/eval_code_locator.py
+++ b/tests/eval_code_locator.py
@@ -9,7 +9,6 @@ symbol matching → coverage loop tier broadening → code_region output.
 Silong: run this after any change to code_locator/ to see if accuracy improves.
 
 Usage:
-    cd pilot/mcp
     .venv/bin/python tests/eval_code_locator.py
     .venv/bin/python tests/eval_code_locator.py --repo /path/to/other/repo
     .venv/bin/python tests/eval_code_locator.py --top-k 5 --verbose
@@ -20,7 +19,7 @@ import os
 import sys
 from pathlib import Path
 
-# Ensure pilot/mcp is on path
+# Ensure MCP repo root is on path
 sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
 
 from fixtures.expected.decisions import ALL_DECISIONS
@@ -277,8 +276,8 @@ def evaluate(
 
 def main():
     parser = argparse.ArgumentParser(description="Code Locator E2E Grounding Evaluation")
-    parser.add_argument("--repo", default=str(Path(__file__).resolve().parents[3]),
-                        help="Path to repo (default: bicameral root)")
+    parser.add_argument("--repo", default=str(Path(__file__).resolve().parents[1]),
+                        help="Path to repo (default: MCP repo root)")
     parser.add_argument("--multi-repo", type=str, default=None,
                         help='JSON map of repo_name→path, e.g. \'{"medusa":"/path/to/medusa"}\'')
     parser.add_argument("--top-k", type=int, default=5, help="Top-K for precision/MRR")

--- a/tests/eval_decision_relevance.py
+++ b/tests/eval_decision_relevance.py
@@ -7,12 +7,10 @@ emits a per-transcript + per-repo JSON report. Used as a CI regression gate
 (warn-only initially) and as the ruler for Phase 5 skill-spec A/B.
 
 Usage:
-    cd pilot/mcp
     .venv/bin/python tests/eval_decision_relevance.py \\
-        --multi-repo '{"medusa":"test-results/.repos/medusa", \\
-                       "saleor":"test-results/.repos/saleor", \\
-                       "vendure":"test-results/.repos/vendure"}' \\
-        -o test-results/m1-relevance.json
+        --multi-repo '{"adversarial": "test-results/.repos/medusa"}' \\
+        --skill-variant from-skill-md \\
+        -o test-results/m1-adversarial.json
 
 Flags:
     --multi-repo      JSON map repo_key -> repo path. Only source_refs whose
@@ -49,13 +47,13 @@ sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
 
 from fixtures.expected.decisions import ALL_DECISIONS, TRANSCRIPT_SOURCES
 
-# Repo root (parent of pilot/mcp/) — used to resolve fixture-relative transcript paths.
-REPO_ROOT = Path(__file__).resolve().parents[3]
+# MCP repo root — used to resolve fixture-relative transcript paths.
+MCP_ROOT = Path(__file__).resolve().parents[1]
 
 
 def _load_transcript(rel_path: str) -> str:
-    """Resolve a transcript path relative to the bicameral repo root."""
-    p = (REPO_ROOT / rel_path).resolve()
+    """Resolve a transcript path relative to the MCP repo root."""
+    p = (MCP_ROOT / rel_path).resolve()
     if not p.exists():
         raise FileNotFoundError(f"transcript not found: {p}")
     return p.read_text(encoding="utf-8")

--- a/tests/fixtures/expected/decisions.py
+++ b/tests/fixtures/expected/decisions.py
@@ -543,31 +543,25 @@ TRANSCRIPT_SOURCES: dict[str, dict] = {
     # tree (any indexed code works — adversarial transcripts measure
     # extraction quality, not grounding precision against a specific
     # codebase). Ground truth for each lives at
-    # pilot/mcp/tests/fixtures/extraction/adv-*.json and is hand-editable.
-    #
-    # Note: the friendly e-commerce corpus (medusa-*, saleor-*, vendure-*)
-    # used to live here as well, but was removed once it became clear that
-    # the friendly transcripts are too easy to be informative about
-    # real-world reliability. The transcript .md files remain in
-    # pilot/ml/data/transcripts/ for reference and other tooling.
+    # tests/fixtures/extraction/adv-*.json and is hand-editable.
     "adv-strat-fake": {
-        "transcript": "pilot/ml/data/transcripts/adv-strat-fake.md",
+        "transcript": "tests/fixtures/transcripts/adv-strat-fake.md",
         "repo_key": "adversarial",
     },
     "adv-vocab-collide": {
-        "transcript": "pilot/ml/data/transcripts/adv-vocab-collide.md",
+        "transcript": "tests/fixtures/transcripts/adv-vocab-collide.md",
         "repo_key": "adversarial",
     },
     "adv-density-extreme": {
-        "transcript": "pilot/ml/data/transcripts/adv-density-extreme.md",
+        "transcript": "tests/fixtures/transcripts/adv-density-extreme.md",
         "repo_key": "adversarial",
     },
     "adv-offtopic-mix": {
-        "transcript": "pilot/ml/data/transcripts/adv-offtopic-mix.md",
+        "transcript": "tests/fixtures/transcripts/adv-offtopic-mix.md",
         "repo_key": "adversarial",
     },
     "adv-reversal": {
-        "transcript": "pilot/ml/data/transcripts/adv-reversal.md",
+        "transcript": "tests/fixtures/transcripts/adv-reversal.md",
         "repo_key": "adversarial",
     },
 }

--- a/tests/fixtures/extraction/README.md
+++ b/tests/fixtures/extraction/README.md
@@ -27,13 +27,13 @@ target.
 ## File format
 
 One file per transcript, named `<source_ref>.json`. `source_ref` matches
-keys in `pilot/mcp/tests/fixtures/expected/decisions.py:TRANSCRIPT_SOURCES`.
+keys in `tests/fixtures/expected/decisions.py:TRANSCRIPT_SOURCES`.
 
 ```json
 {
-  "source_ref": "medusa-payment-timeout",
-  "transcript_path": "pilot/ml/data/transcripts/medusa-payment-timeout.md",
-  "repo_key": "medusa",
+  "source_ref": "adv-strat-fake",
+  "transcript_path": "tests/fixtures/transcripts/adv-strat-fake.md",
+  "repo_key": "adversarial",
   "generated_by": "claude-opus-4-6-20251015",
   "generated_at": "2026-04-13T22:30:00+00:00",
   "skill_md_sha": "abcd1234ef56",
@@ -61,7 +61,7 @@ Fields:
 
 ## How to regenerate
 
-From `pilot/mcp`:
+From the MCP repo root:
 
 ```bash
 export ANTHROPIC_API_KEY=sk-ant-api03-...
@@ -79,7 +79,7 @@ Options:
 Cost (approximate): ~**\$1.75** for a full-corpus regeneration with Opus 4.6.
 One-shot, rarely repeated.
 
-After running, `git diff pilot/mcp/tests/fixtures/extraction/` shows the new
+After running, `git diff tests/fixtures/extraction/` shows the new
 or changed fixtures. Review, hand-edit if needed, commit, push.
 
 ## When to hand-edit

--- a/tests/fixtures/extraction/adv-density-extreme.json
+++ b/tests/fixtures/extraction/adv-density-extreme.json
@@ -1,6 +1,6 @@
 {
   "source_ref": "adv-density-extreme",
-  "transcript_path": "pilot/ml/data/transcripts/adv-density-extreme.md",
+  "transcript_path": "tests/fixtures/transcripts/adv-density-extreme.md",
   "repo_key": "adversarial",
   "category": "DENSITY-EXTREME",
   "generated_by": "claude-opus-4-6[1m]-in-session",

--- a/tests/fixtures/extraction/adv-offtopic-mix.json
+++ b/tests/fixtures/extraction/adv-offtopic-mix.json
@@ -1,6 +1,6 @@
 {
   "source_ref": "adv-offtopic-mix",
-  "transcript_path": "pilot/ml/data/transcripts/adv-offtopic-mix.md",
+  "transcript_path": "tests/fixtures/transcripts/adv-offtopic-mix.md",
   "repo_key": "adversarial",
   "category": "OFFTOPIC-MIX",
   "generated_by": "claude-opus-4-6[1m]-in-session",

--- a/tests/fixtures/extraction/adv-reversal.json
+++ b/tests/fixtures/extraction/adv-reversal.json
@@ -1,6 +1,6 @@
 {
   "source_ref": "adv-reversal",
-  "transcript_path": "pilot/ml/data/transcripts/adv-reversal.md",
+  "transcript_path": "tests/fixtures/transcripts/adv-reversal.md",
   "repo_key": "adversarial",
   "category": "REVERSAL",
   "generated_by": "claude-opus-4-6[1m]-in-session",

--- a/tests/fixtures/extraction/adv-strat-fake.json
+++ b/tests/fixtures/extraction/adv-strat-fake.json
@@ -1,6 +1,6 @@
 {
   "source_ref": "adv-strat-fake",
-  "transcript_path": "pilot/ml/data/transcripts/adv-strat-fake.md",
+  "transcript_path": "tests/fixtures/transcripts/adv-strat-fake.md",
   "repo_key": "adversarial",
   "category": "STRAT-FAKE",
   "generated_by": "claude-opus-4-6[1m]-in-session",

--- a/tests/fixtures/extraction/adv-vocab-collide.json
+++ b/tests/fixtures/extraction/adv-vocab-collide.json
@@ -1,6 +1,6 @@
 {
   "source_ref": "adv-vocab-collide",
-  "transcript_path": "pilot/ml/data/transcripts/adv-vocab-collide.md",
+  "transcript_path": "tests/fixtures/transcripts/adv-vocab-collide.md",
   "repo_key": "adversarial",
   "category": "VOCAB-COLLIDE",
   "generated_by": "claude-opus-4-6[1m]-in-session",

--- a/tests/fixtures/transcripts/adv-density-extreme.md
+++ b/tests/fixtures/transcripts/adv-density-extreme.md
@@ -1,0 +1,57 @@
+Meeting: Architecture Sync — Rate Limiter Rework
+Date: April 10, 2026
+Attendees: Carlos (Platform), Dana (SRE), Priya (Backend Lead)
+
+Carlos: Quick one. The rate limiter situation is finally going to get fixed this sprint. I want to lock in the design and split the work.
+
+Priya: Go.
+
+Carlos: Okay so the plan: we'll move the rate limiter from the in-memory implementation to Redis with a 100-requests-per-minute cap keyed on user ID hash, add Prometheus counters for hits and misses, switch the lease TTL from 60 seconds to 300 seconds, and emit a structured log line on every reject so we can correlate with the auth service's audit trail.
+
+Dana: That's a lot in one sentence.
+
+Carlos: Yeah but it all hangs together. The Redis migration unblocks the TTL change because in-memory can't survive a pod restart, and once we have Redis we want metrics and we want logs, so we may as well do it all at once.
+
+Priya: Fine. Let's also talk about the queue rework while we have everyone here. Dana, you brought it up last week.
+
+Dana: Yeah. So the background job queue. Currently we use the SQL polling strategy. It's been fine but it's getting expensive query-wise and the latency is bad.
+
+Carlos: What about Redis Streams? We're already going to have Redis for the rate limiter.
+
+Dana: Hmm, Redis Streams. Let me think. The consumer groups are nice for the at-least-once semantics. But the ops side — I don't love managing Streams. The XADD / XREADGROUP semantics are subtle and we've had bad experiences when consumers fall behind.
+
+Carlos: Hmm. What's the alternative?
+
+Dana: BullMQ is the obvious one. It's also Redis-backed under the hood but the operational interface is way friendlier. Built-in retries, exponential backoff, dead letter queue, dashboard.
+
+Carlos: Yeah but I just remembered — infra blocked Redis Streams last quarter. They had a bad incident with another team's consumer-group setup and there's a soft moratorium on it.
+
+Priya: Wait, that's news to me. So Streams is off the table?
+
+Carlos: Effectively, yes. I'd have to fight infra to use it and I don't have the political capital this sprint.
+
+Dana: Then BullMQ it is. It uses regular Redis lists and sorted sets, not Streams, so it's not under the moratorium.
+
+Carlos: Does BullMQ handle our retry semantics? We need exponential backoff with a max of 6 retries before dead-lettering, like the webhook delivery flow.
+
+Dana: Yes, that's literally a built-in option. You set the backoff strategy to exponential, set the max attempts, configure the dead letter queue, done.
+
+Carlos: Okay. So BullMQ for the queue, with built-in exponential backoff, capped at 6 retries, dead letter queue enabled.
+
+Priya: Good. Anything else on the queue?
+
+Dana: We should also configure separate concurrency limits per queue. Right now everything shares one worker pool and it causes head-of-line blocking when the email queue gets backed up.
+
+Carlos: Use BullMQ's worker concurrency option. We can set, say, 5 workers for emails and 20 for the order processing queue.
+
+Dana: Yeah, exactly that.
+
+Priya: Okay, so to summarize — Redis, rate limiter rework with all the bells and whistles in one sentence, and BullMQ for the queue with the retry config and per-queue concurrency.
+
+Carlos: That's it. I'll spec out the rate limiter rework today, Dana takes the BullMQ migration, we sync Friday.
+
+Dana: One more thing — for the BullMQ migration, can we ship it behind a feature flag? I want to be able to fall back to SQL polling if something goes sideways during the cutover.
+
+Carlos: Yes, definitely. Use the existing feature flag service. Default off, flip on per environment.
+
+Priya: Good. Done. Five minutes early.

--- a/tests/fixtures/transcripts/adv-offtopic-mix.md
+++ b/tests/fixtures/transcripts/adv-offtopic-mix.md
@@ -1,0 +1,69 @@
+Meeting: Q2 Operating Review
+Date: April 11, 2026
+Attendees: Jin (CTO), Lena (Tech Lead), Anya (Product), Sara (Customer Success), Tomás (DevOps), Priya (Backend Lead)
+
+Jin: Welcome to the Q2 OR. We have 60 minutes, lots to cover, let's keep it tight. Anya, OKR review first.
+
+Anya: Right. Headline: we're at 78% on the conversion-rate OKR, 62% on the activation-funnel OKR, and 91% on the customer satisfaction NPS target. The conversion number is the one I'm worried about. We're underpacing.
+
+Jin: Why?
+
+Anya: A few reasons. The competitive pressure from the new entrant in the mid-market segment is real. Also our pricing experiment from March didn't move the needle the way we expected. Marketing thinks we need to revisit the value-prop messaging.
+
+Sara: From the customer side, I'd say the bigger issue is that the prospects who do convert are taking longer to do it. Sales cycle is up about 11 days quarter-over-quarter.
+
+Anya: Yeah, that tracks. We may need to rethink the trial flow.
+
+Jin: Okay. Park the conversion thing — Anya, can you and Sara own a follow-up next week with a proposal?
+
+Anya: Sure.
+
+Jin: Headcount status. Where are we?
+
+Lena: We made the senior backend hire — Marcus starts next Monday. Still looking for the SRE-2 role. We had two finalists last week, one withdrew, the other we're going to make an offer to this Friday.
+
+Jin: Good. The SRE role is critical. Tomás, you're going to need help once Marcus comes in and starts shipping faster.
+
+Tomás: Yeah, the on-call rotation is already brutal with just me and Dana.
+
+Jin: I hear you. Let's get the offer out. Sara, customer escalations?
+
+Sara: Two big ones this week. AcmeCorp had a multi-tenant data leak scare on Tuesday — turned out to be a false alarm, their staging instance was misconfigured on their side, not ours. But it cost us about three hours of incident response time. The other one is GlobeMart — they're churning unless we ship the multi-currency feature by end of May. That's the third time they've raised it.
+
+Jin: Multi-currency. Priya, where are we on that?
+
+Priya: Spec is done, the engineering work is roughly two weeks once we start. Right now it's queued behind the auth middleware refactor.
+
+Lena: Speaking of which — oh, by the way, Priya's going to do the auth middleware refactor next sprint to use JWTs instead of session cookies. Lena flagged it in the SOC2 review and we need it landed before the audit window closes in June.
+
+Jin: Wait, that's the first I'm hearing of that.
+
+Lena: Yeah, came out of the SOC2 prep meeting Tuesday. The auditors flagged the cookie-based session handling as a finding. Priya volunteered to own it.
+
+Priya: It's a small thing, maybe three days. I can fit it in alongside the multi-currency spec work.
+
+Jin: Okay. Document it in the sprint plan so we don't lose track.
+
+Sara: Back on the customer side — GlobeMart is also asking for SAML SSO. We don't currently support it.
+
+Anya: SAML is going to come up more and more from the enterprise tier. We should add it to the pricing matrix as a "request" feature so prospects know it's on the radar.
+
+Jin: Sales enablement, not engineering work. Tag it in the CRM. Tomás, any infrastructure issues?
+
+Tomás: One thing — the staging cluster auto-scaling has been flapping. I'm investigating but I haven't found the root cause yet. It's not impacting customers but it's annoying.
+
+Jin: Time-box it. If you don't find it by end of week, file it as a known issue and move on. The autoscaler was always brittle.
+
+Tomás: Got it.
+
+Jin: Anything else? Hiring? Customers? Roadmap?
+
+Anya: One thing — the marketing team wants us to draft a blog post about the platform architecture. Something for SEO. They asked if engineering could provide a one-pager.
+
+Lena: I can do that. It's basically the architecture diagram from the design partner deck plus a paragraph.
+
+Jin: Great. Last thing — fundraising. We're closing the bridge round next month. I'll send a separate memo. Don't share externally yet.
+
+Anya: Got it.
+
+Jin: Okay, that's the OR. Thanks everyone. Sara and Anya, follow-up on conversion next week.

--- a/tests/fixtures/transcripts/adv-reversal.md
+++ b/tests/fixtures/transcripts/adv-reversal.md
@@ -1,0 +1,65 @@
+Meeting: Architecture Sync — Webhook Queue Choice
+Date: April 12, 2026
+Attendees: Carlos (Platform), Dana (SRE), Wei (Backend), Priya (Backend Lead)
+
+Carlos: Quick decision today. We need to pick the queue backend for the new webhook delivery service. Wei drafted three options.
+
+Wei: Yeah. So the three are: Redis Streams, BullMQ, and AWS SQS. I have a doc with the pros and cons.
+
+Carlos: My initial take is Redis Streams. We already have Redis in the stack for the rate limiter, the consumer group semantics give us at-least-once for free, and we don't add another dependency.
+
+Wei: That was my first instinct too. Streams is the cleanest fit on paper.
+
+Dana: Let's go with Redis Streams then.
+
+Carlos: Okay, decided. Let's do Redis Streams for the webhook queue.
+
+Priya: Hold on. Dana, didn't infra block Streams last quarter?
+
+Dana: Oh — yeah, you're right, I forgot. There was a moratorium after the consumer-group incident with the analytics team. Sorry, I should have flagged that earlier.
+
+Carlos: Right, I remember now. So Streams is off the table.
+
+Wei: Then BullMQ? It's also Redis-backed but not under the moratorium because it uses regular lists and sorted sets.
+
+Carlos: Actually, I just remembered we got pushback from the infra team on running BullMQ in our Redis cluster too. They want job queues isolated from cache workloads to avoid memory pressure.
+
+Dana: That's news to me. When was that?
+
+Carlos: Two weeks ago. The platform-infra sync. They said any new job-queue workload should go on AWS-managed infrastructure, not our self-hosted Redis.
+
+Wei: So neither Redis option is viable. That leaves SQS.
+
+Carlos: Yeah. Let's go with SQS for the webhook queue.
+
+Priya: SQS gives us managed retries, dead letter queues built in, and we don't have to worry about the Redis isolation issue. I'm fine with it.
+
+Wei: Same. Costs are fine at our volume.
+
+Dana: Wait — one consideration. SQS has visibility timeout semantics that are a little different from how BullMQ handles in-flight jobs. We need to make sure the worker shutdown handling is correct so we don't double-deliver.
+
+Wei: Right. We'd set the visibility timeout to something like 5 minutes, set the max receive count to 6, and use a dead-letter queue for anything that exceeds that.
+
+Carlos: Five-minute visibility timeout, six max receives, DLQ on overflow. That works.
+
+Priya: And what about ordering? Some webhook events need to be delivered in order — like order.placed before order.fulfillment_created.
+
+Wei: SQS standard isn't FIFO. We'd need SQS FIFO for that. But FIFO has lower throughput limits — 300 messages per second per group, or 3,000 with batching.
+
+Carlos: Hmm. Per-merchant ordering or global ordering?
+
+Wei: Per-merchant. Different merchants don't need ordering between each other.
+
+Carlos: Okay so we use FIFO with the merchant ID as the message group ID. That gives us per-merchant ordering and the throughput limits should be fine because each merchant's traffic is way below 300/s.
+
+Wei: Right.
+
+Priya: So the final decision is SQS FIFO, message group keyed on merchant ID, 5-minute visibility timeout, 6 max receives, dead-letter queue on overflow.
+
+Carlos: That's it. Wei, can you write up the final design and link the AWS docs in the spec?
+
+Wei: Will do. Want me to delete the Redis Streams and BullMQ sections from the doc or keep them as "rejected" with rationale?
+
+Carlos: Keep them as rejected. Future me will want to know why we didn't go that way.
+
+Priya: Good. Done.

--- a/tests/fixtures/transcripts/adv-strat-fake.md
+++ b/tests/fixtures/transcripts/adv-strat-fake.md
@@ -1,0 +1,55 @@
+Meeting: Roadmap Sync — Q3 Planning
+Date: April 8, 2026
+Attendees: Priya (Backend Lead), Jin (CTO), Lena (Tech Lead), Tomás (DevOps)
+
+Jin: Alright, Q3 planning. I want to get the wishlist on the table before we cut anything. Priya, you wanted to start?
+
+Priya: Yeah. So big picture, we should probably look into vector embeddings for search someday. The keyword matching is starting to feel limited for some of our newer customer segments.
+
+Jin: "Someday" being when?
+
+Priya: I don't know, Q4 maybe? It's not blocking anything right now. I just want it on the radar.
+
+Jin: Okay, parking it. Tomás, you had thoughts on the database situation?
+
+Tomás: If infra approves, we'll switch from PostgreSQL to ScyllaDB for the analytics workload. I've been talking to the infra team about it but they're nervous about the operational story.
+
+Lena: Do we have a date for the infra decision?
+
+Tomás: No, they said they'd get back to me "soon." Honestly I'm not holding my breath.
+
+Lena: Okay so that's a maybe. Let's not commit to anything depending on that.
+
+Jin: Right. Park it as conditional. What about Redis? I keep hearing different things.
+
+Priya: We're definitely not going to use Redis here. We looked at it last quarter and the ops complexity wasn't worth it for our scale. The in-memory cache we have is fine.
+
+Jin: Good, that's clear at least. Lena, what about the auth rework?
+
+Lena: We're keeping the existing webhook retry logic for now. There was talk about replacing it with a workflow-based system but the team consensus was that the current implementation works and we have higher priorities.
+
+Priya: Yeah, agreed. Status quo on retry.
+
+Jin: Okay. What else is on the wishlist?
+
+Tomás: Eventually I'd love to see us migrate off the monolith. I know it's been talked about forever. But realistically that's not Q3.
+
+Jin: Not Q3, agreed. It's also not Q4. Maybe 2027 if the customer growth justifies it.
+
+Lena: There's also the GraphQL federation thing that came up in the architecture review. We discussed it but didn't decide anything.
+
+Priya: I think we agreed to revisit it after we see how the storefront API holds up under the spring catalog launch.
+
+Lena: Right, so deferred until we have load data.
+
+Jin: Okay. Last thing — I want us to be more performance-focused going forward. That's a vibes statement, I know, but I want it in the team norms doc.
+
+Priya: Sure. We can add it to the engineering principles page.
+
+Jin: Great. Anything else?
+
+Tomás: One real thing — I do need to know whether we're locking in the current observability stack or whether the Datadog migration is still happening.
+
+Priya: That's a budget question. Let's move it to the next finance review.
+
+Jin: Agreed. Park it. Okay, that's it for today.

--- a/tests/fixtures/transcripts/adv-vocab-collide.md
+++ b/tests/fixtures/transcripts/adv-vocab-collide.md
@@ -1,0 +1,47 @@
+Meeting: Customer Experience Sync — Order Flow
+Date: April 9, 2026
+Attendees: Sara (Customer Success), David (Backend Engineer), Anya (Product), Carlos (Platform)
+
+Sara: Let me kick this off with what we're hearing from accounts. The number-one feedback theme this quarter is that the customer journey from product discovery to confirmed purchase has too much friction. There's drop-off at multiple points and people are confused about what's happening between "place order" and "your order is on its way."
+
+Anya: Right, so the experience has gaps. Are we talking about the storefront flow or the dashboard side?
+
+Sara: Both, but storefront is where the volume is.
+
+David: Okay so when you say "friction" — what does that look like in terms of actual behavior we can fix?
+
+Sara: People hit the cart, fill in their address, get to payment, and then the spinner just sits there for a long time. Then they refresh and sometimes the order goes through and sometimes it doesn't. We need a better manager for that whole workflow.
+
+Carlos: A "manager" in what sense?
+
+Sara: I just mean — someone or something that orchestrates all the steps. Right now it feels like the front end and the back end are not in sync, and the customer has no idea what's happening behind the scenes.
+
+David: Yeah I think what Sara is describing is more of an experience problem than a code problem. The order placement service does have a manager class somewhere, but it's not what she's talking about.
+
+Anya: Let's not get bogged down in implementation. The point is the customer doesn't see status updates between submit and confirm. We should add proper handling for the edge cases in the controller — when a payment webhook is delayed, when stock allocation fails midway, when a coupon is invalidated mid-checkout. The user just sees "loading" forever.
+
+Carlos: When you say "the controller" — which one?
+
+Anya: The thing that handles the checkout request from the storefront. I don't know what it's actually called in the code.
+
+David: There are like four things that could be called the checkout controller. We have the GraphQL resolver, there's the workflow runner, there's the cart completion strategy, there's the order placement orchestrator —
+
+Anya: Pick whichever one is closest to where the user-facing latency happens. We need to be more strategic about how we communicate with the customer during the wait.
+
+Sara: Yes — the conversion funnel from add-to-cart to confirmed-purchase is leaking. We should reduce the friction in that journey. That's the headline.
+
+Carlos: Okay, I think we need to translate this into something concrete for engineering. Let me try: there's a UX problem where users don't get feedback during the checkout completion phase. We need some kind of progress indicator and we need to handle a few specific failure modes more gracefully. Is that the gist?
+
+Anya: Yes, but written like that it sounds like a frontend ticket. The actual fix probably touches multiple services.
+
+Sara: Whatever it takes — the customer experience is what matters. We should make the customer journey smoother. End-to-end. That's the goal.
+
+David: Got it. I'll need to think about where in the stack this actually lives. Let me come back with a proposal next week.
+
+Anya: Sounds good. The key thing is — we need a more thoughtful approach to the entire purchase experience. That's the takeaway.
+
+Carlos: Agreed. Sara, can you send us the specific drop-off data so David and I can scope the actual code changes?
+
+Sara: Yeah, I'll pull it from the analytics dashboard. The conversion rates are in there.
+
+Anya: Great. Let's reconvene next Tuesday with a concrete proposal.

--- a/tests/regen_extraction_fixtures.py
+++ b/tests/regen_extraction_fixtures.py
@@ -4,7 +4,7 @@
 Runs the current .claude/skills/bicameral-ingest/SKILL.md Step-1 prompt
 against each transcript in TRANSCRIPT_SOURCES using a strong model
 (default: claude-opus-4-6-20251015) and writes the extracted decisions
-+ action items to pilot/mcp/tests/fixtures/extraction/<source_ref>.json.
++ action items to tests/fixtures/extraction/<source_ref>.json.
 
 The committed JSONs are the **ground truth** for the M1 eval's
 precision/recall metric — they are hand-editable after bootstrap,
@@ -12,11 +12,10 @@ and re-running this script overwrites them. Commit the resulting
 diff like any other reference fixture.
 
 Usage:
-    cd pilot/mcp
     export ANTHROPIC_API_KEY=sk-ant-api03-...
     .venv/bin/python tests/regen_extraction_fixtures.py --all
     .venv/bin/python tests/regen_extraction_fixtures.py \\
-        --source-ref medusa-payment-timeout \\
+        --source-ref adv-strat-fake \\
         --model claude-opus-4-6-20251015
     .venv/bin/python tests/regen_extraction_fixtures.py --all --dry-run
 
@@ -32,7 +31,7 @@ Cost (approximate, one-time bootstrap with Opus 4.6):
     ~9 transcripts × ~2k output tokens × $75/Mtok ≈ $1.35
     Total ≈ $1.75 per full-corpus regen. Cheap.
 
-After running, `git diff pilot/mcp/tests/fixtures/extraction/` should
+After running, `git diff tests/fixtures/extraction/` should
 show the new/changed fixtures. Review, hand-edit if needed, commit.
 """
 from __future__ import annotations
@@ -55,13 +54,13 @@ from _extract_headless import (  # noqa: E402  (sibling module)
     extract_from_current_skill,
 )
 
-REPO_ROOT = Path(__file__).resolve().parents[3]
+MCP_ROOT = Path(__file__).resolve().parents[1]
 FIXTURES_DIR = Path(__file__).resolve().parent / "fixtures" / "extraction"
 RECOMMENDED_MODEL = "claude-opus-4-6-20251015"
 
 
 def _load_transcript(rel_path: str) -> str:
-    p = (REPO_ROOT / rel_path).resolve()
+    p = (MCP_ROOT / rel_path).resolve()
     if not p.exists():
         raise FileNotFoundError(f"transcript not found: {p}")
     return p.read_text(encoding="utf-8")

--- a/tests/test_phase2_ledger.py
+++ b/tests/test_phase2_ledger.py
@@ -198,9 +198,13 @@ async def test_link_commit_idempotent(monkeypatch, surreal_url):
         f"Second link_commit(HEAD) must return 'already_synced', got {r2.reason!r}"
     )
     assert r2.synced is True
-    assert r2.regions_updated == 0
-    assert r2.decisions_reflected == 0
-    assert r2.decisions_drifted == 0
+    # v0.4.8 dedup guard: cached response forwards the first sync's real
+    # counters (B23) so downstream ``sync_status`` consumers don't see
+    # synthetic zeros. Idempotency is asserted via ``reason`` + counter
+    # equality with r1, not by zeros.
+    assert r2.regions_updated == r1.regions_updated
+    assert r2.decisions_reflected == r1.decisions_reflected
+    assert r2.decisions_drifted == r1.decisions_drifted
 
 
 @pytest.mark.phase2

--- a/tests/test_phase3_integration.py
+++ b/tests/test_phase3_integration.py
@@ -39,7 +39,7 @@ RESULTS_DIR = Path(__file__).parent.parent / "test-results" / "e2e"
 def setup_env(monkeypatch, tmp_path):
     """Fresh in-memory ledger for every test."""
     monkeypatch.setenv("SURREAL_URL", "memory://")
-    monkeypatch.setenv("REPO_PATH", str(Path(__file__).resolve().parents[3]))
+    monkeypatch.setenv("REPO_PATH", str(Path(__file__).resolve().parents[1]))
     reset_ledger_singleton()
     RESULTS_DIR.mkdir(parents=True, exist_ok=True)
     yield


### PR DESCRIPTION
## Summary

- Moves the 5 adversarial transcripts (`adv-*.md`) from the parent `bicameral` repo's `pilot/ml/data/transcripts/` into `tests/fixtures/transcripts/`, so the regression suite no longer reaches outside the submodule.
- Rewrites every path helper from `REPO_ROOT = parents[3]` (parent repo) to `MCP_ROOT = parents[1]` (this repo): `regen_extraction_fixtures.py`, `eval_decision_relevance.py`, `eval_code_locator.py`, `conftest.py`, `test_phase3_integration.py`.
- Cleans up stale `pilot/mcp/` and `pilot/ml/` prefixes in docstrings, README examples, and the `file_path` fixture in `conftest.py`. Swaps the retired `medusa-payment-timeout` docstring example to `adv-strat-fake`.
- Adds `.github/workflows/test-mcp-regression.yml` — previously this workflow lived in the parent repo and ran via `working-directory: pilot/mcp`. Now PRs against this repo exercise the full regression suite directly.

## Required one-time setup

For the **M1 adversarial eval** step (warn-only) to authenticate against the Anthropic API, this repo needs:

1. A `ci-test` GitHub environment (Settings → Environments → New environment)
2. `ANTHROPIC_API_KEY` added as an environment secret on that environment

Without the secret the step surfaces as a red `M1 adversarial` node inside the job but the rest of the regression suite still reports.

## Companion work

- The parent `bicameral` repo will get a follow-up PR that deletes `pilot/ml/data/transcripts/adv-*.md`, deletes `.github/workflows/test-mcp-regression.yml`, and bumps this submodule's pointer to the merge SHA of this PR.
- `check-mcp-alignment.yml` stays in the parent repo — it compares code in this repo against a `visual-plans/*.html` document that only exists in the parent.

## Test plan

- [x] `pytest tests/test_phase2_ledger.py` — 15/15 pass locally (~3:24)
- [x] `pytest tests/test_phase3_integration.py` — 7/7 pass locally (~2:00)
- [x] YAML syntax validated
- [x] Every adversarial transcript path resolves from `MCP_ROOT`
- [x] Every `adv-*.json` extraction fixture updated to the new `transcript_path`
- [ ] First CI run on this branch confirms: `Build code locator index` step completes, `Run MCP regression tests` passes, `RAG eval regression gate` passes, `M1 adversarial corpus eval` runs (result depends on `ci-test` env + secret being wired up)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an automated MCP regression test workflow that runs on pull requests and publishes HTML/JUnit reports.

* **Tests**
  * Updated test scripts and fixtures to use a unified repo-root resolution and adjusted an idempotency assertion.

* **Chores**
  * Consolidated test fixtures/transcripts into a streamlined directory layout and updated README/invocation guidance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->