### PR TITLE
fix(ci): clear ruff failures on dev post-#96 merge

### DIFF
--- a/tests/eval/_baseline_io.py
+++ b/tests/eval/_baseline_io.py
@@ -23,14 +23,14 @@ Regression rule (asymmetric — only flags regressions, not improvements):
 Noise floors: tokens 10 (deterministic, but tolerate small generator tweaks),
 latency 0.5ms (OS scheduler + GC jitter on non-realtime kernels).
 """
+
 from __future__ import annotations
 
 import json
 import os
 import platform
-from datetime import datetime, timezone
+from datetime import UTC, datetime, timezone
 from pathlib import Path
-
 
 BASELINE_VERSION = "1"
 RELATIVE_THRESHOLD = 0.20
@@ -71,12 +71,14 @@ def load_baselines(path: Path = BASELINE_PATH) -> list[dict]:
 
 def write_baselines(rows: list[dict], path: Path = BASELINE_PATH) -> None:
     """Sorted, stable-key JSONL output to keep diffs minimal."""
+
     def _sort_key(row: dict) -> tuple:
         return (
             row.get("metric", ""),
             row.get("recorded_on", ""),
             row.get("n_features", -1),
         )
+
     rows_sorted = sorted(rows, key=_sort_key)
     body = "\n".join(json.dumps(r, sort_keys=True, ensure_ascii=False) for r in rows_sorted)
     path.write_text(body + "\n", encoding="utf-8")
@@ -166,4 +168,4 @@ def regression_check(
 
 
 def now_iso() -> str:
-    return datetime.now(timezone.utc).replace(microsecond=0).isoformat().replace("+00:00", "Z")
+    return datetime.now(UTC).replace(microsecond=0).isoformat().replace("+00:00", "Z")

--- a/tests/eval/_seed_ledger.py
+++ b/tests/eval/_seed_ledger.py
@@ -17,6 +17,7 @@ Seeding cost: ~20ms per decision via ``ingest_payload``. At N=1000 (3000
 decisions in 3 decisions-per-feature) the seed phase takes ~60s. Acceptable
 for advisory CI; cached at the test level (one seed per N per session).
 """
+
 from __future__ import annotations
 
 from typing import Any
@@ -95,7 +96,11 @@ async def seed_ledger_from_synthetic(adapter: Any, synthetic: dict) -> int:
 
     # ingest_payload returns a dict (when called on the inner adapter directly)
     # or an IngestResponse model — handle both shapes.
-    created = response.get("created_decisions") if isinstance(response, dict) else getattr(response, "created_decisions", [])
+    created = (
+        response.get("created_decisions")
+        if isinstance(response, dict)
+        else getattr(response, "created_decisions", [])
+    )
     if not created:
         return 0
 
@@ -104,6 +109,7 @@ async def seed_ledger_from_synthetic(adapter: Any, synthetic: dict) -> int:
     desc_to_status = {desc: status for desc, status in desired_statuses}
 
     from ledger.queries import update_decision_status
+
     inner = getattr(adapter, "_inner", adapter)
     client = inner._client
 

--- a/tests/eval/run_preflight_cost_eval.py
+++ b/tests/eval/run_preflight_cost_eval.py
@@ -27,6 +27,7 @@ Modes:
   for the current platform; no assertion runs
 - No baseline for current platform: skip with re-record instructions
 """
+
 from __future__ import annotations
 
 import sys
@@ -59,7 +60,6 @@ from _baseline_io import (  # noqa: E402  (sibling module)
 from _seed_ledger import seed_ledger_from_synthetic  # noqa: E402
 from _synthetic_ledger import GENERATOR_VERSION, generate_ledger  # noqa: E402
 from _token_count import count_tokens, count_tokens_json  # noqa: E402
-
 
 _C3_WARMUP = 10
 _C3_SAMPLES = 100
@@ -149,8 +149,10 @@ def _isolate_handler_environment(monkeypatch, tmp_path):
     monkeypatch.delenv("BICAMERAL_PREFLIGHT_MUTE", raising=False)
     monkeypatch.setenv("HOME", str(tmp_path))
     import handlers.sync_middleware as sm
+
     monkeypatch.setattr(sm, "ensure_ledger_synced", AsyncMock(return_value=None))
     import handlers.preflight as pf
+
     monkeypatch.setattr(pf, "_should_show_product_stage", lambda: False)
 
 

--- a/tests/eval/test_cost_baseline_helpers.py
+++ b/tests/eval/test_cost_baseline_helpers.py
@@ -4,6 +4,7 @@ Pinned coverage for:
 - Synthetic ledger generator: determinism, shape, scaling, status distribution
 - Token counter: basic call, JSON-serialized payloads, monotonicity
 """
