### PR TITLE
fix(skill): capture refinements when prompt contradicts surfaced decision (#154)

### DIFF
--- a/skills/bicameral-preflight/SKILL.md
+++ b/skills/bicameral-preflight/SKILL.md
@@ -382,6 +382,41 @@ A one-line forward narration helps:
 > from idempotency.ts. I'll flag the event.id deduplication question
 > for you to answer before I commit."
 
+### 5.6 Capture refinements when the user's prompt contradicts a surfaced decision
+
+If any decision rendered in the surfaced block describes an approach the user's current request **replaces** (signals: "instead of", "actually we're switching to", "no more X", "I know X said Y but…", "X is out — we're going with Z"), this is a contradiction. Before doing any code work:
+
+1. **Ingest the refinement** with `source=agent_session`, scoped to the same `feature_group` as the contradicted decision:
+
+```
+bicameral.ingest(payload={
+  "query": "<contradicted decision's topic>",
+  "source": "agent_session",
+  "title": "<short label, e.g. 'reorder-text-editor-refactor'>",
+  "date": "<today ISO date>",
+  "decisions": [{ "description": "<user's new direction, stated as a decision>" }]
+}, feature_group="<same feature group as the contradicted decision>")
+```
+
+2. **Wire it to the seeded decision** via `bicameral.resolve_collision`:
+
+```
+bicameral.resolve_collision(
+  new_id="<just-ingested refinement id>",
+  old_id="<surfaced contradicted decision id>",
+  action="supersede" | "keep_both" | "link_parent"
+)
+```
+
+Pick `action` mechanically:
+- `supersede` — user fully replaces the old direction ("drag-drop is out, text-editor instead"). Writes a RELATE edge; old decision's status becomes `superseded`.
+- `keep_both` — user adds a constraint or narrows the surface without invalidating the old ("also need X for accessibility" / "only on the conflict UI surface"). No edge; both remain.
+- `link_parent` — the user's direction is a child decision under a higher-level (e.g. L1) parent; the contradicted decision is the parent. Writes `parent_decision_id`, no supersede edge, no status change.
+
+Mechanical — the user already stated the refinement. Do not ask. PM ratifies in the inbox.
+
+Narrate one line: "Captured refinement: '<paraphrase>' — wired as <action> of <feature> roadmap entry."
+
 ### 6. Honor blocking hints (guided mode vs normal mode)
 
 The agent's `guided_mode` setting controls whether action hints are


### PR DESCRIPTION
## Summary

- Adds **Step 5.6** to `skills/bicameral-preflight/SKILL.md`: when the user's prompt contradicts a decision the surfaced block just rendered, mechanically ingest the refinement with `source=agent_session` and call `bicameral.resolve_collision` to wire it to the seed.
- Documents three `action` values (`supersede` / `keep_both` / `link_parent`) so the agent can pick mechanically without asking — the user has already stated the refinement explicitly.

Closes #154.

## Why P0

Without this, `bicameral.preflight` surfaces contradictions but the correction-capture loop dies — every dev refinement that doesn't survive the session is a silent failure of the bicameral product's central differentiator (*dev contradicts spec → bicameral catches → refinement captured → PM ratifies*).

The v0.9.3 server-side supersession-detection removal moved this cognition onto the agent. This PR teaches the agent to do it.

## Test plan

- [ ] Run `tests/e2e/run_e2e_flows.py` against the pinned `desktop/desktop` commit. Flow 2a should flip **FAIL → PASS** without any other change.
- [ ] Confirm Flow 2 (auto-fire) still PASSES — Step 5.6 fires after the surfaced block renders, not before.
- [ ] Manual sanity: in normal mode, ingest a roadmap decision, then submit a contradicting prompt — agent should call `bicameral.ingest(source="agent_session")` followed by `bicameral.resolve_collision(action="supersede")` before any code work.
- [ ] Spot-check that `keep_both` and `link_parent` are not selected when the user's intent is clearly "replace" — the kind heuristics in the step should bias toward `supersede` for replacement signals.

## Out of scope

- Server-side auto-detection of contradictions (deliberately removed in v0.9.3 per `handlers/ingest.py:262-263`).
- Multi-turn correction capture (already owned by `bicameral-capture-corrections`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)