### PR TITLE
ci(#108): v0 user flow e2e — Claude Code CLI sessions vs desktop/desktop

### DIFF
--- a/.github/workflows/v0-user-flow-e2e.yml
+++ b/.github/workflows/v0-user-flow-e2e.yml
@@ -1,0 +1,110 @@
+name: v0 user flow e2e
+
+# End-to-end validation of BicameralAI/bicameral#108's six canonical user
+# flows via real Claude Code CLI sessions with bicameral-mcp registered.
+# See tests/e2e/README.md for the design.
+#
+# Note: when this workflow file lands, it will not run on the PR that
+# adds it — pull_request workflows execute the version on the base
+# branch (main). First execution is on the next qualifying PR after merge.
+
+on:
+  pull_request:
+    branches: [main, dev]
+    paths:
+      - 'tests/e2e/**'
+      - 'handlers/**'
+      - 'ledger/**'
+      - 'contracts.py'
+      - 'skills/bicameral-**'
+      - 'server.py'
+      - 'pyproject.toml'
+      - '.github/workflows/v0-user-flow-e2e.yml'
+  workflow_dispatch:  # allow manual trigger for debugging
+
+env:
+  PYTHON_VERSION: '3.11'
+  NODE_VERSION: '20'
+  # Pinned commit of github.com/desktop/desktop. Bump when the roadmap.md
+  # shape drifts in ways that break prompts, or when bind targets change.
+  DESKTOP_PINNED_COMMIT: 'e6c50fb028171e9cec03594273c8116bb135847e'
+
+jobs:
+  v0-user-flow-e2e:
+    name: v0 User Flow E2E (Claude Code CLI session)
+    runs-on: ubuntu-latest
+    # production environment provides CLAUDE_CODE_OAUTH_TOKEN for the
+    # Claude Code CLI sessions.
+    environment: production
+    timeout-minutes: 25
+    env:
+      DESKTOP_REPO_PATH: /tmp/desktop-clone
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: ${{ env.PYTHON_VERSION }}
+
+      - name: Setup Node.js (for Claude Code CLI)
+        uses: actions/setup-node@v4
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+
+      - name: Install bicameral-mcp + test deps
+        run: pip install -e ".[test]"
+
+      - name: Install Claude Code CLI
+        run: npm install -g @anthropic-ai/claude-code
+
+      - name: Verify CLI tooling on PATH
+        run: |
+          which claude && claude --version
+          which bicameral-mcp
+
+      # ── Test fixture: github.com/desktop/desktop at a pinned commit ─
+      - name: Clone desktop/desktop at pinned commit
+        run: |
+          mkdir -p ${{ env.DESKTOP_REPO_PATH }}
+          cd ${{ env.DESKTOP_REPO_PATH }}
+          git init -q
+          git remote add origin https://github.com/desktop/desktop
+          git fetch --depth 1 origin "${DESKTOP_PINNED_COMMIT}"
+          git checkout FETCH_HEAD
+          # Stamp a real 'main' branch so flows that branch off it work
+          git checkout -b main
+          git config user.email ci@bicameral.test
+          git config user.name CI
+          # Sanity: required files present
+          test -f docs/process/roadmap.md
+          test -f app/src/lib/git/cherry-pick.ts
+
+      # ── Diagnostic probe: confirm OAuth token is non-empty without leaking it ─
+      - name: Claude Code OAuth token visibility probe
+        run: |
+          set +e
+          if [ -n "${CLAUDE_CODE_OAUTH_TOKEN}" ]; then
+            echo "CLAUDE_CODE_OAUTH_TOKEN: present (length=${#CLAUDE_CODE_OAUTH_TOKEN})"
+          else
+            echo "CLAUDE_CODE_OAUTH_TOKEN: EMPTY or UNSET"
+            echo "  secret expression non-empty: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN != '' }}"
+            exit 1
+          fi
+        env:
+          CLAUDE_CODE_OAUTH_TOKEN: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+
+      # ── Drive the five flows through Claude Code CLI sessions ─
+      - name: Run v0 user flow e2e
+        env:
+          CLAUDE_CODE_OAUTH_TOKEN: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+        run: python tests/e2e/run_e2e_flows.py
+
+      # ── Forensics: keep transcripts even on failure ─
+      - name: Upload e2e transcripts
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: v0-user-flow-e2e-transcripts
+          path: test-results/e2e/
+          retention-days: 30

--- a/tests/e2e/README.md
+++ b/tests/e2e/README.md
@@ -1,0 +1,104 @@
+# v0 user flow e2e
+
+End-to-end validation of `BicameralAI/bicameral#108`'s six canonical user
+flows, driven by **real Claude Code CLI sessions** with `bicameral-mcp`
+registered as an MCP server. Test fixture: a pinned commit of
+`github.com/desktop/desktop`, with `docs/process/roadmap.md` as ingest
+content.
+
+This is the canonical CI test for the spec. The handler-replay simulation
+at `scripts/sim_issue_108_flows.py` complements it for fast local iteration
+on handler logic without burning Claude API calls.
+
+## What it tests
+
+Each flow corresponds to a section of [bicameral#108 spec](https://github.com/BicameralAI/bicameral/issues/108):
+
+| Flow | Spec section | Asserts |
+|---|---|---|
+| 1 | Record decisions from a meeting | `bicameral.ingest` called with mappings |
+| 2 | Begin to write code (preflight) | `bicameral.preflight` called with `file_paths` |
+| 3 | Commit code → reflected | `bicameral.link_commit` + `bicameral.resolve_compliance` (with verdicts) |
+| 4 | End coding session | `bicameral.ingest` called with `source="agent_session"` |
+| 5 | Review what's been tracked | `bicameral.history` called (with seed ingest + ratify) |
+
+Each flow is a separate `claude -p` invocation with a fresh `memory://`
+ledger. Within a session, prompts may chain multiple tool calls — the
+asserter walks the entire stream-json transcript.
+
+## How it works
+
+```
+prompts/flow-N-*.md  →  claude -p  →  stream-json transcript  →  assert
+                          │
+                          ├─ --mcp-config bicameral.mcp.json  (registers bicameral-mcp)
+                          ├─ --strict-mcp-config              (no other MCP servers loaded)
+                          ├─ --allowed-tools mcp__bicameral Read Grep
+                          ├─ --add-dir <desktop_clone>        (skill Read access)
+                          └─ --output-format stream-json --verbose
+```
+
+`run_e2e_flows.py` orchestrates all five flows, captures transcripts to
+`test-results/e2e/flow-N.ndjson`, and asserts on the tool-use blocks.
+
+## Running locally
+
+```bash
+# 1. Install bicameral-mcp + Claude Code CLI
+cd pilot/mcp
+pip install -e ".[test]"
+npm install -g @anthropic-ai/claude-code
+
+# 2. Authenticate Claude Code CLI (interactive — once)
+claude auth
+
+# 3. Clone the test fixture
+git clone --depth=1 https://github.com/desktop/desktop /tmp/desktop-clone
+cd /tmp/desktop-clone && git checkout -b main && cd -
+
+# 4. Run all five flows
+DESKTOP_REPO_PATH=/tmp/desktop-clone python tests/e2e/run_e2e_flows.py
+```
+
+Cost per run: ~$0.50–$2.00 across all five flows depending on how much the
+LLM exercises in each session. Each run is bounded by `--max-budget-usd 2.0`
+per flow.
+
+## CI
+
+GitHub Actions workflow: `.github/workflows/v0-user-flow-e2e.yml`.
+
+- Triggers on PRs touching `tests/e2e/**`, `handlers/**`, `ledger/**`,
+  `contracts.py`, `skills/bicameral-*/**`, or the workflow itself.
+- Runs in the `production` GitHub environment for `CLAUDE_CODE_OAUTH_TOKEN`.
+- Pinned `desktop/desktop` commit in the workflow file (update by editing
+  the env var).
+- Uploads `test-results/e2e/*.ndjson` as job artifacts (30-day retention)
+  for failure forensics.
+
+## Updating
+
+When the spec changes, update both:
+
+1. The relevant `prompts/flow-N-*.md` (natural-language user prompt)
+2. The matching `assert_flow_N` in `run_e2e_flows.py`
+
+When `desktop/desktop`'s `roadmap.md` or `cherry-pick.ts` shape drifts in
+ways that break the prompts or bind targets, bump the pinned commit in
+the workflow + adjust prompts.
+
+## Why not handler-replay only?
+
+The handler-replay sim (`scripts/sim_issue_108_flows.py`) directly imports
+handler functions and calls them. It's fast and useful for iterating on
+handler logic, but it bypasses three layers we need to validate:
+
+- **MCP protocol** — JSON-RPC over stdio, tool schema marshalling
+- **Skill files** — `.claude/skills/bicameral-*/SKILL.md` parsing, trigger
+  matching, prompt construction
+- **Caller LLM** — natural-language → tool-call sequencing, auto-chains
+  (preflight → capture-corrections → context-sentry → ingest → judge_gaps)
+
+This e2e suite covers all three. Together they form the spec's two-level
+validation: handler invariants (replay sim) + user-experience contract
+(this directory).

--- a/tests/e2e/bicameral.mcp.json
+++ b/tests/e2e/bicameral.mcp.json
@@ -1,0 +1,11 @@
+{
+  "mcpServers": {
+    "bicameral": {
+      "command": "bicameral-mcp",
+      "args": [],
+      "env": {
+        "SURREAL_URL": "memory://"
+      }
+    }
+  }
+}

--- a/tests/e2e/bicameral.mcp.json
+++ b/tests/e2e/bicameral.mcp.json
@@ -4,7 +4,8 @@
       "command": "bicameral-mcp",
       "args": [],
       "env": {
-        "SURREAL_URL": "memory://"
+        "SURREAL_URL": "memory://",
+        "REPO_PATH": "${DESKTOP_REPO_PATH}"
       }
     }
   }