+
 from __future__ import annotations
 
 import sys
@@ -28,7 +29,6 @@ from _synthetic_ledger import (  # noqa: E402  (sibling module)
 )
 from _token_count import count_tokens, count_tokens_json  # noqa: E402
 
-
 # ── Generator: determinism ──────────────────────────────────────────────
 
 
@@ -50,7 +50,11 @@ def test_generator_diverges_for_different_seeds():
 def test_generator_top_level_shape():
     ledger = generate_ledger(n_features=10)
     assert set(ledger.keys()) >= {
-        "features", "truncated", "total_features", "as_of", "sync_metrics",
+        "features",
+        "truncated",
+        "total_features",
+        "as_of",
+        "sync_metrics",
         "_generator_version",
     }
     assert ledger["total_features"] == 10
@@ -78,12 +82,7 @@ def test_generator_decision_shape():
 
 def test_drifted_decision_has_drift_evidence_and_fulfillment():
     ledger = generate_ledger(n_features=200, seed=42)
-    drifted = [
-        d
-        for f in ledger["features"]
-        for d in f["decisions"]
-        if d["status"] == "drifted"
-    ]
+    drifted = [d for f in ledger["features"] for d in f["decisions"] if d["status"] == "drifted"]
     assert drifted, "expected at least one drifted decision at N=200"
     for d in drifted:
         assert d["drift_evidence"], "drifted decisions must carry drift_evidence"
@@ -93,10 +92,7 @@ def test_drifted_decision_has_drift_evidence_and_fulfillment():
 def test_ungrounded_decision_has_no_fulfillment():
     ledger = generate_ledger(n_features=200, seed=42)
     ungrounded = [
-        d
-        for f in ledger["features"]
-        for d in f["decisions"]
-        if d["status"] == "ungrounded"
+        d for f in ledger["features"] for d in f["decisions"] if d["status"] == "ungrounded"
     ]
     assert ungrounded, "expected at least one ungrounded decision at N=200"
     for d in ungrounded:
@@ -274,6 +270,7 @@ def test_upsert_appends_when_not_found():
 async def test_seeder_creates_decisions_at_n10(monkeypatch):
     """Seed at N=10 → ledger contains the expected decision count."""
     from _seed_ledger import seed_ledger_from_synthetic
+
     from ledger.adapter import SurrealDBLedgerAdapter
 
     monkeypatch.setenv("SURREAL_URL", "memory://")
@@ -295,6 +292,7 @@ async def test_seeder_status_distribution_matches_synthetic(monkeypatch):
     """The seeded ledger's status distribution should match the generator's
     target distribution (70% reflected / 20% drifted / ~10% other)."""
     from _seed_ledger import seed_ledger_from_synthetic
+
     from ledger.adapter import SurrealDBLedgerAdapter
 
     monkeypatch.setenv("SURREAL_URL", "memory://")
@@ -319,6 +317,7 @@ async def test_seeder_status_distribution_matches_synthetic(monkeypatch):
 async def test_seeder_handles_empty_synthetic(monkeypatch):
     """Empty synthetic dict → no decisions created."""
     from _seed_ledger import seed_ledger_from_synthetic
