### PR TITLE
fix(#69): skip tests of removed preflight contracts (12f25eb)

### DIFF
--- a/tests/test_v0412_preflight.py
+++ b/tests/test_v0412_preflight.py
@@ -1,6 +1,6 @@
 """v0.4.12 — bicameral.preflight regression tests.
 
-Covers:
+Covers (HISTORICAL — see status note below):
 
   1. Pure-function tests for the helpers (_validate_topic, _content_tokens,
      _has_actionable_signal_in_search, _check_dedup) — synchronous, IO-free.
@@ -20,17 +20,43 @@ Covers:
 
   4. Brief chain: triggers when search has actionable signal, OR when
      guided_mode=True. Doesn't fire otherwise.
+
+Status (issue #69): ``_has_actionable_signal_in_search`` was removed in
+commit 12f25eb ("v0.10.0 — hierarchical dashboard, history-based
+preflight, per-section ingest"). The preflight refactor dropped BM25
+topic search; preflight now reads ``bicameral.history()`` and uses LLM
+reasoning to identify relevant feature groups. The "actionable signal"
+predicate this file tested no longer exists as a discrete unit.
+
+Three of the helpers (``_validate_topic``, ``_dedup_key_for``,
+``_check_dedup``) still exist on the new code path, so a future port
+could salvage the validation/dedup tests here. The handler-level mock
+tests are tied to the old BM25 pipeline and would need full rewrites.
+
+The file is kept for git archaeology and skipped at collection time so
+it doesn't break ``pytest`` runs.
 """
 
 from __future__ import annotations
 
-import time
-from types import SimpleNamespace
-from unittest.mock import AsyncMock, patch
-
 import pytest
 
-from contracts import (
+pytest.skip(
+    "Tests cover preflight contracts removed in 12f25eb (v0.10.0 — "
+    "BM25 topic search dropped; _has_actionable_signal_in_search and "
+    "the BM25-based handler pipeline were removed). Kept for archaeology; "
+    "validation/dedup helper tests could be ported if needed. "
+    "See issue #69.",
+    allow_module_level=True,
+)
+
+# Imports below intentionally retained but unreachable — they document the
+# original test file's surface area for future port-forward work.
+import time  # noqa: E402, F401
+from types import SimpleNamespace  # noqa: E402, F401
+from unittest.mock import AsyncMock, patch  # noqa: E402, F401
+
+from contracts import (  # noqa: E402, F401
     BriefDecision,
     BriefDivergence,
     BriefGap,
@@ -40,12 +66,7 @@ from contracts import (
     PreflightResponse,
     SearchDecisionsResponse,
 )
-from handlers.preflight import (
-    _check_dedup,
-    _content_tokens,
-    _dedup_key_for,
-    _has_actionable_signal_in_search,
-    _validate_topic,
+from handlers.preflight import (  # noqa: E402, F401
     handle_preflight,
 )
 

--- a/tests/test_v055_region_anchored_preflight.py
+++ b/tests/test_v055_region_anchored_preflight.py
@@ -10,23 +10,45 @@ negatives on drift/grounding", pinned to some_module.py. The preflight topic is
 description, so ledger keyword search returns nothing. The caller passes
 file_paths=["some_module.py"]; the region-anchored arm looks up the pinned
 decision and surfaces it.
+
+Status (issue #69): the helpers ``_merge_decision_matches`` and
+``_region_anchored_preflight`` were removed in commit 12f25eb
+("v0.10.0 — hierarchical dashboard, history-based preflight, per-section
+ingest"). The preflight refactor dropped BM25 topic search entirely;
+preflight now reads ``bicameral.history()`` and uses LLM reasoning to
+identify relevant feature groups. The contracts these tests exercised
+no longer exist.
+
+The file is kept for git archaeology (the scenarios documented here
+informed the redesign) but is skipped at collection time so it doesn't
+break ``pytest`` runs. If/when an equivalent retrieval contract is
+introduced, port the relevant test bodies to exercise the new public
+API instead.
 """
 
 from __future__ import annotations
 
-from types import SimpleNamespace
-from unittest.mock import AsyncMock, MagicMock, patch
-
 import pytest
 
-from contracts import (
+pytest.skip(
+    "Tests cover preflight contracts removed in 12f25eb (v0.10.0 — "
+    "BM25 topic search dropped; preflight now reads history()). "
+    "Kept for archaeology; rewrite against the new API if needed. "
+    "See issue #69.",
+    allow_module_level=True,
+)
+
+# Imports below intentionally retained but unreachable — they document the
+# original test file's surface area for future port-forward work.
+from types import SimpleNamespace  # noqa: E402, F401
+from unittest.mock import AsyncMock, MagicMock, patch  # noqa: E402, F401
+
+from contracts import (  # noqa: E402, F401
     DecisionMatch,
     LinkCommitResponse,
     SearchDecisionsResponse,
 )
-from handlers.preflight import (
-    _merge_decision_matches,
-    _region_anchored_preflight,
+from handlers.preflight import (  # noqa: E402, F401
     handle_preflight,
 )
 


### PR DESCRIPTION
Closes #69.

## Summary

Two test files failed to collect on `main`:

- `tests/test_v055_region_anchored_preflight.py` — imports `_merge_decision_matches` from `handlers.preflight`
- `tests/test_v0412_preflight.py` — imports `_has_actionable_signal_in_search` from `handlers.preflight`

Both helpers were removed in commit 12f25eb (v0.10.0 — hierarchical dashboard, history-based preflight, per-section ingest). The preflight refactor dropped BM25 topic search entirely; preflight now reads `bicameral.history()` and uses LLM reasoning to identify relevant feature groups. The contracts these test files exercised no longer exist on the new code path.

## Fix

Module-level `pytest.skip(... allow_module_level=True)` on both files with a reason that points at the v0.10.0 commit and explains what was removed.

The original imports are kept (with `# noqa: E402, F401`) below the skip — they document the original surface area for future port-forward work, but are unreachable. The module docstrings are extended with a "Status (issue #69)" paragraph so anyone opening the file sees why it's quarantined before they go looking for the imports.

## Why skip rather than delete?

The scenarios documented in these files (region-anchored decision retrieval, "actionable signal" detection on search responses) informed the v0.10.0 redesign. Keeping the files preserves that history; deleting them would lose the design rationale for anyone reading git log later. If/when the maintainers prefer outright removal, this is a one-commit cleanup.

## Why not port forward?

Three of the v0.4.12 helpers (`_validate_topic`, `_dedup_key_for`, `_check_dedup`) still exist on the new code path, so a partial port is possible — but the handler-level mock tests are tied to the old BM25 pipeline and would need full rewrites against the LLM-reasoning-based preflight. That's a separate, scoped refactor; out of band for this unblocking fix.

## Note on `tests/test_extraction_metrics.py`

Issue #69 also listed `test_extraction_metrics.py` as failing collection. On the current `main` (`6bdff24`) it collects fine (16 tests). The file is left untouched.

## Verification

- [x] `pytest tests/test_v055_region_anchored_preflight.py tests/test_v0412_preflight.py --collect-only -q` — 0 collection errors, 2 skipped with reasons
- [x] No code changes outside `tests/`

## Test plan

- [x] Both target files collect cleanly
- [x] Skip reasons reference issue #69 and the v0.10.0 commit so reviewers can find the context
- [ ] CI green