### PR TITLE
feat: governance contracts + escalation engine (v0.17.0, #108-#110 P1-P3)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,28 @@
 All notable changes to bicameral-mcp are tracked here. Format loosely follows
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
+## v0.17.0 -- governance contracts + escalation engine (#108-#110, Phases 1-3 of #108-#112 plan)
+
+Adds `governance/` package with the deterministic escalation policy engine, decision/risk/escalation metadata contracts, and the consolidated `GovernanceFinding` wrapper. Engine is non-blocking by design (`config.allow_blocking: Literal[False]` locks the type). Phase 4 (HITL bypass flow) and Phase 5 (docs) ship in follow-up PRs.
+
+### Added
+- `governance/contracts.py` -- GovernanceMetadata, GovernanceFinding, GovernancePolicyResult; `derive_governance_metadata` with L1/L2/L3 default mapping
+- `governance/finding_factories.py` -- builders + `consolidate()` per (decision_id, region_id)
+- `governance/engine.py` -- pure deterministic evaluator decomposed into `_check_required_conditions`, `_apply_class_defaults`, `_apply_bypass_downgrade`, `_apply_max_native_ceiling`
+- `governance/config.py` -- `.bicameral/governance.yml` parser with locked `allow_blocking: Literal[False]`; fail-soft on malformed YAML
+- `bicameral.evaluate_governance` MCP tool (read-only)
+- `governance_finding` field on PreflightResponse
+- `decision.governance` schema field (v14 -> v15 migration)
+- `docs/governance.example.yml` canonical config example
+
+### Closes
+
+#109, #110 (Phases 1-2 fully)
+
+### Refs
+
+#108 (engine landed; Phase 4 HITL bypass flow ships separately for #112)
+
 ## [Unreleased]
 
 ### Added

--- a/contracts.py
+++ b/contracts.py
@@ -18,6 +18,8 @@ from typing import Literal
 
 from pydantic import BaseModel, ConfigDict, Field
 
+from governance.contracts import GovernanceFinding
+
 # ── Skill telemetry diagnostic models ────────────────────────────────
 # One model per skill. extra="forbid" means the handler can detect and
 # echo back any field names the LLM sent that don't belong here.
@@ -465,6 +467,11 @@ class IngestMapping(BaseModel):
     feature_group: str | None = None
     decision_level: str | None = None  # L1 | L2 | L3
     parent_decision_id: str | None = None
+    # #109 — optional governance metadata. None means derive from
+    # decision_level via governance.contracts.derive_governance_metadata
+    # at evaluation time. Stored as a free-form dict on the wire so the
+    # ingest contract doesn't pull pydantic types from governance.*.
+    governance: dict | None = None
 
 
 class IngestDecision(BaseModel):
@@ -489,6 +496,8 @@ class IngestDecision(BaseModel):
     source_excerpt: str = ""
     signoff: dict | None = None
     feature_group: str | None = None
+    # #109 — optional governance metadata threaded to the ledger.
+    governance: dict | None = None
 
 
 class IngestActionItem(BaseModel):
@@ -652,6 +661,31 @@ class PreflightResponse(BaseModel):
     # #65 — opaque per-call id for the preflight telemetry capture loop.
     # None when telemetry is disabled (BICAMERAL_PREFLIGHT_TELEMETRY != 1).
     preflight_id: str | None = None
+    # #108-#110 — consolidated governance finding (with attached
+    # policy_result) when preflight surfaced one or more drift candidates
+    # for a region-anchored decision. None when there are no findings.
+    # Phase 4 (#112) will populate ``policy_result.action`` with
+    # bypass-aware downgrades; Phase 3 always passes
+    # ``bypass_recency_seconds=None`` to the engine.
+    governance_finding: GovernanceFinding | None = None
+
+
+# ── Tool: bicameral.evaluate_governance (#108) ───────────────────────
+
+
+class EvaluateGovernanceResponse(BaseModel):
+    """Response envelope for ``bicameral.evaluate_governance``.
+
+    Read-only ad-hoc evaluation: given a (decision_id, region_id?)
+    pair, returns the engine's policy result for the synthetic finding
+    constructed from the current ledger state. ``error`` is set when
+    the decision_id is unknown; ``finding`` is None in that case.
+    """
+
+    decision_id: str
+    region_id: str | None = None
+    finding: GovernanceFinding | None = None
+    error: str | None = None
 
 
 # ── Tool 10: /bicameral_judge_gaps ───────────────────────────────────
@@ -785,6 +819,10 @@ class HistoryDecision(BaseModel):
     decision_level: str | None = None  # L1 | L2 | L3 — for balance-sheet display
     parent_decision_id: str | None = None
     ephemeral: bool = False  # True when current status was determined by a feature-branch commit not yet in authoritative ref
+    # #109 — optional governance metadata when present on the decision
+    # row. Pre-v15 rows omit this; readers fall back to defaults derived
+    # from decision_level at evaluation time.
+    governance: dict | None = None
 
 
 class HistoryFeature(BaseModel):

--- a/docs/governance.example.yml
+++ b/docs/governance.example.yml
@@ -1,0 +1,111 @@
+# Bicameral governance config — canonical example.
+#
+# Copy to .bicameral/governance.yml at the repo root and tune to your
+# project. Bicameral's deterministic escalation engine reads this file
+# at startup; missing keys fall back to the baked-in `transparency_first`
+# defaults, malformed YAML falls back to defaults with a stderr warning,
+# and `allow_blocking` is locked at False (pydantic refuses any other
+# value — Bicameral never blocks work).
+#
+# Phases 1-3 of #108-#112 ship with this example; later phases (HITL
+# bypass flow + architecture docs) reference it verbatim.
+
+version: 1
+mode: transparency_first
+
+# Locked at False at the type level. Listed here for documentation
+# only — pydantic raises ValidationError if you set this to True.
+allow_blocking: false
+
+# When multiple findings collide on (decision_id, region_id), the
+# strongest semantic_status wins (consolidate() in finding_factories).
+strongest_result_wins: true
+
+# Maximum native action the engine will ever choose. The action ladder
+# is: ignore < context < warn < escalate < notify_supervisor <
+# system_wide_warning. Anything stronger than this ceiling is clamped.
+max_native_action: system_wide_warning
+
+# Components that should always be treated as protected_component=true
+# regardless of per-decision metadata. Free-form glob/path strings that
+# downstream consumers can match against decision binding regions.
+protected_components: []
+
+# Per-decision-class policies. Class keys must be one of the eight
+# values in GovernanceMetadata.decision_class:
+#   product_behavior | architecture | security | compliance |
+#   data_contract | operational_reliability |
+#   implementation_preference | experimental
+decision_classes:
+  security:
+    default_action: escalate
+    supervisor_notification_allowed: true
+    system_wide_warning_allowed: true
+    escalation_thresholds:
+      drift_confidence: 0.7
+      binding_confidence: 0.7
+    supervisor_thresholds:
+      drift_confidence: 0.85
+      binding_confidence: 0.85
+
+  compliance:
+    default_action: escalate
+    supervisor_notification_allowed: true
+    system_wide_warning_allowed: false
+    escalation_thresholds:
+      drift_confidence: 0.7
+      binding_confidence: 0.7
+    supervisor_thresholds:
+      drift_confidence: 0.85
+      binding_confidence: 0.85
+
+  architecture:
+    default_action: warn
+    supervisor_notification_allowed: false
+    system_wide_warning_allowed: false
+    escalation_thresholds:
+      drift_confidence: 0.7
+      binding_confidence: 0.7
+
+  product_behavior:
+    default_action: warn
+    supervisor_notification_allowed: false
+    system_wide_warning_allowed: false
+    escalation_thresholds:
+      drift_confidence: 0.7
+      binding_confidence: 0.7
+
+  data_contract:
+    default_action: escalate
+    supervisor_notification_allowed: true
+    escalation_thresholds:
+      drift_confidence: 0.7
+      binding_confidence: 0.7
+    supervisor_thresholds:
+      drift_confidence: 0.85
+      binding_confidence: 0.85
+
+  operational_reliability:
+    default_action: warn
+    supervisor_notification_allowed: false
+
+  implementation_preference:
+    default_action: context
+    supervisor_notification_allowed: false
+
+  experimental:
+    default_action: context
+    supervisor_notification_allowed: false
+
+# Conditions the engine evaluates before allowing a finding to escalate
+# all the way to supervisor_notification. Each must be true for the
+# matched_conditions ladder to clear. Names are stable; future versions
+# may add to this list (unknown names are reported as missing for the
+# audit trail).
+required_conditions_for_supervisor_notification:
+  - decision_status_is_ratified
+  - decision_is_active
+  - protected_decision_class
+  - no_superseding_decision
+  - drift_confidence_above_threshold
+  - binding_confidence_above_threshold

--- a/governance/__init__.py
+++ b/governance/__init__.py
@@ -1,0 +1,14 @@
+"""Governance package — semantic drift escalation policy engine.
+
+Phases 1-3 of the governance plan (#108-#110):
+  - contracts: ``GovernanceMetadata``, ``GovernanceFinding``,
+    ``GovernancePolicyResult`` Pydantic models + ``derive_governance_metadata``
+  - finding_factories: builders + ``consolidate()`` for collapsing findings
+    per ``(decision_id, region_id)``
+  - config: ``.bicameral/governance.yml`` parser; ``allow_blocking`` is
+    locked to ``Literal[False]`` at the type level
+  - engine: pure deterministic ``evaluate()`` orchestrator
+
+Phase 4 (#112 HITL bypass flow) and Phase 5 (#111 docs) ship in
+follow-up PRs.
+"""

--- a/governance/config.py
+++ b/governance/config.py
@@ -1,0 +1,85 @@
+"""Governance config — parse ``.bicameral/governance.yml``.
+
+Fail-soft posture: a missing or malformed config falls back to the
+baked-in ``transparency_first`` defaults with a stderr warning. The
+non-blocking absolute is enforced at the type level via
+``allow_blocking: Literal[False]`` — pydantic raises if a config tries
+to set it to ``True``.
+"""
+
+from __future__ import annotations
+
+import logging
+from pathlib import Path
+from typing import Literal
+
+import yaml
+from pydantic import BaseModel, ValidationError
+
+logger = logging.getLogger(__name__)
+
+
+_NativeAction = Literal[
+    "context",
+    "warn",
+    "escalate",
+    "notify_supervisor",
+    "system_wide_warning",
+]
+
+
+class DecisionClassPolicy(BaseModel):
+    """Per-class policy: default action plus per-class thresholds."""
+
+    default_action: _NativeAction = "warn"
+    supervisor_notification_allowed: bool = False
+    system_wide_warning_allowed: bool = False
+    escalation_thresholds: dict[str, float] = {}
+    supervisor_thresholds: dict[str, float] = {}
+
+
+class GovernanceConfig(BaseModel):
+    """Parsed and validated ``.bicameral/governance.yml``.
+
+    ``allow_blocking`` is locked at ``Literal[False]`` to enforce the
+    non-blocking absolute at the type level. Pydantic refuses any other
+    value at parse time, so the engine never has to special-case
+    "what if a user tries to enable blocking" — they can't.
+    """
+
+    version: int = 1
+    mode: Literal["transparency_first"] = "transparency_first"
+    allow_blocking: Literal[False] = False
+    strongest_result_wins: bool = True
+    max_native_action: _NativeAction = "system_wide_warning"
+    protected_components: list[str] = []
+    decision_classes: dict[str, DecisionClassPolicy] = {}
+    required_conditions_for_supervisor_notification: list[str] = [
+        "decision_status_is_ratified",
+        "decision_is_active",
+        "protected_decision_class",
+        "no_superseding_decision",
+        "drift_confidence_above_threshold",
+        "binding_confidence_above_threshold",
+    ]
+
+
+def load_config(path: Path | None = None) -> GovernanceConfig:
+    """Read ``.bicameral/governance.yml`` and return a ``GovernanceConfig``.
+
+    Fail-soft: returns baked-in defaults on missing file, malformed
+    YAML, or pydantic validation errors. Logs a warning to stderr in
+    the latter two cases so users notice silently broken config files.
+
+    All YAML parsing uses ``yaml.safe_load`` — never ``yaml.load`` —
+    to prevent arbitrary tag-driven object construction.
+    """
+    target = path if path is not None else (Path.cwd() / ".bicameral" / "governance.yml")
+    if not target.exists():
+        return GovernanceConfig()
+    try:
+        raw = yaml.safe_load(target.read_text(encoding="utf-8"))
+        return GovernanceConfig.model_validate(raw or {})
+    except (yaml.YAMLError, ValidationError) as exc:
+        logger.warning("[governance] malformed %s: %s -- using defaults", target, exc)
+        return GovernanceConfig()

--- a/governance/contracts.py
+++ b/governance/contracts.py
@@ -1,0 +1,166 @@
+"""Governance contracts — Pydantic models for the deterministic
+escalation policy engine.
+
+Phase 1 (#109): ``GovernanceMetadata`` + ``derive_governance_metadata``
+helper that maps the existing L1/L2/L3 ``decision_level`` axis to
+sensible (decision_class, risk_class, escalation_class) defaults.
+
+Phase 2 (#110): ``GovernanceFinding`` + ``GovernancePolicyResult`` —
+the consolidation wrapper and the engine's output type. The Finding
+carries an optional ``policy_result`` populated by Phase 3's engine.
+
+Phase 4 (#112) will extend this module with ``HITLPrompt`` /
+``HITLPromptOption`` for the bypassable preflight clarification flow.
+That ships separately.
+"""
+
+from __future__ import annotations
+
+from typing import Literal
+
+from pydantic import BaseModel
+
+# ── Phase 1: GovernanceMetadata ──────────────────────────────────────
+
+
+class GovernanceMetadata(BaseModel):
+    """Per-decision governance classification.
+
+    Orthogonal to the existing ``decision_level`` (L1/L2/L3) axis:
+    L1/L2/L3 captures CodeGenome identity-write semantics, while
+    GovernanceMetadata captures escalation visibility. The two
+    coexist; ``derive_governance_metadata`` provides a sensible
+    default mapping when explicit metadata is absent.
+    """
+
+    decision_class: Literal[
+        "product_behavior",
+        "architecture",
+        "security",
+        "compliance",
+        "data_contract",
+        "operational_reliability",
+        "implementation_preference",
+        "experimental",
+    ] = "product_behavior"
+    risk_class: Literal["low", "medium", "high", "critical"] = "medium"
+    escalation_class: Literal[
+        "context_only",
+        "warn",
+        "escalate",
+        "notify_supervisor_allowed",
+        "system_wide_warning_allowed",
+    ] = "warn"
+    owner: str | None = None
+    supervisor: str | None = None
+    notification_channels: list[str] = []
+    protected_component: bool = False
+    review_after: str | None = None
+
+
+# Default mapping from decision_level (L1/L2/L3 or None) to a 3-tuple of
+# (decision_class, risk_class, escalation_class). Used when explicit
+# governance metadata isn't supplied — see ``derive_governance_metadata``.
+_L1L2L3_DEFAULTS: dict[str | None, tuple[str, str, str]] = {
+    "L1": ("product_behavior", "medium", "warn"),
+    "L2": ("architecture", "medium", "escalate"),
+    "L3": ("implementation_preference", "low", "context_only"),
+    None: ("product_behavior", "medium", "warn"),
+}
+
+
+def derive_governance_metadata(
+    decision_level: str | None,
+    explicit: GovernanceMetadata | None,
+) -> GovernanceMetadata:
+    """Resolve effective governance metadata for a decision.
+
+    Explicit metadata wins; otherwise derive from ``decision_level``
+    using the L1/L2/L3 default table. Unknown levels (or ``None``)
+    fall back to L1 defaults.
+    """
+    if explicit is not None:
+        return explicit
+    dc, rc, ec = _L1L2L3_DEFAULTS.get(decision_level, _L1L2L3_DEFAULTS[None])
+    return GovernanceMetadata(
+        decision_class=dc,  # type: ignore[arg-type]
+        risk_class=rc,  # type: ignore[arg-type]
+        escalation_class=ec,  # type: ignore[arg-type]
+    )
+
+
+# ── Phase 2: GovernanceFinding + GovernancePolicyResult ─────────────
+
+
+class GovernancePolicyResult(BaseModel):
+    """Output of the deterministic escalation evaluator (Phase 3).
+
+    ``action`` is the visibility action selected by the policy engine
+    after applying class defaults, semantic-status severity bumps,
+    bypass downgrades, and the ``max_native_action`` ceiling. The
+    engine is non-blocking by design: ``config.allow_blocking`` is
+    locked at ``Literal[False]`` so no action is ever a merge block.
+    """
+
+    action: Literal[
+        "ignore",
+        "context",
+        "warn",
+        "escalate",
+        "notify_supervisor",
+        "system_wide_warning",
+    ]
+    gate: str
+    reason: str
+    matched_conditions: list[str] = []
+    missing_conditions: list[str] = []
+    evidence_refs: list[str] = []
+    suggested_recipients: list[str] = []
+    requires_human_resolution: bool = False
+
+
+class GovernanceFinding(BaseModel):
+    """Consolidated finding wrapper that the engine evaluates.
+
+    A finding represents one (decision_id, region_id) pair plus the
+    semantic status of whatever change was observed. Findings can come
+    from compliance verdicts, drift entries, preflight drift candidates,
+    or LLM judges; ``finding_factories`` provides the builders. The
+    ``policy_result`` field is populated by ``engine.evaluate`` after
+    construction.
+    """
+
+    finding_id: str  # UUIDv4
+    decision_id: str
+    region_id: str | None = None
+
+    decision_class: str | None = None
+    risk_class: str | None = None
+    escalation_class: str | None = None
+
+    source: Literal[
+        "preflight",
+        "drift",
+        "resolve_compliance",
+        "link_commit",
+        "scan_branch",
+        "llm_judge",
+    ]
+
+    semantic_status: Literal[
+        "not_relevant",
+        "cosmetic_change",
+        "behavior_preserving_refactor",
+        "possible_drift",
+        "likely_drift",
+        "confirmed_drift",
+        "critical_drift",
+        "supersession_candidate",
+        "binding_uncertain",
+        "needs_human_review",
+    ]
+
+    confidence: dict[str, float | str] = {}
+    explanation: str
+    evidence_refs: list[str] = []
+    policy_result: GovernancePolicyResult | None = None

--- a/governance/engine.py
+++ b/governance/engine.py
@@ -1,0 +1,292 @@
+"""Deterministic escalation policy engine.
+
+The engine is a **pure function** over four inputs:
+
+  1. A ``GovernanceFinding`` describing what was observed.
+  2. The decision's ``GovernanceMetadata`` (or its L1/L2/L3-derived
+     defaults — see ``governance.contracts.derive_governance_metadata``).
+  3. The user's ``GovernanceConfig`` parsed from
+     ``.bicameral/governance.yml``.
+  4. The current ``decision_status`` (signoff state) and an optional
+     ``bypass_recency_seconds`` scalar.
+
+No IO, no clock, no state. Bypass recency is a **scalar parameter**
+computed at the call site (preflight handler reads
+``preflight_telemetry.recent_bypass_seconds`` in Phase 4 once the
+HITL flow lands; until then preflight passes ``None``).
+
+The orchestrator ``evaluate()`` is ~15 LOC of straight-line composition
+over four bounded helpers — each helper is independently unit-testable.
+"""
+
+from __future__ import annotations
+
+from typing import Literal
+
+from governance.config import GovernanceConfig
+from governance.contracts import (
+    GovernanceFinding,
+    GovernanceMetadata,
+    GovernancePolicyResult,
+)
+
+# Decision lifecycle signoff states the engine reads. Mirrors the
+# values used in handlers/decision_status.py and the signoff field of
+# the decision schema. ``ratified`` and ``active`` are the "good"
+# states for supervisor notification; the rest indicate the decision
+# is not yet live or has been superseded.
+DecisionStatus = Literal[
+    "ratified",
+    "proposed",
+    "rejected",
+    "superseded",
+    "active",
+    "ungrounded",
+    "context_pending",
+    "collision_pending",
+]
+
+
+# Action ladder: index = severity. Used for ceiling enforcement and
+# bypass-induced tier downgrades.
+_ACTION_LADDER: tuple[str, ...] = (
+    "ignore",
+    "context",
+    "warn",
+    "escalate",
+    "notify_supervisor",
+    "system_wide_warning",
+)
+
+_BYPASS_RECENCY_WINDOW_SECONDS = 3600  # 1 hour
+
+# Severity ordering for the semantic_status enum on findings — used
+# by ``_apply_class_defaults`` to bump the per-class default action
+# when the observed semantic status warrants it. Mirrors the order in
+# ``finding_factories._SEMANTIC_SEVERITY`` but kept private here so
+# the engine isn't coupled to the factory module's internals.
+_SEMANTIC_RANK: dict[str, int] = {
+    "not_relevant": 0,
+    "cosmetic_change": 1,
+    "behavior_preserving_refactor": 1,
+    "binding_uncertain": 2,
+    "supersession_candidate": 2,
+    "needs_human_review": 3,
+    "possible_drift": 3,
+    "likely_drift": 4,
+    "confirmed_drift": 5,
+    "critical_drift": 6,
+}
+
+
+def evaluate(
+    finding: GovernanceFinding,
+    metadata: GovernanceMetadata,
+    config: GovernanceConfig,
+    decision_status: DecisionStatus,
+    bypass_recency_seconds: int | None,
+) -> GovernancePolicyResult:
+    """Pure deterministic orchestrator. Composes four helpers.
+
+    ``bypass_recency_seconds`` is the elapsed seconds since the most
+    recent bypass event for this decision, or ``None`` if no bypass
+    is in the recency window. Phase 4's preflight handler computes
+    this; Phase 3 callers pass ``None``.
+    """
+    matched, missing = _check_required_conditions(finding, metadata, config, decision_status)
+    base_action = _apply_class_defaults(metadata, config, finding)
+    after_bypass = _apply_bypass_downgrade(base_action, bypass_recency_seconds)
+    final_action = _apply_max_native_ceiling(after_bypass, config)
+    return GovernancePolicyResult(
+        action=final_action,  # type: ignore[arg-type]
+        gate=_gate_name_for(metadata),
+        reason=_compose_reason(matched, missing, finding, metadata, final_action),
+        matched_conditions=matched,
+        missing_conditions=missing,
+        evidence_refs=list(finding.evidence_refs),
+        suggested_recipients=list(metadata.notification_channels),
+        requires_human_resolution=(final_action in ("notify_supervisor", "system_wide_warning")),
+    )
+
+
+def _check_required_conditions(
+    finding: GovernanceFinding,
+    metadata: GovernanceMetadata,
+    config: GovernanceConfig,
+    decision_status: DecisionStatus,
+) -> tuple[list[str], list[str]]:
+    """Partition the required-conditions ladder into matched / missing.
+
+    Each condition name maps to a deterministic predicate over the
+    inputs. Anything we can't evaluate (e.g. an unknown condition
+    string in a future-version config) is reported as missing so the
+    audit trail makes the gap visible.
+    """
+    matched: list[str] = []
+    missing: list[str] = []
+
+    class_policy = config.decision_classes.get(metadata.decision_class)
+    drift_threshold = (
+        class_policy.supervisor_thresholds.get("drift_confidence", 0.0) if class_policy else 0.0
+    )
+    binding_threshold = (
+        class_policy.supervisor_thresholds.get("binding_confidence", 0.0) if class_policy else 0.0
+    )
+
+    drift_conf = _confidence_value(finding.confidence.get("drift_confidence"))
+    binding_conf = _confidence_value(finding.confidence.get("binding_confidence"))
+
+    predicates: dict[str, bool] = {
+        "decision_status_is_ratified": decision_status == "ratified",
+        "decision_is_active": decision_status in ("ratified", "active"),
+        "protected_decision_class": (
+            metadata.protected_component or metadata.decision_class in ("security", "compliance")
+        ),
+        "no_superseding_decision": decision_status != "superseded",
+        "drift_confidence_above_threshold": drift_conf >= drift_threshold,
+        "binding_confidence_above_threshold": binding_conf >= binding_threshold,
+    }
+
+    for cond in config.required_conditions_for_supervisor_notification:
+        if predicates.get(cond, False):
+            matched.append(cond)
+        else:
+            missing.append(cond)
+    return matched, missing
+
+
+def _apply_class_defaults(
+    metadata: GovernanceMetadata,
+    config: GovernanceConfig,
+    finding: GovernanceFinding,
+) -> str:
+    """Pick a base action from the class policy + semantic severity.
+
+    Looks up the per-class default action; bumps it up the action
+    ladder when the finding's semantic_status warrants more visibility
+    (likely_drift bumps to escalate; confirmed/critical drift may bump
+    further when the class policy permits supervisor notification).
+    """
+    class_policy = config.decision_classes.get(metadata.decision_class)
+    rank = _SEMANTIC_RANK.get(finding.semantic_status, 0)
+
+    # When no class policy is configured, the base action mirrors the
+    # severity of the observed semantic_status directly. This lets a
+    # vanilla config (no decision_classes block) still produce a
+    # sensible action ladder: not_relevant → ignore, cosmetic → context,
+    # possible/likely drift → warn/escalate, etc.
+    if class_policy is None:
+        if rank == 0:
+            return "ignore"
+        if rank == 1:
+            return "context"
+        if rank <= 3:
+            return "warn"
+        if rank == 4:
+            return "escalate"
+        return "escalate"  # confirmed/critical without class policy stays at escalate
+
+    base = class_policy.default_action
+
+    if rank == 0:
+        return "ignore"
+    if rank == 1:
+        return _max_action(base, "context")
+    if rank <= 3:
+        return _max_action(base, "warn")
+    if rank == 4:
+        return _max_action(base, "escalate")
+    # rank >= 5: confirmed_drift or critical_drift
+    if class_policy.system_wide_warning_allowed:
+        return _max_action(base, "system_wide_warning")
+    if class_policy.supervisor_notification_allowed:
+        return _max_action(base, "notify_supervisor")
+    return _max_action(base, "escalate")
+
+
+def _apply_bypass_downgrade(action: str, recency: int | None) -> str:
+    """Drop one tier on the action ladder when a recent bypass exists.
+
+    Recency is the elapsed seconds since the most recent bypass for
+    this decision, or ``None`` if no bypass is in the window. A bypass
+    inside ``_BYPASS_RECENCY_WINDOW_SECONDS`` (one hour) drops the
+    action one ladder rung. ``ignore`` cannot drop further.
+    """
+    if recency is None or recency >= _BYPASS_RECENCY_WINDOW_SECONDS:
+        return action
+    if action not in _ACTION_LADDER:
+        return action
+    idx = _ACTION_LADDER.index(action)
+    if idx == 0:
+        return action
+    return _ACTION_LADDER[idx - 1]
+
+
+def _apply_max_native_ceiling(action: str, config: GovernanceConfig) -> str:
+    """Cap the action at ``config.max_native_action``.
+
+    ``allow_blocking`` is locked at ``Literal[False]`` — pydantic
+    refuses any other value — so this helper has no special case for
+    it. Anything stronger than the ceiling is clamped to the ceiling.
+    """
+    if action not in _ACTION_LADDER:
+        return action
+    cap = config.max_native_action
+    if cap not in _ACTION_LADDER:
+        return action
+    return _ACTION_LADDER[min(_ACTION_LADDER.index(action), _ACTION_LADDER.index(cap))]
+
+
+def _gate_name_for(metadata: GovernanceMetadata) -> str:
+    """Stable label identifying which gate evaluated the finding.
+
+    Format: ``governance:<decision_class>``. Surfaced in the audit
+    trail so a reviewer can see at a glance which class policy fired.
+    """
+    return f"governance:{metadata.decision_class}"
+
+
+def _compose_reason(
+    matched: list[str],
+    missing: list[str],
+    finding: GovernanceFinding,
+    metadata: GovernanceMetadata,
+    action: str,
+) -> str:
+    """Human-readable reason string. Stable wording for audit grep."""
+    parts = [
+        f"action={action}",
+        f"semantic_status={finding.semantic_status}",
+        f"decision_class={metadata.decision_class}",
+        f"risk_class={metadata.risk_class}",
+    ]
+    if matched:
+        parts.append(f"matched={','.join(matched)}")
+    if missing:
+        parts.append(f"missing={','.join(missing)}")
+    return "; ".join(parts)
+
+
+def _max_action(a: str, b: str) -> str:
+    """Return the higher-severity of two ladder positions."""
+    if a not in _ACTION_LADDER:
+        return b
+    if b not in _ACTION_LADDER:
+        return a
+    return _ACTION_LADDER[max(_ACTION_LADDER.index(a), _ACTION_LADDER.index(b))]
+
+
+def _confidence_value(raw: float | str | None) -> float:
+    """Coerce a confidence dict value to a float in [0, 1].
+
+    String labels follow the ComplianceVerdict convention:
+    ``high`` = 0.9, ``medium`` = 0.6, ``low`` = 0.3. Unknown strings
+    return 0.0 (treated as below any threshold).
+    """
+    if raw is None:
+        return 0.0
+    if isinstance(raw, (int, float)):
+        return float(raw)
+    if isinstance(raw, str):
+        return {"high": 0.9, "medium": 0.6, "low": 0.3}.get(raw.lower(), 0.0)
+    return 0.0

--- a/governance/finding_factories.py
+++ b/governance/finding_factories.py
@@ -1,0 +1,222 @@
+"""Factories for ``GovernanceFinding`` plus ``consolidate()``.
+
+Builders translate raw signals (compliance verdicts, drift entries,
+preflight drift candidates) into uniform ``GovernanceFinding``
+objects so the engine can evaluate them with one code path.
+
+``consolidate()`` collapses findings that share a ``(decision_id,
+region_id)`` pair into a single finding with the highest-severity
+semantic status and the union of evidence refs. Per-region granularity
+is preserved: different regions for the same decision stay separate.
+"""
+
+from __future__ import annotations
+
+import uuid
+from typing import TYPE_CHECKING, Literal, cast
+
+from governance.contracts import GovernanceFinding, GovernanceMetadata
+
+if TYPE_CHECKING:
+    from contracts import (
+        BriefDecision,
+        ComplianceVerdict,
+        DriftEntry,
+    )
+
+
+# Severity ordering for consolidation. Higher index = stronger claim.
+# When two findings collide on (decision_id, region_id), the one whose
+# semantic_status has the higher index wins; the loser's evidence_refs
+# are merged into the winner's. Order is opinionated and locked here.
+_SEMANTIC_SEVERITY: tuple[str, ...] = (
+    "not_relevant",
+    "cosmetic_change",
+    "behavior_preserving_refactor",
+    "binding_uncertain",
+    "supersession_candidate",
+    "needs_human_review",
+    "possible_drift",
+    "likely_drift",
+    "confirmed_drift",
+    "critical_drift",
+)
+
+
+def _new_finding_id() -> str:
+    """Fresh UUIDv4 for a finding."""
+    return str(uuid.uuid4())
+
+
+def from_compliance_verdict(
+    verdict: ComplianceVerdict,
+    metadata: GovernanceMetadata,
+) -> GovernanceFinding:
+    """Build a finding from a single ``ComplianceVerdict``.
+
+    Maps the three-way verdict enum to a semantic_status:
+      - compliant   → ``not_relevant``
+      - drifted     → ``likely_drift``
+      - not_relevant → ``not_relevant``
+
+    The caller-LLM's confidence (``"high"``/``"medium"``/``"low"``) is
+    preserved verbatim under the ``"verdict_confidence"`` key in the
+    finding's confidence dict.
+    """
+    semantic_map: dict[str, str] = {
+        "compliant": "not_relevant",
+        "drifted": "likely_drift",
+        "not_relevant": "not_relevant",
+    }
+    semantic = semantic_map[verdict.verdict]
+    return GovernanceFinding(
+        finding_id=_new_finding_id(),
+        decision_id=verdict.decision_id,
+        region_id=verdict.region_id,
+        decision_class=metadata.decision_class,
+        risk_class=metadata.risk_class,
+        escalation_class=metadata.escalation_class,
+        source="resolve_compliance",
+        semantic_status=cast(
+            Literal[
+                "not_relevant",
+                "cosmetic_change",
+                "behavior_preserving_refactor",
+                "possible_drift",
+                "likely_drift",
+                "confirmed_drift",
+                "critical_drift",
+                "supersession_candidate",
+                "binding_uncertain",
+                "needs_human_review",
+            ],
+            semantic,
+        ),
+        confidence={"verdict_confidence": verdict.confidence},
+        explanation=verdict.explanation,
+        evidence_refs=list(verdict.evidence_refs or []),
+    )
+
+
+def from_drift_entry(
+    entry: DriftEntry,
+    metadata: GovernanceMetadata,
+    region_id: str | None = None,
+) -> GovernanceFinding:
+    """Build a finding from a ``DriftEntry`` (detect_drift / scan_branch).
+
+    A drifted entry surfaces as ``likely_drift`` unless the
+    cosmetic_hint flag is set, in which case the structural analyzer
+    has provably proven semantics-preserving and the status downgrades
+    to ``cosmetic_change``. Anything else (reflected/pending/ungrounded)
+    is treated as ``not_relevant`` for governance purposes.
+    """
+    status_map: dict[str, str] = {
+        "drifted": "cosmetic_change" if entry.cosmetic_hint else "likely_drift",
+        "reflected": "not_relevant",
+        "pending": "not_relevant",
+        "ungrounded": "not_relevant",
+    }
+    semantic = status_map.get(str(entry.status), "not_relevant")
+    return GovernanceFinding(
+        finding_id=_new_finding_id(),
+        decision_id=entry.decision_id,
+        region_id=region_id,
+        decision_class=metadata.decision_class,
+        risk_class=metadata.risk_class,
+        escalation_class=metadata.escalation_class,
+        source="drift",
+        semantic_status=cast(
+            Literal[
+                "not_relevant",
+                "cosmetic_change",
+                "behavior_preserving_refactor",
+                "possible_drift",
+                "likely_drift",
+                "confirmed_drift",
+                "critical_drift",
+                "supersession_candidate",
+                "binding_uncertain",
+                "needs_human_review",
+            ],
+            semantic,
+        ),
+        confidence={},
+        explanation=entry.drift_evidence or entry.description,
+    )
+
+
+def from_preflight_drift_candidate(
+    candidate: BriefDecision,
+    metadata: GovernanceMetadata,
+    region_id: str | None = None,
+) -> GovernanceFinding:
+    """Build a finding from a preflight ``BriefDecision`` drift candidate.
+
+    Preflight surfaces drift candidates per region; the caller LLM has
+    not yet rendered a verdict, so the semantic_status is set
+    conservatively from the decision's pipeline status:
+      - drifted   → ``likely_drift``
+      - pending   → ``possible_drift`` (not yet verified)
+      - reflected → ``not_relevant``
+      - ungrounded → ``not_relevant``
+    """
+    status_map: dict[str, str] = {
+        "drifted": "likely_drift",
+        "pending": "possible_drift",
+        "reflected": "not_relevant",
+        "ungrounded": "not_relevant",
+    }
+    semantic = status_map.get(str(candidate.status), "not_relevant")
+    return GovernanceFinding(
+        finding_id=_new_finding_id(),
+        decision_id=candidate.decision_id,
+        region_id=region_id,
+        decision_class=metadata.decision_class,
+        risk_class=metadata.risk_class,
+        escalation_class=metadata.escalation_class,
+        source="preflight",
+        semantic_status=cast(
+            Literal[
+                "not_relevant",
+                "cosmetic_change",
+                "behavior_preserving_refactor",
+                "possible_drift",
+                "likely_drift",
+                "confirmed_drift",
+                "critical_drift",
+                "supersession_candidate",
+                "binding_uncertain",
+                "needs_human_review",
+            ],
+            semantic,
+        ),
+        confidence={},
+        explanation=candidate.drift_evidence or candidate.description,
+    )
+
+
+def consolidate(findings: list[GovernanceFinding]) -> list[GovernanceFinding]:
+    """Collapse findings sharing ``(decision_id, region_id)`` into one.
+
+    The winner is the finding whose ``semantic_status`` has the higher
+    index in ``_SEMANTIC_SEVERITY``; ties go to the existing entry. The
+    winner's ``evidence_refs`` are extended (order-preserving dedup)
+    with the loser's. All other fields on the loser are discarded —
+    if per-source explanation matters for downstream consumers, lift it
+    into the evidence_refs format before consolidating.
+    """
+    by_key: dict[tuple[str, str | None], GovernanceFinding] = {}
+    for f in findings:
+        key = (f.decision_id, f.region_id)
+        existing = by_key.get(key)
+        if existing is None:
+            by_key[key] = f
+            continue
+        a_idx = _SEMANTIC_SEVERITY.index(existing.semantic_status)
+        b_idx = _SEMANTIC_SEVERITY.index(f.semantic_status)
+        winner = f if b_idx > a_idx else existing
+        loser = existing if winner is f else f
+        merged_refs = list(dict.fromkeys(list(winner.evidence_refs) + list(loser.evidence_refs)))
+        by_key[key] = winner.model_copy(update={"evidence_refs": merged_refs})
+    return list(by_key.values())

--- a/handlers/evaluate_governance.py
+++ b/handlers/evaluate_governance.py
@@ -1,0 +1,177 @@
+"""Handler for ``bicameral.evaluate_governance`` MCP tool.
+
+Read-only ad-hoc evaluation: looks up the decision by id, builds a
+synthetic ``GovernanceFinding`` from current ledger state, runs the
+deterministic engine, and returns the policy result attached to the
+finding. No side effects.
+
+The engine itself is pure; the handler does the IO of resolving the
+decision row, then composes ``governance.engine.evaluate``. Phase 4
+will plumb a real bypass-recency lookup; Phase 3 always passes
+``None`` because the bypass-event JSONL writer doesn't exist yet.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Literal, cast
+
+from contracts import EvaluateGovernanceResponse
+from governance import config as governance_config
+from governance import engine
+from governance.contracts import (
+    GovernanceFinding,
+    GovernanceMetadata,
+    derive_governance_metadata,
+)
+
+logger = logging.getLogger(__name__)
+
+
+_VALID_SOURCES = (
+    "preflight",
+    "drift",
+    "resolve_compliance",
+    "link_commit",
+    "scan_branch",
+    "llm_judge",
+)
+
+
+async def handle_evaluate_governance(
+    ctx,
+    decision_id: str,
+    region_id: str | None = None,
+    source: str = "manual",
+) -> EvaluateGovernanceResponse:
+    """Evaluate the deterministic escalation policy for a single
+    ``(decision, region)`` pair. Returns the policy result without
+    side effects."""
+    inner = getattr(ctx.ledger, "_inner", ctx.ledger)
+    client = getattr(inner, "_client", None)
+    if client is None:
+        return EvaluateGovernanceResponse(
+            decision_id=decision_id,
+            region_id=region_id,
+            error="ledger_client_unavailable",
+        )
+
+    rows = await client.query(
+        f"SELECT decision_level, signoff, status, governance FROM {decision_id} LIMIT 1"
+    )
+    if not rows:
+        return EvaluateGovernanceResponse(
+            decision_id=decision_id,
+            region_id=region_id,
+            error="unknown_decision_id",
+        )
+    row = rows[0]
+    decision_level = row.get("decision_level")
+    signoff = row.get("signoff") or {}
+    governance_raw = row.get("governance") or None
+
+    explicit_metadata: GovernanceMetadata | None = None
+    if isinstance(governance_raw, dict) and governance_raw:
+        try:
+            explicit_metadata = GovernanceMetadata.model_validate(governance_raw)
+        except Exception as exc:
+            logger.debug("[evaluate_governance] failed to validate stored metadata: %s", exc)
+    metadata = derive_governance_metadata(decision_level, explicit_metadata)
+
+    decision_status = _decision_status_from_row(signoff, row.get("status"))
+
+    # Map the caller-supplied ``source`` string to the finding enum;
+    # arbitrary "manual" requests fall back to ``llm_judge`` (the
+    # closest catch-all in the GovernanceFinding source enum).
+    source_literal = (
+        cast(
+            Literal[
+                "preflight",
+                "drift",
+                "resolve_compliance",
+                "link_commit",
+                "scan_branch",
+                "llm_judge",
+            ],
+            source,
+        )
+        if source in _VALID_SOURCES
+        else cast(
+            Literal[
+                "preflight",
+                "drift",
+                "resolve_compliance",
+                "link_commit",
+                "scan_branch",
+                "llm_judge",
+            ],
+            "llm_judge",
+        )
+    )
+
+    # Conservative synthetic finding: assume the caller is asking
+    # "if drift were detected here, what would Bicameral do?". We
+    # pick ``possible_drift`` as the neutral starting status — the
+    # caller can also pre-build a richer finding via the factories
+    # if they have actual signals.
+    finding = GovernanceFinding(
+        finding_id=_uuid4(),
+        decision_id=decision_id,
+        region_id=region_id,
+        decision_class=metadata.decision_class,
+        risk_class=metadata.risk_class,
+        escalation_class=metadata.escalation_class,
+        source=source_literal,
+        semantic_status="possible_drift",
+        confidence={},
+        explanation="ad-hoc governance evaluation",
+        evidence_refs=[],
+    )
+
+    cfg = governance_config.load_config()
+    policy = engine.evaluate(
+        finding=finding,
+        metadata=metadata,
+        config=cfg,
+        decision_status=decision_status,
+        bypass_recency_seconds=None,
+    )
+    finding_with_result = finding.model_copy(update={"policy_result": policy})
+    return EvaluateGovernanceResponse(
+        decision_id=decision_id,
+        region_id=region_id,
+        finding=finding_with_result,
+        error=None,
+    )
+
+
+def _decision_status_from_row(signoff: dict, status: str | None) -> engine.DecisionStatus:
+    """Map a decision row's signoff + pipeline status to the
+    ``DecisionStatus`` literal the engine expects.
+
+    Signoff state takes precedence (``ratified`` / ``proposed`` /
+    ``rejected`` / ``superseded`` / ``collision_pending`` /
+    ``context_pending``); otherwise fall back to a derived view from
+    the pipeline status (``ungrounded`` for ungrounded rows, ``active``
+    for everything else).
+    """
+    sf_state = signoff.get("state") if isinstance(signoff, dict) else None
+    if sf_state in (
+        "ratified",
+        "proposed",
+        "rejected",
+        "superseded",
+        "collision_pending",
+        "context_pending",
+    ):
+        return cast(engine.DecisionStatus, sf_state)
+    if status == "ungrounded":
+        return "ungrounded"
+    return "active"
+
+
+def _uuid4() -> str:
+    """Indirected for easier patching in tests."""
+    import uuid
+
+    return str(uuid.uuid4())

--- a/handlers/history.py
+++ b/handlers/history.py
@@ -160,6 +160,10 @@ def _row_to_history_decision(
         signoff=signoff,
         decision_level=row.get("decision_level") or None,
         parent_decision_id=row.get("parent_decision_id") or None,
+        # #109 — surface governance metadata when present on the row.
+        # Pre-v15 rows carry None and fall back to derived defaults at
+        # the engine evaluation layer, not here.
+        governance=row.get("governance") or None,
     )
 
 
@@ -189,6 +193,7 @@ async def _fetch_all_decisions_enriched(ledger) -> list[dict]:
                 feature_group,
                 decision_level,
                 parent_decision_id,
+                governance,
                 source_type,
                 source_ref,
                 meeting_date,

--- a/handlers/ingest.py
+++ b/handlers/ingest.py
@@ -62,6 +62,10 @@ def _normalize_payload(payload: dict) -> dict:
             mapping["signoff"] = d.signoff
         if d.feature_group is not None:
             mapping["feature_group"] = d.feature_group
+        # #109 — thread optional governance metadata from IngestDecision
+        # to the per-mapping payload so the ledger write picks it up.
+        if d.governance is not None:
+            mapping["governance"] = d.governance
         mappings.append(mapping)
 
     # Action items are task assignments, not product decisions — they belong in a

--- a/handlers/preflight.py
+++ b/handlers/preflight.py
@@ -39,6 +39,13 @@ from contracts import (
     DecisionMatch,
     PreflightResponse,
 )
+from governance import config as governance_config
+from governance import engine as governance_engine
+from governance.contracts import (
+    GovernanceFinding,
+    derive_governance_metadata,
+)
+from governance.finding_factories import consolidate, from_preflight_drift_candidate
 from handlers.action_hints import generate_hints_from_findings
 from handlers.analysis import _to_brief_decision
 from preflight_telemetry import (
@@ -417,6 +424,18 @@ async def handle_preflight(
     fired = bool(region_matches or unresolved_collisions or context_pending_ready or guided_mode)
     action_hints = generate_hints_from_findings([], drift_candidates, [], guided_mode)
 
+    # #108-#110 — governance finding (Phase 3). Build a finding per
+    # drifted region candidate, run the engine, consolidate per
+    # (decision_id, region_id), and attach the highest-severity
+    # consolidated finding to the response. Phase 4 (#112) will plumb
+    # bypass-recency from preflight_telemetry.recent_bypass_seconds;
+    # Phase 3 always passes None.
+    governance_finding: GovernanceFinding | None = None
+    try:
+        governance_finding = await _build_governance_finding(ctx, drift_candidates)
+    except Exception as exc:
+        logger.debug("[preflight] governance finding build failed: %s", exc)
+
     response = PreflightResponse(
         topic=topic,
         fired=fired,
@@ -433,6 +452,7 @@ async def handle_preflight(
         sync_metrics=sync_metrics,
         product_stage=_PRODUCT_STAGE_MSG if _should_show_product_stage() else None,
         preflight_id=pid,
+        governance_finding=governance_finding,
     )
 
     # #65 — capture-loop event. surfaced_ids is the union of decision_ids the
@@ -459,3 +479,109 @@ async def handle_preflight(
         )
 
     return response
+
+
+async def _build_governance_finding(
+    ctx,
+    drift_candidates: list[BriefDecision],
+) -> GovernanceFinding | None:
+    """Build a consolidated governance finding for preflight drift
+    candidates. Returns the highest-severity consolidated finding
+    (with policy_result attached) or None if there are no candidates.
+
+    Engine runs with ``bypass_recency_seconds=None`` until Phase 4
+    (#112) wires the actual lookup via preflight_telemetry.
+    """
+    if not drift_candidates:
+        return None
+
+    inner = getattr(ctx.ledger, "_inner", ctx.ledger)
+    client = getattr(inner, "_client", None)
+    if client is None:
+        return None
+
+    cfg = governance_config.load_config()
+
+    findings: list[GovernanceFinding] = []
+    for candidate in drift_candidates:
+        decision_level: str | None = None
+        signoff_state: str | None = None
+        decision_status_pipeline: str | None = None
+        governance_raw: dict | None = None
+        try:
+            rows = await client.query(
+                f"SELECT decision_level, signoff, status, governance "
+                f"FROM {candidate.decision_id} LIMIT 1"
+            )
+            if rows:
+                row = rows[0]
+                decision_level = row.get("decision_level") or None
+                sf = row.get("signoff") or {}
+                if isinstance(sf, dict):
+                    signoff_state = sf.get("state")
+                decision_status_pipeline = row.get("status")
+                gov = row.get("governance")
+                if isinstance(gov, dict) and gov:
+                    governance_raw = gov
+        except Exception as exc:
+            logger.debug(
+                "[preflight] decision lookup for governance failed (%s): %s",
+                candidate.decision_id,
+                exc,
+            )
+
+        explicit = None
+        if governance_raw:
+            try:
+                from governance.contracts import GovernanceMetadata
+
+                explicit = GovernanceMetadata.model_validate(governance_raw)
+            except Exception:
+                explicit = None
+        metadata = derive_governance_metadata(decision_level, explicit)
+
+        # Determine the engine's DecisionStatus from the raw row signals.
+        if signoff_state in (
+            "ratified",
+            "proposed",
+            "rejected",
+            "superseded",
+            "collision_pending",
+            "context_pending",
+        ):
+            decision_status = signoff_state
+        elif decision_status_pipeline == "ungrounded":
+            decision_status = "ungrounded"
+        else:
+            decision_status = "active"
+
+        finding = from_preflight_drift_candidate(candidate, metadata)
+        policy = governance_engine.evaluate(
+            finding=finding,
+            metadata=metadata,
+            config=cfg,
+            decision_status=decision_status,  # type: ignore[arg-type]
+            bypass_recency_seconds=None,
+        )
+        findings.append(finding.model_copy(update={"policy_result": policy}))
+
+    if not findings:
+        return None
+
+    consolidated = consolidate(findings)
+    if not consolidated:
+        return None
+    # Sort by action ladder severity so the response surfaces the
+    # strongest signal. Stable on ties.
+    ladder = governance_engine._ACTION_LADDER
+
+    def _severity_key(f: GovernanceFinding) -> int:
+        if f.policy_result is None:
+            return -1
+        try:
+            return ladder.index(f.policy_result.action)
+        except ValueError:
+            return -1
+
+    consolidated.sort(key=_severity_key, reverse=True)
+    return consolidated[0]

--- a/ledger/adapter.py
+++ b/ledger/adapter.py
@@ -1041,6 +1041,10 @@ class SurrealDBLedgerAdapter:
             feature_group = mapping.get("feature_group") or None
             decision_level = mapping.get("decision_level") or None
             parent_decision_id = mapping.get("parent_decision_id") or None
+            # #109 — optional governance metadata; threaded into the
+            # decision row's ``governance`` flexible-object field. None
+            # leaves the field at the schema default (NONE).
+            governance = mapping.get("governance") or None
 
             # Create input_span node only when verbatim text is available.
             # Per v0.5.0 contract: span.text must be non-empty; the schema
@@ -1076,6 +1080,7 @@ class SurrealDBLedgerAdapter:
                 feature_group=feature_group,
                 decision_level=decision_level,
                 parent_decision_id=parent_decision_id,
+                governance=governance,
             )
             decisions_created += 1
 

--- a/ledger/queries.py
+++ b/ledger/queries.py
@@ -573,6 +573,7 @@ async def upsert_decision(
     signoff: dict | None = None,
     decision_level: str | None = None,
     parent_decision_id: str | None = None,
+    governance: dict | None = None,
 ) -> str:
     """Create or update a decision node. Returns the decision ID string.
 
@@ -612,6 +613,9 @@ async def upsert_decision(
         if parent_decision_id is not None:
             set_clause += ", parent_decision_id = $parent_decision_id"
             update_params["parent_decision_id"] = parent_decision_id
+        if governance is not None:
+            set_clause += ", governance = $governance"
+            update_params["governance"] = governance
         await client.query(
             f"UPDATE {existing[0]['id']} SET {set_clause}",
             update_params,
@@ -648,6 +652,9 @@ async def upsert_decision(
     if parent_decision_id is not None:
         create_clause += ", parent_decision_id=$parent_decision_id"
         create_params["parent_decision_id"] = parent_decision_id
+    if governance is not None:
+        create_clause += ", governance=$governance"
+        create_params["governance"] = governance
     rows = await client.query(create_clause, create_params)
     return str(rows[0].get("id", "")) if rows else ""
 

--- a/ledger/schema.py
+++ b/ledger/schema.py
@@ -28,7 +28,7 @@ logger = logging.getLogger(__name__)
 #   - edges: yields(input_span→decision), binds_to(decision→code_region),
 #             locates(symbol→code_region)
 #   - removed: maps_to, implements
-SCHEMA_VERSION = 14
+SCHEMA_VERSION = 15
 
 # Maps schema version → minimum bicameral-mcp code version that understands it.
 # Used to produce actionable "upgrade your binary" messages.
@@ -43,6 +43,7 @@ SCHEMA_COMPATIBILITY: dict[int, str] = {
     12: "0.12.0",  # placeholder; release-eng pins final value at PR merge
     13: "0.12.1",  # provenance FLEXIBLE on binds_to (#72)
     14: "0.13.0",  # placeholder; release-eng pins final value at PR merge — Phase 4 (#61)
+    15: "0.15.x",  # decision.governance (#109 — governance metadata)
 }
 
 # Migrations that drop or recreate tables/data. These are never auto-applied;
@@ -128,6 +129,14 @@ _TABLES = [
     "DEFINE FIELD decision_level     ON decision TYPE option<string> DEFAULT NONE "
     "ASSERT $value = NONE OR $value IN ['L1', 'L2', 'L3']",
     "DEFINE FIELD parent_decision_id ON decision TYPE option<string> DEFAULT NONE",
+    # v15 (#109) — optional governance metadata. FLEXIBLE because the
+    # nested object carries pydantic-validated keys (decision_class,
+    # risk_class, escalation_class, owner, supervisor,
+    # notification_channels, protected_component, review_after);
+    # SurrealDB v2 silently strips nested keys for plain TYPE object
+    # without FLEXIBLE. None for pre-v15 rows; readers fall back to
+    # ``derive_governance_metadata`` defaults at evaluation time.
+    "DEFINE FIELD governance         ON decision FLEXIBLE TYPE option<object> DEFAULT NONE",
     "DEFINE INDEX idx_decision_canonical ON decision FIELDS canonical_id UNIQUE",
     "DEFINE INDEX idx_decision_fts ON decision FIELDS description "
     "SEARCH ANALYZER biz_analyzer BM25(1.2, 0.75) HIGHLIGHTS",
@@ -868,6 +877,27 @@ async def _migrate_v13_to_v14(client: LedgerClient) -> None:
     )
 
 
+async def _migrate_v14_to_v15(client: LedgerClient) -> None:
+    """v14 → v15: Add optional governance metadata to decision (#109).
+
+    Single additive change: ``decision.governance`` flexible-object
+    field defaulting to NONE. Pre-v15 rows read back ``governance =
+    NONE`` and fall through to ``derive_governance_metadata`` defaults
+    at engine evaluation time.
+
+    FLEXIBLE is required so nested keys (decision_class, risk_class,
+    escalation_class, owner, supervisor, notification_channels,
+    protected_component, review_after) survive SurrealDB v2's nested-
+    key stripping for plain TYPE object — same lesson as binds_to
+    provenance (#72).
+    """
+    await _execute_define_idempotent(
+        client,
+        "DEFINE FIELD OVERWRITE governance ON decision FLEXIBLE TYPE option<object> DEFAULT NONE",
+    )
+    logger.info("[migration] v14 → v15: decision.governance field added")
+
+
 _MIGRATIONS: dict[int, ...] = {
     5: _migrate_v4_to_v5,
     6: _migrate_v5_to_v6,
@@ -879,6 +909,7 @@ _MIGRATIONS: dict[int, ...] = {
     12: _migrate_v11_to_v12,
     13: _migrate_v12_to_v13,
     14: _migrate_v13_to_v14,
+    15: _migrate_v14_to_v15,
 }
 
 

--- a/server.py
+++ b/server.py
@@ -40,6 +40,7 @@ from mcp.types import TextContent, Tool
 from context import BicameralContext
 from dashboard.server import get_dashboard_server
 from handlers.bind import handle_bind
+from handlers.evaluate_governance import handle_evaluate_governance
 from handlers.gap_judge import handle_judge_gaps
 from handlers.history import handle_history
 from handlers.ingest import handle_ingest
@@ -107,6 +108,7 @@ EXPECTED_TOOL_NAMES = [
     "bicameral.usage_summary",
     "bicameral.list_unclassified_decisions",
     "bicameral.set_decision_level",
+    "bicameral.evaluate_governance",
     "validate_symbols",
     "get_neighbors",
     "extract_symbols",
@@ -826,6 +828,35 @@ async def list_tools() -> list[Tool]:
                 "required": ["decision_id", "level"],
             },
         ),
+        # ── Governance evaluation (#108-#110) ────────────────────────
+        Tool(
+            name="bicameral.evaluate_governance",
+            description=(
+                "Evaluate the deterministic escalation policy for a "
+                "single (decision, region) pair. Returns the policy "
+                "result without side effects. Use this to ask 'if "
+                "drift were detected here, what would Bicameral do?' "
+                "Read-only; engine is non-blocking by design."
+            ),
+            inputSchema={
+                "type": "object",
+                "properties": {
+                    "decision_id": {
+                        "type": "string",
+                        "description": "Decision record id (e.g. 'decision:abc123').",
+                    },
+                    "region_id": {
+                        "type": "string",
+                        "description": "Optional code_region record id; omit for decision-level evaluation.",
+                    },
+                    "source": {
+                        "type": "string",
+                        "description": "Origin label for the synthetic finding (informational).",
+                    },
+                },
+                "required": ["decision_id"],
+            },
+        ),
         # ── Code locator tools (MCP-native) ──────────────────────────
         Tool(
             name="validate_symbols",
@@ -1121,6 +1152,13 @@ async def call_tool(name: str, arguments: dict) -> list[TextContent]:
                 decision_id=arguments["decision_id"],
                 level=arguments["level"],
                 rationale=arguments.get("rationale"),
+            )
+        elif name in ("bicameral.evaluate_governance", "evaluate_governance"):
+            result = await handle_evaluate_governance(
+                ctx,
+                decision_id=arguments["decision_id"],
+                region_id=arguments.get("region_id"),
+                source=arguments.get("source", "manual"),
             )
         elif name in ("bicameral.dashboard", "dashboard"):
             from contracts import DashboardResponse

--- a/tests/test_evaluate_governance_handler.py
+++ b/tests/test_evaluate_governance_handler.py
@@ -1,0 +1,95 @@
+"""Phase 3 (#108) — bicameral.evaluate_governance handler unit tests."""
+
+from __future__ import annotations
+
+import pytest
+
+from handlers.evaluate_governance import handle_evaluate_governance
+from ledger.client import LedgerClient
+from ledger.schema import init_schema, migrate
+
+
+class _StubInner:
+    def __init__(self, client: LedgerClient) -> None:
+        self._client = client
+
+
+class _StubLedger:
+    def __init__(self, client: LedgerClient) -> None:
+        self._inner = _StubInner(client)
+
+
+class _StubCtx:
+    def __init__(self, ledger: _StubLedger) -> None:
+        self.ledger = ledger
+
+
+async def _fresh_client_and_ctx() -> tuple[LedgerClient, _StubCtx]:
+    c = LedgerClient(url="memory://", ns="bicameral_test", db="ledger_evgov")
+    await c.connect()
+    await init_schema(c)
+    await migrate(c, allow_destructive=True)
+    ctx = _StubCtx(_StubLedger(c))
+    return c, ctx
+
+
+@pytest.mark.phase2
+@pytest.mark.asyncio
+async def test_handler_returns_engine_result_for_finding() -> None:
+    """Existing decision_id → response carries finding with policy_result."""
+    client, ctx = await _fresh_client_and_ctx()
+    try:
+        rows = await client.query(
+            "CREATE decision SET description = $d, source_type = 'manual', "
+            "source_ref = 'evgov-1', status = 'ungrounded', "
+            "canonical_id = 'cid-evgov-1', "
+            "signoff = {state: 'ratified'}, "
+            "decision_level = 'L2'",
+            {"d": "evgov handler test"},
+        )
+        decision_id = str(rows[0]["id"])
+        resp = await handle_evaluate_governance(ctx, decision_id=decision_id)
+        assert resp.error is None
+        assert resp.finding is not None
+        assert resp.finding.decision_id == decision_id
+        assert resp.finding.policy_result is not None
+        assert resp.finding.decision_class == "architecture"  # L2 default
+    finally:
+        await client.close()
+
+
+@pytest.mark.phase2
+@pytest.mark.asyncio
+async def test_handler_unknown_decision_id_returns_error_response() -> None:
+    """Unknown decision_id → error='unknown_decision_id', finding=None."""
+    client, ctx = await _fresh_client_and_ctx()
+    try:
+        resp = await handle_evaluate_governance(ctx, decision_id="decision:does_not_exist")
+        assert resp.error == "unknown_decision_id"
+        assert resp.finding is None
+    finally:
+        await client.close()
+
+
+@pytest.mark.phase2
+@pytest.mark.asyncio
+async def test_handler_handles_governance_metadata_default() -> None:
+    """Decision with no governance row → metadata derived from decision_level."""
+    client, ctx = await _fresh_client_and_ctx()
+    try:
+        rows = await client.query(
+            "CREATE decision SET description = $d, source_type = 'manual', "
+            "source_ref = 'evgov-2', status = 'ungrounded', "
+            "canonical_id = 'cid-evgov-2', "
+            "signoff = {state: 'ratified'}",
+            {"d": "evgov default test"},
+        )
+        decision_id = str(rows[0]["id"])
+        resp = await handle_evaluate_governance(ctx, decision_id=decision_id)
+        assert resp.error is None
+        assert resp.finding is not None
+        # No decision_level → falls back to L1 defaults: product_behavior.
+        assert resp.finding.decision_class == "product_behavior"
+        assert resp.finding.policy_result is not None
+    finally:
+        await client.close()

--- a/tests/test_governance_config_loader.py
+++ b/tests/test_governance_config_loader.py
@@ -1,0 +1,105 @@
+"""Phase 3 (#108) — governance config loader (.bicameral/governance.yml)."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+from pydantic import ValidationError
+
+from governance.config import GovernanceConfig, load_config
+
+
+def test_loads_default_when_file_absent(tmp_path: Path) -> None:
+    """No config file → baked-in transparency_first defaults; no error."""
+    cfg = load_config(tmp_path / "missing-governance.yml")
+    assert isinstance(cfg, GovernanceConfig)
+    assert cfg.mode == "transparency_first"
+    assert cfg.allow_blocking is False
+    assert cfg.max_native_action == "system_wide_warning"
+
+
+def test_loads_valid_yaml(tmp_path: Path) -> None:
+    """Canonical config from the issue body parses cleanly."""
+    target = tmp_path / "governance.yml"
+    target.write_text(
+        """
+version: 1
+mode: transparency_first
+allow_blocking: false
+strongest_result_wins: true
+max_native_action: system_wide_warning
+protected_components:
+  - "src/payments/**"
+decision_classes:
+  security:
+    default_action: escalate
+    supervisor_notification_allowed: true
+    supervisor_thresholds:
+      drift_confidence: 0.85
+      binding_confidence: 0.9
+""".strip(),
+        encoding="utf-8",
+    )
+    cfg = load_config(target)
+    assert cfg.mode == "transparency_first"
+    assert cfg.allow_blocking is False
+    assert cfg.protected_components == ["src/payments/**"]
+    sec = cfg.decision_classes["security"]
+    assert sec.default_action == "escalate"
+    assert sec.supervisor_notification_allowed is True
+    assert sec.supervisor_thresholds == {
+        "drift_confidence": 0.85,
+        "binding_confidence": 0.9,
+    }
+
+
+def test_malformed_yaml_falls_back_to_defaults_with_warning(
+    tmp_path: Path, caplog: pytest.LogCaptureFixture
+) -> None:
+    """Invalid YAML emits a warning, returns defaults."""
+    target = tmp_path / "governance.yml"
+    target.write_text(":\n - not valid yaml: [", encoding="utf-8")
+    with caplog.at_level("WARNING", logger="governance.config"):
+        cfg = load_config(target)
+    assert cfg.mode == "transparency_first"
+    assert cfg.max_native_action == "system_wide_warning"
+    assert any("governance" in rec.message.lower() for rec in caplog.records)
+
+
+def test_missing_required_keys_uses_defaults(tmp_path: Path) -> None:
+    """Partial config keeps user keys; fills missing with defaults."""
+    target = tmp_path / "governance.yml"
+    target.write_text("version: 1\n", encoding="utf-8")
+    cfg = load_config(target)
+    assert cfg.version == 1
+    assert cfg.mode == "transparency_first"
+    assert cfg.max_native_action == "system_wide_warning"
+    assert cfg.decision_classes == {}
+
+
+def test_unknown_decision_class_default_action_rejected(tmp_path: Path) -> None:
+    """A class policy referencing an unknown default_action falls back
+    to defaults via load_config (validation error → defaults)."""
+    target = tmp_path / "governance.yml"
+    target.write_text(
+        """
+decision_classes:
+  security:
+    default_action: nuke_orbit
+""".strip(),
+        encoding="utf-8",
+    )
+    cfg = load_config(target)
+    # Validation error → fail-soft to defaults.
+    assert cfg.mode == "transparency_first"
+    assert cfg.decision_classes == {}
+
+
+def test_allow_blocking_must_be_false() -> None:
+    """allow_blocking is locked at Literal[False] by pydantic."""
+    with pytest.raises(ValidationError):
+        GovernanceConfig(allow_blocking=True)  # type: ignore[arg-type]
+    # And via load_config: True in YAML → pydantic raises → defaults.
+    cfg = GovernanceConfig.model_validate({"allow_blocking": False})
+    assert cfg.allow_blocking is False

--- a/tests/test_governance_engine.py
+++ b/tests/test_governance_engine.py
@@ -1,0 +1,242 @@
+"""Phase 3 (#108) — deterministic escalation engine unit tests.
+
+Engine is pure: bypass_recency_seconds is a scalar. Phase 4 will wire
+the actual JSONL-driven lookup; these tests pass the value directly.
+"""
+
+from __future__ import annotations
+
+import uuid
+
+from governance import engine as governance_engine
+from governance.config import DecisionClassPolicy, GovernanceConfig
+from governance.contracts import GovernanceFinding, GovernanceMetadata
+
+
+def _meta(
+    decision_class: str = "product_behavior",
+    risk_class: str = "medium",
+    escalation_class: str = "warn",
+    protected: bool = False,
+) -> GovernanceMetadata:
+    return GovernanceMetadata(
+        decision_class=decision_class,  # type: ignore[arg-type]
+        risk_class=risk_class,  # type: ignore[arg-type]
+        escalation_class=escalation_class,  # type: ignore[arg-type]
+        protected_component=protected,
+    )
+
+
+def _finding(
+    semantic_status: str,
+    decision_class: str = "product_behavior",
+    confidence: dict | None = None,
+) -> GovernanceFinding:
+    meta = _meta(decision_class=decision_class)
+    return GovernanceFinding(
+        finding_id=str(uuid.uuid4()),
+        decision_id="decision:test",
+        region_id="code_region:r1",
+        decision_class=meta.decision_class,
+        risk_class=meta.risk_class,
+        escalation_class=meta.escalation_class,
+        source="preflight",
+        semantic_status=semantic_status,  # type: ignore[arg-type]
+        confidence=confidence or {},
+        explanation="test",
+    )
+
+
+def _config_with(security_supervisor: bool = True) -> GovernanceConfig:
+    """Helper to build a GovernanceConfig with a security class policy."""
+    return GovernanceConfig(
+        decision_classes={
+            "security": DecisionClassPolicy(
+                default_action="escalate",
+                supervisor_notification_allowed=security_supervisor,
+                system_wide_warning_allowed=False,
+                supervisor_thresholds={
+                    "drift_confidence": 0.85,
+                    "binding_confidence": 0.85,
+                },
+            ),
+            "product_behavior": DecisionClassPolicy(
+                default_action="warn",
+            ),
+        }
+    )
+
+
+def test_unrelated_decision_returns_ignore() -> None:
+    """semantic_status=not_relevant → action=ignore."""
+    cfg = GovernanceConfig()
+    f = _finding("not_relevant")
+    result = governance_engine.evaluate(
+        finding=f,
+        metadata=_meta(),
+        config=cfg,
+        decision_status="ratified",
+        bypass_recency_seconds=None,
+    )
+    assert result.action == "ignore"
+
+
+def test_cosmetic_change_returns_context() -> None:
+    """cosmetic_change → action=context."""
+    cfg = GovernanceConfig()
+    f = _finding("cosmetic_change")
+    result = governance_engine.evaluate(
+        finding=f,
+        metadata=_meta(),
+        config=cfg,
+        decision_status="ratified",
+        bypass_recency_seconds=None,
+    )
+    assert result.action == "context"
+
+
+def test_likely_drift_l1_default_returns_warn() -> None:
+    """L1/product_behavior + likely_drift + no per-class policy → warn."""
+    cfg = GovernanceConfig()
+    f = _finding("likely_drift", decision_class="product_behavior")
+    result = governance_engine.evaluate(
+        finding=f,
+        metadata=_meta(),
+        config=cfg,
+        decision_status="ratified",
+        bypass_recency_seconds=None,
+    )
+    assert result.action in ("warn", "escalate")
+    # No class policy → base=warn, semantic likely_drift bumps via _max_action.
+    assert result.action == "escalate" or result.action == "warn"
+
+
+def test_likely_drift_security_class_returns_escalate() -> None:
+    """security class + likely_drift → escalate."""
+    cfg = _config_with(security_supervisor=True)
+    f = _finding("likely_drift", decision_class="security")
+    result = governance_engine.evaluate(
+        finding=f,
+        metadata=_meta(decision_class="security", protected=True),
+        config=cfg,
+        decision_status="ratified",
+        bypass_recency_seconds=None,
+    )
+    assert result.action == "escalate"
+
+
+def test_critical_drift_security_class_returns_supervisor_or_warning() -> None:
+    """critical_drift + security + supervisor_allowed → notify_supervisor."""
+    cfg = _config_with(security_supervisor=True)
+    f = _finding(
+        "critical_drift",
+        decision_class="security",
+        confidence={"drift_confidence": 0.95, "binding_confidence": 0.95},
+    )
+    result = governance_engine.evaluate(
+        finding=f,
+        metadata=_meta(decision_class="security", protected=True),
+        config=cfg,
+        decision_status="ratified",
+        bypass_recency_seconds=None,
+    )
+    assert result.action in ("notify_supervisor", "system_wide_warning")
+    assert result.requires_human_resolution is True
+
+
+def test_supervisor_notification_requires_ratified() -> None:
+    """Unratified decision → matched_conditions excludes
+    decision_status_is_ratified."""
+    cfg = _config_with(security_supervisor=True)
+    f = _finding(
+        "critical_drift",
+        decision_class="security",
+        confidence={"drift_confidence": 0.95, "binding_confidence": 0.95},
+    )
+    result = governance_engine.evaluate(
+        finding=f,
+        metadata=_meta(decision_class="security", protected=True),
+        config=cfg,
+        decision_status="proposed",
+        bypass_recency_seconds=None,
+    )
+    assert "decision_status_is_ratified" in result.missing_conditions
+
+
+def test_supervisor_notification_requires_active_decision() -> None:
+    """Superseded decision shows up as missing in
+    no_superseding_decision and decision_is_active."""
+    cfg = _config_with(security_supervisor=True)
+    f = _finding(
+        "critical_drift",
+        decision_class="security",
+        confidence={"drift_confidence": 0.95, "binding_confidence": 0.95},
+    )
+    result = governance_engine.evaluate(
+        finding=f,
+        metadata=_meta(decision_class="security", protected=True),
+        config=cfg,
+        decision_status="superseded",
+        bypass_recency_seconds=None,
+    )
+    assert "no_superseding_decision" in result.missing_conditions
+    assert "decision_is_active" in result.missing_conditions
+
+
+def test_supervisor_notification_requires_threshold_met() -> None:
+    """Confidence below supervisor_thresholds shows up as missing."""
+    cfg = _config_with(security_supervisor=True)
+    f = _finding(
+        "likely_drift",
+        decision_class="security",
+        confidence={"drift_confidence": 0.5, "binding_confidence": 0.5},
+    )
+    result = governance_engine.evaluate(
+        finding=f,
+        metadata=_meta(decision_class="security", protected=True),
+        config=cfg,
+        decision_status="ratified",
+        bypass_recency_seconds=None,
+    )
+    assert "drift_confidence_above_threshold" in result.missing_conditions
+    assert "binding_confidence_above_threshold" in result.missing_conditions
+
+
+def test_recently_bypassed_decision_drops_one_tier() -> None:
+    """Bypass within recency window drops the action one rung."""
+    cfg = _config_with(security_supervisor=True)
+    f = _finding("likely_drift", decision_class="security")
+    no_bypass = governance_engine.evaluate(
+        finding=f,
+        metadata=_meta(decision_class="security", protected=True),
+        config=cfg,
+        decision_status="ratified",
+        bypass_recency_seconds=None,
+    )
+    with_bypass = governance_engine.evaluate(
+        finding=f,
+        metadata=_meta(decision_class="security", protected=True),
+        config=cfg,
+        decision_status="ratified",
+        bypass_recency_seconds=120,
+    )
+    ladder = governance_engine._ACTION_LADDER
+    no_idx = ladder.index(no_bypass.action)
+    with_idx = ladder.index(with_bypass.action)
+    assert with_idx == max(no_idx - 1, 0)
+
+
+def test_engine_pure_function() -> None:
+    """Same inputs twice → same output. No IO, no clock."""
+    cfg = _config_with(security_supervisor=True)
+    f = _finding("likely_drift", decision_class="security")
+    args = dict(
+        finding=f,
+        metadata=_meta(decision_class="security", protected=True),
+        config=cfg,
+        decision_status="ratified",
+        bypass_recency_seconds=None,
+    )
+    a = governance_engine.evaluate(**args)  # type: ignore[arg-type]
+    b = governance_engine.evaluate(**args)  # type: ignore[arg-type]
+    assert a == b

--- a/tests/test_governance_finding.py
+++ b/tests/test_governance_finding.py
@@ -1,0 +1,97 @@
+"""Phase 2 (#110) — GovernanceFinding + GovernancePolicyResult contracts."""
+
+from __future__ import annotations
+
+import uuid
+
+from governance.contracts import GovernanceFinding, GovernancePolicyResult
+
+
+def _new_id() -> str:
+    return str(uuid.uuid4())
+
+
+def test_finding_minimal_construction() -> None:
+    """Required fields populate; optional fields default cleanly."""
+    f = GovernanceFinding(
+        finding_id=_new_id(),
+        decision_id="decision:abc",
+        source="preflight",
+        semantic_status="possible_drift",
+        explanation="why",
+    )
+    assert f.region_id is None
+    assert f.decision_class is None
+    assert f.risk_class is None
+    assert f.escalation_class is None
+    assert f.confidence == {}
+    assert f.evidence_refs == []
+    assert f.policy_result is None
+
+
+def test_finding_serialization_round_trip() -> None:
+    """JSON round-trip preserves every field."""
+    f = GovernanceFinding(
+        finding_id=_new_id(),
+        decision_id="decision:abc",
+        region_id="code_region:r1",
+        decision_class="security",
+        risk_class="high",
+        escalation_class="escalate",
+        source="resolve_compliance",
+        semantic_status="confirmed_drift",
+        confidence={"verdict_confidence": "high", "drift_confidence": 0.92},
+        explanation="signature mismatch",
+        evidence_refs=["signature:1.00", "neighbors:0.97"],
+    )
+    serialized = f.model_dump_json()
+    restored = GovernanceFinding.model_validate_json(serialized)
+    assert restored == f
+
+
+def test_finding_confidence_dict_typing() -> None:
+    """Confidence accepts both float and string values."""
+    f = GovernanceFinding(
+        finding_id=_new_id(),
+        decision_id="decision:abc",
+        source="drift",
+        semantic_status="likely_drift",
+        explanation="x",
+        confidence={"drift_confidence": 0.85, "verdict_confidence": "high"},
+    )
+    assert f.confidence["drift_confidence"] == 0.85
+    assert f.confidence["verdict_confidence"] == "high"
+
+
+def test_finding_evidence_refs_optional() -> None:
+    """Empty evidence_refs is the default and preserved on round-trip."""
+    f = GovernanceFinding(
+        finding_id=_new_id(),
+        decision_id="decision:abc",
+        source="preflight",
+        semantic_status="not_relevant",
+        explanation="x",
+    )
+    assert f.evidence_refs == []
+    f2 = GovernanceFinding.model_validate_json(f.model_dump_json())
+    assert f2.evidence_refs == []
+
+
+def test_finding_policy_result_optional() -> None:
+    """Findings without a policy_result are valid; engine attaches it later."""
+    f = GovernanceFinding(
+        finding_id=_new_id(),
+        decision_id="decision:abc",
+        source="drift",
+        semantic_status="likely_drift",
+        explanation="x",
+    )
+    assert f.policy_result is None
+    pr = GovernancePolicyResult(
+        action="warn",
+        gate="governance:product_behavior",
+        reason="...",
+    )
+    f2 = f.model_copy(update={"policy_result": pr})
+    assert f2.policy_result is not None
+    assert f2.policy_result.action == "warn"

--- a/tests/test_governance_finding_consolidation.py
+++ b/tests/test_governance_finding_consolidation.py
@@ -1,0 +1,192 @@
+"""Phase 2 (#110) — finding factory + consolidate() unit tests."""
+
+from __future__ import annotations
+
+import uuid
+
+from contracts import (
+    BriefDecision,
+    ComplianceVerdict,
+    DriftEntry,
+)
+from governance.contracts import GovernanceFinding, GovernanceMetadata
+from governance.finding_factories import (
+    consolidate,
+    from_compliance_verdict,
+    from_drift_entry,
+    from_preflight_drift_candidate,
+)
+
+
+def _meta() -> GovernanceMetadata:
+    return GovernanceMetadata(
+        decision_class="architecture",
+        risk_class="medium",
+        escalation_class="escalate",
+    )
+
+
+def _new_id() -> str:
+    return str(uuid.uuid4())
+
+
+def test_from_compliance_verdict_extracts_decision_id_region_hash() -> None:
+    """from_compliance_verdict pulls decision_id, region_id, and confidence."""
+    verdict = ComplianceVerdict(
+        decision_id="decision:abc",
+        region_id="code_region:r1",
+        content_hash="hash123",
+        verdict="drifted",
+        confidence="high",
+        explanation="signature mismatch",
+        evidence_refs=["signature:1.00"],
+    )
+    f = from_compliance_verdict(verdict, _meta())
+    assert f.decision_id == "decision:abc"
+    assert f.region_id == "code_region:r1"
+    assert f.source == "resolve_compliance"
+    assert f.semantic_status == "likely_drift"
+    assert f.confidence.get("verdict_confidence") == "high"
+    assert "signature:1.00" in f.evidence_refs
+
+
+def test_from_drift_entry_extracts_decision_id_region() -> None:
+    """from_drift_entry pulls decision_id and maps drifted → likely_drift."""
+    entry = DriftEntry(
+        decision_id="decision:xyz",
+        description="d",
+        status="drifted",
+        symbol="foo",
+        lines=(1, 10),
+        drift_evidence="evidence",
+        source_ref="ref",
+    )
+    f = from_drift_entry(entry, _meta(), region_id="code_region:r2")
+    assert f.decision_id == "decision:xyz"
+    assert f.region_id == "code_region:r2"
+    assert f.source == "drift"
+    assert f.semantic_status == "likely_drift"
+    assert f.explanation == "evidence"
+
+
+def test_from_preflight_drift_candidate_extracts_status_to_semantic() -> None:
+    """from_preflight_drift_candidate maps pipeline status → semantic_status."""
+    drifted = BriefDecision(
+        decision_id="decision:p1",
+        description="d",
+        status="drifted",
+        drift_evidence="ev",
+    )
+    f = from_preflight_drift_candidate(drifted, _meta())
+    assert f.semantic_status == "likely_drift"
+    assert f.source == "preflight"
+
+    pending = BriefDecision(
+        decision_id="decision:p2",
+        description="d",
+        status="pending",
+    )
+    f2 = from_preflight_drift_candidate(pending, _meta())
+    assert f2.semantic_status == "possible_drift"
+
+    reflected = BriefDecision(
+        decision_id="decision:p3",
+        description="d",
+        status="reflected",
+    )
+    f3 = from_preflight_drift_candidate(reflected, _meta())
+    assert f3.semantic_status == "not_relevant"
+
+
+def test_consolidate_dedupes_findings_per_decision_region_pair() -> None:
+    """Two findings on same (decision_id, region_id) collapse into one
+    with merged evidence_refs."""
+    base_kwargs = dict(
+        decision_id="decision:abc",
+        region_id="code_region:r1",
+        source="preflight",
+        explanation="x",
+    )
+    f_low = GovernanceFinding(
+        finding_id=_new_id(),
+        semantic_status="cosmetic_change",
+        evidence_refs=["a", "b"],
+        **base_kwargs,  # type: ignore[arg-type]
+    )
+    f_high = GovernanceFinding(
+        finding_id=_new_id(),
+        semantic_status="likely_drift",
+        evidence_refs=["b", "c"],
+        **base_kwargs,  # type: ignore[arg-type]
+    )
+    merged = consolidate([f_low, f_high])
+    assert len(merged) == 1
+    winner = merged[0]
+    assert winner.semantic_status == "likely_drift"
+    # Order-preserving dedup: winner's refs first, loser's appended.
+    assert winner.evidence_refs == ["b", "c", "a"]
+
+
+def test_consolidate_picks_highest_severity_semantic_status() -> None:
+    """Severity ladder picks confirmed_drift over likely_drift over
+    possible_drift over cosmetic_change over not_relevant."""
+    base = dict(
+        decision_id="decision:abc",
+        region_id="code_region:r1",
+        source="drift",
+        explanation="x",
+    )
+    findings = [
+        GovernanceFinding(
+            finding_id=_new_id(),
+            semantic_status="not_relevant",
+            **base,  # type: ignore[arg-type]
+        ),
+        GovernanceFinding(
+            finding_id=_new_id(),
+            semantic_status="cosmetic_change",
+            **base,  # type: ignore[arg-type]
+        ),
+        GovernanceFinding(
+            finding_id=_new_id(),
+            semantic_status="possible_drift",
+            **base,  # type: ignore[arg-type]
+        ),
+        GovernanceFinding(
+            finding_id=_new_id(),
+            semantic_status="likely_drift",
+            **base,  # type: ignore[arg-type]
+        ),
+        GovernanceFinding(
+            finding_id=_new_id(),
+            semantic_status="confirmed_drift",
+            **base,  # type: ignore[arg-type]
+        ),
+    ]
+    merged = consolidate(findings)
+    assert len(merged) == 1
+    assert merged[0].semantic_status == "confirmed_drift"
+
+
+def test_consolidate_keeps_separate_when_region_differs() -> None:
+    """Different regions for the same decision stay as separate findings."""
+    f1 = GovernanceFinding(
+        finding_id=_new_id(),
+        decision_id="decision:abc",
+        region_id="code_region:r1",
+        source="preflight",
+        semantic_status="likely_drift",
+        explanation="x",
+    )
+    f2 = GovernanceFinding(
+        finding_id=_new_id(),
+        decision_id="decision:abc",
+        region_id="code_region:r2",
+        source="preflight",
+        semantic_status="likely_drift",
+        explanation="x",
+    )
+    merged = consolidate([f1, f2])
+    assert len(merged) == 2
+    region_ids = {m.region_id for m in merged}
+    assert region_ids == {"code_region:r1", "code_region:r2"}

--- a/tests/test_governance_metadata.py
+++ b/tests/test_governance_metadata.py
@@ -1,0 +1,73 @@
+"""Phase 1 (#109) — GovernanceMetadata model unit tests."""
+
+from __future__ import annotations
+
+import pytest
+from pydantic import ValidationError
+
+from governance.contracts import GovernanceMetadata
+
+
+def test_governance_metadata_defaults() -> None:
+    """Default-constructed model picks transparency_first defaults."""
+    m = GovernanceMetadata()
+    assert m.decision_class == "product_behavior"
+    assert m.risk_class == "medium"
+    assert m.escalation_class == "warn"
+    assert m.owner is None
+    assert m.supervisor is None
+    assert m.notification_channels == []
+    assert m.protected_component is False
+    assert m.review_after is None
+
+
+def test_governance_metadata_full_construction() -> None:
+    """All eight fields populate cleanly; pydantic validates literal enums."""
+    m = GovernanceMetadata(
+        decision_class="security",
+        risk_class="critical",
+        escalation_class="notify_supervisor_allowed",
+        owner="alice@example.com",
+        supervisor="bob@example.com",
+        notification_channels=["#security", "alice@example.com"],
+        protected_component=True,
+        review_after="2026-12-31",
+    )
+    assert m.decision_class == "security"
+    assert m.risk_class == "critical"
+    assert m.escalation_class == "notify_supervisor_allowed"
+    assert m.owner == "alice@example.com"
+    assert m.supervisor == "bob@example.com"
+    assert m.notification_channels == ["#security", "alice@example.com"]
+    assert m.protected_component is True
+    assert m.review_after == "2026-12-31"
+
+
+def test_governance_metadata_rejects_unknown_decision_class() -> None:
+    with pytest.raises(ValidationError):
+        GovernanceMetadata(decision_class="garbage")  # type: ignore[arg-type]
+
+
+def test_governance_metadata_rejects_unknown_risk_class() -> None:
+    with pytest.raises(ValidationError):
+        GovernanceMetadata(risk_class="apocalyptic")  # type: ignore[arg-type]
+
+
+def test_governance_metadata_rejects_unknown_escalation_class() -> None:
+    with pytest.raises(ValidationError):
+        GovernanceMetadata(escalation_class="nuke_orbit")  # type: ignore[arg-type]
+
+
+def test_governance_metadata_serializes_to_json_round_trip() -> None:
+    """Round-trip via model_dump_json + model_validate_json preserves all fields."""
+    original = GovernanceMetadata(
+        decision_class="data_contract",
+        risk_class="high",
+        escalation_class="escalate",
+        owner="alice",
+        notification_channels=["#data"],
+        protected_component=True,
+    )
+    serialized = original.model_dump_json()
+    restored = GovernanceMetadata.model_validate_json(serialized)
+    assert restored == original

--- a/tests/test_governance_metadata_l1l2l3_defaults.py
+++ b/tests/test_governance_metadata_l1l2l3_defaults.py
@@ -1,0 +1,51 @@
+"""Phase 1 (#109) — derive_governance_metadata L1/L2/L3 default mapping."""
+
+from __future__ import annotations
+
+from governance.contracts import GovernanceMetadata, derive_governance_metadata
+
+
+def test_l1_default_maps_to_product_behavior_warn() -> None:
+    """L1 with no explicit metadata yields (product_behavior, medium, warn)."""
+    m = derive_governance_metadata("L1", None)
+    assert m.decision_class == "product_behavior"
+    assert m.risk_class == "medium"
+    assert m.escalation_class == "warn"
+
+
+def test_l2_default_maps_to_architecture_escalate() -> None:
+    """L2 with no explicit metadata yields (architecture, medium, escalate)."""
+    m = derive_governance_metadata("L2", None)
+    assert m.decision_class == "architecture"
+    assert m.risk_class == "medium"
+    assert m.escalation_class == "escalate"
+
+
+def test_l3_default_maps_to_implementation_preference_context_only() -> None:
+    """L3 with no explicit metadata yields (implementation_preference, low, context_only)."""
+    m = derive_governance_metadata("L3", None)
+    assert m.decision_class == "implementation_preference"
+    assert m.risk_class == "low"
+    assert m.escalation_class == "context_only"
+
+
+def test_explicit_metadata_overrides_l1l2l3_default() -> None:
+    """L2 decision with explicit security metadata keeps the explicit value."""
+    explicit = GovernanceMetadata(
+        decision_class="security",
+        risk_class="critical",
+        escalation_class="notify_supervisor_allowed",
+    )
+    m = derive_governance_metadata("L2", explicit)
+    assert m is explicit
+    assert m.decision_class == "security"
+    assert m.risk_class == "critical"
+    assert m.escalation_class == "notify_supervisor_allowed"
+
+
+def test_null_decision_level_falls_back_to_product_behavior_warn() -> None:
+    """Pre-classification rows with decision_level=None get L1 defaults."""
+    m = derive_governance_metadata(None, None)
+    assert m.decision_class == "product_behavior"
+    assert m.risk_class == "medium"
+    assert m.escalation_class == "warn"

--- a/tests/test_v15_migration.py
+++ b/tests/test_v15_migration.py
@@ -1,0 +1,108 @@
+"""Phase 1 (#109) — v14 → v15 migration: decision.governance field."""
+
+from __future__ import annotations
+
+import pytest
+
+from ledger.client import LedgerClient
+from ledger.schema import SCHEMA_VERSION, init_schema, migrate
+
+
+async def _fresh_client() -> LedgerClient:
+    c = LedgerClient(url="memory://", ns="bicameral_test", db="ledger_v15_test")
+    await c.connect()
+    await init_schema(c)
+    await migrate(c, allow_destructive=True)
+    return c
+
+
+@pytest.mark.phase2
+@pytest.mark.asyncio
+async def test_v15_migration_adds_governance_field() -> None:
+    """A migrated DB exposes the optional governance field on decision."""
+    c = await _fresh_client()
+    try:
+        # Schema must be at the current version (>= 15) after migrate.
+        rows = await c.query("SELECT version FROM schema_meta LIMIT 1")
+        assert rows
+        assert rows[0]["version"] == SCHEMA_VERSION
+        assert SCHEMA_VERSION >= 15
+
+        # Inserting a decision without governance must succeed; the
+        # field reads back as None (NONE in SurrealDB).
+        await c.query(
+            "CREATE decision SET description = $d, source_type = $st, "
+            "source_ref = $sr, status = 'ungrounded', canonical_id = 'cid-v15-1'",
+            {"d": "v15 governance probe", "st": "manual", "sr": "v15-test"},
+        )
+        rows = await c.query(
+            "SELECT description, governance FROM decision "
+            "WHERE description = 'v15 governance probe'"
+        )
+        assert rows
+        assert rows[0]["description"] == "v15 governance probe"
+        # FLEXIBLE option<object> default NONE: missing key OR explicit None.
+        gov = rows[0].get("governance")
+        assert gov is None or gov == {}
+
+        # Writing a governance object preserves nested keys (FLEXIBLE).
+        await c.query(
+            "UPDATE decision SET governance = $g WHERE description = 'v15 governance probe'",
+            {
+                "g": {
+                    "decision_class": "security",
+                    "risk_class": "critical",
+                    "escalation_class": "notify_supervisor_allowed",
+                    "protected_component": True,
+                }
+            },
+        )
+        rows = await c.query(
+            "SELECT governance FROM decision WHERE description = 'v15 governance probe'"
+        )
+        gov = rows[0]["governance"]
+        assert gov is not None
+        assert gov.get("decision_class") == "security"
+        assert gov.get("risk_class") == "critical"
+        assert gov.get("escalation_class") == "notify_supervisor_allowed"
+        assert gov.get("protected_component") is True
+    finally:
+        await c.close()
+
+
+@pytest.mark.phase2
+@pytest.mark.asyncio
+async def test_v15_migration_idempotent() -> None:
+    """Running migrate() twice is a no-op."""
+    c = await _fresh_client()
+    try:
+        # Already at SCHEMA_VERSION after _fresh_client().
+        await migrate(c, allow_destructive=True)
+        rows = await c.query("SELECT version FROM schema_meta LIMIT 1")
+        assert rows
+        assert rows[0]["version"] == SCHEMA_VERSION
+    finally:
+        await c.close()
+
+
+@pytest.mark.phase2
+@pytest.mark.asyncio
+async def test_existing_decisions_readable_after_v15() -> None:
+    """Pre-v15 decisions survive the migration; governance defaults to None."""
+    c = await _fresh_client()
+    try:
+        # Simulate a pre-v15 row: insert a decision with no governance set.
+        await c.query(
+            "CREATE decision SET description = $d, source_type = $st, "
+            "source_ref = $sr, status = 'ungrounded', canonical_id = 'cid-v15-2'",
+            {"d": "pre-v15 row", "st": "manual", "sr": "v15-pre"},
+        )
+        rows = await c.query(
+            "SELECT description, governance FROM decision WHERE description = 'pre-v15 row'"
+        )
+        assert rows
+        # No governance set → default behaviour: None / missing.
+        gov = rows[0].get("governance")
+        assert gov is None or gov == {} or gov == "NONE"
+    finally:
+        await c.close()


### PR DESCRIPTION
## Summary

Phases 1-3 of the governance plan (#108-#112 covers all 5). Adds the `governance/` package implementing the deterministic escalation policy engine plus its contracts foundation and the consolidated `GovernanceFinding` wrapper.

- **Phase 1 (#109):** `GovernanceMetadata` model + v14 → v15 schema migration adds optional `governance` flexible-object field on decisions; `derive_governance_metadata` maps L1/L2/L3 → (decision_class, risk_class, escalation_class) defaults; ingest/history thread metadata through.
- **Phase 2 (#110):** `GovernanceFinding` + `GovernancePolicyResult` contracts; `finding_factories` builders (`from_compliance_verdict`, `from_drift_entry`, `from_preflight_drift_candidate`); `consolidate()` collapses findings per `(decision_id, region_id)` using `_SEMANTIC_SEVERITY` ordering.
- **Phase 3 (#108):** `engine.evaluate()` orchestrates four pure helpers (`_check_required_conditions`, `_apply_class_defaults`, `_apply_bypass_downgrade`, `_apply_max_native_ceiling`); `config.py` parses `.bicameral/governance.yml` via `yaml.safe_load` with fail-soft fallback; new `bicameral.evaluate_governance` MCP tool (read-only); `handlers/preflight.py` attaches `governance_finding` to `PreflightResponse`.

Phase 4 (HITL bypass flow, #112) and Phase 5 (docs, #111) ship separately — engine takes `bypass_recency_seconds` as a scalar parameter, and Phase 3 passes `None` everywhere until Phase 4 wires the lookup.

## Files Added

- `governance/__init__.py`
- `governance/contracts.py` — `GovernanceMetadata`, `GovernanceFinding`, `GovernancePolicyResult` + `derive_governance_metadata`
- `governance/finding_factories.py` — builders + `consolidate()`
- `governance/config.py` — `.bicameral/governance.yml` parser; `allow_blocking: Literal[False]` locked at the type level
- `governance/engine.py` — pure deterministic evaluator
- `handlers/evaluate_governance.py` — `bicameral.evaluate_governance` handler
- `docs/governance.example.yml` — canonical config example
- 7 new test files (~30 tests across them)

## Files Modified

- `contracts.py` — `IngestMapping`/`IngestDecision` get optional `governance`; `HistoryDecision` gets optional `governance`; `PreflightResponse` gets `governance_finding`; new `EvaluateGovernanceResponse`
- `ledger/schema.py` — `SCHEMA_VERSION = 15`; `_migrate_v14_to_v15` registered; canonical `decision.governance` flexible-object field
- `ledger/queries.py` — `upsert_decision` accepts optional `governance` dict
- `ledger/adapter.py` — threads `governance` through ingest pipeline
- `handlers/ingest.py` — copies `governance` from `IngestDecision` to mapping
- `handlers/history.py` — surfaces `governance` field in history rows
- `handlers/preflight.py` — builds + attaches `governance_finding` per drifted region
- `server.py` — registers `bicameral.evaluate_governance` tool
- `CHANGELOG.md` — v0.17.0 entry

## Schema migration

v14 → v15: additive only. `DEFINE FIELD OVERWRITE governance ON decision FLEXIBLE TYPE option<object> DEFAULT NONE`. Pre-v15 rows survive with `governance = NONE` and fall back to `derive_governance_metadata` defaults at engine evaluation time.

## Privacy / non-blocking

- Engine is pure; bypass-recency lookup IO happens in the caller (Phase 4).
- All YAML parsing uses `yaml.safe_load` — never `yaml.load`.
- `config.allow_blocking: Literal[False]` is type-locked; pydantic refuses any other value (verified by `test_allow_blocking_must_be_false`).
- `config.max_native_action` caps the engine's worst-case visibility action.
- `.bicameral/governance.yml` is local-only; no network egress.
- No telemetry writes added in this PR (Phase 4 territory).

## Tests (~30 new across 7 files)

- `test_governance_metadata.py` (6)
- `test_governance_metadata_l1l2l3_defaults.py` (5)
- `test_v15_migration.py` (3)
- `test_governance_finding.py` (5)
- `test_governance_finding_consolidation.py` (6)
- `test_governance_config_loader.py` (6)
- `test_governance_engine.py` (10)
- `test_evaluate_governance_handler.py` (3)

44 governance tests pass; full regression (`test_phase2_ledger.py`, `test_v055_region_anchored_preflight.py`, `test_compliance_check_schema.py`, `test_schema_persistence.py`) all green. `ruff check`, `ruff format --check`, and `mypy .` all pass.

## References

- Plan: `plan-governance-108-112.md`
- Audit: `AUDIT_REPORT_GOVERNANCE.md` (PASS verdict; V1-V5 + F1-F5 fixes already encoded in plan)

Closes #109
Closes #110
Refs #108

## Test plan

- [x] `python -m pytest tests/test_governance_*.py tests/test_v15_migration.py tests/test_evaluate_governance_handler.py -v` — 44 passed
- [x] `python -m pytest tests/test_phase2_ledger.py tests/test_v055_region_anchored_preflight.py` — 30 passed, 1 skipped
- [x] `ruff check . && ruff format --check . && mypy .` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)