### PR TITLE
feat: decision_level classifier + MCP primitives + CLI (#77)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,49 @@
 All notable changes to bicameral-mcp are tracked here. Format loosely follows
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
-## v0.16.x -- Dashboard decision_level surfacing (#76 part 1)
+## v0.16.0 -- decision_level classifier + MCP primitives (#77 + Phase 5+6 of #76 in sibling PR)
+
+Adds a heuristic decision-level classifier, a single-row write helper for
+`decision.decision_level`, two MCP primitives that expose classification to
+agents, and a bulk-classify CLI for offline backfill. The companion #76
+dashboard work (amber unclassified badge, filter dropdown, inline edit POST
+endpoint) ships in a sibling PR against the same `dev` branch.
+
+### Added
+
+- **New module: `classify/heuristic.py`** -- pure-function port of the L1/L2/L3
+  rules documented at `skills/bicameral-ingest/SKILL.md` lines 178-217. Single
+  public entrypoint `classify(description, source="") -> (level, rationale)`.
+  Deterministic, no IO, no LLM, no network. Regression-tested against the
+  7 fixtures at `tests/fixtures/ingest_level_classification/` (7/7 pass).
+- **New helper: `ledger.queries.update_decision_level(client, decision_id,
+  level)`** -- single-row write helper, sibling of `update_decision_status`.
+  Idempotent. Includes defensive `_DECISION_ID_RE` shape validation
+  (`^decision:[A-Za-z0-9_]+$`) before SurrealQL interpolation
+  (audit S1 defense-in-depth) and a `_VALID_LEVELS` membership check.
+  Raises `DecisionNotFound` when the row does not exist.
+- **New MCP primitives** (two tools, NOT a bulk wrapper):
+  - `bicameral.list_unclassified_decisions(decision_ids?)` -- read-only.
+    Returns `proposals[]` with `proposed_level`, `rationale`, and
+    `confidence` ("low" when the heuristic defaulted with no signal).
+  - `bicameral.set_decision_level(decision_id, level, rationale?)` --
+    single-row write, idempotent. Errors come back structured
+    (`{ok: false, error: ...}`) rather than raised, so agents recover
+    per-row without aborting the loop.
+- **New contracts**: `UnclassifiedProposal`,
+  `ListUnclassifiedDecisionsResponse`, `SetDecisionLevelResponse`.
+- **New CLI: `bicameral-mcp-classify`** (entrypoint at `cli.classify:main`).
+  Default is dry-run (prints a proposal table); `--apply` writes the
+  proposed levels via the same `update_decision_level` helper. Progress
+  output every 100 rows for large batches. Reuses the heuristic and the
+  ledger helper -- one write path, three callers (CLI, MCP tool, future
+  dashboard endpoint).
+
+### Closes
+
+#77
+
+## v0.16.1 -- Dashboard decision_level surfacing (#76 part 1)
 
 Read-side UI for `decision_level`. The pre-existing L1/L2/L3 badges
 (shipped in #71 / CodeGenome Phase 1+2) are preserved; this PR adds the

--- a/classify/__init__.py
+++ b/classify/__init__.py
@@ -1,0 +1,9 @@
+"""Decision-level classifier (#77).
+
+Pure-function heuristic classifier mapping decision descriptions/sources to
+L1 / L2 / L3 levels. No IO, no LLM, no network — deterministic.
+"""
+
+from classify.heuristic import classify
+
+__all__ = ["classify"]

--- a/classify/heuristic.py
+++ b/classify/heuristic.py
@@ -1,0 +1,239 @@
+"""Heuristic decision-level classifier (#77).
+
+Pure-function port of the L1/L2/L3 rules documented at
+``skills/bicameral-ingest/SKILL.md`` lines 178-217.
+
+Public API:
+
+    classify(description: str, source: str = "") -> tuple[str, str]
+        -> (level, rationale)
+
+``level`` is always one of ``"L1"``, ``"L2"``, ``"L3"``. The classifier never
+returns ``None`` — gate-drop semantics live above this layer (the bicameral-
+ingest skill applies hard-exclude / gate filters after level classification).
+
+Pure: same input twice yields the same output. No IO, no network, no LLM.
+"""
+
+from __future__ import annotations
+
+import re
+
+# ---------------------------------------------------------------------------
+# Pattern tables
+# ---------------------------------------------------------------------------
+
+# Roles named in L1 grammar (subject of an L1 commitment).
+# Source: SKILL.md line 201 ("A user role (Members, Users, Admins, Guests)").
+_L1_ROLES = (
+    "Members",
+    "Users",
+    "Admins",
+    "Guests",
+    "Customers",
+    "Operators",
+    "Agents",
+)
+
+# Modal / commitment verbs that tie a role to an observable behavior.
+_L1_MODALS = (
+    "can",
+    "will",
+    "must",
+    "may",
+    "are able to",
+    "is able to",
+    "receive",
+    "receives",
+    "see",
+    "sees",
+    "get",
+    "gets",
+)
+
+# Compiled regexes for the role + modal + outcome shape.
+# Matches "<Role> <modal> <verb-phrase>" anywhere in the source.
+_L1_ROLE_MODAL_RE = re.compile(
+    r"\b(?P<role>" + "|".join(_L1_ROLES) + r")\b\s+"
+    r"(?P<modal>" + "|".join(re.escape(m) for m in _L1_MODALS) + r")\b",
+    re.IGNORECASE,
+)
+
+# "the system supports/provides/exposes ..." — product contract framing
+# (SKILL.md line 184).
+_L1_SYSTEM_CONTRACT_RE = re.compile(
+    r"\bthe\s+(system|product|app|platform)\s+"
+    r"(supports|provides|exposes|offers|delivers)\b",
+    re.IGNORECASE,
+)
+
+# Behavioral-trigger framing without a named role:
+# "When <event>, the app/system/product <action>" (SKILL.md line 191 example).
+_L1_BEHAVIORAL_TRIGGER_RE = re.compile(
+    r"\bwhen\s+[^.]{1,80}?,\s*the\s+(app|system|product|platform|service)\b",
+    re.IGNORECASE,
+)
+
+# L3 — named external limit / SLA / vendor cap (SKILL.md line 195).
+# Patterns: "max <N>", "<= N", "limit of N", "<vendor> SDK limit".
+_L3_LIMIT_RES: tuple[re.Pattern[str], ...] = (
+    re.compile(r"\bmax(?:imum)?\s+\d+", re.IGNORECASE),
+    re.compile(r"<=\s*\d+", re.IGNORECASE),
+    re.compile(r"\blimit\s+of\s+\d+", re.IGNORECASE),
+    re.compile(r"\b\w+\s+SDK\s+(?:hard\s+)?limit\b", re.IGNORECASE),
+    re.compile(r"\b\w+\s+API\s+cap\b", re.IGNORECASE),
+)
+
+# Strategy-vs-L1 tiebreaker (SKILL.md line 188-191): a roadmap date with no
+# observable behavior is strategy, not L1.
+_DATE_LIKE_RES: tuple[re.Pattern[str], ...] = (
+    re.compile(r"\bby\s+Q[1-4]\b", re.IGNORECASE),
+    re.compile(r"\bin\s+Q[1-4]\b", re.IGNORECASE),
+    re.compile(r"\bship(?:ping|ped)?\s+[^.]{0,40}\bQ[1-4]\b", re.IGNORECASE),
+    re.compile(r"\bby\s+(?:end\s+of\s+)?(?:H[12]|FY\d+|20\d\d)\b", re.IGNORECASE),
+)
+
+# Roadmap-intent verbs that signal "we (the team) will ..." rather than
+# user-observable behavior — the agent is the team, not the user.
+_ROADMAP_VERBS = (
+    "ship",
+    "launch",
+    "release",
+    "deliver",
+    "roll out",
+    "rollout",
+)
+_ROADMAP_INTENT_RE = re.compile(
+    r"\b(we|the team)\s+(will|are going to|plan to|intend to)\s+"
+    r"(?:" + "|".join(_ROADMAP_VERBS) + r")\b",
+    re.IGNORECASE,
+)
+
+# L2 architecture / approach signals — components, mechanisms, vendor names
+# implying a technical choice with an alternative.
+_L2_KEYWORD_RES: tuple[re.Pattern[str], ...] = (
+    re.compile(
+        r"\b(redis|postgres(?:ql)?|surrealdb|mysql|sqlite|kafka|rabbitmq|"
+        r"sidekiq|celery|lambda|kubernetes|docker|nginx|envoy|graphql|"
+        r"webhook|websocket|grpc)\b",
+        re.IGNORECASE,
+    ),
+    re.compile(
+        r"\b(backed|backend|frontend|architecture|service|microservice|"
+        r"middleware|adapter|driver|cache|queue|worker|sharding|replica|"
+        r"horizontal scaling|vertical scaling|load balanc\w+)\b",
+        re.IGNORECASE,
+    ),
+    re.compile(r"\b(use|using|adopt|chose|chosen)\b\s+\w+", re.IGNORECASE),
+    re.compile(r"\binstead\s+of\b", re.IGNORECASE),
+    # Interface / contract specs — "the X API returns fields", "response
+    # contract includes ..." — these are L2 spec material (failed Gate 2,
+    # but the classifier still tags them L2).
+    re.compile(
+        r"\b(API|endpoint|response|request|contract|payload)\b[^.]*\b"
+        r"(returns|includes|contains|exposes|fields)\b",
+        re.IGNORECASE,
+    ),
+)
+
+
+# Lines that mark a sentence as "already classified" upstream and should be
+# stripped before our classifier runs. Used by ingest fixtures that bundle
+# an L1 and an L2 in a single source excerpt with an annotation marker.
+# The separator between "L1" and "already classified" is non-restrictive
+# (any 1-3 chars that aren't a closing bracket) so an ASCII hyphen, en-dash,
+# em-dash, or even cp1252-mojibake variant all match.
+_ALREADY_CLASSIFIED_LINE_RE = re.compile(
+    r"^.*\[\s*L[123]\s*[^\]]{0,5}?\s*already classified\s*\].*$",
+    re.IGNORECASE | re.MULTILINE,
+)
+
+
+# ---------------------------------------------------------------------------
+# Public entrypoint
+# ---------------------------------------------------------------------------
+
+
+def classify(description: str, source: str = "") -> tuple[str, str]:
+    """Classify a decision into L1 / L2 / L3.
+
+    Args:
+        description: The decision text. Often the same as ``source`` for
+            classifier-driven calls; ingest-time callers may pass a shorter
+            framing in ``description`` and the raw excerpt in ``source``.
+        source: Optional broader source excerpt. Both fields are searched.
+
+    Returns:
+        ``(level, rationale)`` where level is one of ``"L1"``, ``"L2"``,
+        ``"L3"`` and rationale is a structured one-line explanation. The
+        rationale string starts with ``"low confidence"`` when no positive
+        signal matched and the classifier defaulted (the bulk-classify CLI
+        renders these with a ``(low confidence)`` flag for human review).
+
+    Pure function — no IO, no LLM, no network.
+    """
+    raw = f"{description}\n{source}".strip()
+    if not raw:
+        return ("L3", "low confidence: empty input -- defaulted to L3")
+
+    # Strip any sentence pre-tagged "[L1 -- already classified]" so the
+    # classifier focuses on the as-yet-unclassified portion. The ingest
+    # fixture 05_l2_driver_inferred_from_l1 exercises this path: an L1
+    # framing precedes the L2 we're meant to classify.
+    text = _ALREADY_CLASSIFIED_LINE_RE.sub("", raw).strip()
+    if not text:
+        text = raw  # nothing left after stripping — fall back to original
+
+    # ── Strategy-vs-L1 tiebreaker: roadmap date + no behavior → L3 ──────
+    has_date = any(p.search(text) for p in _DATE_LIKE_RES)
+    has_roadmap_verb = bool(_ROADMAP_INTENT_RE.search(text))
+    has_role_modal = bool(_L1_ROLE_MODAL_RE.search(text))
+    has_behavioral_trigger = bool(_L1_BEHAVIORAL_TRIGGER_RE.search(text))
+    has_system_contract = bool(_L1_SYSTEM_CONTRACT_RE.search(text))
+
+    if (has_date or has_roadmap_verb) and not (has_role_modal or has_behavioral_trigger):
+        return (
+            "L3",
+            "L3 -- strategy/roadmap intent (date or 'we will ship' without observable behavior)",
+        )
+
+    # ── L1: role + modal + observable behavior ──────────────────────────
+    m = _L1_ROLE_MODAL_RE.search(text)
+    if m:
+        return (
+            "L1",
+            f"L1 -- matches role {m.group('role')!r} + modal {m.group('modal')!r}",
+        )
+
+    if has_behavioral_trigger:
+        return (
+            "L1",
+            "L1 -- matches behavioral trigger ('when <event>, the app ...')",
+        )
+
+    if has_system_contract:
+        return (
+            "L1",
+            "L1 -- matches system-contract framing ('the system supports ...')",
+        )
+
+    # ── L3: hard external limit / SLA cap ───────────────────────────────
+    for pat in _L3_LIMIT_RES:
+        m3 = pat.search(text)
+        if m3:
+            return (
+                "L3",
+                f"L3 -- matches external limit/SLA pattern: {m3.group(0)!r}",
+            )
+
+    # ── L2: any technical / architectural keyword ───────────────────────
+    for pat in _L2_KEYWORD_RES:
+        m2 = pat.search(text)
+        if m2:
+            return (
+                "L2",
+                f"L2 -- matches technical/architectural signal: {m2.group(0)!r}",
+            )
+
+    # ── Fallback: no signal matched ─────────────────────────────────────
+    return ("L3", "low confidence: no commitment or approach signal — defaulted to L3")

--- a/cli/__init__.py
+++ b/cli/__init__.py
@@ -1,0 +1,6 @@
+"""Bicameral-MCP CLI utilities (#77).
+
+Console-script entrypoints exposed via ``pyproject.toml``:
+
+    bicameral-mcp-classify   -> cli.classify:main
+"""

--- a/cli/classify.py
+++ b/cli/classify.py
@@ -1,0 +1,147 @@
+"""Bulk-classify CLI for unclassified decisions (#77).
+
+Reads every decision row whose ``decision_level`` is NONE, runs the
+heuristic classifier, prints a table of (decision_id, proposed_level,
+rationale) for human review, and — when ``--apply`` is passed — persists
+the proposed level via the ``ledger.queries.update_decision_level``
+helper. Same write path as the MCP ``bicameral.set_decision_level`` tool
+and the dashboard inline-edit POST endpoint.
+
+Default is dry-run (no writes). ``--apply`` is required to mutate the
+ledger.
+
+Usage:
+
+    bicameral-mcp-classify           # dry-run, table only
+    bicameral-mcp-classify --apply   # apply heuristic levels to all rows
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import sys
+from typing import TextIO
+
+from classify.heuristic import classify
+from ledger.adapter import SurrealDBLedgerAdapter
+from ledger.queries import update_decision_level
+
+_PROGRESS_INTERVAL = 100
+
+
+def _format_proposal_table(
+    proposals: list[tuple[str, str, str, str]],
+    out: TextIO,
+) -> None:
+    """Render the dry-run proposal table to ``out``.
+
+    proposals: list of (decision_id, description, proposed_level, rationale)
+    """
+    if not proposals:
+        out.write("No unclassified decisions found.\n")
+        return
+
+    out.write(f"{'decision_id':<48}  {'level':<5}  {'rationale'}\n")
+    out.write(f"{'-' * 48}  {'-' * 5}  {'-' * 60}\n")
+    for did, _desc, level, rationale in proposals:
+        flag = " (low confidence)" if rationale.lower().startswith("low confidence") else ""
+        out.write(f"{did:<48}  {level:<5}  {rationale}{flag}\n")
+
+
+async def _gather_proposals(
+    client,
+) -> list[tuple[str, str, str, str]]:
+    """Read every unclassified decision and run the heuristic.
+
+    Returns a list of (decision_id, description, level, rationale) tuples.
+    """
+    rows = await client.query(
+        "SELECT type::string(id) AS decision_id, description "
+        "FROM decision WHERE decision_level = NONE"
+    )
+    proposals: list[tuple[str, str, str, str]] = []
+    for row in rows or []:
+        did = row.get("decision_id") or ""
+        desc = row.get("description") or ""
+        level, rationale = classify(desc)
+        proposals.append((did, desc, level, rationale))
+    return proposals
+
+
+async def _run(
+    apply_changes: bool,
+    *,
+    out: TextIO | None = None,
+    adapter: SurrealDBLedgerAdapter | None = None,
+) -> int:
+    """Core async entry point. Returns process exit code.
+
+    Args:
+        apply_changes: when True, persist proposed levels via
+            ``update_decision_level``; when False, dry-run only.
+        out: where to render the table and status lines. Defaults to
+            ``sys.stdout`` (resolved at call time so test monkeypatches on
+            ``sys.stdout`` work).
+        adapter: optional pre-connected adapter. When supplied, ``_run``
+            does not connect or close it (caller owns the lifecycle). The
+            CLI ``main`` always creates and tears down its own adapter.
+    """
+    if out is None:
+        out = sys.stdout
+
+    owns_adapter = adapter is None
+    if adapter is None:
+        adapter = SurrealDBLedgerAdapter()
+        try:
+            await adapter.connect()
+        except Exception as exc:
+            out.write(f"error: failed to connect to ledger: {exc}\n")
+            return 2
+
+    client = adapter._client
+    try:
+        proposals = await _gather_proposals(client)
+        _format_proposal_table(proposals, out)
+
+        if not apply_changes:
+            out.write(f"\nDry run -- {len(proposals)} proposals shown. Use --apply to write.\n")
+            return 0
+
+        # Apply mode: per-row writes via the same primitive as the MCP tool.
+        applied = 0
+        for i, (did, _desc, level, _rationale) in enumerate(proposals, 1):
+            try:
+                await update_decision_level(client, did, level)
+                applied += 1
+            except Exception as exc:
+                out.write(f"error: failed to update {did}: {exc}\n")
+                return 3
+            if i % _PROGRESS_INTERVAL == 0:
+                out.write(f"  ...applied {i}/{len(proposals)}\n")
+        out.write(f"Applied {applied} classifications.\n")
+        return 0
+    finally:
+        if owns_adapter:
+            await client.close()
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        prog="bicameral-mcp-classify",
+        description=(
+            "Bulk-classify unclassified decisions in the local ledger. "
+            "Default is dry-run (prints proposals); pass --apply to write."
+        ),
+    )
+    parser.add_argument(
+        "--apply",
+        action="store_true",
+        help="Write proposed levels to the ledger (default: dry-run only).",
+    )
+    args = parser.parse_args(argv)
+    return asyncio.run(_run(args.apply))
+
+
+if __name__ == "__main__":  # pragma: no cover
+    raise SystemExit(main())

--- a/contracts.py
+++ b/contracts.py
@@ -851,6 +851,48 @@ class SessionStartBanner(BaseModel):
     truncated: bool = False
 
 
+# ── Tool: bicameral.list_unclassified_decisions / set_decision_level (#77)
+
+
+class UnclassifiedProposal(BaseModel):
+    """One unclassified decision row with a heuristic-proposed level.
+
+    Returned in batches by ``bicameral.list_unclassified_decisions``. The
+    ``rationale`` string explains which signal the heuristic matched and is
+    rendered by the bulk-classify CLI's dry-run table. ``confidence`` is
+    ``"low"`` when the heuristic defaulted (no positive signal matched) so
+    a human reviewer can prioritise these for manual override.
+    """
+
+    decision_id: str
+    description: str
+    proposed_level: Literal["L1", "L2", "L3"]
+    rationale: str
+    confidence: Literal["high", "low"]
+
+
+class ListUnclassifiedDecisionsResponse(BaseModel):
+    """Response envelope for ``bicameral.list_unclassified_decisions``."""
+
+    proposals: list[UnclassifiedProposal]
+    total_count: int
+
+
+class SetDecisionLevelResponse(BaseModel):
+    """Response envelope for ``bicameral.set_decision_level``.
+
+    Errors (invalid level, unknown decision_id) come back structured rather
+    than as exceptions so an agent loop can recover per-row without aborting
+    the whole batch. ``ok=True`` carries ``level``; ``ok=False`` carries
+    ``error``.
+    """
+
+    ok: bool
+    decision_id: str
+    level: str | None = None
+    error: str | None = None
+
+
 # Forward references
 IngestResponse.model_rebuild()
 ResolveCollisionResponse.model_rebuild()

--- a/handlers/list_unclassified_decisions.py
+++ b/handlers/list_unclassified_decisions.py
@@ -1,0 +1,77 @@
+"""Handler for /bicameral.list_unclassified_decisions MCP tool (#77).
+
+Read-only. Returns decisions whose ``decision_level`` is NONE alongside a
+heuristic-proposed level (L1/L2/L3) and rationale per row. The agent loop
+typically reviews each proposal, decides whether to trust the heuristic or
+override, then calls ``bicameral.set_decision_level`` per row.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Literal, cast
+
+from classify.heuristic import classify
+from contracts import ListUnclassifiedDecisionsResponse, UnclassifiedProposal
+
+logger = logging.getLogger(__name__)
+
+
+async def handle_list_unclassified_decisions(
+    ctx,
+    decision_ids: list[str] | None = None,
+) -> ListUnclassifiedDecisionsResponse:
+    """List decisions with NONE decision_level, each with a heuristic proposal.
+
+    Args:
+        ctx: BicameralContext.
+        decision_ids: Optional restriction to a specific subset. When None
+            or empty, returns every unclassified decision in the ledger.
+
+    Returns:
+        ListUnclassifiedDecisionsResponse with proposals[] and total_count.
+    """
+    ledger = ctx.ledger
+    if hasattr(ledger, "connect"):
+        await ledger.connect()
+
+    inner = getattr(ledger, "_inner", ledger)
+    client = inner._client
+
+    if decision_ids:
+        # SurrealDB IN list of record-ids; the helper validates shape on
+        # the write path, but for this read we just filter by membership.
+        rows = await client.query(
+            "SELECT type::string(id) AS decision_id, description "
+            "FROM decision "
+            "WHERE decision_level = NONE AND type::string(id) IN $ids",
+            {"ids": list(decision_ids)},
+        )
+    else:
+        rows = await client.query(
+            "SELECT type::string(id) AS decision_id, description "
+            "FROM decision WHERE decision_level = NONE"
+        )
+
+    proposals: list[UnclassifiedProposal] = []
+    for row in rows or []:
+        did = row.get("decision_id") or ""
+        desc = row.get("description") or ""
+        level, rationale = classify(desc)
+        confidence: Literal["high", "low"] = (
+            "low" if rationale.lower().startswith("low confidence") else "high"
+        )
+        proposals.append(
+            UnclassifiedProposal(
+                decision_id=did,
+                description=desc,
+                proposed_level=cast(Literal["L1", "L2", "L3"], level),
+                rationale=rationale,
+                confidence=confidence,
+            )
+        )
+
+    return ListUnclassifiedDecisionsResponse(
+        proposals=proposals,
+        total_count=len(proposals),
+    )

--- a/handlers/set_decision_level.py
+++ b/handlers/set_decision_level.py
@@ -1,0 +1,85 @@
+"""Handler for /bicameral.set_decision_level MCP tool (#77).
+
+Single-row write. Idempotent. Errors are returned as structured
+``{ok: false, error: ...}`` responses rather than raised exceptions so an
+agent loop can recover per-row without aborting the whole batch.
+
+Uses the same ``ledger.queries.update_decision_level`` primitive as the
+bulk-classify CLI (``cli/classify.py``) and the dashboard inline-edit POST
+endpoint (sibling PR for #76). One write path, three callers.
+"""
+
+from __future__ import annotations
+
+import logging
+
+from contracts import SetDecisionLevelResponse
+from ledger.queries import DecisionNotFound, update_decision_level
+
+logger = logging.getLogger(__name__)
+
+
+async def handle_set_decision_level(
+    ctx,
+    decision_id: str,
+    level: str,
+    rationale: str | None = None,
+) -> SetDecisionLevelResponse:
+    """Set decision_level on a single decision. Idempotent.
+
+    Args:
+        ctx: BicameralContext.
+        decision_id: Full record id (e.g. ``"decision:abc123"``).
+        level: One of ``"L1"``, ``"L2"``, ``"L3"``.
+        rationale: Optional one-line audit note. Currently logged only;
+            persistence pathway is reserved for a future audit-trail row.
+
+    Returns:
+        SetDecisionLevelResponse with ok=True/level on success or
+        ok=False/error on validation/lookup failure.
+    """
+    ledger = ctx.ledger
+    if hasattr(ledger, "connect"):
+        await ledger.connect()
+
+    inner = getattr(ledger, "_inner", ledger)
+    client = inner._client
+
+    try:
+        await update_decision_level(client, decision_id, level)
+    except ValueError as exc:
+        logger.info(
+            "[set_decision_level] validation failed: decision=%s level=%s err=%s",
+            decision_id,
+            level,
+            exc,
+        )
+        return SetDecisionLevelResponse(
+            ok=False,
+            decision_id=decision_id,
+            error=str(exc),
+        )
+    except DecisionNotFound as exc:
+        logger.info(
+            "[set_decision_level] decision_id not found: %s",
+            exc,
+        )
+        return SetDecisionLevelResponse(
+            ok=False,
+            decision_id=decision_id,
+            error=f"decision_id not found: {decision_id}",
+        )
+
+    if rationale:
+        logger.info(
+            "[set_decision_level] decision=%s level=%s rationale=%s",
+            decision_id,
+            level,
+            rationale,
+        )
+
+    return SetDecisionLevelResponse(
+        ok=True,
+        decision_id=decision_id,
+        level=level,
+    )

--- a/ledger/queries.py
+++ b/ledger/queries.py
@@ -11,6 +11,7 @@ No SDK types (RecordID etc.) leak through — normalization happens in client.py
 from __future__ import annotations
 
 import logging
+import re
 from datetime import UTC, datetime
 
 from .client import LedgerClient, LedgerError
@@ -986,6 +987,58 @@ async def update_decision_status(
     await client.execute(
         f"UPDATE {decision_id} SET status = $s",
         {"s": status},
+    )
+
+
+# ── decision_level write helper (#77) ─────────────────────────────────
+# Single write path used by:
+#   - cli/classify.py --apply              (bulk backfill)
+#   - handlers/set_decision_level.py       (MCP tool primitive)
+#   - dashboard/server.py /api/decision/<id>/level (#76 sibling PR)
+# Schema ASSERT at ledger/schema.py enforces L1/L2/L3; this helper adds
+# defense-in-depth callers see clear Python errors before SurrealQL runs.
+
+_VALID_LEVELS = frozenset(("L1", "L2", "L3"))
+_DECISION_ID_RE = re.compile(r"^decision:[A-Za-z0-9_]+$")
+
+
+class DecisionNotFound(LedgerError):
+    """Raised by update_decision_level when the decision_id has no row."""
+
+
+async def update_decision_level(
+    client: LedgerClient,
+    decision_id: str,
+    level: str,
+) -> None:
+    """Set decision_level on a single decision. Idempotent.
+
+    Validates ``level`` against {L1, L2, L3} and ``decision_id`` against
+    the canonical ``^decision:[A-Za-z0-9_]+$`` shape before any SurrealQL
+    runs (audit S1 defense-in-depth — the existing f-string interpolation
+    pattern is consistent with siblings, but a malformed id would still
+    surface as a SurrealDB error rather than silent corruption).
+
+    Args:
+        client: Connected LedgerClient.
+        decision_id: Full record id (e.g. ``"decision:abc123"``).
+        level: One of ``"L1"``, ``"L2"``, ``"L3"``.
+
+    Raises:
+        ValueError: when ``level`` is not in {L1, L2, L3} or
+            ``decision_id`` fails the shape regex.
+        DecisionNotFound: when no row exists at ``decision_id``.
+    """
+    if level not in _VALID_LEVELS:
+        raise ValueError(f"invalid level {level!r}; expected one of L1, L2, L3")
+    if not _DECISION_ID_RE.match(decision_id):
+        raise ValueError(f"invalid decision_id shape: {decision_id!r}")
+    rows = await client.query(f"SELECT id FROM {decision_id} LIMIT 1")
+    if not rows:
+        raise DecisionNotFound(decision_id)
+    await client.execute(
+        f"UPDATE {decision_id} SET decision_level = $level",
+        {"level": level},
     )
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -54,6 +54,7 @@ test = [
 
 [project.scripts]
 bicameral-mcp = "server:cli_main"
+bicameral-mcp-classify = "cli.classify:main"
 
 [tool.hatch.build.targets.wheel]
 packages = ["."]

--- a/server.py
+++ b/server.py
@@ -1,6 +1,6 @@
 """Bicameral MCP Server — Bicameral decision ledger + code locator tools.
 
-13 tools:
+15 tools:
   bicameral.link_commit       — heartbeat: sync a commit into the decision ledger
   bicameral.ingest            — ingest normalized decision/code evidence and advance source cursors
   bicameral.update            — check for or apply a recommended bicameral-mcp update
@@ -11,6 +11,8 @@
   bicameral.ratify            — product sign-off on a decision (double-entry ledger)
   bicameral.history           — read-only ledger dump grouped by feature area
   bicameral.dashboard         — launch live decision dashboard with SSE push updates
+  bicameral.list_unclassified_decisions — list decisions whose decision_level is NULL with proposals (#77)
+  bicameral.set_decision_level — set decision_level (L1/L2/L3) on a single decision (#77)
   validate_symbols            — fuzzy-match candidate symbol names against the code index
   get_neighbors               — 1-hop structural graph traversal around a symbol
   extract_symbols             — tree-sitter symbol extraction from a source file
@@ -42,11 +44,13 @@ from handlers.gap_judge import handle_judge_gaps
 from handlers.history import handle_history
 from handlers.ingest import handle_ingest
 from handlers.link_commit import handle_link_commit
+from handlers.list_unclassified_decisions import handle_list_unclassified_decisions
 from handlers.preflight import handle_preflight
 from handlers.ratify import handle_ratify
 from handlers.reset import handle_reset
 from handlers.resolve_collision import handle_resolve_collision
 from handlers.resolve_compliance import handle_resolve_compliance
+from handlers.set_decision_level import handle_set_decision_level
 from handlers.update import get_update_notice, handle_update
 from ledger.schema import DestructiveMigrationRequired, SchemaVersionTooNew
 
@@ -100,6 +104,9 @@ EXPECTED_TOOL_NAMES = [
     "bicameral.skill_begin",
     "bicameral.skill_end",
     "bicameral.feedback",
+    "bicameral.usage_summary",
+    "bicameral.list_unclassified_decisions",
+    "bicameral.set_decision_level",
     "validate_symbols",
     "get_neighbors",
     "extract_symbols",
@@ -773,6 +780,52 @@ async def list_tools() -> list[Tool]:
                 },
             },
         ),
+        # ── decision_level classification primitives (#77) ───────────
+        Tool(
+            name="bicameral.list_unclassified_decisions",
+            description=(
+                "List decisions whose decision_level is NULL, with a "
+                "heuristic-proposed level (L1/L2/L3) and a rationale per row. "
+                "Read-only. Use this to discover what needs classification "
+                "before calling bicameral.set_decision_level per row."
+            ),
+            inputSchema={
+                "type": "object",
+                "properties": {
+                    "decision_ids": {
+                        "type": "array",
+                        "items": {"type": "string"},
+                        "description": (
+                            "Restrict to these decision_ids; empty/omitted means all unclassified."
+                        ),
+                    },
+                },
+            },
+        ),
+        Tool(
+            name="bicameral.set_decision_level",
+            description=(
+                "Set decision_level (L1/L2/L3) on a single decision. "
+                "Idempotent. Use this after reviewing proposals from "
+                "bicameral.list_unclassified_decisions, or directly when "
+                "you already know the right level."
+            ),
+            inputSchema={
+                "type": "object",
+                "properties": {
+                    "decision_id": {"type": "string"},
+                    "level": {
+                        "type": "string",
+                        "enum": ["L1", "L2", "L3"],
+                    },
+                    "rationale": {
+                        "type": "string",
+                        "description": "Optional one-line audit note.",
+                    },
+                },
+                "required": ["decision_id", "level"],
+            },
+        ),
         # ── Code locator tools (MCP-native) ──────────────────────────
         Tool(
             name="validate_symbols",
@@ -1054,6 +1107,21 @@ async def call_tool(name: str, arguments: dict) -> list[TextContent]:
                 if update_notice:
                     payload["_update"] = update_notice
                 return [TextContent(type="text", text=json.dumps(payload, indent=2))]
+        elif name in (
+            "bicameral.list_unclassified_decisions",
+            "list_unclassified_decisions",
+        ):
+            result = await handle_list_unclassified_decisions(
+                ctx,
+                decision_ids=arguments.get("decision_ids") or None,
+            )
+        elif name in ("bicameral.set_decision_level", "set_decision_level"):
+            result = await handle_set_decision_level(
+                ctx,
+                decision_id=arguments["decision_id"],
+                level=arguments["level"],
+                rationale=arguments.get("rationale"),
+            )
         elif name in ("bicameral.dashboard", "dashboard"):
             from contracts import DashboardResponse
 

--- a/tests/test_bulk_classify_cli.py
+++ b/tests/test_bulk_classify_cli.py
@@ -1,0 +1,164 @@
+"""Phase 4 (#77) — bulk-classify CLI tests."""
+
+from __future__ import annotations
+
+import io
+
+import pytest
+
+from cli.classify import _run, main
+from ledger.adapter import SurrealDBLedgerAdapter
+from ledger.queries import get_decision_level, update_decision_level, upsert_decision
+
+
+@pytest.fixture(autouse=True)
+def _force_memory_ledger(monkeypatch):
+    monkeypatch.setenv("USE_REAL_LEDGER", "1")
+    monkeypatch.setenv("SURREAL_URL", "memory://")
+
+
+@pytest.fixture
+async def adapter():
+    """Yield a connected memory:// SurrealDBLedgerAdapter.
+
+    memory:// SurrealDB instances are per-connection, so tests share a
+    single adapter between seed-time writes and the CLI under test.
+    """
+    a = SurrealDBLedgerAdapter(url="memory://")
+    await a.connect()
+    try:
+        yield a
+    finally:
+        await a._client.close()
+
+
+async def _seed(adapter, description: str, level: str | None = None) -> str:
+    did = await upsert_decision(
+        adapter._client,
+        description=description,
+        source_type="manual",
+        source_ref="cli-test",
+    )
+    if level is not None:
+        await update_decision_level(adapter._client, did, level)
+    return did
+
+
+@pytest.mark.asyncio
+async def test_dry_run_lists_unclassified_decisions(adapter):
+    d1 = await _seed(adapter, "Members can pause their subscription.")
+    d2 = await _seed(adapter, "Use Redis-backed sessions for scaling.")
+    d3 = await _seed(adapter, "Users can export data as CSV.")
+    await _seed(adapter, "Already classified L1.", level="L1")
+    await _seed(adapter, "Already classified L2.", level="L2")
+
+    out = io.StringIO()
+    rc = await _run(apply_changes=False, out=out, adapter=adapter)
+    assert rc == 0
+    text = out.getvalue()
+    assert d1 in text
+    assert d2 in text
+    assert d3 in text
+    assert "Already classified" not in text  # classified rows not surfaced
+    assert "Dry run" in text
+
+
+@pytest.mark.asyncio
+async def test_dry_run_does_not_mutate_ledger(adapter):
+    d1 = await _seed(adapter, "Members can pause their subscription.")
+    d2 = await _seed(adapter, "Use Redis-backed sessions for scaling.")
+
+    out = io.StringIO()
+    rc = await _run(apply_changes=False, out=out, adapter=adapter)
+    assert rc == 0
+
+    for did in (d1, d2):
+        level = await get_decision_level(adapter._client, did)
+        assert level is None, f"row {did} mutated by dry-run: level={level!r}"
+
+
+@pytest.mark.asyncio
+async def test_apply_writes_proposed_levels(adapter):
+    d1 = await _seed(adapter, "Members can pause their subscription.")
+    d2 = await _seed(adapter, "Use Redis-backed sessions for scaling.")
+    d3 = await _seed(adapter, "We will ship offline mode by Q3.")
+
+    out = io.StringIO()
+    rc = await _run(apply_changes=True, out=out, adapter=adapter)
+    assert rc == 0
+    assert "Applied 3 classifications" in out.getvalue()
+
+    assert await get_decision_level(adapter._client, d1) == "L1"
+    assert await get_decision_level(adapter._client, d2) == "L2"
+    assert await get_decision_level(adapter._client, d3) == "L3"
+
+
+@pytest.mark.asyncio
+async def test_apply_skips_already_classified(adapter):
+    d_classified = await _seed(adapter, "Already classified L3.", level="L3")
+    d_new = await _seed(adapter, "Members can pause their subscription.")
+
+    out = io.StringIO()
+    rc = await _run(apply_changes=True, out=out, adapter=adapter)
+    assert rc == 0
+
+    # The pre-classified row keeps its original level (not overwritten).
+    assert await get_decision_level(adapter._client, d_classified) == "L3"
+    # The previously-unclassified row got classified (L1 here).
+    assert await get_decision_level(adapter._client, d_new) == "L1"
+
+
+@pytest.mark.asyncio
+async def test_low_confidence_proposals_marked_in_output(adapter):
+    await _seed(adapter, "stuff happens here")  # no signal -> low confidence
+    await _seed(adapter, "Members can pause their subscription.")  # high
+
+    out = io.StringIO()
+    rc = await _run(apply_changes=False, out=out, adapter=adapter)
+    assert rc == 0
+    text = out.getvalue()
+    assert "(low confidence)" in text
+
+
+@pytest.mark.asyncio
+async def test_cli_exit_code_zero_on_success_nonzero_on_ledger_error(adapter, monkeypatch):
+    """Success path exits 0; when adapter.connect raises, exits non-zero."""
+    await _seed(adapter, "Members can pause their subscription.")
+
+    out = io.StringIO()
+    assert await _run(apply_changes=False, out=out, adapter=adapter) == 0
+
+    # Now monkey-patch SurrealDBLedgerAdapter.connect to raise — and pass
+    # adapter=None so _run owns adapter creation/connect.
+    async def _boom(self):
+        raise RuntimeError("ledger unreachable")
+
+    monkeypatch.setattr(SurrealDBLedgerAdapter, "connect", _boom)
+    out2 = io.StringIO()
+    rc = await _run(apply_changes=False, out=out2, adapter=None)
+    assert rc != 0
+    assert "ledger unreachable" in out2.getvalue()
+
+
+@pytest.mark.asyncio
+async def test_cli_progress_output_for_large_batch(adapter):
+    """When > 100 rows, progress messages print every 100 rows during --apply."""
+    for i in range(105):
+        await _seed(adapter, f"Members can do thing number {i}.")
+
+    out = io.StringIO()
+    rc = await _run(apply_changes=True, out=out, adapter=adapter)
+    assert rc == 0
+    text = out.getvalue()
+    assert "...applied 100/" in text
+
+
+def test_main_argparse_dry_run_default(monkeypatch):
+    """``main([])`` runs dry-run path and exits 0 against an empty ledger."""
+    captured = io.StringIO()
+    # Patch sys.stdout AT the cli.classify module level — that's what _run
+    # captures via ``sys.stdout``-default at call time.
+    monkeypatch.setattr("sys.stdout", captured)
+    rc = main([])
+    assert rc == 0
+    assert "Dry run" in captured.getvalue()

--- a/tests/test_classify_heuristic.py
+++ b/tests/test_classify_heuristic.py
@@ -1,0 +1,145 @@
+"""Phase 1 (#77) — heuristic classifier regression tests.
+
+Each fixture in ``tests/fixtures/ingest_level_classification/*.json`` is the
+ground-truth spec for the classifier. The ``expected_level`` field is the
+*ingest-level* outcome (after gate filters); the *classifier* itself maps
+every input to one of L1/L2/L3 (gate filters drop or park them above this
+layer). These tests assert on the classifier's L1/L2/L3 output directly.
+
+Mapping when ``expected_level`` is null:
+  - 03_strategy_not_l1 -> L3 (strategy tiebreaker: roadmap date, no behavior)
+  - 04_l2_no_fork_drop  -> L2 (interface spec; classifier is L2, gate drops it)
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from classify.heuristic import classify
+
+FIXTURE_DIR = Path(__file__).parent / "fixtures" / "ingest_level_classification"
+
+
+def _load(fixture_id: str) -> dict:
+    """Load a fixture JSON file as UTF-8 (Windows-safe)."""
+    for fp in FIXTURE_DIR.glob("*.json"):
+        if fp.stem == fixture_id or fp.stem.startswith(fixture_id):
+            with fp.open(encoding="utf-8") as f:
+                return json.load(f)
+    raise FileNotFoundError(f"Fixture {fixture_id} not found in {FIXTURE_DIR}")
+
+
+# ── One test per fixture (per-plan naming) ─────────────────────────────────
+
+
+def test_01_l1_subscription_pause_classified_as_l1():
+    data = _load("01_l1_subscription_pause")
+    level, _rationale = classify(data["source"])
+    assert level == "L1", (
+        f"Expected L1 for fixture {data['id']!r}, got {level!r}. Source: {data['source'][:80]!r}"
+    )
+
+
+def test_02_l2_redis_sessions_classified_as_l2():
+    data = _load("02_l2_redis_sessions")
+    level, _rationale = classify(data["source"])
+    assert level == "L2"
+
+
+def test_03_strategy_not_l1_classified_as_l3():
+    """Strategy tiebreaker: 'we will ship offline mode by Q3' -> L3.
+
+    Fixture has expected_level=null because the gate filter drops strategy
+    statements. The classifier itself emits L3 (strategy / roadmap intent
+    without observable behavior).
+    """
+    data = _load("03_strategy_not_l1")
+    level, rationale = classify(data["source"])
+    assert level == "L3"
+    assert "strategy" in rationale.lower() or "roadmap" in rationale.lower()
+
+
+def test_04_l2_no_fork_drop_classified_as_l2():
+    """Interface spec -> L2. Fixture has expected_level=null because the
+    Gate-2 (fork-required) filter drops it, but the classifier still tags
+    the technical content as L2."""
+    data = _load("04_l2_no_fork_drop")
+    level, _rationale = classify(data["source"])
+    assert level == "L2"
+
+
+def test_05_l2_driver_inferred_from_l1_classified_as_l2():
+    data = _load("05_l2_driver_inferred_from_l1")
+    level, _rationale = classify(data["source"])
+    assert level == "L2"
+
+
+def test_06_l1_offline_behavior_classified_as_l1():
+    data = _load("06_l1_offline_behavior")
+    level, _rationale = classify(data["source"])
+    assert level == "L1"
+
+
+def test_07_l2_no_driver_context_pending_classified_as_l2():
+    data = _load("07_l2_no_driver_context_pending")
+    level, _rationale = classify(data["source"])
+    assert level == "L2"
+
+
+# ── Behavioral / API contract tests ────────────────────────────────────────
+
+
+def test_classify_falls_through_to_l3_when_no_signal():
+    """Empty / generic input -> L3 with low-confidence rationale."""
+    level, rationale = classify("")
+    assert level == "L3"
+    assert "low confidence" in rationale.lower()
+
+    level2, rationale2 = classify("blah blah generic words")
+    assert level2 == "L3"
+    assert "low confidence" in rationale2.lower()
+
+
+def test_classify_returns_rationale_for_audit():
+    """Rationale string explains which signal matched. The bulk-classify
+    CLI uses this for the dry-run proposal table."""
+    level, rationale = classify("Members can pause their subscription for up to 90 days.")
+    assert level == "L1"
+    assert isinstance(rationale, str)
+    assert rationale  # non-empty
+    # Audit string mentions the level and either a role or a signal
+    assert "L1" in rationale
+    assert "Members" in rationale or "role" in rationale
+
+
+def test_classify_pure_function():
+    """Same input twice yields the same output. No IO, no network."""
+    sample = "Users can export their data as CSV at any time."
+    a = classify(sample)
+    b = classify(sample)
+    assert a == b
+
+    # And with both args set
+    c = classify("desc", "src body")
+    d = classify("desc", "src body")
+    assert c == d
+
+
+def test_classify_returns_only_valid_levels():
+    """Sanity: every fixture (and a synthetic empty input) yields a
+    valid {L1, L2, L3} level."""
+    valid = {"L1", "L2", "L3"}
+    samples = [
+        "",
+        "blah",
+        "We will ship offline mode by Q3.",
+        "Members can pause their subscription.",
+        "Use Redis for sessions.",
+        "max key length 36 chars — Zoom SDK hard limit.",
+    ]
+    for s in samples:
+        level, _ = classify(s)
+        assert level in valid, f"unexpected level {level!r} for input {s!r}"

--- a/tests/test_list_unclassified_decisions_handler.py
+++ b/tests/test_list_unclassified_decisions_handler.py
@@ -1,0 +1,106 @@
+"""Phase 3 (#77) — list_unclassified_decisions handler tests."""
+
+from __future__ import annotations
+
+import pytest
+
+from handlers.list_unclassified_decisions import handle_list_unclassified_decisions
+from ledger.adapter import SurrealDBLedgerAdapter
+from ledger.queries import update_decision_level, upsert_decision
+
+
+class _Ctx:
+    """Minimal BicameralContext stand-in for handler tests."""
+
+    def __init__(self, ledger):
+        self.ledger = ledger
+
+
+@pytest.fixture
+async def ctx_with_ledger(monkeypatch):
+    monkeypatch.setenv("USE_REAL_LEDGER", "1")
+    monkeypatch.setenv("SURREAL_URL", "memory://")
+    adapter = SurrealDBLedgerAdapter(url="memory://")
+    await adapter.connect()
+    try:
+        yield _Ctx(adapter)
+    finally:
+        await adapter._client.close()
+
+
+async def _seed_decision(ctx, description: str, level: str | None = None) -> str:
+    did = await upsert_decision(
+        ctx.ledger._client,
+        description=description,
+        source_type="manual",
+        source_ref="test",
+    )
+    if level is not None:
+        await update_decision_level(ctx.ledger._client, did, level)
+    return did
+
+
+@pytest.mark.asyncio
+async def test_list_unclassified_returns_only_null_rows(ctx_with_ledger):
+    ctx = ctx_with_ledger
+    # 3 NULL + 2 classified
+    await _seed_decision(ctx, "Members can pause their subscription.")
+    await _seed_decision(ctx, "Use Redis-backed sessions for scaling.")
+    await _seed_decision(ctx, "Users can export data as CSV.")
+    await _seed_decision(ctx, "Already L1 row.", level="L1")
+    await _seed_decision(ctx, "Already L2 row.", level="L2")
+
+    response = await handle_list_unclassified_decisions(ctx)
+    assert response.total_count == 3
+    assert len(response.proposals) == 3
+    descs = sorted(p.description for p in response.proposals)
+    assert descs == sorted(
+        [
+            "Members can pause their subscription.",
+            "Use Redis-backed sessions for scaling.",
+            "Users can export data as CSV.",
+        ]
+    )
+
+
+@pytest.mark.asyncio
+async def test_list_unclassified_filters_by_decision_ids(ctx_with_ledger):
+    ctx = ctx_with_ledger
+    d1 = await _seed_decision(ctx, "Members can pause their subscription.")
+    d2 = await _seed_decision(ctx, "Use Redis-backed sessions for scaling.")
+    await _seed_decision(ctx, "Users can export data as CSV.")  # not in filter
+
+    response = await handle_list_unclassified_decisions(ctx, decision_ids=[d1, d2])
+    assert response.total_count == 2
+    returned_ids = {p.decision_id for p in response.proposals}
+    assert returned_ids == {d1, d2}
+
+
+@pytest.mark.asyncio
+async def test_list_unclassified_includes_proposed_level_and_rationale(ctx_with_ledger):
+    ctx = ctx_with_ledger
+    await _seed_decision(ctx, "Members can pause their subscription for up to 90 days.")
+    await _seed_decision(ctx, "Use Redis-backed session storage for horizontal scaling.")
+
+    response = await handle_list_unclassified_decisions(ctx)
+    proposals_by_desc = {p.description: p for p in response.proposals}
+    p_l1 = proposals_by_desc["Members can pause their subscription for up to 90 days."]
+    p_l2 = proposals_by_desc["Use Redis-backed session storage for horizontal scaling."]
+    assert p_l1.proposed_level == "L1"
+    assert p_l1.rationale  # non-empty
+    assert p_l2.proposed_level == "L2"
+    assert p_l2.rationale
+
+
+@pytest.mark.asyncio
+async def test_list_unclassified_marks_low_confidence(ctx_with_ledger):
+    ctx = ctx_with_ledger
+    # Generic text with no L1/L2/L3 signal -> defaults to L3 with low confidence
+    await _seed_decision(ctx, "stuff happens here")
+    # And one with strong L1 signal
+    await _seed_decision(ctx, "Users can pause their subscription.")
+
+    response = await handle_list_unclassified_decisions(ctx)
+    proposals_by_desc = {p.description: p for p in response.proposals}
+    assert proposals_by_desc["stuff happens here"].confidence == "low"
+    assert proposals_by_desc["Users can pause their subscription."].confidence == "high"

--- a/tests/test_set_decision_level_handler.py
+++ b/tests/test_set_decision_level_handler.py
@@ -1,0 +1,82 @@
+"""Phase 3 (#77) — set_decision_level handler tests."""
+
+from __future__ import annotations
+
+import pytest
+
+from handlers.list_unclassified_decisions import handle_list_unclassified_decisions
+from handlers.set_decision_level import handle_set_decision_level
+from ledger.adapter import SurrealDBLedgerAdapter
+from ledger.queries import upsert_decision
+
+
+class _Ctx:
+    def __init__(self, ledger):
+        self.ledger = ledger
+
+
+@pytest.fixture
+async def ctx_with_ledger(monkeypatch):
+    monkeypatch.setenv("USE_REAL_LEDGER", "1")
+    monkeypatch.setenv("SURREAL_URL", "memory://")
+    adapter = SurrealDBLedgerAdapter(url="memory://")
+    await adapter.connect()
+    try:
+        yield _Ctx(adapter)
+    finally:
+        await adapter._client.close()
+
+
+async def _seed_decision(ctx, description: str) -> str:
+    return await upsert_decision(
+        ctx.ledger._client,
+        description=description,
+        source_type="manual",
+        source_ref="test",
+    )
+
+
+@pytest.mark.asyncio
+async def test_set_decision_level_writes_value(ctx_with_ledger):
+    ctx = ctx_with_ledger
+    did = await _seed_decision(ctx, "Members can pause their subscription.")
+
+    response = await handle_set_decision_level(ctx, decision_id=did, level="L1")
+    assert response.ok is True
+    assert response.decision_id == did
+    assert response.level == "L1"
+    assert response.error is None
+
+    # Subsequent list_unclassified call must not include this row
+    list_resp = await handle_list_unclassified_decisions(ctx)
+    assert all(p.decision_id != did for p in list_resp.proposals)
+
+
+@pytest.mark.asyncio
+async def test_set_decision_level_invalid_level_returns_error_response(ctx_with_ledger):
+    ctx = ctx_with_ledger
+    did = await _seed_decision(ctx, "Members can pause their subscription.")
+
+    response = await handle_set_decision_level(ctx, decision_id=did, level="L4")
+    assert response.ok is False
+    assert response.decision_id == did
+    assert response.level is None
+    assert response.error is not None
+    assert "invalid level" in response.error.lower()
+
+    # Confirm no write happened — row still unclassified
+    list_resp = await handle_list_unclassified_decisions(ctx)
+    assert any(p.decision_id == did for p in list_resp.proposals)
+
+
+@pytest.mark.asyncio
+async def test_set_decision_level_unknown_id_returns_error_response(ctx_with_ledger):
+    ctx = ctx_with_ledger
+    response = await handle_set_decision_level(
+        ctx,
+        decision_id="decision:does_not_exist",
+        level="L1",
+    )
+    assert response.ok is False
+    assert response.error is not None
+    assert "not found" in response.error.lower() or "does_not_exist" in response.error

--- a/tests/test_update_decision_level_query.py
+++ b/tests/test_update_decision_level_query.py
@@ -1,0 +1,101 @@
+"""Phase 2 (#77) — write helper regression tests.
+
+Exercises ``ledger.queries.update_decision_level`` directly against a
+memory:// SurrealDB instance, covering happy path, defensive validation,
+idempotency, and unknown-decision-id behaviour.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from ledger.client import LedgerClient
+from ledger.queries import (
+    DecisionNotFound,
+    get_decision_level,
+    update_decision_level,
+    upsert_decision,
+)
+from ledger.schema import init_schema
+
+
+@pytest.fixture
+async def client():
+    """Yield a connected memory:// LedgerClient with schema applied."""
+    c = LedgerClient(url="memory://")
+    await c.connect()
+    await init_schema(c)
+    try:
+        yield c
+    finally:
+        await c.close()
+
+
+@pytest.fixture
+async def decision_id(client):
+    """Create a fresh decision row and return its full record id."""
+    did = await upsert_decision(
+        client,
+        description="Members can pause their subscription for up to 90 days.",
+        source_type="manual",
+        source_ref="test-fixture",
+    )
+    assert did.startswith("decision:"), f"unexpected id shape: {did!r}"
+    return did
+
+
+# ── Happy path ─────────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_update_decision_level_writes_value(client, decision_id):
+    """Writing 'L2' is observable via get_decision_level."""
+    await update_decision_level(client, decision_id, "L2")
+    level = await get_decision_level(client, decision_id)
+    assert level == "L2"
+
+
+# ── Defensive validation ───────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_update_decision_level_rejects_invalid_value(client, decision_id):
+    """Writing 'L4' raises ValueError before any DB query runs."""
+    with pytest.raises(ValueError, match="invalid level"):
+        await update_decision_level(client, decision_id, "L4")
+    # Ensure nothing got written
+    assert await get_decision_level(client, decision_id) is None
+
+
+@pytest.mark.asyncio
+async def test_update_decision_level_rejects_malformed_id(client):
+    """Malformed decision_id raises ValueError (audit S1 defense-in-depth)."""
+    with pytest.raises(ValueError, match="invalid decision_id shape"):
+        await update_decision_level(client, "foo bar", "L2")
+    with pytest.raises(ValueError, match="invalid decision_id shape"):
+        await update_decision_level(client, "not_a_record_id", "L2")
+    with pytest.raises(ValueError, match="invalid decision_id shape"):
+        await update_decision_level(client, "decision:abc;DROP TABLE x;", "L2")
+
+
+# ── Idempotency ────────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_update_decision_level_idempotent(client, decision_id):
+    """Writing the same level twice is a no-op (no errors, value unchanged)."""
+    await update_decision_level(client, decision_id, "L1")
+    await update_decision_level(client, decision_id, "L1")
+    assert await get_decision_level(client, decision_id) == "L1"
+
+
+# ── Unknown decision id ────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_update_decision_level_unknown_decision_id(client):
+    """Writing to a syntactically valid but nonexistent decision_id raises
+    DecisionNotFound with the bad id."""
+    with pytest.raises(DecisionNotFound) as exc_info:
+        await update_decision_level(client, "decision:does_not_exist", "L2")
+    assert "decision:does_not_exist" in str(exc_info.value)


### PR DESCRIPTION
## Summary

Implements Phases 1-4 of [plan-decision-level-ux-76-77.md](https://github.com/BicameralAI/bicameral-mcp/blob/dev/plan-decision-level-ux-76-77.md) — the Python half of the decision_level UX bundle. The companion #76 dashboard work (Phases 5-6: amber unclassified badge, filter dropdown, inline edit POST endpoint) ships in a sibling PR against the same `dev` branch.

- **`classify/heuristic.py`** — pure-function heuristic classifier porting the L1/L2/L3 rules from `skills/bicameral-ingest/SKILL.md` (lines 178-217). Deterministic, no IO, no LLM, no network. 7/7 of the regression fixtures at `tests/fixtures/ingest_level_classification/` pass.
- **`ledger/queries.py::update_decision_level`** — single-row write helper next to `set_decision_status` (~line 986). Idempotent. Defensive `_DECISION_ID_RE` shape regex (`^decision:[A-Za-z0-9_]+$`) validates record-id before SurrealQL interpolation (audit S1 defense-in-depth). Raises `DecisionNotFound` (subclass of `LedgerError`) on missing rows.
- **Two MCP primitives** (NOT a bulk wrapper):
  - `bicameral.list_unclassified_decisions(decision_ids?)` — read-only, returns `proposals[]` with `proposed_level`, `rationale`, and `confidence` ("low" when the heuristic defaulted with no signal).
  - `bicameral.set_decision_level(decision_id, level, rationale?)` — single-row write, idempotent. Errors come back structured (`{ok: false, error: ...}`) rather than raised, so an agent loop can recover per-row.
- **`bicameral-mcp-classify` CLI** (entrypoint at `cli.classify:main`). Default is dry-run (proposal table). `--apply` writes via the same `update_decision_level` helper. Progress every 100 rows for large batches.

## Two-tool decomposition rationale

Per the plan's "Decisions" section, MCP exposure is a **two-tool decomposition** rather than a bulk wrapper:
- **DRY** — one write path (`ledger.queries.update_decision_level`), three callers (CLI, MCP tool, future dashboard endpoint).
- **Per-row recovery** — agent observes each result; no partial-batch failure modes.
- **Composability** — agent loops `list -> review -> set` per row; idiomatic MCP.

## Test results

```
$ pytest tests/test_classify_heuristic.py \
         tests/test_update_decision_level_query.py \
         tests/test_list_unclassified_decisions_handler.py \
         tests/test_set_decision_level_handler.py \
         tests/test_bulk_classify_cli.py \
         tests/test_phase2_ledger.py
============ 46 passed in 8.42s ============
```

- **Phase 1 classifier**: 11 tests (7 fixtures, fall-through-to-L3, audit rationale, pure function, valid-levels invariants).
- **Phase 2 write helper**: 5 tests (writes value, rejects invalid level, rejects malformed id, idempotent, unknown decision_id raises `DecisionNotFound`).
- **Phase 3 list handler**: 4 tests (only NULL rows, filter by ids, includes proposed_level + rationale, marks low confidence).
- **Phase 3 set handler**: 3 tests (writes value, invalid level → structured error, unknown id → structured error).
- **Phase 4 CLI**: 8 tests (dry-run lists, no-mutate, apply writes, skips classified, low-confidence marker, exit codes, progress > 100, argparse default).
- **Phase 2 ledger regression** (`tests/test_phase2_ledger.py`): 15/15 pass.

Lint/format/type:
```
$ ruff check . && ruff format --check . && mypy .
All checks passed!
174 files already formatted
Success: no issues found in 90 source files
```

## Sibling PR

The dashboard work for #76 (amber `lvl-unclassified` badge, filter dropdown, inline edit POST endpoint) lands in a sibling PR. This PR avoids `assets/dashboard.html` and `dashboard/server.py` entirely — those are the dashboard agent's surface.

## Labels

This PR is `flow:feature` — to be applied via `gh pr edit ... --add-label flow:feature` immediately after open.

Closes #77
Cross-ref #76 (sibling PR)

🤖 Generated with [Claude Code](https://claude.com/claude-code)