### PR TITLE
fix(ci): merged-to-dev labeller fails loudly on permission errors (#115)

### DIFF
--- a/.github/workflows/label-merged-to-dev.yml
+++ b/.github/workflows/label-merged-to-dev.yml
@@ -18,12 +18,27 @@ jobs:
         uses: actions/github-script@v7
         with:
           script: |
+            // Workflow caveat: this job needs Settings -> Actions ->
+            // General -> Workflow permissions set to "Read and write
+            // permissions" at the repo level. The job-level
+            // `permissions: issues: write` block can only NARROW what
+            // the repo allows, never expand it. If the repo default
+            // is read-only, addLabels returns 403 "Resource not
+            // accessible by integration" regardless of the job-level
+            // grant.
+            //
+            // See: #115 (root cause + symptoms) and #104 (admin-side
+            // fix tracked alongside branch-protection setup).
+            //
+            // GitHub close keywords (case-insensitive): close, closes,
+            // closed, fix, fixes, fixed, resolve, resolves, resolved.
             const pr = context.payload.pull_request;
-            // GitHub close keywords: close, closes, closed, fix, fixes, fixed,
-            // resolve, resolves, resolved (case-insensitive).
             const body = pr.body || "";
-            const matches = [...body.matchAll(/(?:close[sd]?|fix(?:es|ed)?|resolve[sd]?)\s+#(\d+)/gi)];
+            const closeRegex = /(?:close[sd]?|fix(?:es|ed)?|resolve[sd]?)\s+#(\d+)/gi;
+            const matches = [...body.matchAll(closeRegex)];
             const issues = [...new Set(matches.map(m => parseInt(m[1])))];
+
+            const failed = [];
             for (const num of issues) {
               try {
                 await github.rest.issues.addLabels({
@@ -34,6 +49,22 @@ jobs:
                 });
                 console.log(`Labeled #${num}`);
               } catch (e) {
-                console.log(`Could not label #${num}: ${e.message}`);
+                console.log(`Failed to label #${num}: ${e.message}`);
+                failed.push({ num, message: e.message });
               }
+            }
+
+            if (failed.length > 0) {
+              const summary = failed
+                .map(f => `  - #${f.num}: ${f.message}`)
+                .join("\n");
+              throw new Error(
+                `merged-to-dev labeller could not label ${failed.length} ` +
+                `issue(s) referenced by PR #${pr.number}:\n${summary}\n\n` +
+                `Most likely cause: repo Settings -> Actions -> General -> ` +
+                `Workflow permissions is set to read-only. ` +
+                `Job-level "permissions: issues: write" cannot expand a ` +
+                `read-only repo default. See #104 (admin fix) and ` +
+                `#115 (root cause).`
+              );
             }


### PR DESCRIPTION
## Summary

The \`label-merged-to-dev\` workflow currently swallows \`addLabels\` 403 errors, logs \"Could not label #N: <msg>\", and exits 0. The check turns ✅ green despite the label not being applied. Three issues (#44, #49, #65) were silently un-labelled this session and required manual intervention to surface.

This PR converts that fail-open path to fail-loud:

- Track failed labels during the loop
- Per-issue logs continue as before
- At end-of-loop, if any failed, \`throw\` a summary error listing affected issues + remediation pointer
- Job exits non-zero; check turns ❌ red on the merged PR

## Behavior change

| Scenario | Before | After |
|---|---|---|
| All labels applied | Per-issue logs, ✅ green | Same |
| One+ labels failed | Silent log, ✅ green (THE BUG) | Per-issue log + summary throw, ❌ red |
| No \`Closes #N\` keywords in PR body | Empty loop, ✅ green | Same |

## Root cause (admin-side, NOT addressed in this PR)

The 403 stems from repo \`Settings -> Actions -> General -> Workflow permissions\` being set to read-only. Job-level \`permissions: issues: write\` cannot expand a read-only repo default. The admin fix is tracked under #104 alongside the branch-protection setup. This PR is the visibility safety-net so future drift doesn't go silently.

The workflow header comment now points contributors at both #115 (root cause) and #104 (admin fix).

## Why fail loud is correct here

The workflow runs on \`pull_request: types: [closed]\` after merge. A failed check on a merged PR does NOT block any future PR -- it surfaces post-hoc as a notification. Strictly better than silent green: the maintainer notices, applies labels manually, addresses the admin setting.

## Test plan

- [x] YAML syntactically valid (\`yaml.safe_load\`)
- [x] Regex unchanged from prior implementation -- still covers all 9 GitHub close-keywords
- [x] Permission block unchanged
- [x] No new dependencies (still uses \`actions/github-script@v7\`)
- [ ] Will be exercised on this PR's own merge (next \`Closes #115\` triggers it). If admin setting is correct, ✅. If admin setting is wrong, the new ❌ failure path documents the problem.

## Closes

Closes #115

🤖 Authored via [QorLogic SDLC](https://github.com/MythologIQ-Labs-LLC/qor-logic) (plan -> audit -> implement).