### PR TITLE
test(ci): repro PR #165 failures on dev (do not merge)

### DIFF
--- a/tests/e2e/README.md
+++ b/tests/e2e/README.md
@@ -102,3 +102,6 @@ handler logic, but it bypasses three layers we need to validate:
 This e2e suite covers all three. Together they form the spec's two-level
 validation: handler invariants (replay sim) + user-experience contract
 (this directory).
+
+<!-- ci-repro: dummy edit to trigger workflows on dev (no-op) -->
+


### PR DESCRIPTION
## Summary

Dummy no-op PR to run `e2e assertions (auto)` and `ruff + mypy` against `dev` HEAD, mirroring the failing checks on #165 (`triage-from-dev` → `main`).

Goal: figure out whether the two CI failures on #165 are inherent to `dev` or were introduced by the three triage-only commits on top of it (the v0 CI workflow carry-over, the missing `tests/e2e/bicameral.mcp.json`, and the `ruff + mypy` config additions).

## Diff

- `tests/e2e/README.md` — three lines added (HTML comment). Touches the e2e workflow path filter so the assertions job actually fires; lint+typecheck has no path filter and runs on every PR to `dev`.

## Do not merge

This is a CI probe. Close once the checks have reported.