### PR TITLE
docs(#75): add decision-level reference doc + expand schema comment

### DIFF
--- a/docs/decision-level.md
+++ b/docs/decision-level.md
@@ -1,0 +1,65 @@
+# `decision_level` — reference
+
+**Field:** `decision.decision_level`
+**Type:** `option<string>` (nullable)
+**Constraint:** `$value = NONE OR $value IN ['L1', 'L2', 'L3']`
+**Defined in:** `ledger/schema.py` (initial DEFINE) and `_migrate_v8_to_v9` (migration path)
+**Read by:** `handlers/bind.py` (L1 exemption guard), dashboard (planned — see #76)
+
+This reference exists because the field controls a behavioural switch in the codegenome write path that isn't obvious from the schema alone. The full rationale is in `docs/spec-governance-feedback.md`; this doc is the quick-lookup version.
+
+---
+
+## Values
+
+| Value | Meaning | CodeGenome write? | Examples |
+|-------|---------|-------------------|----------|
+| `"L1"` | **Behavioural / product claim.** A statement about what the system MUST do, observable from outside. Verified by PMs via evidence/probes, not by code-region fingerprinting. | **No** — skip silently. | "MUST emit a compliance verdict within 200ms." "MUST persist drift events for 30 days." |
+| `"L2"` | **Implementation identity.** A specific function/class/region with crisp boundaries, a content hash, and a useful continuity story across renames/moves. | **Yes** — write `subject_identity` row. | "Function `evaluate_continuity_for_drift` at `codegenome/continuity_service.py:42-89`." |
+| `"L3"` | **Glue / infrastructure detail.** Stable for the project's lifetime; fingerprinting it adds noise without signal. | **No** — skip silently. | "We use SurrealDB v2 embedded." "We run on Python 3.13." |
+| `NULL` (NONE) | **Unclassified.** Legacy row from before the level concept existed, or a freshly-created row whose level hasn't been set yet. | **No** — treated as L3 by tolerant policy. | Most decisions created before v0.9.3. |
+
+The tolerant NULL policy is described in `docs/spec-governance-feedback.md` §3 (Q2). It's reversible — adding a `decision_level` later just changes future behaviour, not stored data — so legacy rows can stay unclassified until they surface in the dashboard ("unclassified" badge, planned in #76).
+
+## Why the L1 exemption matters
+
+Without this guard, every L1 claim that happens to be `bicameral.bind`-ed to *any* region produces a `subject_identity` fingerprint in the codegenome graph. L1 claims drift on every refactor — the underlying code that satisfies the claim changes constantly even when the claim itself is stable. The fingerprint then drifts too, generating noise that obscures real implementation drift on L2 rows.
+
+The guard fixes this by reading `decision_level` before invoking `write_codegenome_identity`. Only `level == "L2"` proceeds. Everything else (`L1`, `L3`, `NULL`, lookup error) skips and logs at debug.
+
+## Where the value comes from
+
+- **New decisions** — set by the caller-LLM via `bicameral.ingest` when the decision is first recorded. The classification is best-effort; PMs can correct via the dashboard once #76 lands.
+- **Legacy decisions** (pre-v0.9.3) — `NULL`. They will stay `NULL` until either:
+  1. A PM edits them via the dashboard inline edit (#76 stretch goal).
+  2. The bulk-classify utility (#77) proposes a level and a PM accepts.
+- **Schema migration** — `_migrate_v8_to_v9` adds the field with `DEFAULT NONE`; no backfill is performed.
+
+## Reading the value
+
+From Python:
+
+```python
+from ledger.queries import get_decision_level
+
+level = await get_decision_level(client, decision_id)
+# level is one of: "L1", "L2", "L3", or None
+```
+
+From the adapter:
+
+```python
+level = await ledger.get_decision_level(decision_id)
+```
+
+The ledger-internal query is read-only and mechanical — policy lives at the handler layer (per `docs/spec-governance-feedback.md` §4 / Q3).
+
+## Cross-references
+
+- `docs/spec-governance-feedback.md` — the L1/L2 spec-governance proposal and the response that produced this field's enforcement model.
+- `handlers/bind.py` — site of the L1 exemption guard.
+- `ledger/queries.py::get_decision_level` — the read query.
+- `tests/test_codegenome_l1_exemption.py` — the regression suite covering all four level cases plus response-shape invariance.
+- Issue #75 — this documentation.
+- Issue #76 — dashboard surfacing (planned).
+- Issue #77 — bulk-classify utility (planned).

--- a/docs/spec-governance-feedback.md
+++ b/docs/spec-governance-feedback.md
@@ -113,11 +113,12 @@ While resolving #71 review feedback and rebasing #73, these surfaced as legitima
 | `binds_to.provenance` declared `TYPE object` (not `FLEXIBLE`) silently strips nested keys | bug | already filed as #72 |
 | `events/writer.py:16` does top-level `import fcntl` (Unix-only) — breaks 17 ephemeral_authoritative tests on Windows | portability bug | already filed as #74 |
 | 81 pre-existing Windows test failures (non-codegenome) | platform | already filed as #67–70 |
-| Document `decision_level` field on `decision` table in `ARCHITECTURE_PLAN.md` | docs gap | new — file as docs issue |
+| Document `decision_level` field on `decision` table | docs gap | filed as #75 — addressed in `docs/decision-level.md` |
 | `INFO FOR TABLE` returns empty in v2 embedded — schema introspection tooling needs to use `schema.py` | already documented in CLAUDE.md | no action |
 | `count() AS n` requires `GROUP ALL` in v2 embedded — caught during continuity_ledger tests | already documented (added to v2 quirks list) | no action |
-| Dashboard should surface `decision_level` and an "unclassified" badge | feature | new — file once Q2 ships |
-| Bulk-classify utility for legacy `NULL` rows | feature | new — gated on dashboard surfacing |
+| Dashboard should surface `decision_level` and an "unclassified" badge | feature | filed as #76 |
+| Bulk-classify utility for legacy `NULL` rows | feature | filed as #77 |
+| `claim_evaluator` persistence shape design | design | filed as #78 (deferred, gated on first concrete evaluator) |
 
 ## §7 — Summary
 

--- a/ledger/schema.py
+++ b/ledger/schema.py
@@ -112,8 +112,18 @@ _TABLES = [
     # from compliance_check aggregation at read time via project_decision_status.
     # Shape: {state: 'proposed'|'ratified', session_id, created_at/ratified_at, signer?, note?}
     "DEFINE FIELD signoff ON decision FLEXIBLE TYPE option<object> DEFAULT NONE",
-    # v0.9.3 — hierarchical decision model (CodeGenome-aligned)
-    # L1 = product commitment (claim layer), L2 = architecture (identity layer), L3 = detail (rarely tracked)
+    # v0.9.3 — hierarchical decision model (CodeGenome-aligned).
+    # See docs/decision-level.md for the full reference, including the
+    # tolerant-NULL policy and codegenome-write semantics per level.
+    #
+    # Quick reference (full doc covers nuance + examples):
+    #   L1   = behavioural / product claim   → no codegenome identity write
+    #   L2   = implementation identity       → codegenome identity write enabled
+    #   L3   = glue / infrastructure detail  → no codegenome identity write
+    #   NONE = unclassified (legacy rows)    → treated as L3 (skip), tolerant policy
+    #
+    # Enforced by handlers/bind.py L1-exemption guard; the ASSERT below
+    # is the only schema-level constraint.
     "DEFINE FIELD decision_level     ON decision TYPE option<string> DEFAULT NONE "
     "ASSERT $value = NONE OR $value IN ['L1', 'L2', 'L3']",
     "DEFINE FIELD parent_decision_id ON decision TYPE option<string> DEFAULT NONE",


### PR DESCRIPTION
Closes #75.

## Summary

The `decision_level` field on `decision` controls the L1 exemption guard in `handlers/bind.py` (added in #71/#59). It was previously documented only inline in `docs/spec-governance-feedback.md` and a terse 2-line schema comment, so new contributors had no canonical place to look up valid values or write semantics.

This PR adds that canonical place.

## Changes

- **New `docs/decision-level.md`** — single reference for the field. Covers:
  - All four values (`L1`, `L2`, `L3`, `NULL`) with their codegenome-write semantics
  - The tolerant-NULL policy rationale (cross-links to spec-governance-feedback §3)
  - Where the value comes from (caller-LLM at ingest, dashboard edit, bulk-classify utility, schema migration)
  - The read APIs (`ledger.queries.get_decision_level`, adapter wrapper)
  - Cross-references to handler/test/issue links
- **`ledger/schema.py`** — expanded the comment block above `DEFINE FIELD decision_level` from 2 lines to a full quick-reference table that points at the new doc.
- **`docs/spec-governance-feedback.md` §6** — follow-up table updated: all four new items (#75/76/77/78) now show as filed; #75 row marks itself addressed by this PR.

## Stacking

Stacked on `claude/codegenome-phase-1-2-qor` (PR #71). Will rebase to `main` once #71 lands.

## Verification

- [x] `python -c \"import ast; ast.parse(open('ledger/schema.py').read())\"` — clean
- [x] `pytest tests/test_codegenome_l1_exemption.py` — 5/5 pass
- [x] No code change. ASSERT constraint unchanged.

## Test plan

- [x] Schema parses
- [x] L1-exemption regression suite passes
- [ ] Reviewer reads `docs/decision-level.md` cold and confirms the four-value table is unambiguous