+
     from ledger.adapter import SurrealDBLedgerAdapter
 
     monkeypatch.setenv("SURREAL_URL", "memory://")

--- a/tests/test_ephemeral_authoritative.py
+++ b/tests/test_ephemeral_authoritative.py
@@ -1468,9 +1468,7 @@ async def test_e18_bind_branch_local_file(_eph_repo):
     repo = _eph_repo
 
     _checkout(repo, "feat/new-module", create=True)
-    (repo / "src/new_module.py").write_text(
-        "def compute(x: int) -> int:\n    return x * 2\n"
-    )
+    (repo / "src/new_module.py").write_text("def compute(x: int) -> int:\n    return x * 2\n")
     _commit(repo, "add new_module.py (branch-only file)")
 
     ctx = BicameralContext.from_env()
@@ -1482,19 +1480,22 @@ async def test_e18_bind_branch_local_file(_eph_repo):
     assert ingest.ingested
     decision_id = ingest.created_decisions[0].decision_id
 
-    bind_resp = await handle_bind(ctx, [{
-        "decision_id": decision_id,
-        "file_path": "src/new_module.py",
-        "symbol_name": "compute",
-        "start_line": 1,
-        "end_line": 2,
-    }])
+    bind_resp = await handle_bind(
+        ctx,
+        [
+            {
+                "decision_id": decision_id,
+                "file_path": "src/new_module.py",
+                "symbol_name": "compute",
+                "start_line": 1,
+                "end_line": 2,
+            }
+        ],
+    )
 
     assert bind_resp.bindings, "no bind results"
     b = bind_resp.bindings[0]
-    assert not b.error, (
-        f"bind must succeed for a branch-local file; got error: {b.error}"
-    )
+    assert not b.error, f"bind must succeed for a branch-local file; got error: {b.error}"
     assert b.content_hash, "content_hash must be non-empty after successful bind"
 
 
@@ -1545,13 +1546,18 @@ async def test_e19_bind_modified_function_uses_branch_hash(_eph_repo):
     assert ingest.ingested
     decision_id = ingest.created_decisions[0].decision_id
 
-    bind_resp = await handle_bind(ctx, [{
-        "decision_id": decision_id,
-        "file_path": "src/calc.py",
-        "symbol_name": "rate",
-        "start_line": 1,
-        "end_line": 2,
-    }])
+    bind_resp = await handle_bind(
+        ctx,
+        [
+            {
+                "decision_id": decision_id,
+                "file_path": "src/calc.py",
+                "symbol_name": "rate",
+                "start_line": 1,
+                "end_line": 2,
+            }
+        ],
+    )
 
     assert bind_resp.bindings, "no bind results"
     b = bind_resp.bindings[0]
@@ -1612,13 +1618,18 @@ async def test_e20_bind_link_commit_hash_consistency_no_phantom_drift(_eph_repo)
     assert ingest.ingested
     decision_id = ingest.created_decisions[0].decision_id
 
-    bind_resp = await handle_bind(ctx, [{
-        "decision_id": decision_id,
-        "file_path": "src/calc.py",
-        "symbol_name": "rate",
-        "start_line": 1,
-        "end_line": 2,
-    }])
+    bind_resp = await handle_bind(
+        ctx,
+        [
+            {
+                "decision_id": decision_id,
+                "file_path": "src/calc.py",
+                "symbol_name": "rate",
+                "start_line": 1,
+                "end_line": 2,
+            }
+        ],
+    )
     assert bind_resp.bindings and not bind_resp.bindings[0].error
     bind_hash = bind_resp.bindings[0].content_hash
     assert bind_hash, "bind must return content_hash"
@@ -1632,7 +1643,7 @@ async def test_e20_bind_link_commit_hash_consistency_no_phantom_drift(_eph_repo)
     # First link_commit: surfaces pending check at H_branch.
     lc1 = await handle_link_commit(ctx, "HEAD")
     pending = [p for p in lc1.pending_compliance_checks if p.decision_id == decision_id]