--- a/tests/e2e/prompts/flow-1-ingest.md
+++ b/tests/e2e/prompts/flow-1-ingest.md
@@ -1,0 +1,13 @@
+I just reviewed the GitHub Desktop roadmap and want to capture some of their recent feature decisions in bicameral so we can track them.
+
+Here are three roadmap items:
+
+1. **High signal notifications (2.9.10 and 3.0.0)** — Receive a notification when checks fail. Receive a notification when your pull request is reviewed.
+
+2. **Improved commit history (2.9.0)** — Reorder commits via drag/drop. Squash commits via drag/drop. Amend last commit. Create a branch from a previous commit.
+
+3. **Cherry-picking commits from one branch to another (2.7.1)** — Cherry-pick commits with a context menu and interactively.
+
+Please ingest these as decisions into the bicameral ledger. The source is `desktop/desktop:docs/process/roadmap.md`.
+
+After ingesting, briefly confirm what was captured (decision IDs and signoff state) so I know they landed.

--- a/tests/e2e/prompts/flow-2-preflight.md
+++ b/tests/e2e/prompts/flow-2-preflight.md
@@ -1,0 +1,5 @@
+Before I refactor the cherry-pick logic in GitHub Desktop, I want to make sure I'm aware of any prior decisions or context that touch this code path.
+
+I'm specifically going to be modifying `app/src/lib/git/cherry-pick.ts`.
+
+Please run a preflight check against this file path and tell me what comes back — any bound decisions, unresolved collisions, or context-pending items I should know about before I start writing code.

