### PR TITLE
docs(backlog): B5 — event-sourced ledger RFC (tracks #97)

### DIFF
--- a/docs/BACKLOG.md
+++ b/docs/BACKLOG.md
@@ -34,6 +34,18 @@
       enables the false-positive-rate benchmark called for in #60's exit
       criteria. Add as a follow-up PR before #61 starts.
 
+- [ ] [B5] Event-sourced ledger RFC — append-only event log with
+      SurrealDB/SQLite as a rebuildable projection. Tracked as Issue #97.
+      v1.0.0 candidate; load-bearing iff multi-machine/team sync enters
+      the roadmap. We already get partial event-sourcing today via the
+      META_LEDGER chain and the `compliance_check` CHANGEFEED (Phase 4 /
+      #61); the RFC asks whether to extend that pattern to all
+      mutation-bearing tables. Cheap v0.14.0 wedge proposed in the issue:
+      extend `CHANGEFEED 30d INCLUDE ORIGINAL` to `code_subject`,
+      `subject_identity`, `binds_to`, `code_region` without committing
+      to the full rewrite. Decision blocked on Jin's call about team
+      sync as a v1.0.0 goal.
+
 ## Wishlist (Nice to Have)
 <!-- Format: - [ ] [W#] Description -->
 - [ ] [W1] Section-4 razor enforcement on legacy oversized files


### PR DESCRIPTION
## Summary

- Adds `[B5]` to `docs/BACKLOG.md` — single-line index entry for the event-sourced-ledger RFC opened as #97.

## Why

A contributor suggestion arrived during PR #93 review (out of scope for that PR): make the runtime ledger append-only event-sourced with SurrealDB/SQLite as a rebuildable projection. After analysis the conclusion was \"v1.0.0 territory, blocked on team-sync roadmap call\" — not actionable now, but worth tracking.

Issue #97 carries the full analysis, costs/benefits, the proposed v0.14.0 wedge (extend CHANGEFEED to all mutation-bearing tables), and the open questions for Jin. This PR just logs it in BACKLOG so it doesn't get lost.

## Linked

Refs #97

## Test plan

- [x] BACKLOG entry renders cleanly
- [x] Format matches existing B# entries (multi-line description with rationale)
- [x] No code changes; no skill changes; no schema changes

## Plan / Audit / Seal

Plan: trivial; risk:L1 (single-file docs change, single BACKLOG entry).