### PR TITLE
feat: dashboard decision_level surfacing -- amber unclassified badge + filter (#76 part 1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,45 @@
 All notable changes to bicameral-mcp are tracked here. Format loosely follows
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
+## v0.16.x -- Dashboard decision_level surfacing (#76 part 1)
+
+Read-side UI for `decision_level`. The pre-existing L1/L2/L3 badges
+(shipped in #71 / CodeGenome Phase 1+2) are preserved; this PR adds the
+missing amber **Unclassified** state for rows where `decision_level` is
+NULL plus a top-of-page filter dropdown so reviewers can scope the
+ledger view to a single level (or to the unclassified backlog).
+
+### Added
+
+- `.lvl-unclassified` CSS class in `assets/dashboard.html` -- amber
+  (`rgb(249, 115, 22)`) badge that pairs visually with the existing
+  L1/L2/L3 family.
+- Rendering branch in `renderDec` for null `decision_level`: emits a
+  `lvl-unclassified` badge labeled `Unclassified` and stamps the row
+  with `data-level="unclassified"`.
+- Each rendered decision row now carries
+  `data-level="L1"|"L2"|"L3"|"unclassified"` and the
+  `decision-row` class so client-side filters can target it.
+- `<select id="lvl-filter">` in the topbar with five options
+  (All / L1 / L2 / L3 / Unclassified) wired to a new
+  `applyLevelFilter(value)` JS helper that toggles row visibility via
+  `style.display`.
+- `tests/test_dashboard_unclassified_rendering.py` -- six HTML-pattern
+  assertions covering the CSS rule, the render branch, the dropdown
+  markup, and the filter function. The dashboard render path is inline
+  JS in the HTML template, so the tests assert against the
+  source-of-truth template rather than booting a DOM.
+
+### Deferred to part 2
+
+- Inline-edit POST endpoint (Phase 6 of the plan). It calls
+  `ledger.queries.update_decision_level`, which lands in the sibling
+  classifier PR (#77). Part 2 ships once that helper is on `dev`.
+
+### Closes
+
+Refs #76 (part 1 of 2)
+
 ## v0.15.0 — Preflight telemetry capture loop (pieces 1–4) — built via [QorLogic SDLC](https://github.com/MythologIQ-Labs-LLC/qor-logic)
 
 First slice of the failure-mode triage workflow from #65. Adds a local-only,

--- a/assets/dashboard.html
+++ b/assets/dashboard.html
@@ -255,6 +255,7 @@ body {
 .lvl-l1 { background: var(--accent-soft); border-color: var(--accent); color: var(--accent); }
 .lvl-l2 { background: transparent; border-color: var(--border-dark); color: var(--text-dim); }
 .lvl-l3 { background: transparent; border-color: var(--border); color: var(--text-light); }
+.lvl-unclassified { background: rgba(249, 115, 22, 0.15); border-color: rgb(249, 115, 22); color: rgb(249, 115, 22); }
 .depth-spacer { flex-shrink: 0; display: inline-block; }
 
 /* ── EXPANDED BODY ─────────────────────────────────────────── */
@@ -353,6 +354,16 @@ body {
   <label class="topbar-toggle">
     <input type="checkbox" id="show-rejected" onchange="applyToggle()">
     show rejected
+  </label>
+  <label class="topbar-toggle">
+    level:
+    <select id="lvl-filter" onchange="applyLevelFilter(this.value)">
+      <option value="all">All levels</option>
+      <option value="L1">L1 only</option>
+      <option value="L2">L2 only</option>
+      <option value="L3">L3 only</option>
+      <option value="unclassified">Unclassified only</option>
+    </select>
   </label>
   <span id="tref" class="topbar-ref"></span>
 </header>
@@ -546,11 +557,14 @@ function renderDec(d, idx, depth) {
   const superseded = d.signoff_state === 'superseded';
   const rejected = isRejected(d);
   const level    = d.decision_level || (depth === 0 ? null : depth === 1 ? 'L2' : 'L3');
-  const lvlBadge = level ? `<span class="lvl-badge lvl-${level.toLowerCase()}">${level}</span>` : '';
+  const lvlClass = level ? `lvl-${level.toLowerCase()}` : 'lvl-unclassified';
+  const lvlLabel = level || 'Unclassified';
+  const lvlBadge = `<span class="lvl-badge ${lvlClass}">${lvlLabel}</span>`;
+  const dataLevel = level || 'unclassified';
   const spacer   = depth > 0 ? `<span class="depth-spacer" style="width:${depth * 18}px"></span>` : '';
   const body     = renderDetailSources(d) + renderCodeChips(d);
   return `
-<div class="dec ${stCls}${proposed ? ' is-proposed' : ''}${discovered ? ' is-discovered' : ''}${superseded ? ' is-superseded' : ''}${rejected ? ' is-rejected' : ''}" id="d${idx}" onclick="toggleDec(this)">
+<div class="dec decision-row ${stCls}${proposed ? ' is-proposed' : ''}${discovered ? ' is-discovered' : ''}${superseded ? ' is-superseded' : ''}${rejected ? ' is-rejected' : ''}" data-level="${dataLevel}" id="d${idx}" onclick="toggleDec(this)">
   <div class="dec-hdr">
     <div class="d-text-col">
       ${spacer}${lvlBadge}<span class="d-text">${esc(d.summary)}</span>
@@ -702,6 +716,14 @@ function applyToggle() {
   });
   document.querySelectorAll('.dec.is-rejected').forEach(el => {
     el.style.display = showRejected ? '' : 'none';
+  });
+}
+
+// ── level filter (#76) ────────────────────────────────────────
+function applyLevelFilter(value) {
+  document.querySelectorAll('.decision-row').forEach(row => {
+    const level = row.dataset.level || 'unclassified';
+    row.style.display = (value === 'all' || value === level) ? '' : 'none';
   });
 }
 

--- a/tests/test_dashboard_unclassified_rendering.py
+++ b/tests/test_dashboard_unclassified_rendering.py
@@ -1,0 +1,88 @@
+"""HTML-pattern tests for the dashboard's decision_level surfacing (#76 part 1).
+
+The dashboard render path lives in `assets/dashboard.html` as inline JS, so
+these tests assert that the source-of-truth template carries the markup,
+classes, and JS branches the runtime relies on. No DOM/Playwright runtime is
+booted — the tests are pure string-pattern assertions against the HTML file.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+import pytest
+
+DASHBOARD_HTML = Path(__file__).resolve().parent.parent / "assets" / "dashboard.html"
+
+
+@pytest.fixture(scope="module")
+def html() -> str:
+    assert DASHBOARD_HTML.exists(), f"missing dashboard template at {DASHBOARD_HTML}"
+    return DASHBOARD_HTML.read_text(encoding="utf-8")
+
+
+def test_unclassified_css_class_defined(html: str) -> None:
+    """Amber `.lvl-unclassified` rule sits next to the L1/L2/L3 family."""
+    pattern = (
+        r"\.lvl-unclassified\s*\{[^}]*"
+        r"background:\s*rgba\(249,\s*115,\s*22,\s*0\.15\)[^}]*"
+        r"border-color:\s*rgb\(249,\s*115,\s*22\)[^}]*"
+        r"color:\s*rgb\(249,\s*115,\s*22\)"
+    )
+    assert re.search(pattern, html, re.DOTALL), "expected amber .lvl-unclassified rule"
+
+
+def test_render_branch_handles_null_decision_level(html: str) -> None:
+    """`renderDec` must produce an Unclassified label + lvl-unclassified class
+    when `decision_level` is falsy."""
+    # The literal label string — used both as badge text and as a regression
+    # canary against accidental rename.
+    assert "'Unclassified'" in html, "expected the literal 'Unclassified' label"
+    assert "lvl-unclassified" in html, "expected the lvl-unclassified class token"
+    # The rendering branch should fall back to 'unclassified' as the data-level
+    # so the filter dropdown's 'unclassified' option keys onto these rows.
+    assert "'unclassified'" in html, "expected 'unclassified' data-level fallback"
+
+
+def test_l1_l2_l3_decisions_unaffected_by_unclassified_branch(html: str) -> None:
+    """Pre-existing L1/L2/L3 badge classes survive the patch unchanged."""
+    assert re.search(r"\.lvl-l1\s*\{", html), ".lvl-l1 rule must remain"
+    assert re.search(r"\.lvl-l2\s*\{", html), ".lvl-l2 rule must remain"
+    assert re.search(r"\.lvl-l3\s*\{", html), ".lvl-l3 rule must remain"
+    # The level computation continues to use `decision_level || ...depth fallback`.
+    assert "d.decision_level ||" in html, "decision_level fallback chain must remain"
+
+
+def test_decision_row_carries_data_level_attr(html: str) -> None:
+    """Each decision row must emit `data-level=\"...\"` for filter targeting,
+    and the row must carry the `decision-row` class the filter selects on."""
+    assert 'data-level="${dataLevel}"' in html, "decision row must template data-level"
+    assert "decision-row" in html, "decision row must carry .decision-row class"
+
+
+def test_filter_dropdown_present_with_five_options(html: str) -> None:
+    """`<select id=\"lvl-filter\">` exists with 5 options keyed to the data-level
+    values."""
+    assert re.search(
+        r'<select\s+id="lvl-filter"\s+onchange="applyLevelFilter\(this\.value\)"',
+        html,
+    ), "expected #lvl-filter <select> wired to applyLevelFilter"
+    for value, label in [
+        ("all", "All levels"),
+        ("L1", "L1 only"),
+        ("L2", "L2 only"),
+        ("L3", "L3 only"),
+        ("unclassified", "Unclassified only"),
+    ]:
+        assert f'<option value="{value}">{label}</option>' in html, (
+            f"expected filter option {value!r}/{label!r}"
+        )
+
+
+def test_apply_level_filter_function_defined(html: str) -> None:
+    """`applyLevelFilter(value)` toggles row visibility based on dataset.level."""
+    assert "function applyLevelFilter(value)" in html
+    assert ".decision-row" in html
+    # Show when filter is 'all' or matches; hide otherwise.
+    assert "value === 'all' || value === level" in html


### PR DESCRIPTION
## Summary

Read-side UI for `decision_level` in `assets/dashboard.html`. Pre-existing L1/L2/L3 badges (shipped in #71 / CodeGenome Phase 1+2) are untouched; this PR adds the missing amber **Unclassified** state for NULL `decision_level` rows plus a top-bar filter dropdown so reviewers can scope the ledger view to a single level (or to the unclassified backlog).

- `.lvl-unclassified` CSS class -- amber `rgb(249, 115, 22)`, sibling of `.lvl-l1` / `.lvl-l2` / `.lvl-l3`.
- `renderDec` branch for null `decision_level` -- emits `lvl-unclassified` badge labeled `Unclassified` and stamps the row with `data-level="unclassified"`.
- Each decision row now carries `data-level="L1"|"L2"|"L3"|"unclassified"` and the `decision-row` class.
- New `<select id="lvl-filter">` in the topbar (All / L1 / L2 / L3 / Unclassified) wired to a new client-side `applyLevelFilter(value)` helper.
- HTML-pattern tests in `tests/test_dashboard_unclassified_rendering.py` -- six assertions covering CSS, render branch, dropdown markup, filter function. The render path is inline JS, so the tests assert against the source-of-truth template rather than booting a DOM.

## Part 1 of 2

Phase 6 of the original plan (inline-edit POST endpoint) is **deferred to a follow-up PR**. That endpoint calls `ledger.queries.update_decision_level`, which is being added in the sibling classifier PR (#77 / `feat/decision-level-classify-77`). Once that helper lands on `dev`, part 2 ships and closes the remaining slice of #76.

## No server changes

Pure HTML/CSS/JS edit plus one new pytest module. No touches to `classify/`, `cli/`, `handlers/`, `ledger/queries.py`, `contracts.py`, or `server.py` -- those are the sibling classifier PR's surface.

## Test plan

- [x] `pytest tests/test_dashboard_unclassified_rendering.py -v` -- 6 passed in 0.67s
- [x] `python -c "from dashboard.server import get_dashboard_server"` -- imports clean
- [x] `ruff check .` -- clean
- [x] `ruff format --check .` -- 164 files already formatted
- [x] `mypy tests/test_dashboard_unclassified_rendering.py` -- no issues
- [ ] Browser spot-check (out-of-band; not blocking PR open)

## Labels

`flow:feature` -- read-side UI surfacing existing classifier output.

## Refs

- Refs #76 (part 1 of 2)
- Sibling: #77 / `feat/decision-level-classify-77` (provides `update_decision_level` for part 2)

Generated with [Claude Code](https://claude.com/claude-code)