--- a/tests/e2e/prompts/flow-3-commit-sync.md
+++ b/tests/e2e/prompts/flow-3-commit-sync.md
@@ -1,0 +1,8 @@
+I just made a commit that touched `app/src/lib/git/cherry-pick.ts`. Please sync the bicameral ledger to reflect the new HEAD and resolve any pending compliance checks that surface for that file.
+
+Specifically:
+1. Call link_commit on HEAD to detect drift against any decisions bound to that file.
+2. For each pending compliance check that comes back, evaluate whether the current code semantically matches the decision and emit a verdict (compliant / drifted / not_relevant) via resolve_compliance. Use the file content as evidence.
+3. After resolving, summarize: how many decisions transitioned to reflected vs drifted vs stayed pending.
+
+Before you start, you'll need to set up a bound decision against `app/src/lib/git/cherry-pick.ts` so there's something to sync. Use this decision text: "Cherry-pick commits with a context menu and interactively (GitHub Desktop roadmap, version 2.7.1)". Bind it to the `CherryPickResult` enum at the top of that file (lines 31–60).

--- a/tests/e2e/prompts/flow-4-session-end.md
+++ b/tests/e2e/prompts/flow-4-session-end.md
@@ -1,0 +1,7 @@
+We're wrapping up our coding session. Earlier in our conversation I mentioned a constraint that we never wrote down explicitly:
+
+> "The cherry-pick implementation should never require interactive prompts during conflict resolution — conflicts must always be resolvable through the visual conflict UI, not via stdin."
+
+That's a real constraint that affects implementation. Please capture it as a session-end correction and ingest it into the bicameral ledger using the `agent_session` source so we know it came from this conversation rather than a transcript or doc.
+
+After ingesting, confirm the decision_id and the signoff state.

--- a/tests/e2e/prompts/flow-5-history.md
+++ b/tests/e2e/prompts/flow-5-history.md
@@ -1,0 +1,11 @@
+Show me the full decision history for this repo. Group decisions by feature area and for each one, surface BOTH axes:
+
+- **status** — code-compliance side: reflected | drifted | pending | ungrounded
+- **signoff.state** — human-approval side: proposed | ratified | rejected | superseded | collision_pending | context_pending
+
+Before you call history, ingest two seed decisions so the response isn't empty:
+
+1. "Reorder commits via drag/drop" (feature_group: Improved commit history) — leave at default proposed/ungrounded.
+2. "Native support for Apple silicon machines" (feature_group: Apple silicon) — ingest, then ratify it so it shows ratified × ungrounded in the readout.
+
+After history returns, render a brief table showing each decision's two axes so I can scan it.

--- a/tests/e2e/run_e2e_flows.py
+++ b/tests/e2e/run_e2e_flows.py
@@ -34,8 +34,8 @@ import pathlib
 import shutil
 import subprocess
 import sys
+from collections.abc import Callable
 from dataclasses import dataclass, field
-from typing import Callable
 
 E2E_ROOT = pathlib.Path(__file__).resolve().parent
 PROMPTS_DIR = E2E_ROOT / "prompts"
@@ -62,8 +62,7 @@ if not shutil.which("claude"):
 
 if not shutil.which("bicameral-mcp"):
     sys.stderr.write(
-        "ERROR: 'bicameral-mcp' command not found on PATH.\n"
-        "Install via: pip install -e .\n"
+        "ERROR: 'bicameral-mcp' command not found on PATH.\nInstall via: pip install -e .\n"
     )
     sys.exit(2)
 
@@ -234,13 +233,11 @@ def assert_flow_1(calls: list[dict]) -> tuple[bool, str]:
     if len(items) < 1:
         payload = _ingest_payload(ingest_calls[0])
         return False, (
-            f"ingest called without decisions/mappings "
-            f"(payload keys: {list(payload.keys())})"
+            f"ingest called without decisions/mappings (payload keys: {list(payload.keys())})"
         )
 
     return True, (
-        f"bicameral.ingest called with {len(items)} item(s); "
-        f"total bicameral calls: {len(bcalls)}"
+        f"bicameral.ingest called with {len(items)} item(s); total bicameral calls: {len(bcalls)}"
     )
 
 
@@ -255,10 +252,7 @@ def assert_flow_2(calls: list[dict]) -> tuple[bool, str]:
 
     file_paths = preflight_calls[0]["input"].get("file_paths") or []
     if not file_paths or not any("cherry-pick.ts" in p for p in file_paths):
-        return False, (
-            f"preflight called without expected file_paths; "
-            f"got: {file_paths}"
-        )
+        return False, (f"preflight called without expected file_paths; got: {file_paths}")
 
     return True, (
         f"bicameral.preflight called with file_paths={file_paths}; "
@@ -291,8 +285,7 @@ def assert_flow_3(calls: list[dict]) -> tuple[bool, str]:
         return False, "resolve_compliance called without verdicts"
 
     return True, (
-        f"link_commit + resolve_compliance both called; verdicts={len(verdicts)}; "
-        f"sequence: {names}"
+        f"link_commit + resolve_compliance both called; verdicts={len(verdicts)}; sequence: {names}"
     )
 
 
@@ -300,7 +293,10 @@ def assert_flow_4(calls: list[dict]) -> tuple[bool, str]:
     bcalls = _bicameral_tool_calls(calls)
     ingest_calls = _calls_named(bcalls, "bicameral_ingest")
     if not ingest_calls:
-        return False, f"expected ingest with agent_session source; saw: {[c['name'] for c in bcalls]}"
+        return (
+            False,
+            f"expected ingest with agent_session source; saw: {[c['name'] for c in bcalls]}",
+        )
 
     # Source can live at payload.source (top-level) or per-decision via
     # span.source_type. Check both, since the MCP tool schema wraps in payload.
@@ -320,8 +316,7 @@ def assert_flow_4(calls: list[dict]) -> tuple[bool, str]:
         )
 
     return True, (
-        f"bicameral.ingest called with agent_session source "
-        f"(payload.source={top_source!r})"
+        f"bicameral.ingest called with agent_session source (payload.source={top_source!r})"
     )
 
 
