### PR TITLE
fix: stale test cluster — 5 orthogonal fixes (#70)

### DIFF
--- a/server.py
+++ b/server.py
@@ -231,7 +231,7 @@ async def list_tools() -> list[Tool]:
             description=(
                 "Fail-safe valve for a polluted or stale ledger. Returns a replay plan and, "
                 "if confirmed, wipes state according to wipe_mode. "
-                "wipe_mode='ledger' (default): wipes only the materialized SurrealDB rows — "
+                "wipe_mode='ledger' (default): wipes only the materialized decision ledger — "
                 "config and event files are preserved. Safe for bug recovery; server stays live. "
                 "wipe_mode='full': deletes the entire .bicameral/ directory (ledger + config.yaml "
                 "+ team event files). Nuclear restart. Always show the dry-run warning to the user "

--- a/tests/test_bind.py
+++ b/tests/test_bind.py
@@ -186,7 +186,8 @@ async def test_bind_symbol_not_found():
 
 @pytest.mark.phase2
 @pytest.mark.asyncio
-async def test_bind_idempotent():
+@patch("ledger.status.get_git_content", return_value="# stub")
+async def test_bind_idempotent(_mock_git_content):
     """Calling bind twice for the same (decision, region) pair is idempotent."""
     client = await _fresh_client()
     try:
@@ -222,7 +223,8 @@ async def test_bind_idempotent():
 
 @pytest.mark.phase2
 @pytest.mark.asyncio
-async def test_bind_status_transition():
+@patch("ledger.status.get_git_content", return_value="# stub")
+async def test_bind_status_transition(_mock_git_content):
     """After bind, decision status transitions from 'ungrounded' to 'pending'."""
     client = await _fresh_client()
     try:

--- a/tests/test_desync_scenarios.py
+++ b/tests/test_desync_scenarios.py
@@ -338,6 +338,9 @@ async def test_scenario_06_code_added_ungrounded_resolvable(_scenario_repo):
         "def cart_total(items: list) -> float:\n    return sum(i['price'] for i in items)\n"
     )
     _commit(_scenario_repo, "add cart_total")
+    object.__setattr__(
+        ctx, "authoritative_sha", _git(_scenario_repo, "rev-parse", "HEAD").strip()
+    )
     invalidate_sync_cache(ctx)
     lc2 = await handle_link_commit(ctx, "HEAD")
 

--- a/tests/test_sync_middleware.py
+++ b/tests/test_sync_middleware.py
@@ -180,8 +180,9 @@ async def test_ensure_calls_link_commit_when_head_advanced():
 
 
 @pytest.mark.asyncio
-async def test_ensure_skips_link_commit_when_already_synced():
-    ctx = _make_ctx(last_sync_sha="current_sha")
+async def test_ensure_skips_link_commit_when_already_synced(monkeypatch):
+    monkeypatch.setattr("handlers.sync_middleware._LAST_SYNCED_SHA", "current_sha")
+    ctx = _make_ctx()
 
     with (
         patch("handlers.link_commit._read_current_head_sha", return_value="current_sha"),

--- a/tests/test_v0420_history.py
+++ b/tests/test_v0420_history.py
@@ -137,9 +137,9 @@ async def test_single_source_reflected(ctx):
     # Status should be ungrounded (no real file) or reflected if hash matched
     assert dec.status in ("reflected", "ungrounded", "discovered")
     # fulfillment populated since we passed code_regions
-    assert dec.fulfillment is not None
-    assert dec.fulfillment.file_path == "server.py"
-    assert dec.fulfillment.symbol == "validate_symbols"
+    assert dec.fulfillments
+    assert dec.fulfillments[0].file_path == "server.py"
+    assert dec.fulfillments[0].symbol == "validate_symbols"
 
 
 @pytest.mark.phase2
@@ -187,7 +187,7 @@ async def test_ungrounded_no_fulfillment(ctx):
     assert len(matching) >= 1
 
     dec = matching[0]
-    assert dec.fulfillment is None
+    assert len(dec.fulfillments) == 0
     assert dec.status in ("ungrounded", "discovered")
 
 


### PR DESCRIPTION
## Summary

Resolves the 9-test AssertionError cluster from #70 via 5 orthogonal fixes (zero file overlap):

1. **server.py** — strip "SurrealDB" jargon from `bicameral.reset` description (jargon-hygiene contract).
2. **tests/test_bind.py** — mock `ledger.status.get_git_content` in `test_bind_idempotent` and `test_bind_status_transition` so the bind handler's file-existence check is satisfied without real git content.
3. **tests/test_desync_scenarios.py** — `test_scenario_06_code_added_ungrounded_resolvable` now refreshes `ctx.authoritative_sha` to the new HEAD after the in-test commit (via `object.__setattr__` since `BicameralContext` is a frozen dataclass).
4. **tests/test_sync_middleware.py** — `test_ensure_skips_link_commit_when_already_synced` now monkeypatches the module-level `_LAST_SYNCED_SHA` instead of `ctx._sync_state` (which the middleware never reads).
5. **tests/test_v0420_history.py** — assertions updated from singular `dec.fulfillment` to plural `dec.fulfillments` list contract per the v0.4.20 API.

## Verification

`pytest tests/test_v0417_jargon_hygiene.py tests/test_bind.py tests/test_desync_scenarios.py tests/test_sync_middleware.py tests/test_v0420_history.py -v`

All 9 previously-failing tests now pass. Two pre-existing failures remain (`test_no_backend_jargon_in_skill_files`, `test_bind_success_with_explicit_lines`) — both reproduce on `upstream/dev` without our changes and are out of scope for this PR.

No product behavior change. Audit verdict was **PASS** (`.agent/staging/AUDIT_REPORT_70.md`).

Closes #70