### PR TITLE
feat: preflight HITL bypass flow (v0.17.1, #112)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,24 @@
 All notable changes to bicameral-mcp are tracked here. Format loosely follows
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
+## v0.17.1 -- preflight HITL bypass flow (#112)
+
+Wires the deterministic engine into the preflight HITL surface. Unresolved signoff states (proposed, ai_surfaced, needs_context, collision_pending, context_pending) trigger AskUserQuestion prompts with mandatory bypass option. Bypass writes a `preflight_prompt_bypassed` event via `preflight_telemetry.py` (V4 idempotent within 1-hour recency window) without mutating decision state. The engine reads recent bypass events and drops one tier of escalation for recently-bypassed decisions.
+
+### Added
+
+- `governance/contracts.py` -- `HITLPrompt`, `HITLPromptOption` (mandatory bypass last)
+- `contracts.py` -- `hitl_prompts: list[HITLPrompt] = []` on `PreflightResponse`; `RecordBypassResponse`
+- `preflight_telemetry.py` -- `write_bypass_event` (V4 idempotent), `recent_bypass_seconds` (F3 bounded tail-read, ≤1000 lines)
+- `bicameral.record_bypass` MCP tool (returns `{recorded, deduped, reason}`)
+- `handlers/preflight.py` -- HITL trigger logic + JSONL-driven recency wired into `engine.evaluate`
+- `handlers/record_bypass.py` -- new MCP write handler
+- `skills/bicameral-preflight/SKILL.md` -- step 5.4 documents trigger conditions, mandatory-last bypass, and the tier-drop semantics
+
+### Closes
+
+#112
+
 ## v0.17.0 -- governance contracts + escalation engine (#108-#110, Phases 1-3 of #108-#112 plan)
 
 Adds `governance/` package with the deterministic escalation policy engine, decision/risk/escalation metadata contracts, and the consolidated `GovernanceFinding` wrapper. Engine is non-blocking by design (`config.allow_blocking: Literal[False]` locks the type). Phase 4 (HITL bypass flow) and Phase 5 (docs) ship in follow-up PRs.

--- a/contracts.py
+++ b/contracts.py
@@ -18,7 +18,7 @@ from typing import Literal
 
 from pydantic import BaseModel, ConfigDict, Field
 
-from governance.contracts import GovernanceFinding
+from governance.contracts import GovernanceFinding, HITLPrompt
 
 # ── Skill telemetry diagnostic models ────────────────────────────────
 # One model per skill. extra="forbid" means the handler can detect and
@@ -664,10 +664,20 @@ class PreflightResponse(BaseModel):
     # #108-#110 — consolidated governance finding (with attached
     # policy_result) when preflight surfaced one or more drift candidates
     # for a region-anchored decision. None when there are no findings.
-    # Phase 4 (#112) will populate ``policy_result.action`` with
-    # bypass-aware downgrades; Phase 3 always passes
-    # ``bypass_recency_seconds=None`` to the engine.
+    # Phase 4 (#112) populates ``policy_result.action`` with
+    # bypass-aware downgrades by passing the JSONL-derived recency
+    # scalar to the engine; Phase 3 always passed
+    # ``bypass_recency_seconds=None``.
     governance_finding: GovernanceFinding | None = None
+    # #112 — HITL clarification prompts for unresolved signoff states
+    # (proposed, ai_surfaced, needs_context, collision_pending,
+    # context_pending). Each prompt carries a mandatory ``bypass``
+    # option as its LAST option; the skill side asserts this and
+    # routes the bypass selection to ``bicameral.record_bypass``.
+    # Bypass does NOT mutate decision state; the engine reads the
+    # bypass JSONL log and drops one tier of escalation when a recent
+    # bypass exists for the same decision_id.
+    hitl_prompts: list[HITLPrompt] = []
 
 
 # ── Tool: bicameral.evaluate_governance (#108) ───────────────────────
@@ -686,6 +696,25 @@ class EvaluateGovernanceResponse(BaseModel):
     region_id: str | None = None
     finding: GovernanceFinding | None = None
     error: str | None = None
+
+
+# ── Tool: bicameral.record_bypass (#112) ─────────────────────────────
+
+
+class RecordBypassResponse(BaseModel):
+    """Response envelope for ``bicameral.record_bypass``.
+
+    ``recorded`` is True iff a new ``preflight_prompt_bypassed`` event
+    was appended to the JSONL log. ``deduped`` is True iff the call
+    was a no-op because a prior bypass for the same decision_id is
+    still inside the recency window (V4 idempotency guard). When
+    telemetry is disabled both are False and ``reason`` carries the
+    ``telemetry_disabled`` sentinel.
+    """
+
+    recorded: bool
+    deduped: bool
+    reason: str | None = None
 
 
 # ── Tool 10: /bicameral_judge_gaps ───────────────────────────────────

--- a/governance/__init__.py
+++ b/governance/__init__.py
@@ -9,6 +9,12 @@ Phases 1-3 of the governance plan (#108-#110):
     locked to ``Literal[False]`` at the type level
   - engine: pure deterministic ``evaluate()`` orchestrator
 
-Phase 4 (#112 HITL bypass flow) and Phase 5 (#111 docs) ship in
-follow-up PRs.
+Phase 4 (#112 HITL bypass flow):
+  - contracts: ``HITLPrompt``, ``HITLPromptOption`` (mandatory-last
+    bypass option). Wired into ``handlers/preflight.py`` as
+    ``PreflightResponse.hitl_prompts``; ``handlers/record_bypass.py``
+    exposes the bypass writer as the ``bicameral.record_bypass`` MCP
+    tool.
+
+Phase 5 (#111 docs) ships in a follow-up PR.
 """

--- a/governance/contracts.py
+++ b/governance/contracts.py
@@ -164,3 +164,54 @@ class GovernanceFinding(BaseModel):
     explanation: str
     evidence_refs: list[str] = []
     policy_result: GovernancePolicyResult | None = None
+
+
+# ── Phase 4: HITL prompt + option (#112) ─────────────────────────────
+
+
+class HITLPromptOption(BaseModel):
+    """One selectable option in a preflight HITL clarification prompt.
+
+    The ``kind`` enum is closed; the skill side renders ``label`` to
+    the user and routes the chosen kind back to the appropriate
+    follow-up tool. ``bypass`` is mandatory and must always be the
+    final option (skill-side assertion enforces ordering).
+    """
+
+    kind: Literal[
+        "ratify",
+        "reject",
+        "needs_context",
+        "defer",
+        "bypass",
+        "supersedes_a_b",
+        "supersedes_b_a",
+        "keep_parallel",
+        "confirm_proposed",
+        "ratify_now",
+    ]
+    label: str
+
+
+class HITLPrompt(BaseModel):
+    """A preflight clarification prompt the agent should surface via
+    AskUserQuestion when a decision has an unresolved signoff state.
+
+    Bypass is mandatory and enforced as the LAST option in
+    ``options`` -- the skill assertion fails otherwise. Bypass writes
+    a ``preflight_prompt_bypassed`` event via ``preflight_telemetry``
+    but does NOT mutate decision state; the unresolved status persists
+    for future preflight surfaces. Recently-bypassed decisions are
+    treated one tier softer by the engine.
+    """
+
+    decision_id: str
+    trigger: Literal[
+        "proposed",
+        "ai_surfaced",
+        "needs_context",
+        "collision_pending",
+        "context_pending",
+    ]
+    question: str
+    options: list[HITLPromptOption]

--- a/handlers/preflight.py
+++ b/handlers/preflight.py
@@ -43,6 +43,8 @@ from governance import config as governance_config
 from governance import engine as governance_engine
 from governance.contracts import (
     GovernanceFinding,
+    HITLPrompt,
+    HITLPromptOption,
     derive_governance_metadata,
 )
 from governance.finding_factories import consolidate, from_preflight_drift_candidate
@@ -50,6 +52,7 @@ from handlers.action_hints import generate_hints_from_findings
 from handlers.analysis import _to_brief_decision
 from preflight_telemetry import (
     new_preflight_id,
+    recent_bypass_seconds,
     telemetry_enabled,
     write_preflight_event,
 )
@@ -427,14 +430,24 @@ async def handle_preflight(
     # #108-#110 — governance finding (Phase 3). Build a finding per
     # drifted region candidate, run the engine, consolidate per
     # (decision_id, region_id), and attach the highest-severity
-    # consolidated finding to the response. Phase 4 (#112) will plumb
-    # bypass-recency from preflight_telemetry.recent_bypass_seconds;
-    # Phase 3 always passes None.
+    # consolidated finding to the response. #112 (Phase 4) plumbs
+    # bypass-recency from preflight_telemetry.recent_bypass_seconds
+    # so recently-bypassed decisions render one tier softer.
     governance_finding: GovernanceFinding | None = None
     try:
         governance_finding = await _build_governance_finding(ctx, drift_candidates)
     except Exception as exc:
         logger.debug("[preflight] governance finding build failed: %s", exc)
+
+    # #112 — HITL clarification prompts. Iterate every decision that
+    # surfaced (region matches + collision/context-pending HITL rows)
+    # and emit a prompt for any unresolved signoff state. Bypass option
+    # is mandatory and last in every prompt's option list.
+    hitl_prompts = _build_hitl_prompts(
+        region_matches,
+        unresolved_collisions,
+        context_pending_ready,
+    )
 
     response = PreflightResponse(
         topic=topic,
@@ -453,6 +466,7 @@ async def handle_preflight(
         product_stage=_PRODUCT_STAGE_MSG if _should_show_product_stage() else None,
         preflight_id=pid,
         governance_finding=governance_finding,
+        hitl_prompts=hitl_prompts,
     )
 
     # #65 — capture-loop event. surfaced_ids is the union of decision_ids the
@@ -489,8 +503,11 @@ async def _build_governance_finding(
     candidates. Returns the highest-severity consolidated finding
     (with policy_result attached) or None if there are no candidates.
 
-    Engine runs with ``bypass_recency_seconds=None`` until Phase 4
-    (#112) wires the actual lookup via preflight_telemetry.
+    #112 (Phase 4): bypass-recency is read at the call site via
+    ``preflight_telemetry.recent_bypass_seconds`` and passed as a
+    scalar into the engine. Engine purity is preserved -- IO happens
+    here, not in ``evaluate()``. When telemetry is disabled the
+    recency lookup is skipped entirely.
     """
     if not drift_candidates:
         return None
@@ -556,12 +573,25 @@ async def _build_governance_finding(
             decision_status = "active"
 
         finding = from_preflight_drift_candidate(candidate, metadata)
+        # #112 — Phase 4 wiring. Read bypass recency from the JSONL
+        # log; engine drops one escalation tier when within window.
+        recency: int | None = None
+        if telemetry_enabled():
+            try:
+                recency = recent_bypass_seconds(candidate.decision_id)
+            except Exception as exc:  # pragma: no cover — defensive
+                logger.debug(
+                    "[preflight] recent_bypass_seconds(%s) failed: %s",
+                    candidate.decision_id,
+                    exc,
+                )
+                recency = None
         policy = governance_engine.evaluate(
             finding=finding,
             metadata=metadata,
             config=cfg,
             decision_status=decision_status,  # type: ignore[arg-type]
-            bypass_recency_seconds=None,
+            bypass_recency_seconds=recency,
         )
         findings.append(finding.model_copy(update={"policy_result": policy}))
 
@@ -585,3 +615,130 @@ async def _build_governance_finding(
 
     consolidated.sort(key=_severity_key, reverse=True)
     return consolidated[0]
+
+
+# ── #112 — HITL clarification prompts ────────────────────────────────
+
+# Bypass option is mandatory and last in every prompt. The skill side
+# asserts ``options[-1].kind == "bypass"`` -- breaking this contract
+# breaks the surface.
+_BYPASS_OPTION = HITLPromptOption(
+    kind="bypass",
+    label="Bypass — proceed without resolving (recorded)",
+)
+
+# Trigger states that yield a HITL prompt. Mirrors the
+# ``HITLPrompt.trigger`` literal in ``governance/contracts.py``. Any
+# decision whose ``signoff_state`` is in this set surfaces a prompt.
+_HITL_TRIGGER_STATES: frozenset[str] = frozenset(
+    {
+        "proposed",
+        "ai_surfaced",
+        "needs_context",
+        "collision_pending",
+        "context_pending",
+    }
+)
+
+
+def _hitl_options_for(trigger: str) -> list[HITLPromptOption]:
+    """Return the option set for a given trigger.
+
+    Three shapes per the plan:
+      - generic: ratify / reject / needs_context / defer / bypass
+      - collision_pending: supersedes_a_b / supersedes_b_a /
+        keep_parallel / defer / bypass
+      - ai_surfaced: confirm_proposed / ratify_now / reject /
+        needs_context / bypass
+
+    Bypass is ALWAYS last.
+    """
+    if trigger == "collision_pending":
+        return [
+            HITLPromptOption(kind="supersedes_a_b", label="A supersedes B"),
+            HITLPromptOption(kind="supersedes_b_a", label="B supersedes A"),
+            HITLPromptOption(kind="keep_parallel", label="Keep both in parallel"),
+            HITLPromptOption(kind="defer", label="Defer — decide later"),
+            _BYPASS_OPTION,
+        ]
+    if trigger == "ai_surfaced":
+        return [
+            HITLPromptOption(kind="confirm_proposed", label="Confirm as proposed"),
+            HITLPromptOption(kind="ratify_now", label="Ratify now"),
+            HITLPromptOption(kind="reject", label="Reject — not a real decision"),
+            HITLPromptOption(kind="needs_context", label="Needs more context"),
+            _BYPASS_OPTION,
+        ]
+    # Generic: proposed, needs_context, context_pending.
+    return [
+        HITLPromptOption(kind="ratify", label="Ratify"),
+        HITLPromptOption(kind="reject", label="Reject"),
+        HITLPromptOption(kind="needs_context", label="Needs more context"),
+        HITLPromptOption(kind="defer", label="Defer — decide later"),
+        _BYPASS_OPTION,
+    ]
+
+
+def _hitl_question_for(trigger: str, description: str) -> str:
+    """Compose a one-line clarification question for the prompt."""
+    snippet = (description or "").strip()
+    if len(snippet) > 80:
+        snippet = snippet[:77] + "..."
+    if trigger == "collision_pending":
+        return f"Two decisions appear to conflict — which path applies? ({snippet})"
+    if trigger == "ai_surfaced":
+        return f"AI surfaced this as a possible decision — confirm? ({snippet})"
+    if trigger == "needs_context":
+        return f"This decision needs more context — what's missing? ({snippet})"
+    if trigger == "context_pending":
+        return f"Awaiting context to ground this decision — provide one? ({snippet})"
+    return f"This decision is unresolved — confirm or revise? ({snippet})"
+
+
+def _prompt_from(decision_id: str, description: str, trigger: str) -> HITLPrompt:
+    """Build a HITLPrompt for a single (decision_id, signoff_state)."""
+    return HITLPrompt(
+        decision_id=decision_id,
+        trigger=trigger,  # type: ignore[arg-type]
+        question=_hitl_question_for(trigger, description),
+        options=_hitl_options_for(trigger),
+    )
+
+
+def _build_hitl_prompts(
+    region_matches: list[DecisionMatch],
+    unresolved_collisions: list[BriefDecision],
+    context_pending_ready: list[BriefDecision],
+) -> list[HITLPrompt]:
+    """Scan all surfaced decisions and emit one HITLPrompt per
+    unresolved signoff_state. De-duped by decision_id.
+
+    Triggers come from ``signoff_state`` directly when it is one of
+    the configured trigger states; ``unresolved_collisions`` rows
+    always emit a ``collision_pending`` prompt and
+    ``context_pending_ready`` rows always emit a ``context_pending``
+    prompt -- those queries explicitly target those states.
+    """
+    prompts: list[HITLPrompt] = []
+    seen: set[str] = set()
+
+    def _add(decision_id: str, description: str, trigger: str) -> None:
+        if not decision_id or decision_id in seen:
+            return
+        if trigger not in _HITL_TRIGGER_STATES:
+            return
+        prompts.append(_prompt_from(decision_id, description, trigger))
+        seen.add(decision_id)
+
+    for m in region_matches:
+        state = (m.signoff_state or "").strip()
+        if state in _HITL_TRIGGER_STATES:
+            _add(m.decision_id, m.description, state)
+
+    for d in unresolved_collisions:
+        _add(d.decision_id, d.description, "collision_pending")
+
+    for d in context_pending_ready:
+        _add(d.decision_id, d.description, "context_pending")
+
+    return prompts

--- a/handlers/record_bypass.py
+++ b/handlers/record_bypass.py
@@ -1,0 +1,81 @@
+"""Handler for ``bicameral.record_bypass`` MCP tool (#112).
+
+Small write tool exposed to skill context so the bypass option on a
+preflight HITL prompt can be persisted from outside the server. The
+handler is a thin wrapper around ``preflight_telemetry.write_bypass_event``:
+
+  - Returns ``recorded=True, deduped=False`` on a fresh bypass write.
+  - Returns ``recorded=False, deduped=True`` when a prior bypass for
+    the same ``decision_id`` is still inside the recency window
+    (V4 idempotent guard prevents indefinite escalation suppression).
+  - Returns ``recorded=False, deduped=False, reason='telemetry_disabled'``
+    when ``BICAMERAL_PREFLIGHT_TELEMETRY`` is off.
+
+Bypass does NOT mutate decision state. The unresolved ``signoff_state``
+persists for future preflight surfaces. The governance engine reads
+bypass recency at preflight call time and drops one tier on the action
+ladder when a recent bypass exists -- acknowledgement that the user
+has seen the unresolved state, not a permanent suppression.
+"""
+
+from __future__ import annotations
+
+import logging
+
+from contracts import RecordBypassResponse
+
+logger = logging.getLogger(__name__)
+
+
+async def handle_record_bypass(
+    ctx,
+    decision_id: str,
+    reason: str = "user_bypassed",
+    state_preserved: str = "proposed",
+) -> RecordBypassResponse:
+    """Record that the user bypassed a preflight HITL prompt.
+
+    ``ctx`` is the standard ``BicameralContext`` -- unused here because
+    bypass storage lives in the local JSONL log (no ledger write).
+    Idempotent within the 1-hour recency window: a second call inside
+    the window returns ``deduped=True`` without writing. Caller-side
+    skills can rely on ``recorded`` to distinguish a fresh bypass from
+    a within-window repeat.
+    """
+    del ctx  # unused — bypass storage is local JSONL, not the ledger.
+
+    if not decision_id or not isinstance(decision_id, str):
+        return RecordBypassResponse(
+            recorded=False,
+            deduped=False,
+            reason="invalid_decision_id",
+        )
+
+    # Imported lazily so tests that monkeypatch ``preflight_telemetry``
+    # observe the patched module. Otherwise the import freezes at
+    # server-startup time and breaks the per-test ``Path.home()``
+    # reload pattern used elsewhere in the suite.
+    from preflight_telemetry import (
+        recent_bypass_seconds,
+        telemetry_enabled,
+        write_bypass_event,
+    )
+
+    if not telemetry_enabled():
+        return RecordBypassResponse(
+            recorded=False,
+            deduped=False,
+            reason="telemetry_disabled",
+        )
+
+    was_recent = recent_bypass_seconds(decision_id) is not None
+    write_bypass_event(
+        decision_id,
+        reason=reason,
+        state_preserved=state_preserved,
+    )
+    return RecordBypassResponse(
+        recorded=not was_recent,
+        deduped=was_recent,
+        reason=None,
+    )

--- a/preflight_telemetry.py
+++ b/preflight_telemetry.py
@@ -54,6 +54,22 @@ _MAX_BYTES = 50 * 10**6  # 50 MB
 _MAX_AGE_DAYS = 30
 _KEEP_ROTATIONS = 5
 
+# #112 — Phase 4 HITL bypass flow.
+# A bypass event written within this window suppresses subsequent writes
+# for the same decision_id (V4 idempotency guard) AND causes the
+# governance engine to drop one escalation tier (acknowledgement that
+# the user has seen the unresolved state). 1 hour is short enough that
+# a forgotten bypass doesn't permanently silence a finding, long enough
+# that follow-up preflights inside the same work session don't double-
+# prompt.
+_BYPASS_RECENCY_WINDOW_SECONDS = 3600
+
+# F3 bound: ``recent_bypass_seconds`` scans at most this many trailing
+# JSONL lines and breaks early on the first event older than the
+# recency window. Keeps per-call cost O(min(N, 1000)) for any file
+# size under the 50 MB rotation cap.
+_BYPASS_TAIL_SCAN_LIMIT = 1000
+
 
 # ── Env gates ────────────────────────────────────────────────────────
 
@@ -301,3 +317,138 @@ def write_engagement(
         "attribution": attribution,
     }
     _append(_ENGAGEMENTS_FILE, record)
+
+
+# ── Phase 4: #112 HITL bypass flow ───────────────────────────────────
+
+
+def write_bypass_event(
+    decision_id: str,
+    reason: str = "user_bypassed",
+    state_preserved: str = "proposed",
+) -> None:
+    """Append a ``preflight_prompt_bypassed`` event to the JSONL log.
+
+    Idempotent within ``_BYPASS_RECENCY_WINDOW_SECONDS`` (V4 spam-
+    bypass guard): if a bypass for ``decision_id`` already exists in
+    the window, this call is a no-op. The first bypass establishes
+    the recency fingerprint; subsequent calls inside the hour cannot
+    extend it. Prevents indefinite escalation suppression on a
+    sensitive decision.
+
+    No-op when telemetry is disabled. Reuses the existing salt +
+    rotation + 0o600-mode path of ``preflight_events.jsonl``. Bypass
+    does NOT mutate decision state -- the unresolved signoff_state
+    persists for future preflight surfaces.
+    """
+    if not telemetry_enabled():
+        return
+    if recent_bypass_seconds(decision_id) is not None:
+        return
+    record = {
+        "ts": datetime.now(UTC).isoformat(),
+        "event_type": "preflight_prompt_bypassed",
+        "decision_id": decision_id,
+        "reason": reason,
+        "state_preserved": state_preserved,
+        "risk_visible": True,
+    }
+    _append(_EVENTS_FILE, record)
+
+
+def recent_bypass_seconds(decision_id: str) -> int | None:
+    """Return seconds since the most recent bypass for ``decision_id``,
+    or ``None`` if no bypass exists in the recency window.
+
+    F3 bounded tail-read: scans at most ``_BYPASS_TAIL_SCAN_LIMIT``
+    trailing JSONL lines and breaks early on the first event older
+    than ``_BYPASS_RECENCY_WINDOW_SECONDS``. Per-call cost is
+    O(min(N, 1000)) regardless of file size; the 50 MB rotation cap
+    bounds the worst case further.
+    """
+    if not _EVENTS_FILE.exists():
+        return None
+    now_dt = datetime.now(UTC)
+    window = _BYPASS_RECENCY_WINDOW_SECONDS
+
+    # Read all lines (file is bounded by the 50 MB rotation cap; the
+    # JSONL writer uses line-delimited records, so a streaming reverse
+    # walk is safe). Cap at the tail scan limit per F3.
+    try:
+        with _EVENTS_FILE.open("rb") as fh:
+            tail_lines = _read_tail_lines(fh, _BYPASS_TAIL_SCAN_LIMIT)
+    except OSError:
+        return None
+
+    # Walk from newest -> oldest, short-circuit on first event past window.
+    for raw in reversed(tail_lines):
+        line = raw.strip()
+        if not line:
+            continue
+        try:
+            row = json.loads(line)
+        except json.JSONDecodeError:
+            continue
+        ts_raw = row.get("ts")
+        if not isinstance(ts_raw, str):
+            continue
+        try:
+            ts_dt = datetime.fromisoformat(ts_raw)
+        except ValueError:
+            continue
+        if ts_dt.tzinfo is None:
+            ts_dt = ts_dt.replace(tzinfo=UTC)
+        age = (now_dt - ts_dt).total_seconds()
+        if age >= window:
+            # F3 short-circuit: events are JSONL-appended chronologically,
+            # so any event older than the window means everything before
+            # it is also older. Stop scanning.
+            return None
+        if (
+            row.get("event_type") == "preflight_prompt_bypassed"
+            and row.get("decision_id") == decision_id
+        ):
+            seconds = int(age) if age >= 0 else 0
+            return seconds
+    return None
+
+
+def _read_tail_lines(fh, limit: int) -> list[bytes]:
+    """Return at most the last ``limit`` newline-delimited lines from
+    ``fh`` (a file opened in binary mode).
+
+    Reads in 8 KiB blocks from the end, splits on ``\\n``, and stops
+    once ``limit + 1`` line boundaries are seen so we have ``limit``
+    complete lines plus the partial leading line we then discard.
+    Tiny files are read whole.
+    """
+    block_size = 8192
+    fh.seek(0, os.SEEK_END)
+    size = fh.tell()
+    if size == 0:
+        return []
+    blocks: list[bytes] = []
+    pos = size
+    line_count = 0
+    while pos > 0 and line_count <= limit:
+        read_size = min(block_size, pos)
+        pos -= read_size
+        fh.seek(pos)
+        chunk = fh.read(read_size)
+        blocks.append(chunk)
+        line_count += chunk.count(b"\n")
+    data = b"".join(reversed(blocks))
+    # Split out lines; drop the first if it is a partial leading line
+    # (i.e. we did not read from byte 0).
+    lines = data.split(b"\n")
+    # The split's last element is whatever followed the final \n —
+    # typically empty for properly-terminated JSONL; if non-empty it's
+    # an unterminated trailing record we still want to consider.
+    if pos > 0 and lines:
+        # Drop the partial first line.
+        lines = lines[1:]
+    # Decode non-empty lines.
+    out: list[bytes] = [ln for ln in lines if ln.strip()]
+    if len(out) > limit:
+        out = out[-limit:]
+    return out

--- a/server.py
+++ b/server.py
@@ -48,6 +48,7 @@ from handlers.link_commit import handle_link_commit
 from handlers.list_unclassified_decisions import handle_list_unclassified_decisions
 from handlers.preflight import handle_preflight
 from handlers.ratify import handle_ratify
+from handlers.record_bypass import handle_record_bypass
 from handlers.reset import handle_reset
 from handlers.resolve_collision import handle_resolve_collision
 from handlers.resolve_compliance import handle_resolve_compliance
@@ -109,6 +110,7 @@ EXPECTED_TOOL_NAMES = [
     "bicameral.list_unclassified_decisions",
     "bicameral.set_decision_level",
     "bicameral.evaluate_governance",
+    "bicameral.record_bypass",
     "validate_symbols",
     "get_neighbors",
     "extract_symbols",
@@ -857,6 +859,39 @@ async def list_tools() -> list[Tool]:
                 "required": ["decision_id"],
             },
         ),
+        # ── Governance HITL bypass (#112) ───────────────────────────
+        Tool(
+            name="bicameral.record_bypass",
+            description=(
+                "Record that the user bypassed a preflight HITL prompt. "
+                "Bypass does NOT mutate decision state -- it preserves "
+                "the unresolved status while recording that the user "
+                "chose to continue. Idempotent within a 1-hour recency "
+                "window (returns deduped=true on a within-window repeat). "
+                "The governance engine reads recent bypass events at "
+                "preflight call time and drops one tier of escalation."
+            ),
+            inputSchema={
+                "type": "object",
+                "properties": {
+                    "decision_id": {
+                        "type": "string",
+                        "description": "Decision record id whose HITL prompt the user bypassed.",
+                    },
+                    "reason": {
+                        "type": "string",
+                        "default": "user_bypassed",
+                        "description": "Free-form reason label for the audit trail.",
+                    },
+                    "state_preserved": {
+                        "type": "string",
+                        "default": "proposed",
+                        "description": "The decision's signoff_state at bypass time (recorded for audit).",
+                    },
+                },
+                "required": ["decision_id"],
+            },
+        ),
         # ── Code locator tools (MCP-native) ──────────────────────────
         Tool(
             name="validate_symbols",
@@ -1159,6 +1194,13 @@ async def call_tool(name: str, arguments: dict) -> list[TextContent]:
                 decision_id=arguments["decision_id"],
                 region_id=arguments.get("region_id"),
                 source=arguments.get("source", "manual"),
+            )
+        elif name in ("bicameral.record_bypass", "record_bypass"):
+            result = await handle_record_bypass(
+                ctx,
+                decision_id=arguments["decision_id"],
+                reason=arguments.get("reason", "user_bypassed"),
+                state_preserved=arguments.get("state_preserved", "proposed"),
             )
         elif name in ("bicameral.dashboard", "dashboard"):
             from contracts import DashboardResponse

--- a/skills/bicameral-preflight/SKILL.md
+++ b/skills/bicameral-preflight/SKILL.md
@@ -283,6 +283,61 @@ format. Lead with the `(bicameral surfaced)` attribution line.
 Then, if `response.action_hints` is non-empty, render each hint
 verbatim — never paraphrase the `message` field.
 
+### 5.4 Surface HITL clarification prompts (#112)
+
+If `response.hitl_prompts` is non-empty, the server has detected one
+or more decisions with an unresolved `signoff_state`. Each prompt
+already carries the question, the trigger label, and a closed option
+list. Render them via `AskUserQuestion`.
+
+**Trigger conditions** — a prompt is emitted whenever a surfaced
+decision's `signoff_state` is one of:
+
+- `proposed` — decision exists but no one has ratified it yet.
+- `ai_surfaced` — auto-extracted by an LLM, awaiting human review.
+- `needs_context` — decision text is unclear; asks for more.
+- `collision_pending` — two decisions appear to conflict.
+- `context_pending` — awaiting a span to ground it.
+
+Bypass is **mandatory and last** in every option list — assert
+`prompt.options[-1].kind == "bypass"` before rendering. Trust contract:
+Bicameral does NOT block work, the bypass option is always reachable.
+
+```python
+for prompt in response.hitl_prompts:
+    assert prompt.options[-1].kind == "bypass"
+    answer = AskUserQuestion({
+        "question": prompt.question,
+        "multiSelect": False,
+        "options": [
+            {"label": opt.label, "description": opt.kind}
+            for opt in prompt.options
+        ],
+    })
+    if answer.kind == "bypass":
+        bicameral.record_bypass(decision_id=prompt.decision_id)
+```
+
+**Bypass semantics**:
+
+- Bypass does NOT mutate decision state. The unresolved
+  `signoff_state` persists for future preflight surfaces.
+- Calling `bicameral.record_bypass(decision_id)` writes a
+  `preflight_prompt_bypassed` event to the local JSONL log
+  (`~/.bicameral/preflight_events.jsonl`). Idempotent within a 1-hour
+  recency window — repeat calls inside the window return
+  `deduped=true` without re-writing (V4 spam-bypass guard prevents
+  indefinite escalation suppression).
+- The governance engine reads recent bypass events and drops one
+  escalation tier (e.g. `escalate` → `warn`, `warn` → `context`) when
+  the same decision is resurfaced inside the recency window. This
+  acknowledges that the user has SEEN the unresolved state without
+  permanently silencing the finding.
+- Telemetry must be enabled (`BICAMERAL_PREFLIGHT_TELEMETRY=1`) for
+  bypass writes to persist; otherwise `record_bypass` returns
+  `recorded=false, deduped=false, reason="telemetry_disabled"` and the
+  engine sees no recency.
+
 ### 5.5 Confirm finding relevance (ground truth for calibration)
 
 > **Guard**: Only run this step if guided mode is enabled (`guided: true` in `.bicameral/config.yaml`). In normal mode, skip and set `g10_user_overrode = 0`.

--- a/tests/test_bypass_event_persistence.py
+++ b/tests/test_bypass_event_persistence.py
@@ -1,0 +1,183 @@
+"""Phase 4 (#112) — bypass event JSONL persistence + engine integration.
+
+Mirrors the per-test ``Path.home()`` reload pattern from
+``test_preflight_telemetry.py`` so each test gets an isolated
+``~/.bicameral/preflight_events.jsonl``. The engine integration test
+exercises the actual JSONL-driven recency lookup that Phase 3
+mocked.
+"""
+
+from __future__ import annotations
+
+import importlib
+import json
+from datetime import UTC, datetime, timedelta
+from pathlib import Path
+
+import pytest
+
+
+def _reload_pt(monkeypatch, home: Path):
+    """Point HOME at ``home`` and reload preflight_telemetry so its
+    module-level Path.home()-derived constants pick up the override."""
+    monkeypatch.setenv("HOME", str(home))
+    monkeypatch.setenv("USERPROFILE", str(home))
+    monkeypatch.setattr(Path, "home", classmethod(lambda cls: home))
+    import preflight_telemetry as pt
+
+    importlib.reload(pt)
+    return pt
+
+
+@pytest.fixture
+def pt(monkeypatch, tmp_path):
+    """Fresh preflight_telemetry pointed at tmp_path, telemetry enabled."""
+    monkeypatch.setenv("BICAMERAL_PREFLIGHT_TELEMETRY", "1")
+    monkeypatch.delenv("BICAMERAL_PREFLIGHT_TELEMETRY_RAW", raising=False)
+    return _reload_pt(monkeypatch, tmp_path)
+
+
+@pytest.fixture
+def pt_disabled(monkeypatch, tmp_path):
+    """Fresh preflight_telemetry pointed at tmp_path, telemetry disabled."""
+    monkeypatch.delenv("BICAMERAL_PREFLIGHT_TELEMETRY", raising=False)
+    monkeypatch.delenv("BICAMERAL_PREFLIGHT_TELEMETRY_RAW", raising=False)
+    return _reload_pt(monkeypatch, tmp_path)
+
+
+# ── Persistence tests ────────────────────────────────────────────────
+
+
+def test_bypass_event_appends_to_jsonl(pt, tmp_path):
+    """write_bypass_event appends a preflight_prompt_bypassed line."""
+    pt.write_bypass_event("dec-1", reason="user_bypassed", state_preserved="proposed")
+    events_file = tmp_path / ".bicameral" / "preflight_events.jsonl"
+    assert events_file.exists()
+    rows = [json.loads(line) for line in events_file.read_text().splitlines() if line.strip()]
+    assert len(rows) == 1
+    row = rows[0]
+    assert row["event_type"] == "preflight_prompt_bypassed"
+    assert row["decision_id"] == "dec-1"
+    assert row["reason"] == "user_bypassed"
+    assert row["state_preserved"] == "proposed"
+    assert row["risk_visible"] is True
+    assert "ts" in row
+
+
+def test_bypass_event_records_state_preserved(pt, tmp_path):
+    """state_preserved is recorded verbatim for the audit trail."""
+    pt.write_bypass_event("dec-2", state_preserved="collision_pending")
+    events_file = tmp_path / ".bicameral" / "preflight_events.jsonl"
+    rows = [json.loads(line) for line in events_file.read_text().splitlines() if line.strip()]
+    assert rows[0]["state_preserved"] == "collision_pending"
+
+
+def test_bypass_event_no_op_when_telemetry_disabled(pt_disabled, tmp_path):
+    """No write happens when BICAMERAL_PREFLIGHT_TELEMETRY=0."""
+    pt_disabled.write_bypass_event("dec-x", reason="user_bypassed")
+    events_file = tmp_path / ".bicameral" / "preflight_events.jsonl"
+    assert not events_file.exists()
+
+
+def test_bypass_event_idempotent_within_window(pt, tmp_path):
+    """V4 spam-bypass guard: second write inside the window is a no-op."""
+    pt.write_bypass_event("dec-recent")
+    pt.write_bypass_event("dec-recent")  # should be a no-op
+    events_file = tmp_path / ".bicameral" / "preflight_events.jsonl"
+    rows = [json.loads(line) for line in events_file.read_text().splitlines() if line.strip()]
+    assert len(rows) == 1, "second bypass within recency window must be deduped (V4 guard)"
+
+
+def test_recent_bypass_seconds_ignores_events_older_than_window(pt, tmp_path):
+    """An event older than the recency window does not block a new write."""
+    events_file = tmp_path / ".bicameral" / "preflight_events.jsonl"
+    events_file.parent.mkdir(parents=True, exist_ok=True)
+    old_ts = (
+        datetime.now(UTC) - timedelta(seconds=pt._BYPASS_RECENCY_WINDOW_SECONDS + 60)
+    ).isoformat()
+    events_file.write_text(
+        json.dumps(
+            {
+                "ts": old_ts,
+                "event_type": "preflight_prompt_bypassed",
+                "decision_id": "dec-old",
+                "reason": "user_bypassed",
+                "state_preserved": "proposed",
+                "risk_visible": True,
+            }
+        )
+        + "\n"
+    )
+    # Out-of-window — recency lookup returns None.
+    assert pt.recent_bypass_seconds("dec-old") is None
+    # And a fresh write goes through (not deduped by the stale event).
+    pt.write_bypass_event("dec-old")
+    rows = [json.loads(line) for line in events_file.read_text().splitlines() if line.strip()]
+    # Two rows: the stale one + the fresh write.
+    assert len(rows) == 2
+
+
+def test_engine_reads_recent_bypass_drops_tier(pt, tmp_path):
+    """End-to-end: engine.evaluate sees the JSONL-driven recency and
+    drops one tier on the action ladder.
+
+    Phase 3 verified ``_apply_bypass_downgrade`` directly with mocked
+    integers; Phase 4 wires the actual JSONL lookup. We write a fresh
+    bypass for ``dec-eng-1``, look it up via ``recent_bypass_seconds``,
+    pass the scalar into the engine, and assert the action drops one
+    rung.
+    """
+    from governance import config as governance_config
+    from governance import engine as governance_engine
+    from governance.contracts import GovernanceFinding, GovernanceMetadata
+
+    # Fresh bypass; recency should be < window.
+    pt.write_bypass_event("dec-eng-1")
+    recency = pt.recent_bypass_seconds("dec-eng-1")
+    assert recency is not None
+    assert recency < pt._BYPASS_RECENCY_WINDOW_SECONDS
+
+    # Build a finding + metadata that would land on `escalate` under
+    # default config + likely_drift severity. After bypass downgrade
+    # we expect `warn` (one tier softer).
+    finding = GovernanceFinding(
+        finding_id="f-1",
+        decision_id="dec-eng-1",
+        region_id=None,
+        decision_class="architecture",
+        risk_class="medium",
+        escalation_class="escalate",
+        source="preflight",
+        semantic_status="likely_drift",
+        confidence={},
+        explanation="test",
+        evidence_refs=[],
+    )
+    metadata = GovernanceMetadata(
+        decision_class="architecture",
+        risk_class="medium",
+        escalation_class="escalate",
+    )
+    cfg = governance_config.GovernanceConfig()
+
+    # Without bypass: escalate (or higher pre-ceiling).
+    no_bypass = governance_engine.evaluate(
+        finding=finding,
+        metadata=metadata,
+        config=cfg,
+        decision_status="ratified",
+        bypass_recency_seconds=None,
+    )
+    # With bypass: one tier softer.
+    with_bypass = governance_engine.evaluate(
+        finding=finding,
+        metadata=metadata,
+        config=cfg,
+        decision_status="ratified",
+        bypass_recency_seconds=recency,
+    )
+    ladder = governance_engine._ACTION_LADDER
+    assert ladder.index(with_bypass.action) == max(0, ladder.index(no_bypass.action) - 1), (
+        f"expected one-tier downgrade; baseline={no_bypass.action}, "
+        f"after_bypass={with_bypass.action}"
+    )

--- a/tests/test_preflight_hitl_prompts.py
+++ b/tests/test_preflight_hitl_prompts.py
@@ -1,0 +1,135 @@
+"""Phase 4 (#112) — preflight HITL prompt emission unit tests.
+
+These tests exercise the pure HITL builder helpers in
+``handlers.preflight``. They do not boot a ledger; they hand the
+builder synthesised ``DecisionMatch`` / ``BriefDecision`` rows and
+verify the emitted prompts.
+
+The bypass-option-mandatory-and-last contract is tested across every
+trigger shape — that's the skill-side assertion contract, so we lock
+it down at the type/shape level.
+"""
+
+from __future__ import annotations
+
+from contracts import BriefDecision, CodeRegionSummary, DecisionMatch
+from handlers.preflight import _build_hitl_prompts
+
+
+def _match(decision_id: str, signoff_state: str, description: str = "") -> DecisionMatch:
+    """Helper: build a minimal DecisionMatch for HITL prompt scanning."""
+    return DecisionMatch(
+        decision_id=decision_id,
+        description=description or f"decision text for {decision_id}",
+        status="pending",
+        signoff_state=signoff_state,
+        confidence=0.9,
+        source_ref="ref-1",
+        code_regions=[CodeRegionSummary(file_path="x.py", symbol="f", lines=(1, 5), purpose="t")],
+    )
+
+
+def _brief(decision_id: str, description: str = "") -> BriefDecision:
+    return BriefDecision(
+        decision_id=decision_id,
+        description=description or f"brief text for {decision_id}",
+        status="pending",
+    )
+
+
+def test_proposed_decision_triggers_prompt() -> None:
+    """A proposed signoff_state on a region match emits the generic prompt."""
+    prompts = _build_hitl_prompts(
+        region_matches=[_match("dec-1", "proposed", "Adopt Stripe webhook idempotency")],
+        unresolved_collisions=[],
+        context_pending_ready=[],
+    )
+    assert len(prompts) == 1
+    p = prompts[0]
+    assert p.decision_id == "dec-1"
+    assert p.trigger == "proposed"
+    kinds = [opt.kind for opt in p.options]
+    assert kinds == ["ratify", "reject", "needs_context", "defer", "bypass"]
+
+
+def test_collision_pending_triggers_competing_prompt() -> None:
+    """unresolved_collisions emits the competing-decisions option set."""
+    prompts = _build_hitl_prompts(
+        region_matches=[],
+        unresolved_collisions=[_brief("dec-coll-A", "Use Redis for sessions")],
+        context_pending_ready=[],
+    )
+    assert len(prompts) == 1
+    p = prompts[0]
+    assert p.trigger == "collision_pending"
+    kinds = [opt.kind for opt in p.options]
+    assert kinds == [
+        "supersedes_a_b",
+        "supersedes_b_a",
+        "keep_parallel",
+        "defer",
+        "bypass",
+    ]
+
+
+def test_ai_surfaced_triggers_ai_surfaced_prompt() -> None:
+    """ai_surfaced signoff_state emits the AI-surfaced option set."""
+    prompts = _build_hitl_prompts(
+        region_matches=[_match("dec-ai", "ai_surfaced", "Use bcrypt for password hashing")],
+        unresolved_collisions=[],
+        context_pending_ready=[],
+    )
+    assert len(prompts) == 1
+    p = prompts[0]
+    assert p.trigger == "ai_surfaced"
+    kinds = [opt.kind for opt in p.options]
+    assert kinds == [
+        "confirm_proposed",
+        "ratify_now",
+        "reject",
+        "needs_context",
+        "bypass",
+    ]
+
+
+def test_ratified_decision_does_not_trigger_prompt() -> None:
+    """A ratified signoff_state is resolved → no HITL prompt."""
+    prompts = _build_hitl_prompts(
+        region_matches=[_match("dec-r", "ratified")],
+        unresolved_collisions=[],
+        context_pending_ready=[],
+    )
+    assert prompts == []
+
+
+def test_every_prompt_includes_bypass_option_last() -> None:
+    """Skill-side contract: bypass option is mandatory and last."""
+    prompts = _build_hitl_prompts(
+        region_matches=[
+            _match("dec-1", "proposed"),
+            _match("dec-2", "ai_surfaced"),
+            _match("dec-3", "needs_context"),
+        ],
+        unresolved_collisions=[_brief("dec-4")],
+        context_pending_ready=[_brief("dec-5")],
+    )
+    # 5 unique decisions × 1 prompt each.
+    assert len(prompts) == 5
+    for p in prompts:
+        assert len(p.options) >= 2  # at least one real option + bypass
+        assert p.options[-1].kind == "bypass", (
+            f"prompt for {p.decision_id} ({p.trigger}) does not end with bypass option"
+        )
+
+
+def test_prompt_preserves_decision_id_for_audit() -> None:
+    """The decision_id round-trips into the prompt for skill-side dispatch."""
+    prompts = _build_hitl_prompts(
+        region_matches=[_match("dec:abc123", "proposed", "test description")],
+        unresolved_collisions=[],
+        context_pending_ready=[],
+    )
+    assert len(prompts) == 1
+    assert prompts[0].decision_id == "dec:abc123"
+    # Question contains a snippet of the description for context.
+    assert "test description" in prompts[0].question or "..." in prompts[0].question

--- a/tests/test_record_bypass_handler.py
+++ b/tests/test_record_bypass_handler.py
@@ -1,0 +1,96 @@
+"""Phase 4 (#112) — bicameral.record_bypass MCP handler tests.
+
+Covers:
+  - Fresh write returns recorded=True, deduped=False.
+  - Telemetry disabled returns recorded=False, deduped=False,
+    reason="telemetry_disabled".
+  - Idempotency: second call inside the window returns
+    recorded=False, deduped=True (V4 spam-bypass guard).
+  - Missing/empty decision_id returns recorded=False, deduped=False,
+    reason="invalid_decision_id".
+"""
+
+from __future__ import annotations
+
+import importlib
+from pathlib import Path
+
+import pytest
+
+from handlers.record_bypass import handle_record_bypass
+
+
+def _reload_pt(monkeypatch, home: Path):
+    """Reload preflight_telemetry against an isolated home dir."""
+    monkeypatch.setenv("HOME", str(home))
+    monkeypatch.setenv("USERPROFILE", str(home))
+    monkeypatch.setattr(Path, "home", classmethod(lambda cls: home))
+    import preflight_telemetry as pt
+
+    importlib.reload(pt)
+    return pt
+
+
+@pytest.fixture
+def pt(monkeypatch, tmp_path):
+    monkeypatch.setenv("BICAMERAL_PREFLIGHT_TELEMETRY", "1")
+    return _reload_pt(monkeypatch, tmp_path)
+
+
+@pytest.fixture
+def pt_disabled(monkeypatch, tmp_path):
+    monkeypatch.delenv("BICAMERAL_PREFLIGHT_TELEMETRY", raising=False)
+    return _reload_pt(monkeypatch, tmp_path)
+
+
+class _StubCtx:
+    """Handler ignores ctx (bypass storage is local JSONL, not ledger)."""
+
+
+@pytest.mark.asyncio
+async def test_fresh_bypass_returns_recorded_true(pt, tmp_path):
+    """First call writes a row and returns recorded=True, deduped=False."""
+    resp = await handle_record_bypass(_StubCtx(), decision_id="dec-fresh")
+    assert resp.recorded is True
+    assert resp.deduped is False
+    assert resp.reason is None
+    events_file = tmp_path / ".bicameral" / "preflight_events.jsonl"
+    assert events_file.exists()
+    contents = events_file.read_text()
+    assert "preflight_prompt_bypassed" in contents
+    assert "dec-fresh" in contents
+
+
+@pytest.mark.asyncio
+async def test_telemetry_disabled_no_op(pt_disabled, tmp_path):
+    """Telemetry off: handler returns the disabled sentinel, no write."""
+    resp = await handle_record_bypass(_StubCtx(), decision_id="dec-x")
+    assert resp.recorded is False
+    assert resp.deduped is False
+    assert resp.reason == "telemetry_disabled"
+    events_file = tmp_path / ".bicameral" / "preflight_events.jsonl"
+    assert not events_file.exists()
+
+
+@pytest.mark.asyncio
+async def test_idempotent_within_window_returns_deduped_true(pt, tmp_path):
+    """Second call inside the recency window returns deduped=True."""
+    first = await handle_record_bypass(_StubCtx(), decision_id="dec-dup")
+    assert first.recorded is True and first.deduped is False
+    second = await handle_record_bypass(_StubCtx(), decision_id="dec-dup")
+    assert second.recorded is False
+    assert second.deduped is True
+    assert second.reason is None
+    # Only one row in the JSONL.
+    events_file = tmp_path / ".bicameral" / "preflight_events.jsonl"
+    rows = [ln for ln in events_file.read_text().splitlines() if ln.strip()]
+    assert len(rows) == 1
+
+
+@pytest.mark.asyncio
+async def test_missing_decision_id_returns_invalid_decision_id(pt):
+    """Empty/None decision_id is rejected without writing."""
+    resp = await handle_record_bypass(_StubCtx(), decision_id="")
+    assert resp.recorded is False
+    assert resp.deduped is False
+    assert resp.reason == "invalid_decision_id"


### PR DESCRIPTION
## Summary

Phase 4 of `plan-governance-108-112.md` -- wires the deterministic governance engine (landed in #116) into the preflight HITL surface. Closes #112.

- **HITL prompts**: Five trigger conditions (`proposed`, `ai_surfaced`, `needs_context`, `collision_pending`, `context_pending`) yield `HITLPrompt`s on `PreflightResponse.hitl_prompts`. Bypass option is mandatory and last in every option list (skill-side asserts `options[-1].kind == \"bypass\"`).
- **Bypass writer**: `preflight_telemetry.write_bypass_event` appends a `preflight_prompt_bypassed` line to the existing JSONL log, reusing the salt/rotation/0o600 path.
- **Engine wiring**: `handlers/preflight.py` reads `recent_bypass_seconds` and passes the scalar into `engine.evaluate`. Engine purity is preserved -- IO happens at the call site. `_apply_bypass_downgrade` (Phase 3) drops one ladder rung when a recent bypass exists.
- **MCP tool**: `bicameral.record_bypass(decision_id, reason?, state_preserved?)` returns `{recorded, deduped, reason}` so skills can distinguish a fresh bypass from a within-window repeat.
- **Skill update**: `skills/bicameral-preflight/SKILL.md` step 5.4 documents trigger conditions, the mandatory-last bypass contract, and the tier-drop semantics.

Bypass does NOT mutate decision state -- the unresolved `signoff_state` persists for future preflight surfaces.

## Audit fix call-outs (per AUDIT_REPORT_GOVERNANCE.md)

- **V4 idempotency guard**: `write_bypass_event` is a no-op when `recent_bypass_seconds(decision_id) is not None`. The first bypass establishes the recency fingerprint; subsequent calls inside the 1-hour window cannot extend it. Prevents indefinite escalation suppression on a sensitive decision. Tested in `test_bypass_event_idempotent_within_window` and `test_idempotent_within_window_returns_deduped_true`.
- **F3 bounded tail-read**: `recent_bypass_seconds` reads the JSONL file via an 8 KiB-block reverse walk, capped at the last 1000 lines, with a short-circuit when an event older than the recency window is encountered. Per-call cost is O(min(N, 1000)). Tested in `test_recent_bypass_seconds_ignores_events_older_than_window`.
- **Engine purity preserved**: `governance/engine.py` was NOT modified. Bypass recency is computed at the preflight call site and passed in as a scalar, exactly as Phase 3 designed.

## Test counts

- `tests/test_preflight_hitl_prompts.py` -- 6 tests (trigger shapes + bypass-last contract + decision_id round-trip)
- `tests/test_bypass_event_persistence.py` -- 6 tests (JSONL append, telemetry-disabled no-op, V4 idempotency, out-of-window stale event, engine integration tier drop)
- `tests/test_record_bypass_handler.py` -- 4 tests (fresh write, telemetry-disabled, idempotent dedup, invalid decision_id)
- **Total: 16 new tests, all passing**
- **Regression: 44 governance tests + 19 preflight_telemetry tests still pass**; 6 pre-existing failures on `upstream/dev` (Windows cp1252 + bind/ephemeral-authoritative) are unrelated to this PR.

## Tooling status

- `ruff check`: clean
- `ruff format --check`: clean
- `mypy`: clean (no issues found)

## Test plan

- [x] `pytest tests/test_preflight_hitl_prompts.py tests/test_bypass_event_persistence.py tests/test_record_bypass_handler.py -v` -- 16/16 pass
- [x] `pytest tests/test_governance_*.py tests/test_v15_migration.py tests/test_evaluate_governance_handler.py tests/test_v055_region_anchored_preflight.py` -- 44/44 pass (1 skipped)
- [x] Engine.py untouched -- `git diff upstream/dev -- governance/engine.py governance/finding_factories.py governance/config.py` is empty
- [x] Bypass writes are V4 idempotent + F3 tail-bounded
- [x] Skill asserts bypass is last option in every prompt

## References

- Plan: `plan-governance-108-112.md` (Phase 4)
- Prior PR: #116 (Phases 1-3 -- governance contracts + escalation engine, v0.17.0)
- Phase 5 (docs for #111) ships separately

Closes #112

🤖 Generated with [Claude Code](https://claude.com/claude-code)