-    assert pending, f"link_commit must surface pending check for the bound decision"
+    assert pending, "link_commit must surface pending check for the bound decision"
     assert pending[0].content_hash == bind_hash, (
         f"pending_check.content_hash ({pending[0].content_hash[:8]}) must equal "
         f"bind_result.content_hash ({bind_hash[:8]}) — hash consistency invariant"
@@ -1642,14 +1653,16 @@ async def test_e20_bind_link_commit_hash_consistency_no_phantom_drift(_eph_repo)
     rc = await handle_resolve_compliance(
         ctx,
         phase="ingest",
-        verdicts=[{
-            "decision_id": decision_id,
-            "region_id": pending[0].region_id,
-            "content_hash": pending[0].content_hash,
-            "verdict": "compliant",
-            "confidence": "high",
-            "explanation": "branch content verified",
-        }],
+        verdicts=[
+            {
+                "decision_id": decision_id,
+                "region_id": pending[0].region_id,
+                "content_hash": pending[0].content_hash,
+                "verdict": "compliant",
+                "confidence": "high",
+                "explanation": "branch content verified",
+            }
+        ],
         flow_id=lc1.flow_id,
     )
     assert rc.accepted, f"resolve_compliance rejected: {rc.rejected}"
@@ -1715,8 +1728,7 @@ async def test_e21_ungrounded_feature_bind_reflected_ephemeral(_eph_repo):
     # Engineer creates feature branch and writes the implementation.
     _checkout(repo, "feat/cap-discount", create=True)
     (repo / "src/calc.py").write_text(
-        "def rate(order_total: float) -> float:\n"
-        "    return min(order_total * 0.30, order_total)\n"
+        "def rate(order_total: float) -> float:\n    return min(order_total * 0.30, order_total)\n"
     )
     _commit(repo, "cap discount at 30% (feat/cap-discount)")
 
@@ -1729,13 +1741,18 @@ async def test_e21_ungrounded_feature_bind_reflected_ephemeral(_eph_repo):
     )
 
     # Bind to the implementation on the feature branch.
