### PR TITLE
test(e2e): rewrite demo flow prompts in realistic per-role voice

### DIFF
--- a/tests/e2e/prompts/flow-1-ingest.md
+++ b/tests/e2e/prompts/flow-1-ingest.md
@@ -1,11 +1,9 @@
-Just got out of our roadmap review for GitHub Desktop. Three items the team agreed to start tracking:
+Just out of roadmap review. Three things we agreed to track:
 
-1. **High-signal notifications** (versions 2.9.10 and 3.0.0) — notify on failed checks, notify when a PR gets reviewed.
-2. **Improved commit history** (2.9.0) — drag-and-drop to reorder commits, drag-and-drop to squash, amend last commit, branch from a previous commit.
-3. **Cherry-picking commits between branches** (2.7.1) — context-menu cherry-pick and an interactive variant.
+- High-signal notifications (2.9.10 / 3.0.0): notify on failed checks, notify on PR review.
+- Improved commit history (2.9.0): drag-to-reorder, drag-to-squash, amend last commit, branch from a previous commit.
+- Cherry-pick between branches (2.7.1): context-menu and an interactive variant.
 
-Source is `desktop/desktop:docs/process/roadmap.md`.
+Source: desktop/desktop:docs/process/roadmap.md.
 
-Two of these have an obvious code home so we can keep code in sync with intent later. The reorder/improved-commit-history piece anchors to `app/src/lib/git/reorder.ts` (the `reorder` function near the top of the file). The cherry-pick item anchors to `app/src/lib/git/cherry-pick.ts`, specifically the `CherryPickResult` enum (lines 31–60). Anchor those two so the ledger has something to verify against once we start changing the code.
-
-I've already reviewed all three with the team and we're aligned — please sign these off on our end so we can move forward on a clean slate.
+Already aligned with the team — please log these and sign them off on our end. If any have an obvious code home, bind them too so we can catch drift later.

--- a/tests/e2e/prompts/flow-2-preflight.md
+++ b/tests/e2e/prompts/flow-2-preflight.md
@@ -1,3 +1,3 @@
-Quick context shift on `app/src/lib/git/reorder.ts` — I know the roadmap said drag-and-drop to reorder commits, but actually we're switching to a text-editor approach where the user types the desired commit order as a numbered list and we apply it from there. No more drag-drop interactions on this surface.
+Quick scope shift on the reorder feature — drag-and-drop is out; we're going with a text-editor flow where the user types the desired commit order as a numbered list. No more drag-drop on this surface.
 
-Help me start the refactor. I'll handle the call-site cleanup separately.
+Help me start the refactor — I'll deal with the call-site cleanup separately.

--- a/tests/e2e/prompts/flow-3-commit-sync.md
+++ b/tests/e2e/prompts/flow-3-commit-sync.md
@@ -1,3 +1,3 @@
-Quick housekeeping commit. Add a one-line comment at the top of `app/src/lib/git/cherry-pick.ts` (just above the `CherryPickResult` enum) — something like `// Cherry-pick: roadmap v2.7.1 — context menu + interactive`.
+Need a quick docs commit. Drop a one-line comment above the CherryPickResult enum in cherry-pick.ts pointing back to the roadmap — something like `// Cherry-pick: roadmap v2.7.1 — context menu + interactive`.
 
-Then stage and commit it as `docs: annotate cherry-pick origin`.
+Stage and commit it as `docs: annotate cherry-pick origin`.

--- a/tests/e2e/prompts/flow-4-session-end.md
+++ b/tests/e2e/prompts/flow-4-session-end.md
@@ -1,5 +1,5 @@
-Hmm wait — quick aside before we go further on the reorder.ts refactor.
+hmm wait — small thing before we keep going on reorder.
 