@@ -346,8 +341,7 @@ def assert_flow_5(calls: list[dict]) -> tuple[bool, str]:
         )
 
     return True, (
-        f"bicameral.history called; ingest seeded={len(ingest_calls)}, "
-        f"ratified={len(ratify_calls)}"
+        f"bicameral.history called; ingest seeded={len(ingest_calls)}, ratified={len(ratify_calls)}"
     )
 
 

--- a/tests/e2e/run_e2e_flows.py
+++ b/tests/e2e/run_e2e_flows.py
@@ -39,7 +39,7 @@ from typing import Callable
 
 E2E_ROOT = pathlib.Path(__file__).resolve().parent
 PROMPTS_DIR = E2E_ROOT / "prompts"
-MCP_CONFIG_PATH = E2E_ROOT / "bicameral.mcp.json"
+MCP_CONFIG_TEMPLATE = E2E_ROOT / "bicameral.mcp.json"
 RESULTS_DIR = pathlib.Path(__file__).resolve().parents[2] / "test-results" / "e2e"
 RESULTS_DIR.mkdir(parents=True, exist_ok=True)
 
@@ -66,6 +66,25 @@ if not shutil.which("bicameral-mcp"):
         "Install via: pip install -e .\n"
     )
     sys.exit(2)
+
+
+def _materialize_mcp_config() -> pathlib.Path:
+    """Read the MCP config template, substitute env-var placeholders, write
+    a runtime copy. The template uses ``${DESKTOP_REPO_PATH}`` so it works
+    locally (any clone path) and in CI (the workflow's clone path).
+
+    Claude Code's MCP spawn behaviour for env replacement vs merge is
+    implementation-defined; passing REPO_PATH explicitly via the config
+    avoids that ambiguity.
+    """
+    raw = MCP_CONFIG_TEMPLATE.read_text(encoding="utf-8")
+    materialized = raw.replace("${DESKTOP_REPO_PATH}", DESKTOP_REPO_PATH)
+    out = RESULTS_DIR / "bicameral.mcp.materialized.json"
+    out.write_text(materialized, encoding="utf-8")
+    return out
+
+
+MCP_CONFIG_PATH = _materialize_mcp_config()
 
 
 @dataclass
@@ -186,6 +205,22 @@ def _calls_named(calls: list[dict], suffix: str) -> list[dict]:
 # ── Per-flow assertions ─────────────────────────────────────────────────
 
 
+def _ingest_payload(call: dict) -> dict:
+    """Extract the inner payload from an ingest tool call.
+
+    The MCP tool schema wraps the IngestPayload in a ``payload`` key. Some
+    skill versions also list mappings under ``decisions`` (the natural-LLM
+    spelling) rather than ``mappings`` (the internal field). Handle both.
+    """
+    inp = call.get("input") or {}
+    return inp.get("payload") or inp
+
+
+def _ingest_items(call: dict) -> list[dict]:
+    p = _ingest_payload(call)
+    return p.get("decisions") or p.get("mappings") or []
+
+
 def assert_flow_1(calls: list[dict]) -> tuple[bool, str]:
     bcalls = _bicameral_tool_calls(calls)
     ingest_calls = _calls_named(bcalls, "bicameral_ingest")
@@ -195,12 +230,16 @@ def assert_flow_1(calls: list[dict]) -> tuple[bool, str]:
             f"calls: {[c['name'] for c in bcalls]}"
         )
 
-    mappings = ingest_calls[0]["input"].get("mappings") or []
-    if len(mappings) < 1:
-        return False, f"ingest called without mappings (input keys: {list(ingest_calls[0]['input'].keys())})"
+    items = _ingest_items(ingest_calls[0])
+    if len(items) < 1:
+        payload = _ingest_payload(ingest_calls[0])
+        return False, (
+            f"ingest called without decisions/mappings "
+            f"(payload keys: {list(payload.keys())})"
+        )
 
     return True, (
-        f"bicameral.ingest called with {len(mappings)} mapping(s); "
+        f"bicameral.ingest called with {len(items)} item(s); "
         f"total bicameral calls: {len(bcalls)}"
     )
 
@@ -240,8 +279,14 @@ def assert_flow_3(calls: list[dict]) -> tuple[bool, str]:
         return False, f"expected resolve_compliance; saw: {names}"
 
     # Verify resolve_compliance carried verdicts of expected shape
+    # (input may wrap in 'payload' depending on tool schema version)
     resolve_calls = _calls_named(bcalls, "bicameral_resolve_compliance")
-    verdicts = (resolve_calls[0]["input"].get("verdicts") if resolve_calls else None) or []
+    if resolve_calls:
+        rinput = resolve_calls[0]["input"] or {}
+        rpayload = rinput.get("payload") or rinput
+        verdicts = rpayload.get("verdicts") or []
+    else:
+        verdicts = []
     if not verdicts:
         return False, "resolve_compliance called without verdicts"
 
