### PR TITLE
release: v0.13.5 (triage) — bug fixes + event vocabulary backport (#74, #95, #97, #98, #124)

### DIFF
--- a/.github/workflows/test-mcp-regression.yml
+++ b/.github/workflows/test-mcp-regression.yml
@@ -19,6 +19,7 @@ jobs:
     env:
       SURREAL_URL: 'memory://'
       REPO_PATH: ${{ github.workspace }}
+      BICAMERAL_SKIP_CONSENT_NOTICE: '1'
     steps:
       - uses: actions/checkout@v4
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,74 @@
 All notable changes to bicameral-mcp are tracked here. Format loosely follows
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
+## v0.14.0 — Local-only telemetry counters + usage summary + first-boot consent — built via [QorLogic SDLC](https://github.com/MythologIQ-Labs-LLC/qor-logic)
+
+Privacy-first observability foundation. Adds a local-only counter sink
+that runs alongside (not replacing) the existing network relay, a new
+`bicameral.usage_summary` MCP tool that aggregates ledger and counter
+state into actionable percentages, and a non-blocking first-boot notice
+so users upgrading to this binary see the telemetry policy before any
+data flows.
+
+### Added
+
+- **`local_counters.py`** (#39) — append-only JSONL sink at
+  `~/.bicameral/counters.jsonl`. Records only `{tool_name, delta=1, ts}`
+  per call. Mode `0o600` on POSIX; thread-safe; no network egress.
+  Always-on regardless of network telemetry consent — counters are
+  local introspection, distinct from the relay. Kill-switch:
+  `BICAMERAL_LOCAL_COUNTERS=0`. API: `increment(tool_name)` and
+  `read_counters() -> dict[str, int]`.
+- **`consent.py`** (#39) — owns `~/.bicameral/consent.json`,
+  `telemetry_allowed()` predicate, and `notify_if_first_run()`. Marker
+  shape: `{telemetry, policy_version, acknowledged_at, acknowledged_via}`
+  with `acknowledged_via` distinguishing `"wizard"` (explicit choice)
+  from `"first_boot_notice"` (passive ack). `POLICY_VERSION` constant
+  re-fires the notice for everyone once when telemetry policy changes.
+- **`bicameral.usage_summary`** MCP tool (#42) — aggregate readout over
+  the last N days (default 7). Returns ingest/bind call counts (from
+  the local counters file), decision counts by status (from ledger),
+  reflected/drift percentages, cosmetic-drift percentage (from
+  compliance_check verdicts), and error rate. Privacy-preserving:
+  aggregate counts and floats only.
+- **First-boot consent notice** — non-blocking, fires once per
+  `policy_version` via stderr (always) and MCP `notifications/message`
+  (when an active session is available). Server keeps running; if
+  marker write fails, notice is logged at debug and the server
+  continues. Test escape hatch: `BICAMERAL_SKIP_CONSENT_NOTICE=1`.
+
+### Changed
+
+- **`telemetry.send_event` now uses `consent.telemetry_allowed()`** as
+  the single gating predicate. Behavior preserved for users without a
+  marker (default-on); newly opted-out users (marker says `disabled`
+  via the wizard) suppress the relay even when env var is unset.
+- **`telemetry.send_event` always increments the local counter** before
+  the relay path — never raises, wrapped in try/except. Counter
+  failure cannot affect the caller; relay path runs independently.
+- **`setup_wizard._select_telemetry`** now calls
+  `consent.write_consent(via="wizard")` after the user's choice. Hard
+  fails (raises `OSError`) if the marker cannot be written — guarantees
+  a "no" answer never silently leaves telemetry on.
+- **`server.serve_stdio`** calls `consent.notify_if_first_run()` once
+  during startup. Wrapped in try/except — startup is never blocked by
+  notice machinery.
+
+### CI
+
+- `BICAMERAL_SKIP_CONSENT_NOTICE: "1"` added to the test job env in
+  `.github/workflows/test-mcp-regression.yml` so test runs do not emit
+  notices into job logs.
+- `tests/conftest.py` adds a session-scoped autouse fixture that
+  reroutes `~/.bicameral/` to a per-session tmp dir and sets the skip
+  env var. Stdlib only — no third-party fixture plugin.
+
+### Closes
+
+#39, #42.
+
+---
+
 ## v0.11.0 — CodeGenome Phase 1+2 (#59) — adapter boundary + identity records — built via [QorLogic SDLC](https://github.com/MythologIQ-Labs-LLC/qor-logic)
 
 Foundation PR for the three-phase CodeGenome rollout (issues #59 / #60 / #61).

--- a/cli/_link_commit_runner.py
+++ b/cli/_link_commit_runner.py
@@ -1,0 +1,37 @@
+"""Sync wrapper around handle_link_commit. Shared by branch-scan and
+link_commit CLI subcommands. Lazy-imports SurrealDB-touching modules
+so callers don't pay the import cost when no ledger is configured.
+
+Promoted from cli/branch_scan.py (#48) to a shared module under #124
+when the link_commit CLI subcommand was added.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from pathlib import Path
+
+from contracts import LinkCommitResponse
+
+
+def invoke_link_commit(commit_hash: str = "HEAD") -> LinkCommitResponse | None:
+    """Drive the async ``handle_link_commit`` from sync context.
+
+    Returns ``None`` when:
+      - ``~/.bicameral/ledger.db`` does not exist (no configured ledger), OR
+      - the underlying handler raises (graceful skip — caller decides on
+        loud vs. silent failure semantics).
+    """
+    if not (Path.home() / ".bicameral" / "ledger.db").exists():
+        return None
+    from context import BicameralContext
+    from handlers.link_commit import handle_link_commit
+
+    async def _run() -> LinkCommitResponse:
+        ctx = BicameralContext.from_env()
+        return await handle_link_commit(ctx, commit_hash=commit_hash)
+
+    try:
+        return asyncio.run(_run())
+    except Exception:  # noqa: BLE001 — caller decides loud vs. silent
+        return None

--- a/cli/link_commit_cli.py
+++ b/cli/link_commit_cli.py
@@ -1,0 +1,31 @@
+"""link_commit CLI subcommand entry point (#124).
+
+Wraps the shared ``cli._link_commit_runner.invoke_link_commit`` for
+human-driven invocation. JSON-to-stdout by default; ``--quiet`` for
+hook scripts that pipe to /dev/null.
+
+Always exits 0 — the post-commit hook depends on this so commits are
+never blocked. Hook-side loudness (stderr) is handled in the installed
+shell script, not here.
+"""
+
+from __future__ import annotations
+
+import json
+
+from cli._link_commit_runner import invoke_link_commit
+
+
+def main(commit_hash: str = "HEAD", *, quiet: bool = False) -> int:
+    """Run link_commit against ``commit_hash`` (default HEAD).
+
+    Returns 0 on success, on no-ledger graceful skip, and on
+    handler-exception graceful skip — the runner already collapses
+    those cases to ``None``. Print JSON to stdout unless ``quiet``.
+    """
+    response = invoke_link_commit(commit_hash)
+    if response is None:
+        return 0
+    if not quiet:
+        print(json.dumps(response.model_dump(), default=str, indent=2))
+    return 0

--- a/consent.py
+++ b/consent.py
@@ -1,0 +1,138 @@
+"""User consent for outbound telemetry (issue #39).
+
+Three responsibilities, kept independent of ``telemetry.py``:
+
+  1. **Consent marker** — persisted at ``~/.bicameral/consent.json`` with
+     ``{telemetry: "enabled"|"disabled", policy_version, acknowledged_at,
+     acknowledged_via}``. File mode 0o600 on POSIX.
+
+  2. **First-boot notice** — non-blocking. On the first boot of an
+     upgraded binary that hasn't acknowledged the current policy version,
+     emits the notice via MCP ``notifications/message`` (when an active
+     session is available) and stderr (always). Server keeps running.
+
+  3. **``telemetry_allowed()``** — single source of truth for the
+     network relay. Returns True when env var ``BICAMERAL_TELEMETRY != "0"``
+     AND (marker missing OR marker.telemetry == "enabled"). Missing
+     marker preserves current default-on behavior so users don't lose
+     telemetry between upgrade and first-boot acknowledgment.
+
+Test escape hatch: ``BICAMERAL_SKIP_CONSENT_NOTICE=1`` short-circuits
+``notify_if_first_run`` (used by tests/conftest.py and CI).
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Callable
+
+logger = logging.getLogger(__name__)
+
+POLICY_VERSION = 1
+"""Bump when telemetry policy changes (new fields, new endpoints).
+Re-fires the first-boot notice once for everyone on the next boot."""
+
+_CONSENT_FILE = Path.home() / ".bicameral" / "consent.json"
+_OFF_VALUES = frozenset({"0", "false", "no", "off"})
+
+
+_NOTICE_TEXT = (
+    "Bicameral collects anonymous usage statistics (skill name, duration, "
+    "version, error flag — no code, no decision text, no file paths). "
+    "To opt out: run `bicameral-mcp setup`, or set BICAMERAL_TELEMETRY=0 "
+    "in your `.mcp.json` env block. This notice will not appear again "
+    "unless the telemetry policy changes."
+)
+
+
+def read_consent() -> dict | None:
+    """Return the marker contents, or None if missing/malformed."""
+    if not _CONSENT_FILE.exists():
+        return None
+    try:
+        return json.loads(_CONSENT_FILE.read_text(encoding="utf-8"))
+    except (json.JSONDecodeError, OSError) as exc:
+        logger.debug("[consent] read failed: %s", exc)
+        return None
+
+
+def write_consent(telemetry: bool, *, via: str) -> None:
+    """Atomic write of the consent marker. Mode 0o600 on POSIX.
+
+    Raises OSError on disk failure — wizard treats this as fatal;
+    notify_if_first_run swallows it.
+    """
+    record: dict[str, Any] = {
+        "telemetry": "enabled" if telemetry else "disabled",
+        "policy_version": POLICY_VERSION,
+        "acknowledged_at": datetime.now(timezone.utc).isoformat(),
+        "acknowledged_via": via,
+    }
+    _CONSENT_FILE.parent.mkdir(parents=True, exist_ok=True)
+    tmp = _CONSENT_FILE.with_suffix(".json.tmp")
+    flags = os.O_WRONLY | os.O_CREAT | os.O_TRUNC
+    fd = os.open(str(tmp), flags, 0o600)
+    with os.fdopen(fd, "w", encoding="utf-8") as f:
+        json.dump(record, f, separators=(",", ":"))
+    os.replace(tmp, _CONSENT_FILE)
+
+
+def telemetry_allowed() -> bool:
+    """Single source of truth for whether the relay path may run.
+
+    True when:
+      - env var BICAMERAL_TELEMETRY != "0" (allows runtime opt-out), AND
+      - marker is missing (default-on for upgraders) OR
+        marker.telemetry == "enabled"
+    """
+    env_val = os.getenv("BICAMERAL_TELEMETRY", "1").strip().lower()
+    if env_val in _OFF_VALUES:
+        return False
+    marker = read_consent()
+    if marker is None:
+        return True  # default-on for users who haven't seen the notice yet
+    return marker.get("telemetry") == "enabled"
+
+
+def _should_notify() -> bool:
+    """True iff the notice has not been emitted for the current policy version."""
+    if os.getenv("BICAMERAL_SKIP_CONSENT_NOTICE", "").strip() == "1":
+        return False
+    marker = read_consent()
+    if marker is None:
+        return True
+    return int(marker.get("policy_version", 0)) < POLICY_VERSION
+
+
+def notify_if_first_run(send_mcp_notification: Callable[[str, str], Any] | None = None) -> None:
+    """Emit the first-boot notice once and stamp the marker. Never raises.
+
+    ``send_mcp_notification`` is a callable taking (severity, message).
+    When provided and a session is active, the notice surfaces in the
+    user's MCP client (Claude Code, etc.). stderr mirror covers headless
+    contexts and provides a record either way.
+    """
+    try:
+        if not _should_notify():
+            return
+        # Surface to MCP client if available.
+        if send_mcp_notification is not None:
+            try:
+                send_mcp_notification("info", _NOTICE_TEXT)
+            except Exception as exc:
+                logger.debug("[consent] MCP notification failed: %s", exc)
+        # Stderr mirror — always.
+        print(_NOTICE_TEXT, file=sys.stderr, flush=True)
+        # Stamp marker so we don't repeat. Default = enabled (matches
+        # current opt-out posture); user changes via wizard or env var.
+        try:
+            write_consent(telemetry=True, via="first_boot_notice")
+        except OSError as exc:
+            logger.debug("[consent] marker write failed: %s", exc)
+    except Exception as exc:
+        logger.debug("[consent] notify_if_first_run failed: %s", exc)

--- a/docs/BACKLOG.md
+++ b/docs/BACKLOG.md
@@ -26,6 +26,18 @@
 - [ ] [B3] Issue #61 — CodeGenome Phase 4 semantic drift evaluation in
       `resolve_compliance`. Depends on #59; recommended after #60.
 
+- [ ] [B5] Event-sourced ledger RFC — append-only event log with
+      SurrealDB/SQLite as a rebuildable projection. Tracked as Issue #97.
+      v1.0.0 candidate; load-bearing iff multi-machine/team sync enters
+      the roadmap. We already get partial event-sourcing today via the
+      META_LEDGER chain and the `compliance_check` CHANGEFEED (Phase 4 /
+      #61); the RFC asks whether to extend that pattern to all
+      mutation-bearing tables. Cheap v0.14.0 wedge proposed in the issue:
+      extend `CHANGEFEED 30d INCLUDE ORIGINAL` to `code_subject`,
+      `subject_identity`, `binds_to`, `code_region` without committing
+      to the full rewrite. Decision blocked on Jin's call about team
+      sync as a v1.0.0 goal.
+
 ## Wishlist (Nice to Have)
 <!-- Format: - [ ] [W#] Description -->
 - [ ] [W1] Section-4 razor enforcement on legacy oversized files

--- a/events/materializer.py
+++ b/events/materializer.py
@@ -94,6 +94,56 @@ class EventMaterializer:
                             payload.get("commit_hash", ""), payload.get("repo_path", ""),
                         )
                         replayed += 1
+                    elif etype == "decision_ratified.completed":
+                        # Resolve canonical_id → local decision_id; the
+                        # event was emitted by a peer whose local
+                        # decision_id is meaningless in this DB.
+                        from ledger.queries import find_decision_by_canonical_id
+
+                        local_id = await find_decision_by_canonical_id(
+                            inner_adapter._client,
+                            payload.get("canonical_id", ""),
+                        )
+                        if local_id is None:
+                            logger.warning(
+                                "[materializer] skipping decision_ratified — "
+                                "canonical_id %r not found locally (ingest event missing or out-of-order)",
+                                payload.get("canonical_id"),
+                            )
+                            continue
+                        await inner_adapter.apply_ratify(
+                            local_id,
+                            payload.get("signoff", {}),
+                        )
+                        replayed += 1
+                    elif etype == "decision_superseded.completed":
+                        from ledger.queries import find_decision_by_canonical_id
+
+                        local_new = await find_decision_by_canonical_id(
+                            inner_adapter._client,
+                            payload.get("new_canonical_id", ""),
+                        )
+                        local_old = await find_decision_by_canonical_id(
+                            inner_adapter._client,
+                            payload.get("old_canonical_id", ""),
+                        )
+                        if local_new is None or local_old is None:
+                            logger.warning(
+                                "[materializer] skipping decision_superseded — "
+                                "canonical_id resolution failed (new=%r old=%r)",
+                                payload.get("new_canonical_id"),
+                                payload.get("old_canonical_id"),
+                            )
+                            continue
+                        await inner_adapter.apply_supersede(
+                            new_id=local_new,
+                            old_id=local_old,
+                            signer=payload.get("signer", ""),
+                            signoff_note=payload.get("signoff_note", ""),
+                            superseded_at=payload.get("superseded_at", ""),
+                            session_id=payload.get("session_id", ""),
+                        )
+                        replayed += 1
                 new_offsets[author] = f.tell()
 
         if new_offsets != offsets:

--- a/events/team_adapter.py
+++ b/events/team_adapter.py
@@ -10,6 +10,8 @@ from __future__ import annotations
 import logging
 from pathlib import Path
 
+from ledger.queries import find_decision_by_canonical_id, get_canonical_id
+
 from .materializer import EventMaterializer
 from .writer import EventFileWriter
 
@@ -136,6 +138,63 @@ class TeamWriteAdapter:
             repo=repo,
             ref=ref,
             purpose=purpose,
+        )
+
+    async def apply_ratify(self, decision_id: str, signoff: dict) -> str:
+        """Emit decision_ratified event, then delegate to inner adapter.
+
+        The event payload carries ``canonical_id`` so cross-author replay
+        can resolve to the peer's local decision row.
+        """
+        await self._ensure_ready()
+        canonical_id = await get_canonical_id(self._inner._client, decision_id)
+        self._writer.write(
+            "decision_ratified.completed",
+            {
+                "canonical_id": canonical_id,
+                "decision_id": decision_id,
+                "signoff": signoff,
+            },
+        )
+        return await self._inner.apply_ratify(decision_id, signoff)
+
+    async def apply_supersede(
+        self,
+        new_id: str,
+        old_id: str,
+        signer: str = "",
+        signoff_note: str = "",
+        superseded_at: str = "",
+        session_id: str = "",
+    ) -> dict:
+        """Emit decision_superseded event, then delegate to inner adapter.
+
+        The event payload carries canonical_ids for both decisions so
+        cross-author replay can resolve to the peer's local rows.
+        """
+        await self._ensure_ready()
+        new_canonical = await get_canonical_id(self._inner._client, new_id)
+        old_canonical = await get_canonical_id(self._inner._client, old_id)
+        self._writer.write(
+            "decision_superseded.completed",
+            {
+                "new_canonical_id": new_canonical,
+                "old_canonical_id": old_canonical,
+                "new_id": new_id,
+                "old_id": old_id,
+                "signer": signer,
+                "signoff_note": signoff_note,
+                "superseded_at": superseded_at,
+                "session_id": session_id,
+            },
+        )
+        return await self._inner.apply_supersede(
+            new_id=new_id,
+            old_id=old_id,
+            signer=signer,
+            signoff_note=signoff_note,
+            superseded_at=superseded_at,
+            session_id=session_id,
         )
 
     async def wipe_all_rows(self, repo: str) -> None:

--- a/events/writer.py
+++ b/events/writer.py
@@ -13,17 +13,60 @@ DB-level ``canonical_id`` UNIQUE index instead of filesystem collisions.
 
 from __future__ import annotations
 
-import fcntl
 import json
 import logging
 import subprocess
+import sys
 from datetime import datetime, timezone
 from pathlib import Path
-from typing import Any
+from typing import Any, IO
 
 from pydantic import BaseModel, Field
 
 logger = logging.getLogger(__name__)
+
+# Cross-platform advisory file lock for the event JSONL writer.
+#
+# Background: this module appends one line per event to a per-author
+# ``.bicameral/events/{email}.jsonl`` file. A single ``write()`` under
+# ``O_APPEND`` is atomic for lines up to PIPE_BUF (~4 KB on Linux/macOS),
+# but events can exceed that, so we take an advisory exclusive lock for
+# the duration of the write.
+#
+# POSIX (Linux, macOS): ``fcntl.flock(LOCK_EX)`` / ``LOCK_UN``.
+# Windows: ``msvcrt.locking(LK_LOCK)`` / ``LK_UNLCK`` — needs a byte-range,
+# so we lock 1 byte at the file's current position. Contention semantics
+# are equivalent for the single-writer-per-author pattern this module uses.
+#
+# Both branches are ``# pragma: no cover`` for the inactive platform.
+if sys.platform == "win32":  # pragma: no cover - exercised only on Windows
+    import msvcrt
+
+    # On Windows, ``msvcrt.locking`` operates on a byte-range starting at
+    # the current file position. We always lock byte 0 (the same byte for
+    # every writer) so concurrent writers serialize on a shared mutex
+    # byte. The actual append happens via ``open(..., "ab")``, which on
+    # Windows seeks to EOF for each write — the byte-0 lock is the
+    # serialization primitive, not a region lock.
+    def _lock_exclusive(f: IO[bytes]) -> None:
+        """Acquire an exclusive advisory lock on byte 0 (Windows)."""
+        f.seek(0)
+        msvcrt.locking(f.fileno(), msvcrt.LK_LOCK, 1)
+
+    def _unlock(f: IO[bytes]) -> None:
+        """Release the advisory lock on byte 0 (Windows)."""
+        f.seek(0)
+        msvcrt.locking(f.fileno(), msvcrt.LK_UNLCK, 1)
+else:
+    import fcntl
+
+    def _lock_exclusive(f: IO[bytes]) -> None:
+        """Acquire an exclusive advisory lock (POSIX)."""
+        fcntl.flock(f.fileno(), fcntl.LOCK_EX)
+
+    def _unlock(f: IO[bytes]) -> None:
+        """Release the advisory lock (POSIX)."""
+        fcntl.flock(f.fileno(), fcntl.LOCK_UN)
 
 
 class EventEnvelope(BaseModel):
@@ -78,10 +121,10 @@ class EventFileWriter:
         )
         line = json.dumps(envelope.model_dump(), separators=(",", ":"), default=str) + "\n"
         with open(self._path, "ab") as f:
-            fcntl.flock(f.fileno(), fcntl.LOCK_EX)
+            _lock_exclusive(f)
             try:
                 f.write(line.encode("utf-8"))
             finally:
-                fcntl.flock(f.fileno(), fcntl.LOCK_UN)
+                _unlock(f)
         logger.debug("[events] appended %s to %s.jsonl", event_type, self._author)
         return self._path

--- a/handlers/ratify.py
+++ b/handlers/ratify.py
@@ -16,7 +16,11 @@ import logging
 from datetime import datetime, timezone
 
 from contracts import RatifyResponse
-from ledger.queries import decision_exists, project_decision_status, update_decision_status
+from ledger.queries import decision_exists, project_decision_status
+# triage-adapt: dropped preflight_telemetry import from auto-merge — module
+# is on dev (#65 preflight telemetry) but not on triage; the cherry-picked
+# body doesn't actually reference it (intent of e6d4b8f for this file is
+# routing through ledger.apply_ratify, not adding telemetry)
 
 logger = logging.getLogger(__name__)
 
@@ -90,13 +94,9 @@ async def handle_ratify(
             "note": note,
         }
 
-    await client.query(
-        f"UPDATE {decision_id} SET signoff = $signoff",
-        {"signoff": signoff},
-    )
-
-    projected = await project_decision_status(client, decision_id)
-    await update_decision_status(client, decision_id, projected)
+    # Routes through TeamWriteAdapter when in team mode so the signoff
+    # change is emitted as a decision_ratified.completed event.
+    projected = await ledger.apply_ratify(decision_id, signoff)
 
     logger.info(
         "[ratify] decision=%s action=%s signer=%s projected_status=%s",

--- a/handlers/resolve_collision.py
+++ b/handlers/resolve_collision.py
@@ -28,7 +28,6 @@ from ledger.queries import (
     decision_exists,
     project_decision_status,
     relate_context_for,
-    relate_supersedes,
     update_decision_status,
 )
 
@@ -71,35 +70,20 @@ async def handle_resolve_collision(
             if not await decision_exists(client, old_id):
                 raise ValueError(f"No decision row for old_id={old_id}")
 
-            # Write supersedes edge (idempotent)
-            await relate_supersedes(
-                client, new_id, old_id,
-                confidence=1.0,
-                reason=f"human-confirmed supersession via resolve_collision session={_session_id}",
+            # Routes through TeamWriteAdapter when in team mode so the
+            # supersession is emitted as a decision_superseded.completed
+            # event. The adapter handles edge creation + frozen-signoff
+            # merge so the old decision's prior ratification record is
+            # preserved (drift sweeps skip signoff.state='superseded').
+            result = await ledger.apply_supersede(
+                new_id=new_id,
+                old_id=old_id,
+                signer=_session_id,
+                signoff_note="",
+                superseded_at=_now_iso,
+                session_id=_session_id,
             )
-
-            # Mark old decision as superseded in signoff (not status).
-            # Supersession is a human editorial decision, not a code-compliance observation.
-            # The old decision's status field retains its last code-compliance value
-            # and is frozen — drift sweeps skip decisions where signoff.state='superseded'.
-            # Merge with existing signoff so a prior ratification record is preserved.
-            _existing_rows = await client.query(
-                f"SELECT signoff FROM {old_id} LIMIT 1"
-            )
-            _old_signoff: dict = {}
-            if _existing_rows and isinstance(_existing_rows[0], dict):
-                _old_signoff = _existing_rows[0].get("signoff") or {}
-            await client.execute(
-                f"UPDATE {old_id} SET signoff = $s",
-                {"s": {
-                    **_old_signoff,
-                    "state": "superseded",
-                    "superseded_by": new_id,
-                    "superseded_at": _now_iso,
-                    "session_id": _session_id,
-                }},
-            )
-            old_status = "superseded"
+            old_status = result.get("old_status", "superseded")
 
             logger.info(
                 "[resolve_collision] supersede: %s supersedes %s", new_id, old_id

--- a/handlers/usage_summary.py
+++ b/handlers/usage_summary.py
@@ -1,0 +1,104 @@
+"""Handler for /bicameral_usage_summary MCP tool (issue #42).
+
+Aggregate operational readout — converts raw ledger state into actionable
+percentages over a configurable window. Privacy-preserving: returns only
+counts and floats. No event rows, no session IDs, no user content.
+
+Pairs with local_counters.py (#39) for tool-call counts; pulls
+decision-state metrics directly from the SurrealDB ledger.
+"""
+
+from __future__ import annotations
+
+import logging
+from datetime import datetime, timedelta, timezone
+
+from local_counters import read_counters
+
+logger = logging.getLogger(__name__)
+
+
+async def handle_usage_summary(ctx, days: int = 7) -> dict:
+    """Aggregate usage stats over the last `days` days.
+
+    Returns the schema specified in #42:
+        period_days, ingest_calls, bind_calls_total, decisions_ingested,
+        decisions_ungrounded, decisions_pending, decisions_reflected,
+        decisions_drifted, reflected_pct, drift_pct, cosmetic_drift_pct,
+        error_rate.
+    """
+    period_days = max(0, int(days))
+    base = {
+        "period_days": period_days,
+        "ingest_calls": 0,
+        "bind_calls_total": 0,
+        "decisions_ingested": 0,
+        "decisions_ungrounded": 0,
+        "decisions_pending": 0,
+        "decisions_reflected": 0,
+        "decisions_drifted": 0,
+        "reflected_pct": 0.0,
+        "drift_pct": 0.0,
+        "cosmetic_drift_pct": 0.0,
+        "error_rate": 0.0,
+    }
+
+    # ── Tool-call counts (local-only, from #39's counters.jsonl) ──
+    counters = read_counters()
+    base["ingest_calls"] = int(counters.get("bicameral-ingest", 0))
+    base["bind_calls_total"] = int(counters.get("bicameral-bind", 0))
+
+    # ── Decision state counts (from ledger) ──
+    if period_days == 0:
+        return base
+
+    try:
+        ledger = ctx.ledger
+        cutoff = (datetime.now(timezone.utc) - timedelta(days=period_days)).isoformat()
+        client = getattr(getattr(ledger, "_inner", ledger), "_client", None)
+        if client is None:
+            return base
+
+        rows = await client.query(
+            "SELECT status, count() AS n FROM decision "
+            f"WHERE created_at > <datetime>'{cutoff}' GROUP BY status"
+        )
+        status_counts: dict[str, int] = {}
+        for r in rows or []:
+            s = r.get("status")
+            n = int(r.get("n", 0))
+            if isinstance(s, str):
+                status_counts[s] = n
+
+        base["decisions_ungrounded"] = status_counts.get("ungrounded", 0)
+        base["decisions_pending"] = status_counts.get("pending", 0)
+        base["decisions_reflected"] = status_counts.get("reflected", 0)
+        base["decisions_drifted"] = status_counts.get("drifted", 0)
+        base["decisions_ingested"] = sum(status_counts.values())
+
+        grounded = base["decisions_reflected"] + base["decisions_drifted"]
+        if grounded > 0:
+            base["reflected_pct"] = round(base["decisions_reflected"] / grounded, 4)
+            base["drift_pct"] = round(base["decisions_drifted"] / grounded, 4)
+
+        # Cosmetic drift: count compliance_check verdicts of cosmetic_autopass
+        # over total drift verdicts in the window.
+        try:
+            cc_rows = await client.query(
+                "SELECT verdict, count() AS n FROM compliance_check "
+                f"WHERE checked_at > <datetime>'{cutoff}' "
+                "AND verdict IN ['drifted', 'cosmetic_autopass'] GROUP BY verdict"
+            )
+            cc_counts = {
+                r.get("verdict"): int(r.get("n", 0)) for r in (cc_rows or [])
+            }
+            cosmetic = cc_counts.get("cosmetic_autopass", 0)
+            drift_total = cosmetic + cc_counts.get("drifted", 0)
+            if drift_total > 0:
+                base["cosmetic_drift_pct"] = round(cosmetic / drift_total, 4)
+        except Exception as exc:
+            logger.debug("[usage_summary] cosmetic_drift query failed: %s", exc)
+    except Exception as exc:
+        logger.debug("[usage_summary] aggregate query failed: %s", exc)
+
+    return base

--- a/ledger/adapter.py
+++ b/ledger/adapter.py
@@ -39,6 +39,7 @@ from .queries import (
     relate_binds_to,
     relate_has_identity,
     relate_locates,
+    relate_supersedes,
     relate_yields,
     search_by_bm25,
     update_decision_status,
@@ -1115,3 +1116,66 @@ class SurrealDBLedgerAdapter:
             if db_path:
                 shutil.rmtree(db_path, ignore_errors=True)
         await self._ensure_connected()
+
+    # ── Decision signoff write path (#97 event vocabulary) ────────────
+    # Both methods are idempotent so the materializer can replay them
+    # safely. Handlers do their own pre-write idempotency / collision
+    # checks; the adapter just performs the write and re-projects status.
+
+    async def apply_ratify(self, decision_id: str, signoff: dict) -> str:
+        """Write a ratify/reject signoff and re-project the decision's status.
+
+        Idempotent. Returns the projected decision status after the write.
+        """
+        await self._ensure_connected()
+        await self._client.query(
+            f"UPDATE {decision_id} SET signoff = $signoff",
+            {"signoff": signoff},
+        )
+        projected = await project_decision_status(self._client, decision_id)
+        await update_decision_status(self._client, decision_id, projected)
+        return projected
+
+    async def apply_supersede(
+        self,
+        new_id: str,
+        old_id: str,
+        signer: str = "",
+        signoff_note: str = "",
+        superseded_at: str = "",
+        session_id: str = "",
+    ) -> dict:
+        """Write the supersedes edge and freeze the old decision's signoff.
+
+        Idempotent: ``relate_supersedes`` upserts the edge and the signoff
+        UPDATE is a full overwrite. Returns ``{"old_status": "superseded"}``.
+        """
+        await self._ensure_connected()
+        await relate_supersedes(
+            self._client,
+            new_id,
+            old_id,
+            confidence=1.0,
+            reason=(
+                f"human-confirmed supersession via resolve_collision session={session_id}"
+            ),
+        )
+        rows = await self._client.query(f"SELECT signoff FROM {old_id} LIMIT 1")
+        old_signoff: dict = {}
+        if rows and isinstance(rows[0], dict):
+            old_signoff = rows[0].get("signoff") or {}
+        await self._client.execute(
+            f"UPDATE {old_id} SET signoff = $s",
+            {
+                "s": {
+                    **old_signoff,
+                    "state": "superseded",
+                    "superseded_by": new_id,
+                    "superseded_at": superseded_at,
+                    "session_id": session_id,
+                    "signer": signer,
+                    "note": signoff_note,
+                }
+            },
+        )
+        return {"old_status": "superseded"}

--- a/ledger/queries.py
+++ b/ledger/queries.py
@@ -942,6 +942,47 @@ async def update_decision_status(
     )
 
 
+# ── canonical_id ↔ decision_id resolution (#97 event replay) ──────────
+# Decision rows carry both a SurrealDB-generated ``id`` (e.g. ``decision:abc``)
+# and a content-addressed ``canonical_id`` (UUIDv5 from description +
+# source_type + source_ref). The local id is per-DB; canonical_id is
+# stable across authors and machines, so it's the only id safe to ship
+# across the JSONL event log.
+
+async def get_canonical_id(
+    client: LedgerClient,
+    decision_id: str,
+) -> str | None:
+    """Return the canonical_id for a local decision row, or None."""
+    rows = await client.query(
+        f"SELECT canonical_id FROM {decision_id} LIMIT 1",
+    )
+    if rows and isinstance(rows[0], dict):
+        cid = rows[0].get("canonical_id")
+        return str(cid) if cid else None
+    return None
+
+
+async def find_decision_by_canonical_id(
+    client: LedgerClient,
+    canonical_id: str,
+) -> str | None:
+    """Return the local decision id for a canonical_id, or None."""
+    if not canonical_id:
+        return None
+    rows = await client.query(
+        "SELECT id FROM decision WHERE canonical_id = $cid LIMIT 1",
+        {"cid": canonical_id},
+    )
+    if rows and isinstance(rows[0], dict):
+        did = rows[0].get("id")
+        return str(did) if did else None
+    return None
+
+
+# triage-adapt: dropped #77 update_decision_level block from auto-merge —
+# triage doesn't carry decision_level work (PR #107, v0.16.0); not part
+# of e6d4b8f's actual +38-line diff for #97
 async def update_region_hash(
     client: LedgerClient,
     region_id: str,

--- a/local_counters.py
+++ b/local_counters.py
@@ -1,0 +1,88 @@
+"""Local-only tool-usage counters (issue #39).
+
+Append-only JSONL sink for the user's own machine. Independent of the
+network telemetry relay (``telemetry.py``); counters are written for
+every tool invocation regardless of consent state, so users can see
+their own usage even with telemetry opted out.
+
+Privacy invariant:
+  - Only ``tool_name`` (string) + ``delta`` (int) + ``timestamp`` are
+    recorded. No payload, no path, no diagnostic dict.
+  - File is mode 0o600 on POSIX (user-only).
+  - No network egress.
+
+Kill switch: ``BICAMERAL_LOCAL_COUNTERS=0`` disables all writes.
+
+API:
+  ``increment(tool_name)``     — record a call
+  ``read_counters()``          — aggregate counts by tool name
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+import sys
+import threading
+from collections import Counter
+from datetime import datetime, timezone
+from pathlib import Path
+
+logger = logging.getLogger(__name__)
+
+_COUNTERS_FILE = Path.home() / ".bicameral" / "counters.jsonl"
+_OFF_VALUES = frozenset({"0", "false", "no", "off"})
+_LOCK = threading.Lock()
+
+
+def _enabled() -> bool:
+    val = os.getenv("BICAMERAL_LOCAL_COUNTERS", "1").strip().lower()
+    return val not in _OFF_VALUES
+
+
+def _open_for_append_secure(path: Path) -> "os.PathLike":
+    """Open the counters file with 0o600 mode on POSIX (user-only)."""
+    flags = os.O_WRONLY | os.O_CREAT | os.O_APPEND
+    fd = os.open(str(path), flags, 0o600)
+    return os.fdopen(fd, "ab")
+
+
+def increment(tool_name: str, *, delta: int = 1) -> None:
+    """Append one counter event. Never raises. Thread-safe."""
+    if not _enabled():
+        return
+    try:
+        _COUNTERS_FILE.parent.mkdir(parents=True, exist_ok=True)
+        record = {
+            "tool": tool_name,
+            "delta": int(delta),
+            "ts": datetime.now(timezone.utc).isoformat(),
+        }
+        line = json.dumps(record, separators=(",", ":")) + "\n"
+        with _LOCK:
+            with _open_for_append_secure(_COUNTERS_FILE) as f:
+                f.write(line.encode("utf-8"))
+    except Exception as exc:
+        logger.debug("[counters] increment failed (non-fatal): %s", exc)
+
+
+def read_counters() -> dict[str, int]:
+    """Aggregate the JSONL into ``{tool_name: total_delta}``."""
+    if not _COUNTERS_FILE.exists():
+        return {}
+    counts: Counter = Counter()
+    try:
+        with open(_COUNTERS_FILE, "rb") as f:
+            for raw in f:
+                try:
+                    rec = json.loads(raw.decode("utf-8"))
+                except json.JSONDecodeError:
+                    continue
+                tool = rec.get("tool")
+                delta = rec.get("delta", 1)
+                if isinstance(tool, str) and isinstance(delta, int):
+                    counts[tool] += delta
+    except Exception as exc:
+        logger.debug("[counters] read failed: %s", exc)
+    return dict(counts)

--- a/server.py
+++ b/server.py
@@ -28,6 +28,7 @@ from __future__ import annotations
 import asyncio
 import sys
 from argparse import ArgumentParser
+from typing import Any
 
 import mcp.server.stdio
 from mcp.server import Server
@@ -1129,22 +1130,31 @@ async def serve_stdio() -> None:
 
 
 def cli_main(argv: list[str] | None = None) -> int:
+    """Entry point — build parser, register subcommands via _register_subparsers, dispatch via _dispatch."""
     parser = ArgumentParser(description="Bicameral MCP server")
     subparsers = parser.add_subparsers(dest="command")
+    _register_subparsers(parser, subparsers)
+    args = parser.parse_args(argv)
+    return _dispatch(args)
 
-    # config subcommand
+
+def _register_subparsers(parser: ArgumentParser, subparsers: Any) -> None:
+    """Wire all subparser definitions + top-level flags onto parser.
+
+    triage-adapt: omits dev's branch-scan subparser and the setup
+    --with-push-hook flag — both are #48 prerequisites that aren't on
+    this branch. Keeps dev's link_commit subparser (the actual #124 fix)
+    and the helper-extraction shape (so test_hook_command_registration.py
+    can introspect registered subcommands).
+    """
     subparsers.add_parser(
         "config",
         help="interactive config editor — update mode, guided, and telemetry settings",
     )
-
-    # reset subcommand
     subparsers.add_parser(
         "reset",
         help="interactive ledger reset — wipes state with confirmation",
     )
-
-    # setup subcommand
     setup_parser = subparsers.add_parser(
         "setup",
         help="interactive setup — configure MCP client to use this server",
@@ -1161,7 +1171,21 @@ def cli_main(argv: list[str] | None = None) -> int:
         metavar="PATH",
         help="separate directory for .bicameral/ history storage (default: same as repo)",
     )
-
+    link_parser = subparsers.add_parser(
+        "link_commit",
+        help="hash-level sync — link the given commit (default HEAD) into the ledger (#124)",
+    )
+    link_parser.add_argument(
+        "commit_hash",
+        nargs="?",
+        default="HEAD",
+        help="commit hash to link (default: HEAD)",
+    )
+    link_parser.add_argument(
+        "--quiet",
+        action="store_true",
+        help="suppress JSON output (still exits 0 on success)",
+    )
     parser.add_argument(
         "--smoke-test",
         action="store_true",
@@ -1172,27 +1196,31 @@ def cli_main(argv: list[str] | None = None) -> int:
         action="version",
         version=f"%(prog)s {SERVER_VERSION}",
     )
-    args = parser.parse_args(argv)
 
+
+def _dispatch(args: Any) -> int:
+    """Route parsed args to the appropriate handler. Returns exit code."""
     if args.command == "config":
         from setup_wizard import run_config_wizard
         return run_config_wizard()
-
     if args.command == "reset":
         from setup_wizard import run_reset_wizard
         return run_reset_wizard()
-
     if args.command == "setup":
         from setup_wizard import run_setup
         return run_setup(args.repo_path, args.history_path)
-
+    # triage-adapt: link_commit dispatch — added per #124 backport without
+    # the broader _register_subparsers/_dispatch refactor or the branch-scan
+    # / --with-push-hook prerequisites
+    if args.command == "link_commit":
+        from cli.link_commit_cli import main as link_commit_main
+        return link_commit_main(args.commit_hash, quiet=args.quiet)
     if args.smoke_test:
         result = asyncio.run(run_smoke_test())
         print(f"{result['server_name']} {result['server_version']} smoke test passed")
         for tool_name in result["tool_names"]:
             print(tool_name)
         return 0
-
     asyncio.run(serve_stdio())
     return 0
 

--- a/server.py
+++ b/server.py
@@ -701,6 +701,26 @@ async def list_tools() -> list[Tool]:
                 "required": ["skill", "trying_to", "attempted", "stuck_on"],
             },
         ),
+        Tool(
+            name="bicameral.usage_summary",
+            description=(
+                "Aggregate operational readout — counts and percentages over the last N days. "
+                "Returns ingest_calls, bind_calls_total, decision counts by status, "
+                "reflected/drift/cosmetic_drift percentages, and error_rate. "
+                "Privacy-preserving: aggregates only, no event rows, no user content. "
+                "Read-only over the local ledger plus the local-only counters file."
+            ),
+            inputSchema={
+                "type": "object",
+                "properties": {
+                    "days": {
+                        "type": "integer",
+                        "description": "Window size in days (default 7). Pass 0 for tool-call counts only.",
+                        "default": 7,
+                    },
+                },
+            },
+        ),
         # ── Code locator tools (MCP-native) ──────────────────────────
         Tool(
             name="validate_symbols",
@@ -845,6 +865,11 @@ async def call_tool(name: str, arguments: dict) -> list[TextContent]:
             stuck_on=arguments.get("stuck_on", ""),
         )
         return [TextContent(type="text", text=json.dumps({"recorded": True}))]
+
+    if name == "bicameral.usage_summary":
+        from handlers.usage_summary import handle_usage_summary
+        data = await handle_usage_summary(ctx, days=int(arguments.get("days", 7)))
+        return [TextContent(type="text", text=json.dumps(data, indent=2))]
 
     # Auto-sync HEAD on every tool call except link_commit (which syncs itself).
     # Returns the LinkCommitResponse when a new commit was just processed so we
@@ -1078,6 +1103,15 @@ async def serve_stdio() -> None:
     # It binds to a free port and stays running for the session.
     dashboard_srv = get_dashboard_server()
     await dashboard_srv.start(ctx_factory=BicameralContext.from_env)
+
+    # First-boot telemetry consent notice (non-blocking, fires once per
+    # policy_version). Stderr-only here; MCP-channel surfacing happens
+    # below once the session is live.
+    try:
+        from consent import notify_if_first_run
+        notify_if_first_run()
+    except Exception:
+        pass
 
     async with mcp.server.stdio.stdio_server() as (read_stream, write_stream):
         await server.run(

--- a/setup_wizard.py
+++ b/setup_wizard.py
@@ -521,11 +521,19 @@ def _select_guided_mode() -> bool:
 
 
 def _select_telemetry() -> bool:
-    """Prompt user for anonymous telemetry consent.
+    """Prompt user for anonymous telemetry consent and persist the choice.
 
-    Shows the exact event schema before asking. Defaults to Yes (opt-in).
+    Shows the exact event schema before asking. On any answer (including
+    non-interactive auto-yes), writes ``~/.bicameral/consent.json`` via
+    consent.write_consent() so the in-server first-boot notice does not
+    fire on next start.
+
+    Hard-fails (raises) if the consent marker cannot be written — a "no"
+    answer must never silently leave telemetry on.
     """
     import questionary
+
+    from consent import write_consent
 
     print()
     print("  Anonymous telemetry — exact payload that would be sent:")
@@ -539,6 +547,7 @@ def _select_telemetry() -> bool:
     print()
 
     if not _is_interactive():
+        write_consent(telemetry=True, via="wizard")
         return True
 
     result = questionary.select(
@@ -550,7 +559,9 @@ def _select_telemetry() -> bool:
         default=True,
     ).ask()
 
-    return result if result is not None else True
+    choice = result if result is not None else True
+    write_consent(telemetry=choice, via="wizard")
+    return choice
 
 
 def _write_collaboration_config(

--- a/setup_wizard.py
+++ b/setup_wizard.py
@@ -421,8 +421,14 @@ _GIT_POST_COMMIT_HOOK = """\
 #!/bin/sh
 # Bicameral MCP — post-commit hook (installed by bicameral-mcp setup, Guided mode)
 # Syncs the decision ledger after every commit so drift status is current immediately.
-# Silent on failure; only runs when .bicameral/ exists.
-[ -d .bicameral ] && bicameral-mcp link_commit HEAD >/dev/null 2>&1 || true
+# Loud-but-non-blocking failure: any stderr from link_commit is captured to
+# ${HOME}/.bicameral/hook-errors.log and surfaced on stderr in the same commit.
+# The `>` redirection truncates the log file each run, so successful commits
+# auto-clear stale errors from prior failed runs. Always exits 0 — the commit
+# itself never blocks on a sync hook failure (#124).
+[ -d .bicameral ] && bicameral-mcp link_commit HEAD >/dev/null 2>"${HOME}/.bicameral/hook-errors.log"
+[ -s "${HOME}/.bicameral/hook-errors.log" ] && echo "Bicameral post-commit hook failed; see ${HOME}/.bicameral/hook-errors.log" >&2
+exit 0
 """
 
 

--- a/telemetry.py
+++ b/telemetry.py
@@ -54,8 +54,13 @@ _TELEMETRY_OFF = frozenset({"0", "false", "no", "off"})
 
 
 def _is_enabled() -> bool:
-    val = os.getenv("BICAMERAL_TELEMETRY", "1").strip().lower()
-    return val not in _TELEMETRY_OFF
+    """Single source of truth: defers to consent.telemetry_allowed().
+
+    Kept as a thin wrapper so existing callers don't need rewrites and
+    the env-var override (BICAMERAL_TELEMETRY=0) continues to work.
+    """
+    from consent import telemetry_allowed
+    return telemetry_allowed()
 
 
 def _get_device_id() -> str:
@@ -109,6 +114,16 @@ def send_event(version: str, diagnostic: dict | None = None, **properties: str |
                    duration_ms=412, errored=False,
                    diagnostic={"decisions_ingested": 3})
     """
+    # Always-local counter increment — runs regardless of network consent.
+    # Privacy-preserving: only the skill/tool name + 1 are written, no payload.
+    try:
+        from local_counters import increment as _local_increment
+        skill_name = properties.get("skill") or properties.get("tool")
+        if isinstance(skill_name, str):
+            _local_increment(skill_name)
+    except Exception as exc:
+        logger.debug("[telemetry] local-counter increment failed (non-fatal): %s", exc)
+
     if not _is_enabled():
         return
     try:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -16,6 +16,33 @@ from pathlib import Path
 import pytest
 
 
+@pytest.fixture(scope="session", autouse=True)
+def _isolate_consent_state(tmp_path_factory):
+    """Reroute ~/.bicameral/ to a per-session tmp dir and skip the consent
+    notice by default (issue #39).
+
+    Tests that explicitly exercise the consent-notice path unset
+    BICAMERAL_SKIP_CONSENT_NOTICE within the test body. Stdlib only — no
+    third-party fixture plugin.
+    """
+    home = tmp_path_factory.mktemp("bicameral_home")
+    saved = {
+        k: os.environ.get(k)
+        for k in ("HOME", "USERPROFILE", "BICAMERAL_SKIP_CONSENT_NOTICE")
+    }
+    os.environ["HOME"] = str(home)
+    os.environ["USERPROFILE"] = str(home)
+    os.environ["BICAMERAL_SKIP_CONSENT_NOTICE"] = "1"
+    try:
+        yield home
+    finally:
+        for k, v in saved.items():
+            if v is None:
+                os.environ.pop(k, None)
+            else:
+                os.environ[k] = v
+
+
 def pytest_configure(config):
     config.addinivalue_line("markers", "phase1: requires RealCodeLocatorAdapter")
     config.addinivalue_line("markers", "phase2: requires SurrealDBLedgerAdapter + SurrealDB")

--- a/tests/test_consent_notice.py
+++ b/tests/test_consent_notice.py
@@ -1,0 +1,200 @@
+"""Tests for consent.py (issue #39): marker, notice, telemetry_allowed."""
+
+from __future__ import annotations
+
+import json
+import os
+import sys
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pytest
+
+
+def _reload_consent():
+    import importlib
+    import consent
+    importlib.reload(consent)
+    return consent
+
+
+# ── telemetry_allowed() — gating behavior ──────────────────────────────
+
+
+def test_telemetry_allowed_no_marker_default_on(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """No marker: default-on (preserves upgrade-path behavior)."""
+    monkeypatch.setenv("HOME", str(tmp_path))
+    monkeypatch.setenv("USERPROFILE", str(tmp_path))
+    monkeypatch.delenv("BICAMERAL_TELEMETRY", raising=False)
+    consent = _reload_consent()
+    assert consent.telemetry_allowed() is True
+
+
+def test_telemetry_allowed_env_off_overrides_marker(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """Env BICAMERAL_TELEMETRY=0 wins even when marker says enabled."""
+    monkeypatch.setenv("HOME", str(tmp_path))
+    monkeypatch.setenv("USERPROFILE", str(tmp_path))
+    monkeypatch.setenv("BICAMERAL_TELEMETRY", "0")
+    consent = _reload_consent()
+    consent.write_consent(telemetry=True, via="wizard")
+    assert consent.telemetry_allowed() is False
+
+
+def test_telemetry_allowed_marker_disabled(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """Marker 'disabled' suppresses relay even without env var."""
+    monkeypatch.setenv("HOME", str(tmp_path))
+    monkeypatch.setenv("USERPROFILE", str(tmp_path))
+    monkeypatch.delenv("BICAMERAL_TELEMETRY", raising=False)
+    consent = _reload_consent()
+    consent.write_consent(telemetry=False, via="wizard")
+    assert consent.telemetry_allowed() is False
+
+
+def test_telemetry_allowed_marker_enabled(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("HOME", str(tmp_path))
+    monkeypatch.setenv("USERPROFILE", str(tmp_path))
+    monkeypatch.delenv("BICAMERAL_TELEMETRY", raising=False)
+    consent = _reload_consent()
+    consent.write_consent(telemetry=True, via="wizard")
+    assert consent.telemetry_allowed() is True
+
+
+# ── write_consent() — file shape + permissions ─────────────────────────
+
+
+def test_write_consent_records_fields(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("HOME", str(tmp_path))
+    monkeypatch.setenv("USERPROFILE", str(tmp_path))
+    consent = _reload_consent()
+    consent.write_consent(telemetry=True, via="wizard")
+
+    marker = tmp_path / ".bicameral" / "consent.json"
+    assert marker.exists()
+    record = json.loads(marker.read_text(encoding="utf-8"))
+    assert record["telemetry"] == "enabled"
+    assert record["acknowledged_via"] == "wizard"
+    assert record["policy_version"] == consent.POLICY_VERSION
+    assert "acknowledged_at" in record
+
+
+@pytest.mark.skipif(sys.platform == "win32", reason="POSIX file modes only")
+def test_write_consent_mode_0o600_on_posix(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("HOME", str(tmp_path))
+    monkeypatch.setenv("USERPROFILE", str(tmp_path))
+    consent = _reload_consent()
+    consent.write_consent(telemetry=True, via="wizard")
+    marker = tmp_path / ".bicameral" / "consent.json"
+    assert (marker.stat().st_mode & 0o777) == 0o600
+
+
+# ── notify_if_first_run() — non-blocking notice ────────────────────────
+
+
+def test_notice_emitted_on_first_boot(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture
+) -> None:
+    monkeypatch.setenv("HOME", str(tmp_path))
+    monkeypatch.setenv("USERPROFILE", str(tmp_path))
+    monkeypatch.delenv("BICAMERAL_SKIP_CONSENT_NOTICE", raising=False)
+    consent = _reload_consent()
+
+    mcp_send = MagicMock()
+    consent.notify_if_first_run(send_mcp_notification=mcp_send)
+
+    captured = capsys.readouterr()
+    assert "Bicameral collects" in captured.err
+    mcp_send.assert_called_once()
+    assert mcp_send.call_args.args[0] == "info"
+
+    marker = consent.read_consent()
+    assert marker is not None
+    assert marker["acknowledged_via"] == "first_boot_notice"
+
+
+def test_notice_suppressed_after_marker(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture
+) -> None:
+    monkeypatch.setenv("HOME", str(tmp_path))
+    monkeypatch.setenv("USERPROFILE", str(tmp_path))
+    monkeypatch.delenv("BICAMERAL_SKIP_CONSENT_NOTICE", raising=False)
+    consent = _reload_consent()
+    consent.write_consent(telemetry=True, via="wizard")
+
+    capsys.readouterr()  # reset
+    consent.notify_if_first_run()
+    captured = capsys.readouterr()
+    assert captured.err == ""
+
+
+def test_notice_re_emitted_on_policy_version_bump(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture
+) -> None:
+    monkeypatch.setenv("HOME", str(tmp_path))
+    monkeypatch.setenv("USERPROFILE", str(tmp_path))
+    monkeypatch.delenv("BICAMERAL_SKIP_CONSENT_NOTICE", raising=False)
+    consent = _reload_consent()
+
+    # Simulate a stale marker (older policy version).
+    (tmp_path / ".bicameral").mkdir(parents=True, exist_ok=True)
+    (tmp_path / ".bicameral" / "consent.json").write_text(
+        json.dumps({"telemetry": "enabled", "policy_version": 0, "acknowledged_at": "x", "acknowledged_via": "wizard"}),
+        encoding="utf-8",
+    )
+
+    consent.notify_if_first_run()
+    captured = capsys.readouterr()
+    assert "Bicameral collects" in captured.err
+    new_marker = consent.read_consent()
+    assert new_marker["policy_version"] == consent.POLICY_VERSION
+
+
+def test_notice_skipped_when_env_var_set(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture
+) -> None:
+    monkeypatch.setenv("HOME", str(tmp_path))
+    monkeypatch.setenv("USERPROFILE", str(tmp_path))
+    monkeypatch.setenv("BICAMERAL_SKIP_CONSENT_NOTICE", "1")
+    consent = _reload_consent()
+
+    consent.notify_if_first_run()
+    captured = capsys.readouterr()
+    assert captured.err == ""
+    assert consent.read_consent() is None
+
+
+def test_notice_swallows_marker_write_failure(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """If marker write fails, notify_if_first_run still completes silently."""
+    monkeypatch.setenv("HOME", str(tmp_path))
+    monkeypatch.setenv("USERPROFILE", str(tmp_path))
+    monkeypatch.delenv("BICAMERAL_SKIP_CONSENT_NOTICE", raising=False)
+    consent = _reload_consent()
+    monkeypatch.setattr(consent, "write_consent", lambda *a, **kw: (_ for _ in ()).throw(OSError("disk full")))
+    # Must not raise.
+    consent.notify_if_first_run()
+
+
+def test_telemetry_send_event_blocked_when_consent_disabled(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """telemetry.send_event suppresses relay when consent says disabled."""
+    monkeypatch.setenv("HOME", str(tmp_path))
+    monkeypatch.setenv("USERPROFILE", str(tmp_path))
+    monkeypatch.delenv("BICAMERAL_TELEMETRY", raising=False)
+    consent = _reload_consent()
+    consent.write_consent(telemetry=False, via="wizard")
+
+    import importlib
+    import telemetry
+    importlib.reload(telemetry)
+
+    # Patch the network path; if relay was attempted, this would be called.
+    sent = []
+    monkeypatch.setattr(telemetry, "_send_bg", lambda payload: sent.append(payload))
+    telemetry.send_event("0.13.3", skill="bicameral-ingest", duration_ms=100)
+    # Counter should still increment locally.
+    import local_counters
+    importlib.reload(local_counters)
+    # Relay was NOT called (consent denied).
+    assert sent == []

--- a/tests/test_event_writer.py
+++ b/tests/test_event_writer.py
@@ -1,0 +1,126 @@
+"""Cross-platform regression tests for ``events.writer`` (issue #74).
+
+Issue #74: ``import fcntl`` was at module top-level, which is Unix-only
+and broke ALL ingest-using tests on Windows at import time.
+
+These tests verify:
+
+1. ``events.writer`` imports cleanly on the current platform.
+2. ``EventFileWriter.write()`` produces a well-formed JSONL line and
+   can be invoked twice in succession (i.e. the lock is taken and
+   released correctly — a leaked lock would deadlock the second call).
+3. The platform-conditional lock helpers exist and dispatch correctly.
+
+We don't test concurrent multi-process locking here — that's the
+domain of an OS-level integration test. We just guarantee the
+single-writer happy path works on every platform we support.
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+import pytest
+
+from events.writer import EventFileWriter, _lock_exclusive, _unlock
+
+
+def test_writer_module_imports_cleanly() -> None:
+    """Sanity: the module imports without raising on this platform.
+
+    The original bug (#74) raised ``ModuleNotFoundError: No module
+    named 'fcntl'`` at import time on Windows. Hitting any code path
+    that pulled in ``events.writer`` collapsed the whole test session.
+    """
+    import events.writer  # noqa: F401 — import side-effect IS the test
+
+
+def test_lock_helpers_exist_for_current_platform() -> None:
+    """Sanity: the platform-dispatched helpers are callable."""
+    assert callable(_lock_exclusive)
+    assert callable(_unlock)
+
+
+def test_write_produces_jsonl_line(tmp_path: Path) -> None:
+    """A single write() yields a parseable JSONL line."""
+    events_dir = tmp_path / "events"
+    writer = EventFileWriter(events_dir, "test@example.com")
+
+    path = writer.write("decision_recorded", {"decision_id": "decision:abc"})
+
+    assert path == events_dir / "test@example.com.jsonl"
+    assert path.exists()
+    content = path.read_text(encoding="utf-8")
+    assert content.endswith("\n"), "JSONL line must terminate with newline"
+    line = content.rstrip("\n")
+    parsed = json.loads(line)
+    assert parsed["event_type"] == "decision_recorded"
+    assert parsed["author"] == "test@example.com"
+    assert parsed["payload"] == {"decision_id": "decision:abc"}
+
+
+def test_consecutive_writes_release_lock(tmp_path: Path) -> None:
+    """Two writes back-to-back must succeed — proves the lock is released.
+
+    A leaked exclusive lock would deadlock the second ``open(... "ab")``
+    + ``_lock_exclusive`` call, hanging the test until pytest's
+    timeout. If this test passes quickly, the lock is being released.
+    """
+    events_dir = tmp_path / "events"
+    writer = EventFileWriter(events_dir, "test@example.com")
+
+    writer.write("event_one", {"n": 1})
+    writer.write("event_two", {"n": 2})
+
+    lines = (events_dir / "test@example.com.jsonl").read_text(encoding="utf-8").splitlines()
+    assert len(lines) == 2
+    assert json.loads(lines[0])["event_type"] == "event_one"
+    assert json.loads(lines[1])["event_type"] == "event_two"
+
+
+def test_write_with_empty_file_locks_cleanly(tmp_path: Path) -> None:
+    """Locking byte 0 on a previously-empty file must succeed.
+
+    Windows-specific concern: ``msvcrt.locking`` operates on a byte
+    range — an empty file has no bytes. We lock byte 0 anyway because
+    the OS-level lock is a metadata marker, not a region read. Verify
+    the first write to a fresh file works (file is created at 0 bytes,
+    then we open + lock + write).
+    """
+    events_dir = tmp_path / "events"
+    writer = EventFileWriter(events_dir, "fresh@example.com")
+    target = events_dir / "fresh@example.com.jsonl"
+    assert not target.exists(), "precondition: file should not exist yet"
+
+    writer.write("first_event", {"hello": "world"})
+
+    assert target.exists()
+    line = target.read_text(encoding="utf-8").rstrip("\n")
+    assert json.loads(line)["event_type"] == "first_event"
+
+
+@pytest.mark.skipif(sys.platform != "win32", reason="Windows-specific dispatch")
+def test_windows_uses_msvcrt() -> None:
+    """On Windows, the lock helpers dispatch to msvcrt, not fcntl."""
+    import events.writer as ew
+
+    # If the module accidentally re-introduces a top-level ``fcntl``
+    # import on Windows, this test still passes — but the very first
+    # test (``test_writer_module_imports_cleanly``) would fail at
+    # collection time. That covers the regression directly.
+    assert "msvcrt" in sys.modules, "msvcrt should be loaded on Windows"
+    # Spot-check the helpers are bound (not the POSIX versions).
+    assert ew._lock_exclusive.__doc__ is not None
+    assert "Windows" in ew._lock_exclusive.__doc__
+
+
+@pytest.mark.skipif(sys.platform == "win32", reason="POSIX-specific dispatch")
+def test_posix_uses_fcntl() -> None:
+    """On POSIX, the lock helpers dispatch to fcntl."""
+    import events.writer as ew
+
+    assert "fcntl" in sys.modules, "fcntl should be loaded on POSIX"
+    assert ew._lock_exclusive.__doc__ is not None
+    assert "POSIX" in ew._lock_exclusive.__doc__

--- a/tests/test_hook_command_registration.py
+++ b/tests/test_hook_command_registration.py
@@ -1,0 +1,81 @@
+"""Issue #124 Phase 2 — hook command registration smoke tests.
+
+Walks every ``bicameral-mcp <subcommand>`` invocation in installed
+hook scripts and asserts each subcommand is registered as a subparser
+in ``server.cli_main``. Catches the original #124 bug at PR time:
+the post-commit hook called ``link_commit`` for months without
+``link_commit`` ever being a registered subcommand.
+
+These tests assume Phase 0a's ``_register_subparsers`` is the source
+of truth for registered commands — it builds the parser without
+running the dispatch.
+"""
+
+from __future__ import annotations
+
+import re
+from argparse import ArgumentParser
+
+# triage-adapt: dropped _GIT_PRE_PUSH_HOOK import + the pre-push test
+# below — _GIT_PRE_PUSH_HOOK is a #48 prerequisite (pre-push drift hook)
+# that doesn't exist on triage. Post-commit coverage is preserved (the
+# actual #124 regression).
+from server import _register_subparsers
+from setup_wizard import _GIT_POST_COMMIT_HOOK
+
+# Match `bicameral-mcp <subcommand>` where the subcommand is a
+# lower-snake-or-dash identifier. Anchors on the literal command
+# token to avoid matching e.g. comments that mention bicameral-mcp.
+_CMD_RE = re.compile(r"\bbicameral-mcp\s+([a-z][a-z0-9_-]+)\b")
+
+
+def _extract_bicameral_mcp_commands(hook_script: str) -> set[str]:
+    """Return the set of unique subcommand tokens invoked in the script."""
+    return set(_CMD_RE.findall(hook_script))
+
+
+def _registered_subcommands() -> set[str]:
+    """Build a fresh parser via _register_subparsers and return the
+    set of registered subparser names."""
+    parser = ArgumentParser()
+    subparsers = parser.add_subparsers(dest="command")
+    _register_subparsers(parser, subparsers)
+    return set(subparsers.choices.keys())
+
+
+def test_post_commit_hook_command_is_registered() -> None:
+    """The post-commit hook calls ``link_commit``; that subcommand
+    must be a registered subparser. THIS TEST WAS RED ON DEV
+    BEFORE #124 — the regression that the original bug report named."""
+    invoked = _extract_bicameral_mcp_commands(_GIT_POST_COMMIT_HOOK)
+    registered = _registered_subcommands()
+    missing = invoked - registered
+    assert not missing, (
+        f"Post-commit hook invokes {invoked} but only {registered} are "
+        f"registered. Missing: {missing}"
+    )
+
+
+# triage-adapt: dropped test_pre_push_hook_command_is_registered —
+# pre-push hook is from #48 (missing prerequisite on triage)
+
+
+def test_all_hook_commands_have_dispatch_branches() -> None:
+    """Every command referenced in any installed hook script must
+    appear in server._dispatch as an ``args.command == "..."``
+    branch — registered-but-not-dispatched would still pass the
+    register tests above but would silently no-op at runtime.
+
+    triage-adapt: scoped to _GIT_POST_COMMIT_HOOK only — pre-push
+    hook is from #48, not on triage."""
+    import inspect
+
+    from server import _dispatch
+
+    dispatch_src = inspect.getsource(_dispatch)
+    invoked = _extract_bicameral_mcp_commands(_GIT_POST_COMMIT_HOOK)
+    missing = {cmd for cmd in invoked if f'args.command == "{cmd}"' not in dispatch_src}
+    assert not missing, (
+        f"Hook scripts invoke {invoked} but _dispatch has branches for "
+        f"only {invoked - missing}. Missing: {missing}"
+    )

--- a/tests/test_link_commit_cli.py
+++ b/tests/test_link_commit_cli.py
@@ -1,0 +1,96 @@
+"""Issue #124 Phase 1 — link_commit CLI subcommand contract tests.
+
+Tests the CLI surface of ``cli.link_commit_cli.main`` in isolation:
+mocks the shared runner so no SurrealDB / no real git activity is
+required. Six tests cover argparse defaults, output shape, --quiet
+flag, and the two graceful-skip paths (no ledger, handler exception).
+"""
+
+from __future__ import annotations
+
+import json
+from unittest.mock import patch
+
+from contracts import LinkCommitResponse
+
+
+def _fake_response(commit_hash: str = "abc123") -> LinkCommitResponse:
+    """Minimal valid LinkCommitResponse for output-shape tests."""
+    return LinkCommitResponse(
+        commit_hash=commit_hash,
+        synced=True,
+        reason="new_commit",
+    )
+
+
+def test_default_commit_hash_is_HEAD() -> None:
+    """``main()`` with no positional arg passes ``HEAD`` to the runner."""
+    from cli import link_commit_cli
+
+    with patch.object(link_commit_cli, "invoke_link_commit") as mock:
+        mock.return_value = None
+        link_commit_cli.main()
+    mock.assert_called_once_with("HEAD")
+
+
+def test_explicit_commit_hash_passed_through() -> None:
+    """``main("abc1234")`` passes the explicit hash to the runner."""
+    from cli import link_commit_cli
+
+    with patch.object(link_commit_cli, "invoke_link_commit") as mock:
+        mock.return_value = None
+        link_commit_cli.main("abc1234")
+    mock.assert_called_once_with("abc1234")
+
+
+def test_json_output_on_success(capsys) -> None:
+    """A successful sync prints valid JSON with the response shape."""
+    from cli import link_commit_cli
+
+    with patch.object(link_commit_cli, "invoke_link_commit") as mock:
+        mock.return_value = _fake_response("deadbeef")
+        rc = link_commit_cli.main("deadbeef")
+    captured = capsys.readouterr()
+    assert rc == 0
+    payload = json.loads(captured.out)
+    assert payload["commit_hash"] == "deadbeef"
+    assert payload["synced"] is True
+    assert payload["reason"] == "new_commit"
+
+
+def test_quiet_flag_suppresses_output(capsys) -> None:
+    """``--quiet`` (quiet=True) emits no stdout but still exits 0."""
+    from cli import link_commit_cli
+
+    with patch.object(link_commit_cli, "invoke_link_commit") as mock:
+        mock.return_value = _fake_response()
+        rc = link_commit_cli.main("HEAD", quiet=True)
+    captured = capsys.readouterr()
+    assert rc == 0
+    assert captured.out == ""
+
+
+def test_no_ledger_returns_zero_silently(capsys) -> None:
+    """Runner returns None (no ledger) → main exits 0, no stdout."""
+    from cli import link_commit_cli
+
+    with patch.object(link_commit_cli, "invoke_link_commit") as mock:
+        mock.return_value = None
+        rc = link_commit_cli.main()
+    captured = capsys.readouterr()
+    assert rc == 0
+    assert captured.out == ""
+
+
+def test_handler_exception_returns_zero_silently(capsys) -> None:
+    """Runner swallows exceptions and returns None — main treats it
+    identically to no-ledger (exit 0, silent). The hook's
+    failure-loud semantics live in shell, not Python."""
+    from cli import link_commit_cli
+
+    with patch.object(link_commit_cli, "invoke_link_commit") as mock:
+        mock.return_value = None  # runner already converted exception → None
+        rc = link_commit_cli.main()
+    captured = capsys.readouterr()
+    assert rc == 0
+    assert captured.out == ""

--- a/tests/test_local_counters.py
+++ b/tests/test_local_counters.py
@@ -1,0 +1,114 @@
+"""Unit tests for local_counters.py (issue #39)."""
+
+from __future__ import annotations
+
+import os
+import threading
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+
+def _counters_path(home: Path) -> Path:
+    return home / ".bicameral" / "counters.jsonl"
+
+
+def test_increment_creates_counter_file(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("HOME", str(tmp_path))
+    monkeypatch.setenv("USERPROFILE", str(tmp_path))
+    import importlib
+    import local_counters
+    importlib.reload(local_counters)
+
+    local_counters.increment("bicameral-ingest")
+
+    p = _counters_path(tmp_path)
+    assert p.exists()
+    lines = p.read_text(encoding="utf-8").splitlines()
+    assert len(lines) == 1
+
+
+def test_increment_appends(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("HOME", str(tmp_path))
+    monkeypatch.setenv("USERPROFILE", str(tmp_path))
+    import importlib
+    import local_counters
+    importlib.reload(local_counters)
+
+    for _ in range(50):
+        local_counters.increment("bicameral-ingest")
+    lines = _counters_path(tmp_path).read_text(encoding="utf-8").splitlines()
+    assert len(lines) == 50
+
+
+def test_read_counters_aggregates(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("HOME", str(tmp_path))
+    monkeypatch.setenv("USERPROFILE", str(tmp_path))
+    import importlib
+    import local_counters
+    importlib.reload(local_counters)
+
+    for _ in range(3):
+        local_counters.increment("bicameral-ingest")
+    for _ in range(7):
+        local_counters.increment("bicameral-bind")
+
+    counts = local_counters.read_counters()
+    assert counts == {"bicameral-ingest": 3, "bicameral-bind": 7}
+
+
+def test_no_network_calls(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """Patch urlopen to raise; increment must still succeed."""
+    monkeypatch.setenv("HOME", str(tmp_path))
+    monkeypatch.setenv("USERPROFILE", str(tmp_path))
+    import importlib
+    import local_counters
+    importlib.reload(local_counters)
+
+    with patch("urllib.request.urlopen", side_effect=RuntimeError("net down")):
+        local_counters.increment("bicameral-ingest")
+    assert _counters_path(tmp_path).exists()
+
+
+def test_concurrent_increments_no_data_loss(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("HOME", str(tmp_path))
+    monkeypatch.setenv("USERPROFILE", str(tmp_path))
+    import importlib
+    import local_counters
+    importlib.reload(local_counters)
+
+    def _worker(idx: int) -> None:
+        for _ in range(50):
+            local_counters.increment(f"tool-{idx % 4}")
+
+    threads = [threading.Thread(target=_worker, args=(i,)) for i in range(4)]
+    for t in threads:
+        t.start()
+    for t in threads:
+        t.join()
+
+    counts = local_counters.read_counters()
+    assert sum(counts.values()) == 200
+
+
+def test_disabled_when_env_off(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("HOME", str(tmp_path))
+    monkeypatch.setenv("USERPROFILE", str(tmp_path))
+    monkeypatch.setenv("BICAMERAL_LOCAL_COUNTERS", "0")
+    import importlib
+    import local_counters
+    importlib.reload(local_counters)
+
+    local_counters.increment("bicameral-ingest")
+    assert not _counters_path(tmp_path).exists()
+
+
+def test_read_counters_handles_missing_file(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("HOME", str(tmp_path))
+    monkeypatch.setenv("USERPROFILE", str(tmp_path))
+    import importlib
+    import local_counters
+    importlib.reload(local_counters)
+
+    assert local_counters.read_counters() == {}

--- a/tests/test_team_event_replay.py
+++ b/tests/test_team_event_replay.py
@@ -1,0 +1,195 @@
+"""Round-trip tests for the team event log replay path (#97).
+
+For each decision-status event type:
+    1. Setup team mode: inner adapter (memory://) wrapped in TeamWriteAdapter
+    2. Mutate state via the adapter (writes JSONL + DB)
+    3. Spin up a fresh adapter pointing at the same JSONL log but a fresh
+       memory:// inner DB and a fresh watermark
+    4. Connect — triggers materializer replay from offset 0
+    5. Assert the fresh DB ends up in the same end-state
+
+Covers the new event vocabulary added in this PR:
+    - decision_ratified.completed
+    - decision_superseded.completed
+
+Plus regression coverage for the pre-existing emit/replay surface:
+    - ingest.completed (decision row + signoff round-trip)
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from events.materializer import EventMaterializer
+from events.team_adapter import TeamWriteAdapter
+from events.writer import EventFileWriter
+from ledger.adapter import SurrealDBLedgerAdapter
+from ledger.queries import find_decision_by_canonical_id, get_canonical_id
+
+
+def _build_team_adapter(
+    events_dir: Path,
+    local_dir: Path,
+    author: str = "tester@example.com",
+) -> tuple[TeamWriteAdapter, SurrealDBLedgerAdapter]:
+    """Wire up an in-memory inner adapter + JSONL event log + materializer."""
+    inner = SurrealDBLedgerAdapter(url="memory://")
+    writer = EventFileWriter(events_dir, author)
+    materializer = EventMaterializer(events_dir, local_dir)
+    return TeamWriteAdapter(inner, writer, materializer), inner
+
+
+def _payload(intent: str, source_ref: str) -> dict:
+    """Minimal single-decision payload for ingest_payload."""
+    return {
+        "query": intent,
+        "repo": "test-repo",
+        "commit_hash": "deadbeef00000000000000000000000000000000",
+        "analyzed_at": "2026-04-29T12:00:00Z",
+        "mappings": [
+            {
+                "span": {
+                    "span_id": f"span-{source_ref}",
+                    "source_type": "transcript",
+                    "text": intent,
+                    "speaker": "Tester",
+                    "source_ref": source_ref,
+                },
+                "intent": intent,
+                "symbols": [],
+                "code_regions": [],
+                "dependency_edges": [],
+            }
+        ],
+    }
+
+
+@pytest.mark.asyncio
+async def test_ratify_event_roundtrip(tmp_path: Path) -> None:
+    """A ratify on the live adapter replays into a fresh adapter's DB.
+
+    Cross-DB lookup goes through canonical_id since SurrealDB-generated
+    decision ids are per-DB.
+    """
+    events_dir = tmp_path / "events"
+    local_dir_a = tmp_path / "local_a"
+
+    team_a, inner_a = _build_team_adapter(events_dir, local_dir_a)
+    await team_a.connect()
+
+    res = await team_a.ingest_payload(_payload("ratify-roundtrip", "rt-mtg"))
+    decision_id_a = res["created_decisions"][0]["decision_id"]
+    canonical = await get_canonical_id(inner_a._client, decision_id_a)
+    assert canonical, "canonical_id not stamped on decision row"
+
+    signoff = {
+        "state": "ratified",
+        "signer": "tester",
+        "note": "round-trip",
+        "ratified_at": "2026-04-29T13:00:00Z",
+    }
+    await team_a.apply_ratify(decision_id_a, signoff)
+
+    rows = await inner_a._client.query(
+        f"SELECT signoff FROM {decision_id_a} LIMIT 1"
+    )
+    assert rows and rows[0]["signoff"]["state"] == "ratified"
+
+    # Fresh adapter, same JSONL log, fresh watermark — replay from 0.
+    local_dir_b = tmp_path / "local_b"
+    team_b, inner_b = _build_team_adapter(events_dir, local_dir_b)
+    await team_b.connect()
+
+    decision_id_b = await find_decision_by_canonical_id(inner_b._client, canonical)
+    assert decision_id_b, "ingest event did not replay (no row for canonical_id)"
+    rows_b = await inner_b._client.query(
+        f"SELECT signoff FROM {decision_id_b} LIMIT 1"
+    )
+    replayed_signoff = rows_b[0].get("signoff") or {}
+    assert replayed_signoff.get("state") == "ratified", (
+        "decision_ratified.completed event did not replay; "
+        f"got signoff={replayed_signoff!r}"
+    )
+
+
+@pytest.mark.asyncio
+async def test_supersede_event_roundtrip(tmp_path: Path) -> None:
+    """A supersede on the live adapter replays edge + frozen signoff."""
+    events_dir = tmp_path / "events"
+    local_dir_a = tmp_path / "local_a"
+
+    team_a, inner_a = _build_team_adapter(events_dir, local_dir_a)
+    await team_a.connect()
+
+    r_old = await team_a.ingest_payload(_payload("old-decision", "old-mtg"))
+    r_new = await team_a.ingest_payload(_payload("new-decision", "new-mtg"))
+    old_id_a = r_old["created_decisions"][0]["decision_id"]
+    new_id_a = r_new["created_decisions"][0]["decision_id"]
+    old_canonical = await get_canonical_id(inner_a._client, old_id_a)
+    new_canonical = await get_canonical_id(inner_a._client, new_id_a)
+    assert old_canonical and new_canonical
+
+    await team_a.apply_supersede(
+        new_id=new_id_a,
+        old_id=old_id_a,
+        signer="tester",
+        signoff_note="superseding for round-trip",
+        superseded_at="2026-04-29T13:00:00Z",
+        session_id="test-session",
+    )
+
+    rows = await inner_a._client.query(f"SELECT signoff FROM {old_id_a} LIMIT 1")
+    assert rows and rows[0]["signoff"]["state"] == "superseded"
+
+    local_dir_b = tmp_path / "local_b"
+    team_b, inner_b = _build_team_adapter(events_dir, local_dir_b)
+    await team_b.connect()
+
+    old_id_b = await find_decision_by_canonical_id(inner_b._client, old_canonical)
+    new_id_b = await find_decision_by_canonical_id(inner_b._client, new_canonical)
+    assert old_id_b and new_id_b, "ingest events did not replay (canonical lookup failed)"
+
+    rows_b = await inner_b._client.query(f"SELECT signoff FROM {old_id_b} LIMIT 1")
+    replayed = rows_b[0].get("signoff") or {}
+    assert replayed.get("state") == "superseded", (
+        "decision_superseded.completed event did not replay; "
+        f"got signoff={replayed!r}"
+    )
+    assert replayed.get("superseded_by") == new_id_b
+
+    edge_rows = await inner_b._client.query(
+        f"SELECT id FROM supersedes WHERE in = {new_id_b} AND out = {old_id_b} LIMIT 1"
+    )
+    assert edge_rows, "supersedes edge did not replay"
+
+
+@pytest.mark.asyncio
+async def test_ingest_event_roundtrip_regression(tmp_path: Path) -> None:
+    """Pre-existing ingest.completed emit/replay still works.
+
+    This is the regression guard for the existing event vocabulary —
+    ensures the new emit calls did not perturb the established path.
+    """
+    events_dir = tmp_path / "events"
+    local_dir_a = tmp_path / "local_a"
+
+    team_a, _ = _build_team_adapter(events_dir, local_dir_a)
+    await team_a.connect()
+
+    res = await team_a.ingest_payload(_payload("regression-intent", "reg-mtg"))
+    decision_id_a = res["created_decisions"][0]["decision_id"]
+    canonical = await get_canonical_id(team_a._inner._client, decision_id_a)
+
+    local_dir_b = tmp_path / "local_b"
+    team_b, inner_b = _build_team_adapter(events_dir, local_dir_b)
+    await team_b.connect()
+
+    decision_id_b = await find_decision_by_canonical_id(inner_b._client, canonical)
+    assert decision_id_b, "ingest.completed regression — canonical lookup failed"
+    rows = await inner_b._client.query(
+        f"SELECT description FROM {decision_id_b} LIMIT 1"
+    )
+    assert rows, "ingest.completed regression — decision row missing after replay"
+    assert "regression-intent" in str(rows[0].get("description", ""))

--- a/tests/test_usage_summary.py
+++ b/tests/test_usage_summary.py
@@ -1,0 +1,115 @@
+"""Tests for handlers/usage_summary.py (issue #42)."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from handlers.usage_summary import handle_usage_summary
+
+
+def _ctx_with_decisions(rows: list[dict] | None = None, cc_rows: list[dict] | None = None) -> SimpleNamespace:
+    """Build a fake ctx whose ledger.client.query returns staged rows."""
+    client = MagicMock()
+    call_count = {"i": 0}
+
+    async def _query(sql: str, *args, **kwargs):
+        call_count["i"] += 1
+        if "FROM decision" in sql:
+            return rows or []
+        if "FROM compliance_check" in sql:
+            return cc_rows or []
+        return []
+
+    client.query = _query
+    inner = SimpleNamespace(_client=client)
+    ledger = SimpleNamespace(_inner=inner)
+    return SimpleNamespace(ledger=ledger)
+
+
+@pytest.mark.asyncio
+async def test_zero_days_returns_zeros(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """days=0 short-circuits the ledger query and returns base zeros + counter reads."""
+    monkeypatch.setenv("HOME", str(tmp_path))
+    monkeypatch.setenv("USERPROFILE", str(tmp_path))
+    ctx = _ctx_with_decisions()
+    out = await handle_usage_summary(ctx, days=0)
+    assert out["period_days"] == 0
+    assert out["decisions_ingested"] == 0
+    assert out["reflected_pct"] == 0.0
+    assert out["drift_pct"] == 0.0
+
+
+@pytest.mark.asyncio
+async def test_aggregate_decision_counts(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("HOME", str(tmp_path))
+    monkeypatch.setenv("USERPROFILE", str(tmp_path))
+    rows = [
+        {"status": "reflected", "n": 8},
+        {"status": "drifted", "n": 2},
+        {"status": "ungrounded", "n": 5},
+        {"status": "pending", "n": 3},
+    ]
+    ctx = _ctx_with_decisions(rows=rows, cc_rows=[])
+    out = await handle_usage_summary(ctx, days=7)
+    assert out["decisions_reflected"] == 8
+    assert out["decisions_drifted"] == 2
+    assert out["decisions_ungrounded"] == 5
+    assert out["decisions_pending"] == 3
+    assert out["decisions_ingested"] == 18
+    assert out["reflected_pct"] == 0.8
+    assert out["drift_pct"] == 0.2
+    # reflected_pct + drift_pct ≤ 1.0 (acceptance criterion)
+    assert out["reflected_pct"] + out["drift_pct"] <= 1.0
+
+
+@pytest.mark.asyncio
+async def test_cosmetic_drift_pct(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("HOME", str(tmp_path))
+    monkeypatch.setenv("USERPROFILE", str(tmp_path))
+    cc = [
+        {"verdict": "drifted", "n": 4},
+        {"verdict": "cosmetic_autopass", "n": 6},
+    ]
+    ctx = _ctx_with_decisions(rows=[], cc_rows=cc)
+    out = await handle_usage_summary(ctx, days=7)
+    assert out["cosmetic_drift_pct"] == 0.6
+    # Acceptance: between 0.0 and 1.0
+    assert 0.0 <= out["cosmetic_drift_pct"] <= 1.0
+
+
+@pytest.mark.asyncio
+async def test_empty_ledger_no_error(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """Empty tool_events / decision tables: numeric fields are 0.0, no error."""
+    monkeypatch.setenv("HOME", str(tmp_path))
+    monkeypatch.setenv("USERPROFILE", str(tmp_path))
+    ctx = _ctx_with_decisions(rows=[], cc_rows=[])
+    out = await handle_usage_summary(ctx, days=7)
+    assert out["decisions_ingested"] == 0
+    assert out["reflected_pct"] == 0.0
+    assert out["drift_pct"] == 0.0
+    assert out["cosmetic_drift_pct"] == 0.0
+
+
+@pytest.mark.asyncio
+async def test_tool_call_counts_from_local_counters(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """ingest_calls and bind_calls_total come from the local counters file."""
+    monkeypatch.setenv("HOME", str(tmp_path))
+    monkeypatch.setenv("USERPROFILE", str(tmp_path))
+    import importlib
+    import local_counters
+    importlib.reload(local_counters)
+    for _ in range(3):
+        local_counters.increment("bicameral-ingest")
+    for _ in range(2):
+        local_counters.increment("bicameral-bind")
+
+    ctx = _ctx_with_decisions(rows=[], cc_rows=[])
+    out = await handle_usage_summary(ctx, days=7)
+    assert out["ingest_calls"] == 3
+    assert out["bind_calls_total"] == 2


### PR DESCRIPTION
## Release v0.13.5 (triage)

### North star

This release advances the [v0 Architecture (Notion)](https://app.notion.com/p/v0-Architecture-3512a51619c481ac97fcd66251c094d9). Triage releases (per DEV_CYCLE.md §10.5) ship the subset of \`dev\` work that's user-facing, isolated, and §10.5.1-eligible — letting fast iteration on \`dev\` coexist with deliberate user-visible delivery on \`main\`.

### Headline

Restores Guided-mode post-commit hook behavior (#124) and ships event vocabulary extension for cross-author replay (#97), alongside earlier carry-forward fixes (#74 Windows ingest, #95 telemetry counters, #98 RFC docs).

### Cherry-picked commits

Per DEV_CYCLE §10.5.4, every triage release PR enumerates each cherry-picked commit with provenance:

| Triage SHA | Source dev SHA | Source PR | Issue | §10.5.3 status |
|---|---|---|---|---|
| \`bb76ad5\` | \`431e202\` | #127 → #134 | **#124** | Adapted (6 hunks: drop #48 prereqs incl. branch-scan, --with-push-hook) |
| \`5f60eed\` | \`e6d4b8f\` | #132 → #133 | **#97** (RFC) | Adapted (3 hunks: drop #77 + #65 prereqs) |
| \`cb682c4\` | (orphan — not on current dev) | #80 | **#74** (Windows ingest crash) | Pre-§10.5 era — no \`-x\` provenance |
| \`b420abc\` | reapplied (≠ dev's \`089986d\`) | #95 | — | Pre-§10.5 era — different SHA from dev |
| \`85a5dc7\` | reapplied (≠ dev's \`695fe39\`) | #98 | #97 (tracking RFC) | Pre-§10.5 era — different SHA from dev |

The two §10.5-era commits (\`5f60eed\`, pending-\`#134\`) carry full \`(cherry picked from commit ...)\` provenance and \`Adaptation:\` trailers in their commit messages. The three pre-§10.5 commits are sunk-cost divergence per §10.5.3 ("Do **not** rewrite history on \`triage-from-dev\` to fix the divergence — it is a published branch") — going forward every cherry-pick re-converges the audit trail.

### Per-issue narrative

- **#124** (post-commit hook silent no-op) — the hook installed by \`bicameral-mcp setup\` (Guided mode) called \`bicameral-mcp link_commit HEAD\`, but \`link_commit\` was never registered as a CLI subcommand. Every commit since the hook was added silently failed. This release registers the subcommand and hardens the hook to write stderr to \`${HOME}/.bicameral/hook-errors.log\` and surface a one-line summary. **Architectural caveat**: \`link_commit\` syncs ledger state but does NOT auto-resolve drift. Pending-compliance indicators still need \`resolve_compliance\` to clear them (caller-driven, by design — selection over generation per CLAUDE.md). Active Claude Code sessions get tool-call auto-sync independently; this fix matters most for out-of-session committers.
- **#97** (event vocabulary extension) — adds \`decision_ratified\` and \`decision_superseded\` event types to the JSONL + materializer pipeline, with \`canonical_id\` (UUIDv5) for cross-author replay. Foundation work for the event-sourced ledger RFC tracked in #97 (RFC stays open per convention).
- **#74** (Windows ingest crash) — \`events/writer.py\` top-level \`import fcntl\` blocked all ingest-using tests on Windows. Cross-platform shim (POSIX fcntl + Windows msvcrt) lands here.
- **#95** (telemetry counters + first-boot consent) — local telemetry counters, \`usage_summary\` tool, first-boot consent flow. Originally landed as v0.14.0 on dev; reapplied on triage as a different SHA (pre-§10.5 era).
- **#98** (event-sourced ledger RFC docs) — backlog entry tracking #97. Reapplied with different SHA (pre-§10.5 era).

### Schema

**No schema migrations.** Schema-migrating dev work (decision_level classifier #77/v0.16.0, governance contracts v0.17.0, preflight telemetry #65) is intentionally held out — not triage-eligible per §10.5.1 without migration coordination on main.

### Breaking changes

**None** in the API/data sense. The post-commit hook in #124 newly surfaces failures on stderr (was silent); observable behavior change for users who had silent failures, but no API/data change. Existing installs that had been silently failing will start surfacing errors — interpret these as the system telling you something was already broken, not a new regression.

### Documentation

- **This PR body** is the canonical per-release narrative per §10.5.4
- Each triage commit's message documents its individual scope
- DEV_CYCLE.md §10.5 (triage lane) + §10.5.3 (adaptation clause) are the policy backing for the four §10.5-era commits (#134-pending, #133's \`5f60eed\`)
- v0 Architecture (Notion) — north-star context: https://app.notion.com/p/v0-Architecture-3512a51619c481ac97fcd66251c094d9

### Test plan

- [x] All §10.5-era cherry-picks pass their local target tests (4/4 for \`5f60eed\` event-replay, 8/8 for #134 link_commit registration)
- [x] Local import smoke: \`server\`, \`handlers.ratify\`, \`handlers.resolve_collision\`, \`SurrealDBLedgerAdapter.apply_ratify\`, \`SurrealDBLedgerAdapter.apply_supersede\`, both new \`cli/\` modules — all clean
- [x] Local CLI smoke: \`_register_subparsers\` registers exactly \`['config', 'link_commit', 'reset', 'setup']\` (the triage-eligible set; no branch-scan, no --with-push-hook)
- [ ] CI green on this PR's \`main\`-bound checks once #134 lands
- [ ] Manual smoke: \`bicameral-mcp link_commit HEAD\` renders JSON; \`bicameral-mcp setup\` installs working hook

### Pre-existing carry-overs (not new regressions)

Two preflight test files fail at collection time on triage at HEAD due to missing dev-only symbols:
- \`tests/test_v0412_preflight.py\` — \`ImportError: cannot import name '_has_actionable_signal_in_search'\`
- \`tests/test_v055_region_anchored_preflight.py\` — \`ImportError: cannot import name '_merge_decision_matches'\`

Both predate this release. Carrying forward — they're a separate issue tied to triage's pre-§10.5 divergence, not introduced by anything in this PR.

### Sequencing

1. ~~**#134** (\`triage/124-link-commit-cli → triage-from-dev\`) merges first → adds \`feat(#124)\` SHA to \`triage-from-dev\`~~ — ✅ landed as \`bb76ad5\`
2. **This PR** (\`triage-from-dev → main\`) is now mergeable with the full 5-commit set
3. **Tag** \`v0.13.5\` on \`main\`, publish GitHub Release
4. **Sync** \`main\` → \`dev\` per DEV_CYCLE §10 (merge or cherry-pick the tag commit)

### References

- [v0 Architecture (Notion)](https://app.notion.com/p/v0-Architecture-3512a51619c481ac97fcd66251c094d9) — north-star roadmap
- DEV_CYCLE.md §6 (release cycle)
- DEV_CYCLE.md §10.5 (triage lane), §10.5.3 (adaptation clause), §10.5.4 (release PR template)
- DEV_CYCLE.md §5.1 (merge style — repo-level squash disabled; rebase-and-merge default)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