-Reading through the cherry-pick conflict path I committed earlier, I realized that handler shouldn't ever fall back to a stdin prompt when there's a merge conflict. The visual conflict UI has to be the only resolution path — if the implementation drifts toward a terminal prompt, that's wrong and we'd have to roll it back.
+just realized: the cherry-pick conflict handler shouldn't ever fall back to a stdin prompt. visual conflict UI is the only resolution path, full stop. if it drifts toward a terminal prompt that's a rollback.
 
-Anyway — back to `app/src/lib/git/reorder.ts`. Please continue the refactor we started: keep pulling out the `reorder()` function for the new text-editor flow.
+ok back to reorder.ts — keep going on the `reorder()` function for the text-editor flow.

--- a/tests/e2e/prompts/flow-5-history.md
+++ b/tests/e2e/prompts/flow-5-history.md
@@ -1,3 +1,3 @@
-Doing a Friday review across the ledger. Walk me through everything we're tracking — grouped by feature, with both axes for each one (code-compliance status and signoff state).
+Doing a Friday review across all the things we're tracking. Walk me through them grouped by feature — for each one, where it stands on the implementation side and whether it's been signed off.
 
-Anything still in `proposed` that's been sitting around — flag those, talk me through them in a sentence each, and pick whichever one looks most ready (clear scope, supporting context, no unresolved conflicts) and ratify it. Then show me the table again so I can scan what changed.
+Anything still on the to-do pile that hasn't moved — flag those, give me a one-sentence read on each, and pick whichever one looks most ready (clear scope, supporting context, no open questions) and sign it off. Then show me the updated view.


### PR DESCRIPTION
## Summary

Replaces tool-aware demo prompts with how each role (PM / dev) would actually type. The original prompts leaked product jargon (\"ledger\", \"ratify\", \"code home\", \"compliance status\") and engineer-shaped scaffolding (specific line ranges, exact file paths in PM voice). The new versions sound like real Slack/chat input.

| Flow | Persona | Pick |
|---|---|---|
| 1 — `flow-1-ingest.md` | PM post-roadmap | PM-natural, no file paths |
| 2 — `flow-2-preflight.md` | PM UX pivot | PM voice, no file path |
| 3 — `flow-3-commit-sync.md` | Dev commit chore | Dev, conversational |
| 4 — `flow-4-session-end.md` | Dev mid-refactor flag | Slack-think-out-loud |
| 5 — `flow-5-history.md` | PM Friday review | PM-natural, no jargon |

## Why this matters

The demo's whole pitch is: bicameral works on prompts a real human types. If the demo prompts read like a test harness, the demo undermines its own claim. Each flow now matches how a PM or dev would ping Claude in the wild.

## Risk

`assert_flow_1` requires `bind_targets` to include both `cherry-pick.ts` and `reorder.ts`. The new Flow 1 prompt drops file paths entirely — the ingest skill's caller-LLM has to derive them from feature names. **This is intentional**: it's an e2e test of the binding heuristic that is supposed to be the product's value prop. If it fails, fix the skill or the heuristic; don't add file paths back to the prompt.

`assert_flow_2` has a scaffolding fallback (run_e2e_flows.py:1222) that names `reorder.ts` directly when auto-fire fails, so Flow 2 has a safety net.

## Test plan

- [ ] Run `tests/e2e/run_e2e_flows.py` against the pinned `desktop/desktop` commit. All five flows should still PASS.
- [ ] If Flow 1 fails: the ingest skill is the right place to fix, not the prompt. File a follow-up if it reveals a binding-derivation gap.
- [ ] Spot-check the rendered demo videos (pm.mp4 / dev.mp4) — the on-screen prompt text should now feel like real human input, not tool documentation.

## Out of scope

- `composite-demo.md` is unchanged. It uses tool-aware language deliberately (\"call \`bicameral.ingest\`\") because it's the recording script, not a flow prompt. Worth a follow-up if we want full consistency.
- Harness assertions (`run_e2e_flows.py`). If Flow 1's binding test now exposes a real gap in the ingest skill, that's a separate PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)