-    bind_resp = await handle_bind(ctx_feat, [{
-        "decision_id": decision_id,
-        "file_path": "src/calc.py",
-        "symbol_name": "rate",
-        "start_line": 1,
-        "end_line": 2,
-    }])
+    bind_resp = await handle_bind(
+        ctx_feat,
+        [
+            {
+                "decision_id": decision_id,
+                "file_path": "src/calc.py",
+                "symbol_name": "rate",
+                "start_line": 1,
+                "end_line": 2,
+            }
+        ],
+    )
     assert bind_resp.bindings and not bind_resp.bindings[0].error, (
         f"bind must succeed on feature branch: "
         f"{bind_resp.bindings[0].error if bind_resp.bindings else 'no results'}"
@@ -1757,14 +1774,16 @@ async def test_e21_ungrounded_feature_bind_reflected_ephemeral(_eph_repo):
     rc = await handle_resolve_compliance(
         ctx_feat,
         phase="ingest",
-        verdicts=[{
-            "decision_id": decision_id,
-            "region_id": pending[0].region_id,
-            "content_hash": pending[0].content_hash,
-            "verdict": "compliant",
-            "confidence": "high",
-            "explanation": "cap implementation verified",
-        }],
+        verdicts=[
+            {
+                "decision_id": decision_id,
+                "region_id": pending[0].region_id,
+                "content_hash": pending[0].content_hash,
+                "verdict": "compliant",
+                "confidence": "high",
+                "explanation": "cap implementation verified",
+            }
+        ],
         flow_id=lc.flow_id,
     )
     assert rc.accepted, f"resolve_compliance rejected: {rc.rejected}"
@@ -1825,21 +1844,25 @@ async def test_e22_switch_to_main_no_stale_reflected(_eph_repo):
     # Feature branch: implement + bind + resolve → reflected, ephemeral=True.
     _checkout(repo, "feat/cap-v2", create=True)
     (repo / "src/calc.py").write_text(
-        "def rate(order_total: float) -> float:\n"
-        "    return min(order_total * 0.30, order_total)\n"
+        "def rate(order_total: float) -> float:\n    return min(order_total * 0.30, order_total)\n"
     )
     _commit(repo, "cap at 30%")
 
     # Fresh ctx on the feature branch.
     ctx_feat = BicameralContext.from_env()
 
-    bind_resp = await handle_bind(ctx_feat, [{
-        "decision_id": decision_id,
-        "file_path": "src/calc.py",
-        "symbol_name": "rate",
-        "start_line": 1,
-        "end_line": 2,
-    }])
+    bind_resp = await handle_bind(
+        ctx_feat,
+        [
+            {
+                "decision_id": decision_id,
+                "file_path": "src/calc.py",
+                "symbol_name": "rate",
+                "start_line": 1,
+                "end_line": 2,
+            }
+        ],
+    )
     assert bind_resp.bindings and not bind_resp.bindings[0].error
 
     lc_feat = await handle_link_commit(ctx_feat, "HEAD")
@@ -1850,14 +1873,16 @@ async def test_e22_switch_to_main_no_stale_reflected(_eph_repo):
     rc = await handle_resolve_compliance(
         ctx_feat,
         phase="ingest",
-        verdicts=[{
-            "decision_id": decision_id,
-            "region_id": pending[0].region_id,
-            "content_hash": pending[0].content_hash,
-            "verdict": "compliant",
-            "confidence": "high",
-            "explanation": "verified on branch",
-        }],
+        verdicts=[
+            {
+                "decision_id": decision_id,
+                "region_id": pending[0].region_id,
+                "content_hash": pending[0].content_hash,
+                "verdict": "compliant",
+                "confidence": "high",
+                "explanation": "verified on branch",
+            }
+        ],
         flow_id=lc_feat.flow_id,
     )
     assert rc.accepted


### PR DESCRIPTION
## Summary

Fast-follow lint hygiene PR after PR #96 (preflight eval phase 3 — real-I/O C2/C3) merged with ruff failures still on its HEAD. Dev's CI Phase 1 \`ruff + mypy\` check is currently red on \`5f773e6\`; this PR clears it.

## Why

Timeline:

1. PR #96 was retargeted from main → dev and rebased to resolve 19 conflicts.
2. The ruff+mypy CI Phase 1 gate (PR #102) flagged 8 lint issues on the merged SHA \`6bf4a91\`.
3. I pushed lint fixes to PR #96's branch (\`f052421\`, \`956d5ef\`, \`e111860\`) but the squash-merge had already executed at \`6bf4a91\` before those landed.
4. Dev now has the lint issues, blocking every subsequent PR's CI.

This PR re-applies the same fixes directly against current dev HEAD.

## What changed

| File | Fix |
|---|---|
| \`tests/eval/_baseline_io.py\` | ruff format (4 lines) |
| \`tests/eval/run_preflight_cost_eval.py\` | ruff format (line wrapping) |
| \`tests/eval/test_cost_baseline_helpers.py\` | I001 import sort + format |
| \`tests/eval/_seed_ledger.py\` | ruff format |
| \`tests/test_ephemeral_authoritative.py\` | F541 — \`f"..."\` with no placeholder → \`"..."\` |

8 auto-fixes total, 5 files reformatted, **zero behavioural changes**.

## Linked

Refs #96 (the merge that introduced the regression), #102 (the CI gate that caught it).

## Test plan

- [x] \`ruff check tests/eval/ tests/test_ephemeral_authoritative.py\` — all checks passed
- [x] \`ruff format --check\` — clean
- [x] \`pytest tests/eval/test_cost_baseline_helpers.py -q\` — 35/35 passed (unchanged behaviour)

## Plan / Audit / Seal

Plan: trivial; risk:L1 (lint hygiene only; no behavioural code paths).