@@ -257,11 +302,12 @@ def assert_flow_4(calls: list[dict]) -> tuple[bool, str]:
     if not ingest_calls:
         return False, f"expected ingest with agent_session source; saw: {[c['name'] for c in bcalls]}"
 
-    # Check that the source field somewhere indicates agent_session
-    payload = ingest_calls[0]["input"]
+    # Source can live at payload.source (top-level) or per-decision via
+    # span.source_type. Check both, since the MCP tool schema wraps in payload.
+    payload = _ingest_payload(ingest_calls[0])
     top_source = payload.get("source", "")
-    span_sources = []
-    for m in payload.get("mappings") or []:
+    span_sources: list[str] = []
+    for m in _ingest_items(ingest_calls[0]):
         span = m.get("span") or {}
         if "source_type" in span:
             span_sources.append(span["source_type"])
@@ -273,7 +319,10 @@ def assert_flow_4(calls: list[dict]) -> tuple[bool, str]:
             f"top_source={top_source!r}, span_source_types={span_sources}"
         )
 
-    return True, f"bicameral.ingest called with agent_session source"
+    return True, (
+        f"bicameral.ingest called with agent_session source "
+        f"(payload.source={top_source!r})"
+    )
 
 
 def assert_flow_5(calls: list[dict]) -> tuple[bool, str]:

--- a/tests/e2e/run_e2e_flows.py
+++ b/tests/e2e/run_e2e_flows.py
@@ -1,0 +1,390 @@
+"""
+v0 user flow e2e — Claude Code CLI session orchestrator.
+
+Drives a real Claude Code CLI session per flow (5 sessions total), with
+bicameral-mcp registered as the only MCP server, and asserts on the
+stream-json transcript that the right MCP tools were called with the
+right shapes.
+
+Each flow:
+  1. Reads ``prompts/flow-N-*.md`` (natural-language user prompt)
+  2. Invokes ``claude -p <prompt> --mcp-config bicameral.mcp.json
+       --strict-mcp-config --output-format stream-json --add-dir <desktop_clone>``
+  3. Streams stdout to ``test-results/e2e/flow-N.ndjson``
+  4. Walks the transcript for tool_use blocks under ``mcp__bicameral__*``
+  5. Asserts per-flow invariants and prints PASS/FAIL
+
+The point: this exercises the full skill + MCP layer the way a user
+experiences it. The handler-replay sim at ``scripts/sim_issue_108_flows.py``
+remains useful for fast dev iteration on handler logic.
+
+Required env:
+  CLAUDE_CODE_OAUTH_TOKEN  Claude Code CLI auth (set by GitHub Actions
+                           ``production`` environment in CI).
+  DESKTOP_REPO_PATH        Path to a local clone of github.com/desktop/desktop.
+
+CI: see .github/workflows/v0-user-flow-e2e.yml.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import pathlib
+import shutil
+import subprocess
+import sys
+from dataclasses import dataclass, field
+from typing import Callable
+
+E2E_ROOT = pathlib.Path(__file__).resolve().parent
+PROMPTS_DIR = E2E_ROOT / "prompts"
+MCP_CONFIG_PATH = E2E_ROOT / "bicameral.mcp.json"
+RESULTS_DIR = pathlib.Path(__file__).resolve().parents[2] / "test-results" / "e2e"
+RESULTS_DIR.mkdir(parents=True, exist_ok=True)
+
+DESKTOP_REPO_PATH = os.environ.get("DESKTOP_REPO_PATH", "").strip()
+if not DESKTOP_REPO_PATH:
+    sys.stderr.write(
+        "ERROR: DESKTOP_REPO_PATH env var not set.\n"
+        "CI sets this automatically; locally:\n"
+        "  git clone --depth=1 https://github.com/desktop/desktop /tmp/desktop-clone\n"
+        "  DESKTOP_REPO_PATH=/tmp/desktop-clone python tests/e2e/run_e2e_flows.py\n"
+    )
+    sys.exit(2)
+
+if not shutil.which("claude"):
+    sys.stderr.write(
+        "ERROR: 'claude' CLI not found on PATH.\n"
+        "Install via: npm install -g @anthropic-ai/claude-code\n"
+    )
+    sys.exit(2)
+
+if not shutil.which("bicameral-mcp"):
+    sys.stderr.write(
+        "ERROR: 'bicameral-mcp' command not found on PATH.\n"
+        "Install via: pip install -e .\n"
+    )
+    sys.exit(2)
+
+
+@dataclass
+class FlowResult:
+    flow_id: str
+    prompt_file: str
+    verdict: str  # "PASS" | "FAIL" | "ERROR"
+    body: str
+    tool_calls: list[dict] = field(default_factory=list)
+    transcript_path: str = ""
+
+
+RESULTS: list[FlowResult] = []
+
+
+def section(result: FlowResult) -> None:
+    RESULTS.append(result)
+    line = result.body.splitlines()[0] if result.body else ""
+    print(f"[{result.flow_id}] {result.verdict} — {line[:100]}")
+
+
+# ── Claude Code CLI invocation ──────────────────────────────────────────
+
+
+def run_claude_session(flow_id: str, prompt: str) -> tuple[list[dict], pathlib.Path, int]:
+    """Invoke ``claude -p`` with stream-json output. Return (tool_calls, transcript_path, exit_code).
+
+    stream-json emits one JSON object per line on stdout — system init, user
+    prompts, assistant turns (with tool_use blocks), tool results, and a final
+    result object. We capture all lines for the audit trail and extract
+    tool_use blocks for assertions.
+    """
+    transcript_path = RESULTS_DIR / f"{flow_id}.ndjson"
+
+    cmd = [
+        "claude",
+        "-p",
+        prompt,
+        "--mcp-config",
+        str(MCP_CONFIG_PATH),
+        "--strict-mcp-config",
+        # Allow bicameral MCP tools + Read/Grep so skills can inspect bound files.
+        # Bash is intentionally NOT allowed — bicameral skills shouldn't need shell.
+        # Comma-separated single arg is unambiguous vs space-separated variadic.
+        "--allowed-tools",
+        "mcp__bicameral,Read,Grep",
+        "--add-dir",
+        DESKTOP_REPO_PATH,
+        "--output-format",
+        "stream-json",
+        "--verbose",  # required by stream-json for full event detail
+        "--no-session-persistence",
+        "--max-budget-usd",
+        "2.0",
+        "--dangerously-skip-permissions",
+    ]
+
+    print(f"\n=== {flow_id} — invoking claude (cwd=pilot/mcp) ===")
+    proc = subprocess.run(
+        cmd,
+        cwd=pathlib.Path(__file__).resolve().parents[2],  # pilot/mcp
+        capture_output=True,
+        text=True,
+        timeout=300,
+    )
+
+    transcript_path.write_text(proc.stdout, encoding="utf-8")
+    if proc.returncode != 0:
+        sys.stderr.write(
+            f"[{flow_id}] claude CLI exit={proc.returncode}\n"
+            f"  stderr (last 500 chars): {proc.stderr[-500:]}\n"
+        )
+
+    tool_calls = _extract_tool_calls(proc.stdout)
+    return tool_calls, transcript_path, proc.returncode
+
+
+def _extract_tool_calls(stream_json: str) -> list[dict]:
+    """Walk stream-json output, extract every tool_use block under mcp__bicameral.
+
+    stream-json shape: one JSON object per line. Assistant messages contain
+    ``message.content`` arrays with ``{"type":"tool_use","name":"...","input":{...}}``.
+    """
+    calls: list[dict] = []
+    for line in stream_json.splitlines():
+        line = line.strip()
+        if not line:
+            continue
+        try:
+            obj = json.loads(line)
+        except json.JSONDecodeError:
+            continue
+
+        # Assistant turns carry tool_use blocks
+        if obj.get("type") == "assistant":
+            content = (obj.get("message") or {}).get("content") or []
+            for block in content:
+                if isinstance(block, dict) and block.get("type") == "tool_use":
+                    calls.append(
+                        {
+                            "name": block.get("name", ""),
+                            "input": block.get("input") or {},
+                            "id": block.get("id", ""),
+                        }
+                    )
+    return calls
+
+
+def _bicameral_tool_calls(calls: list[dict]) -> list[dict]:
+    return [c for c in calls if c["name"].startswith("mcp__bicameral__")]
+
+
+def _calls_named(calls: list[dict], suffix: str) -> list[dict]:
+    """Return calls whose tool name ends with the given suffix (server-name-agnostic)."""
+    return [c for c in calls if c["name"].endswith(suffix) or c["name"].endswith(f"_{suffix}")]
+
+
+# ── Per-flow assertions ─────────────────────────────────────────────────
+
+
+def assert_flow_1(calls: list[dict]) -> tuple[bool, str]:
+    bcalls = _bicameral_tool_calls(calls)
+    ingest_calls = _calls_named(bcalls, "bicameral_ingest")
+    if not ingest_calls:
+        return False, (
+            f"expected bicameral.ingest to be called; saw {len(bcalls)} bicameral "
+            f"calls: {[c['name'] for c in bcalls]}"
+        )
+
+    mappings = ingest_calls[0]["input"].get("mappings") or []
+    if len(mappings) < 1:
+        return False, f"ingest called without mappings (input keys: {list(ingest_calls[0]['input'].keys())})"
+
+    return True, (
+        f"bicameral.ingest called with {len(mappings)} mapping(s); "
+        f"total bicameral calls: {len(bcalls)}"
+    )
+
+
+def assert_flow_2(calls: list[dict]) -> tuple[bool, str]:
+    bcalls = _bicameral_tool_calls(calls)
+    preflight_calls = _calls_named(bcalls, "bicameral_preflight")
+    if not preflight_calls:
+        return False, (
+            f"expected bicameral.preflight to be called; saw {len(bcalls)} bicameral "
+            f"calls: {[c['name'] for c in bcalls]}"
+        )
+
+    file_paths = preflight_calls[0]["input"].get("file_paths") or []
+    if not file_paths or not any("cherry-pick.ts" in p for p in file_paths):
+        return False, (
+            f"preflight called without expected file_paths; "
+            f"got: {file_paths}"
+        )
+
+    return True, (
+        f"bicameral.preflight called with file_paths={file_paths}; "
+        f"total bicameral calls: {len(bcalls)}"
+    )
+
+
+def assert_flow_3(calls: list[dict]) -> tuple[bool, str]:
+    bcalls = _bicameral_tool_calls(calls)
+    names = [c["name"].split("__")[-1] for c in bcalls]
+
+    has_link_commit = any("link_commit" in n for n in names)
+    has_resolve = any("resolve_compliance" in n for n in names)
+
+    if not has_link_commit:
+        return False, f"expected link_commit; saw: {names}"
+    if not has_resolve:
+        return False, f"expected resolve_compliance; saw: {names}"
+
+    # Verify resolve_compliance carried verdicts of expected shape
+    resolve_calls = _calls_named(bcalls, "bicameral_resolve_compliance")
+    verdicts = (resolve_calls[0]["input"].get("verdicts") if resolve_calls else None) or []
+    if not verdicts:
+        return False, "resolve_compliance called without verdicts"
+
+    return True, (
+        f"link_commit + resolve_compliance both called; verdicts={len(verdicts)}; "
+        f"sequence: {names}"
+    )
+
+
+def assert_flow_4(calls: list[dict]) -> tuple[bool, str]:
+    bcalls = _bicameral_tool_calls(calls)
+    ingest_calls = _calls_named(bcalls, "bicameral_ingest")
+    if not ingest_calls:
+        return False, f"expected ingest with agent_session source; saw: {[c['name'] for c in bcalls]}"
+
+    # Check that the source field somewhere indicates agent_session
+    payload = ingest_calls[0]["input"]
+    top_source = payload.get("source", "")
+    span_sources = []
+    for m in payload.get("mappings") or []:
+        span = m.get("span") or {}
+        if "source_type" in span:
+            span_sources.append(span["source_type"])
+
+    is_agent_session = top_source == "agent_session" or "agent_session" in span_sources
+    if not is_agent_session:
+        return False, (
+            f"ingest source not agent_session; "
+            f"top_source={top_source!r}, span_source_types={span_sources}"
+        )
+
+    return True, f"bicameral.ingest called with agent_session source"
+
+
+def assert_flow_5(calls: list[dict]) -> tuple[bool, str]:
+    bcalls = _bicameral_tool_calls(calls)
+    history_calls = _calls_named(bcalls, "bicameral_history")
+    if not history_calls:
+        return False, f"expected bicameral.history; saw: {[c['name'] for c in bcalls]}"
+
+    # Flow 5 prompt also asks to seed two decisions and ratify one — so we
+    # expect at least one ingest and at least one ratify call too.
+    ingest_calls = _calls_named(bcalls, "bicameral_ingest")
+    ratify_calls = _calls_named(bcalls, "bicameral_ratify")
+
+    seeded = bool(ingest_calls)
+    ratified = bool(ratify_calls)
+
+    if not (seeded and ratified):
+        return False, (
+            f"history called but seed pre-conditions weak: "
+            f"ingest={len(ingest_calls)}, ratify={len(ratify_calls)}"
+        )
+
+    return True, (
+        f"bicameral.history called; ingest seeded={len(ingest_calls)}, "
+        f"ratified={len(ratify_calls)}"
+    )
+
+
+FLOW_PLAN: list[tuple[str, str, Callable[[list[dict]], tuple[bool, str]]]] = [
+    ("Flow 1", "flow-1-ingest.md", assert_flow_1),
+    ("Flow 2", "flow-2-preflight.md", assert_flow_2),
+    ("Flow 3", "flow-3-commit-sync.md", assert_flow_3),
+    ("Flow 4", "flow-4-session-end.md", assert_flow_4),
+    ("Flow 5", "flow-5-history.md", assert_flow_5),
+]
+
+
+# ── Main ────────────────────────────────────────────────────────────────
+
+
+def main() -> int:
+    print("=== v0 user flow e2e — Claude Code CLI sessions ===")
+    print(f"DESKTOP_REPO_PATH:  {DESKTOP_REPO_PATH}")
+    print(f"MCP config:         {MCP_CONFIG_PATH}")
+    print(f"Transcripts:        {RESULTS_DIR}")
+    print(f"Flows:              {len(FLOW_PLAN)}\n")
+
+    for flow_id, prompt_file, asserter in FLOW_PLAN:
+        prompt_path = PROMPTS_DIR / prompt_file
+        prompt = prompt_path.read_text(encoding="utf-8")
+        try:
+            tool_calls, transcript_path, exit_code = run_claude_session(flow_id, prompt)
+        except subprocess.TimeoutExpired:
+            section(
+                FlowResult(
+                    flow_id=flow_id,
+                    prompt_file=prompt_file,
+                    verdict="ERROR",
+                    body="claude CLI session timed out (>300s)",
+                )
+            )
+            continue
+        except Exception as exc:
+            section(
+                FlowResult(
+                    flow_id=flow_id,
+                    prompt_file=prompt_file,
+                    verdict="ERROR",
+                    body=f"claude CLI invocation failed: {exc!r}",
+                )
+            )
+            continue
+
+        passed, detail = asserter(tool_calls)
+        bicameral_calls = _bicameral_tool_calls(tool_calls)
+
+        body = (
+            f"prompt:                   {prompt_file}\n"
+            f"claude exit:              {exit_code}\n"
+            f"transcript:               {transcript_path.relative_to(RESULTS_DIR.parents[1])}\n"
+            f"total tool calls:         {len(tool_calls)}\n"
+            f"bicameral tool calls:     {len(bicameral_calls)}\n"
+            f"  → {[c['name'].split('__')[-1] for c in bicameral_calls]}\n\n"
+            f"assertion: {detail}\n"
+        )
+        section(
+            FlowResult(
+                flow_id=flow_id,
+                prompt_file=prompt_file,
+                verdict="PASS" if passed else "FAIL",
+                body=body,
+                tool_calls=tool_calls,
+                transcript_path=str(transcript_path),
+            )
+        )
+
+    print("\n\n=== REPORT ===\n")
+    overall_pass = all(r.verdict == "PASS" for r in RESULTS)
+    for r in RESULTS:
+        print(f"\n## {r.flow_id} — {r.verdict}\n")
+        print(r.body)
+
+    print("\n=== SUMMARY ===\n")
+    print(f"{'Flow':<10} {'Verdict':<8}")
+    print(f"{'-' * 10} {'-' * 8}")
+    for r in RESULTS:
+        print(f"{r.flow_id:<10} {r.verdict:<8}")
+    print(f"\nOverall: {'PASS' if overall_pass else 'FAIL'}")
+
+    return 0 if overall_pass else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary

Adds **\`v0 user flow e2e\`** — a CI workflow that drives a real Claude Code CLI session per spec flow with \`bicameral-mcp\` registered as the only MCP server, and asserts on the stream-json transcript that the right MCP tools were called with the right shapes.

This is the canonical user-experience test for [\`BicameralAI/bicameral#108\`](https://github.com/BicameralAI/bicameral/issues/108). It complements the handler-replay simulation that landed in #139 (\`scripts/sim_issue_108_flows.py\`).

## Why two tests?

The handler-replay sim imports handler functions directly and calls them. Fast, no API spend, useful for iterating on handler logic. But it bypasses three layers a real user exercises:

- **MCP protocol** — JSON-RPC over stdio, tool schema marshalling
- **Skill files** — \`.claude/skills/bicameral-*/SKILL.md\` trigger matching, auto-chains
- **Caller LLM** — natural-language → tool-call sequencing

This e2e suite exercises all three. The two tests together form the spec's two-level validation: handler invariants (replay sim) + user-experience contract (this directory).

## Test fixture: github.com/desktop/desktop

Pinned commit \`e6c50fb028171e9cec03594273c8116bb135847e\`. Real-world ingest content from \`docs/process/roadmap.md\`; bind target is the \`CherryPickResult\` enum in \`app/src/lib/git/cherry-pick.ts\` (a stable, slow-changing public type that genuinely corresponds to the cherry-pick roadmap item — bind is meaningful, not arbitrary).

## What's in the PR

| File | Notes |
|---|---|
| \`tests/e2e/run_e2e_flows.py\` | Orchestrator: per flow, invokes \`claude -p\` with the prompt + bicameral MCP config, captures stream-json, asserts on tool-use blocks |
| \`tests/e2e/bicameral.mcp.json\` | MCP config — registers \`bicameral-mcp\` with \`SURREAL_URL=memory://\` so each flow gets a fresh ledger |
| \`tests/e2e/prompts/flow-{1..5}-*.md\` | Five natural-language user prompts, one per flow |
| \`tests/e2e/README.md\` | Local-run instructions + per-flow contract + design rationale |
| \`.github/workflows/v0-user-flow-e2e.yml\` | CI workflow — \`production\` env (for \`CLAUDE_CODE_OAUTH_TOKEN\`), pinned desktop/desktop commit, transcript artifact upload |

## Per-flow contract (asserted by the orchestrator)

| Flow | What's asserted |
|---|---|
| 1 — record decisions | \`bicameral.ingest\` called with \`mappings\` (≥1) |
| 2 — preflight | \`bicameral.preflight\` called with \`file_paths\` containing \`cherry-pick.ts\` |
| 3 — commit→reflected | \`bicameral.link_commit\` + \`bicameral.resolve_compliance\` both called; resolve_compliance carries \`verdicts\` |
| 4 — session-end | \`bicameral.ingest\` called with \`source='agent_session'\` (top-level or per-mapping \`span.source_type\`) |
| 5 — history | \`bicameral.history\` called; seed pre-conditions (\`ingest\` + \`ratify\`) present |

## CI shape

\`\`\`yaml
environment: production              # CLAUDE_CODE_OAUTH_TOKEN
on:
  pull_request:
    paths: [tests/e2e/**, handlers/**, ledger/**, contracts.py, skills/bicameral-**, ...]
  workflow_dispatch:                 # manual debug trigger
\`\`\`

Triggers on PRs touching paths whose behaviour the e2e validates. \`workflow_dispatch\` lets maintainers re-run on demand without a code change.

## Test plan

\`\`\`bash
# Locally (after npm i -g @anthropic-ai/claude-code + claude auth):
cd pilot/mcp
git clone --depth=1 https://github.com/desktop/desktop /tmp/desktop-clone
(cd /tmp/desktop-clone && git checkout -b main)
DESKTOP_REPO_PATH=/tmp/desktop-clone python tests/e2e/run_e2e_flows.py
\`\`\`

Expected: \`Overall: PASS\` after ~3-5 minutes (5 Claude sessions). Cost ~\$0.50-\$2.00 per run.

In CI: this PR will trigger the workflow on itself once the workflow file lands on \`dev\`. (GitHub workflows execute the version on the base branch, so the very first run is on the *next* qualifying PR after merge.)

## Risk

**L2** — new CI workflow, real API spend per run. Mitigations:

- \`--max-budget-usd 2.0\` per flow caps cost (worst case ~\$10/run, typical ~\$1)
- \`--strict-mcp-config\` ensures only bicameral-mcp is loaded (no other MCP servers leak in from runner)
- Bash tool intentionally NOT in \`--allowed-tools\` (only \`mcp__bicameral,Read,Grep\`) — bicameral skills shouldn't need shell
- Transcripts uploaded as artifacts on every run (30-day retention) for forensics
- Pinned desktop/desktop commit — fixture won't drift mid-CI

## Out of scope (deferred)

- Caching \`@anthropic-ai/claude-code\` install across runs (small win; npm i is ~10s)
- Splitting flows into separate jobs for parallelism (would 5x cost but cut wall time; defer until we have data on flake rate)
- Cross-flow state (each flow uses fresh \`memory://\` ledger; flows that need history seed it inline in their prompt)

Refs #108. Follow-on to PRs #138 (#135 dashboard tooltip) and #139 (#108 handler-replay sim + skill correction).

🤖 Generated with [Claude Code](https://claude.com/claude-code)