### PR TITLE
fix(skill): force resolve_collision via PostToolUse hook on preflight (#154)

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -9,6 +9,15 @@
             "command": "python3 scripts/hooks/post_commit_sync_reminder.py"
           }
         ]
+      },
+      {
+        "matcher": "mcp__bicameral__bicameral_preflight",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "python3 scripts/hooks/post_preflight_capture_reminder.py"
+          }
+        ]
       }
     ],
     "SessionEnd": [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -57,6 +57,7 @@ bicameral-mcp = "server:cli_main"
 bicameral-mcp-classify = "cli.classify:main"
 bicameral-mcp-preflight-reminder = "scripts.hooks.preflight_reminder:main"
 bicameral-mcp-post-commit-sync-reminder = "scripts.hooks.post_commit_sync_reminder:main"
+bicameral-mcp-collision-capture-reminder = "scripts.hooks.post_preflight_capture_reminder:main"
 
 [tool.hatch.build.targets.wheel]
 packages = ["."]

--- a/scripts/hooks/post_preflight_capture_reminder.py
+++ b/scripts/hooks/post_preflight_capture_reminder.py
@@ -1,0 +1,110 @@
+"""PostToolUse hook for ``bicameral.preflight``.
+
+When preflight surfaces ≥1 decision, inject a system-reminder templating
+the correction-capture loop (Step 5.6 of ``skills/bicameral-preflight``):
+
+  1. ``bicameral.ingest(source="agent_session", ...)`` — capture the user's
+     refinement.
+  2. ``bicameral.resolve_collision(new_id=..., old_id=..., action=...)`` —
+     wire the refinement to the contradicted decision.
+
+The reminder is *conditional* — it tells the agent "IF your prompt
+contradicts a surfaced decision, do this." Preflight has no view of the
+user's prompt, so the hook over-fires on any non-empty surfaced block;
+the LLM is the gate. Mirrors the existing UserPromptSubmit reminder
+pattern in ``preflight_reminder.py`` (over-fires on any
+implementation-verb prompt; the skill is the gate).
+
+Per Claude Code 2.x hook contract: read JSON ``{tool_name, tool_input,
+tool_response}`` from stdin. ``tool_response`` is either a JSON string or
+a dict — both are handled. Output is plain stdout text (the same shape
+the existing PostToolUse/Bash hook in ``setup_wizard.py`` uses); the CLI
+appends it to the tool result the agent sees on the next turn. Errors
+swallowed silently (exit 0, empty response) so a broken hook never
+blocks a user.
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+
+PREFLIGHT_TOOL_NAME = "mcp__bicameral__bicameral_preflight"
+
+
+def _coerce_response(raw: object) -> dict:
+    """Return a dict view of ``tool_response`` whether it arrived as a
+    JSON string or already-decoded dict. On any failure return ``{}`` —
+    the caller treats an empty dict as "no decisions to template."
+    """
+    if isinstance(raw, dict):
+        return raw
+    if isinstance(raw, str):
+        try:
+            decoded = json.loads(raw)
+        except (json.JSONDecodeError, ValueError):
+            return {}
+        return decoded if isinstance(decoded, dict) else {}
+    return {}
+
+
+def _format_reminder(decisions: list[dict]) -> str:
+    bullets = "\n".join(
+        f"  - {d.get('decision_id', '<unknown>')}: {d.get('description', '<no description>')}"
+        for d in decisions
+    )
+    return (
+        "<system-reminder>\n"
+        f"bicameral.preflight surfaced {len(decisions)} decision(s):\n"
+        f"{bullets}\n"
+        "\n"
+        "If your current prompt CONTRADICTS any surfaced decision (signals: "
+        '"instead of", "actually we\'re switching to", "no more X", '
+        '"I know X said Y but..."), you MUST do this BEFORE any code edits, '
+        "per skills/bicameral-preflight Step 5.6:\n"
+        "\n"
+        "  1. bicameral.ingest(payload={\n"
+        '       "query": "<contradicted decision\'s topic>",\n'
+        '       "source": "agent_session",\n'
+        '       "title": "<short label>",\n'
+        '       "date": "<today ISO date>",\n'
+        '       "decisions": [{"description": "<user\'s new direction>"}]\n'
+        '     }, feature_group="<same feature group as the contradicted decision>")\n'
+        "\n"
+        "  2. bicameral.resolve_collision(\n"
+        '       new_id="<just-ingested refinement id>",\n'
+        '       old_id="<contradicted decision_id from list above>",\n'
+        '       action="supersede" | "keep_both" | "link_parent"\n'
+        "     )\n"
+        "\n"
+        "Pick action mechanically: supersede (full replace), keep_both "
+        "(added constraint), link_parent (child decision under L1 parent). "
+        "Do not ask the user — they already stated the refinement.\n"
+        "\n"
+        "If your prompt is COMPATIBLE with the surfaced decisions, ignore "
+        "this and proceed normally.\n"
+        "</system-reminder>"
+    )
+
+
+def main() -> int:
+    try:
+        payload = json.load(sys.stdin)
+    except (json.JSONDecodeError, ValueError):
+        return 0
+    if not isinstance(payload, dict):
+        return 0
+    if payload.get("tool_name") != PREFLIGHT_TOOL_NAME:
+        return 0
+    response = _coerce_response(payload.get("tool_response"))
+    if not response.get("fired"):
+        return 0
+    decisions = response.get("decisions") or []
+    if not isinstance(decisions, list) or not decisions:
+        return 0
+    sys.stdout.write(_format_reminder(decisions))
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/hooks/post_preflight_capture_reminder.py
+++ b/scripts/hooks/post_preflight_capture_reminder.py
@@ -6,14 +6,23 @@ the correction-capture loop (Step 5.6 of ``skills/bicameral-preflight``):
   1. ``bicameral.ingest(source="agent_session", ...)`` — capture the user's
      refinement.
   2. ``bicameral.resolve_collision(new_id=..., old_id=..., action=...)`` —
-     wire the refinement to the contradicted decision.
+     wire the refinement to the surfaced decision.
 
-The reminder is *conditional* — it tells the agent "IF your prompt
-contradicts a surfaced decision, do this." Preflight has no view of the
-user's prompt, so the hook over-fires on any non-empty surfaced block;
-the LLM is the gate. Mirrors the existing UserPromptSubmit reminder
-pattern in ``preflight_reminder.py`` (over-fires on any
-implementation-verb prompt; the skill is the gate).
+The reminder is *unconditional* — Step 5.6 capture is mechanical, not a
+judgment call. An earlier conditional shape ("IF your prompt contradicts
+a surfaced decision …") let the agent skip capture on borderline prompts
+(observed: agent acknowledged the surfaced decision in its text, then
+chose 'proceeding with the refactor' without calling ingest /
+resolve_collision). The PM resolves ambiguity in the inbox, not the
+agent — missed capture is irreversible context loss while a noisy
+ledger is reversible.
+
+Tradeoff: the hook now fires on every preflight that returns ≥1
+decision, so it spams a refinement-capture reminder even when the
+user's request is fully compatible with prior decisions. Tracked as a
+follow-up to make this less spammy (e.g. inspect the user prompt via a
+co-located UserPromptSubmit handoff, or compare topic similarity to
+surfaced decisions).
 
 Per Claude Code 2.x hook contract: read JSON ``{tool_name, tool_input,
 tool_response}`` from stdin. ``tool_response`` is either a JSON string or
@@ -59,34 +68,41 @@ def _format_reminder(decisions: list[dict]) -> str:
     )
     return (
         "<system-reminder>\n"
-        f"bicameral.preflight surfaced {len(decisions)} decision(s):\n"
+        f"bicameral.preflight surfaced {len(decisions)} prior decision(s):\n"
         f"{bullets}\n"
         "\n"
-        "If your current prompt CONTRADICTS any surfaced decision (signals: "
-        '"instead of", "actually we\'re switching to", "no more X", '
-        '"I know X said Y but..."), you MUST do this BEFORE any code edits, '
-        "per skills/bicameral-preflight Step 5.6:\n"
+        "BEFORE any code edits, you MUST capture the user's current request "
+        "as a refinement of the surfaced decision(s) by calling these two "
+        "tools mechanically — do NOT judge whether the request 'really' "
+        "contradicts what was surfaced; the PM resolves ambiguity in the "
+        "inbox, not the agent. Per skills/bicameral-preflight Step 5.6:\n"
         "\n"
         "  1. bicameral.ingest(payload={\n"
-        '       "query": "<contradicted decision\'s topic>",\n'
+        '       "query": "<surfaced decision\'s topic>",\n'
         '       "source": "agent_session",\n'
-        '       "title": "<short label>",\n'
+        '       "title": "<short label of user\'s direction>",\n'
         '       "date": "<today ISO date>",\n'
-        '       "decisions": [{"description": "<user\'s new direction>"}]\n'
-        '     }, feature_group="<same feature group as the contradicted decision>")\n'
+        '       "decisions": [{"description": "<user\'s direction, stated as a decision>"}]\n'
+        '     }, feature_group="<same feature group as the surfaced decision>")\n'
         "\n"
         "  2. bicameral.resolve_collision(\n"
         '       new_id="<just-ingested refinement id>",\n'
-        '       old_id="<contradicted decision_id from list above>",\n'
+        '       old_id="<surfaced decision_id from list above>",\n'
         '       action="supersede" | "keep_both" | "link_parent"\n'
         "     )\n"
         "\n"
-        "Pick action mechanically: supersede (full replace), keep_both "
-        "(added constraint), link_parent (child decision under L1 parent). "
-        "Do not ask the user — they already stated the refinement.\n"
+        "Pick action mechanically based on what the user said, not whether "
+        "you think it conflicts:\n"
+        "  - supersede   — user fully replaces the prior approach\n"
+        "                  (e.g. 'X is out, Y instead', 'switching from X to Y')\n"
+        "  - keep_both   — user adds, narrows, or scopes alongside the prior\n"
+        "                  (e.g. 'also need X for Y', 'only on this surface')\n"
+        "  - link_parent — user's direction is a child decision under a higher-\n"
+        "                  level surfaced parent (L1 parent → L2 child)\n"
         "\n"
-        "If your prompt is COMPATIBLE with the surfaced decisions, ignore "
-        "this and proceed normally.\n"
+        "Capture is cheap; missed capture is irreversible context loss. Even "
+        "if the user's request looks compatible, log the refinement so the "
+        "PM has the trace.\n"
         "</system-reminder>"
     )
 

--- a/scripts/hooks/post_preflight_capture_reminder.py
+++ b/scripts/hooks/post_preflight_capture_reminder.py
@@ -17,11 +17,15 @@ implementation-verb prompt; the skill is the gate).
 
 Per Claude Code 2.x hook contract: read JSON ``{tool_name, tool_input,
 tool_response}`` from stdin. ``tool_response`` is either a JSON string or
-a dict — both are handled. Output is plain stdout text (the same shape
-the existing PostToolUse/Bash hook in ``setup_wizard.py`` uses); the CLI
-appends it to the tool result the agent sees on the next turn. Errors
-swallowed silently (exit 0, empty response) so a broken hook never
-blocks a user.
+a dict — both are handled. Output is the structured envelope
+``{"hookSpecificOutput": {"hookEventName": "PostToolUse",
+"additionalContext": "..."}}`` written to stdout; the CLI surfaces
+``additionalContext`` next to the tool result the model sees on the next
+turn. Plain stdout is silently dropped to the debug log for PostToolUse
+events (per https://code.claude.com/docs/en/hooks — only
+UserPromptSubmit / UserPromptExpansion / SessionStart treat raw stdout
+as agent-visible context). Errors swallowed silently (exit 0, empty
+response) so a broken hook never blocks a user.
 """
 
 from __future__ import annotations
@@ -102,7 +106,15 @@ def main() -> int:
     decisions = response.get("decisions") or []
     if not isinstance(decisions, list) or not decisions:
         return 0
-    sys.stdout.write(_format_reminder(decisions))
+    json.dump(
+        {
+            "hookSpecificOutput": {
+                "hookEventName": "PostToolUse",
+                "additionalContext": _format_reminder(decisions),
+            }
+        },
+        sys.stdout,
+    )
     return 0
 
 

--- a/setup_wizard.py
+++ b/setup_wizard.py
@@ -417,13 +417,26 @@ _BICAMERAL_POST_COMMIT_COMMAND = "bicameral-mcp-post-commit-sync-reminder"
 # file directly via python3).
 _BICAMERAL_PREFLIGHT_REMINDER_COMMAND = "bicameral-mcp-preflight-reminder"
 
+# PostToolUse hook scoped to the bicameral.preflight tool: when preflight
+# surfaces ≥1 decision, prints a system-reminder templating the
+# correction-capture loop (Step 5.6 of bicameral-preflight) so the agent
+# reliably calls bicameral.ingest(source=agent_session) +
+# bicameral.resolve_collision when the user's prompt contradicts a
+# surfaced decision. Closes #154 for end-user installs (the dogfood path
+# invokes the source file directly via python3).
+_BICAMERAL_COLLISION_CAPTURE_REMINDER_COMMAND = "bicameral-mcp-collision-capture-reminder"
+_BICAMERAL_PREFLIGHT_TOOL_NAME = "mcp__bicameral__bicameral_preflight"
+
 
 def _install_claude_hooks(repo_path: Path) -> bool:
     """Merge bicameral hooks into the project-level .claude/settings.json.
 
-    Installs three hooks:
+    Installs four hooks:
     - PostToolUse/Bash: reminds the agent to call link_commit immediately
       after git write-ops (commit / merge / pull / rebase --continue).
+    - PostToolUse/bicameral_preflight: reminds the agent to capture
+      refinements via ingest(agent_session) + resolve_collision when
+      preflight surfaces decisions that the user's prompt contradicts.
     - SessionEnd: runs bicameral-capture-corrections to catch uningested
       mid-session corrections (only fires when .bicameral/ exists).
     - UserPromptSubmit: deterministic verb-list classifier injects a
@@ -431,7 +444,7 @@ def _install_claude_hooks(repo_path: Path) -> bool:
       default tool-selection priority on code-implementation prompts.
 
     Idempotent — safe to call on every setup run. Returns True if any new
-    entry was written, False if all three were already present.
+    entry was written, False if all four were already present.
     """
     settings_path = repo_path / ".claude" / "settings.json"
     settings_path.parent.mkdir(parents=True, exist_ok=True)
@@ -458,6 +471,29 @@ def _install_claude_hooks(repo_path: Path) -> bool:
     new_post_hook = {"type": "command", "command": _BICAMERAL_POST_COMMIT_COMMAND}
     if non_bic != old_hooks or new_post_hook not in old_hooks:
         bash_entry["hooks"] = non_bic + [new_post_hook]
+        wrote_anything = True
+
+    # ── PostToolUse / bicameral_preflight — collision capture reminder ─
+    preflight_entry = next(
+        (e for e in post_tool_use if e.get("matcher") == _BICAMERAL_PREFLIGHT_TOOL_NAME),
+        None,
+    )
+    if preflight_entry is None:
+        preflight_entry = {"matcher": _BICAMERAL_PREFLIGHT_TOOL_NAME, "hooks": []}
+        post_tool_use.append(preflight_entry)
+    old_pre_hooks = preflight_entry.get("hooks", [])
+    non_bic_pre = [
+        h
+        for h in old_pre_hooks
+        if "bicameral" not in h.get("command", "")
+        and "post_preflight_capture_reminder" not in h.get("command", "")
+    ]
+    new_pre_hook = {
+        "type": "command",
+        "command": _BICAMERAL_COLLISION_CAPTURE_REMINDER_COMMAND,
+    }
+    if non_bic_pre != old_pre_hooks or new_pre_hook not in old_pre_hooks:
+        preflight_entry["hooks"] = non_bic_pre + [new_pre_hook]
         wrote_anything = True
 
     # ── SessionEnd — capture uningested corrections ──────────────────

--- a/skills/bicameral-preflight/SKILL.md
+++ b/skills/bicameral-preflight/SKILL.md
@@ -417,6 +417,19 @@ Mechanical — the user already stated the refinement. Do not ask. PM ratifies i
 
 Narrate one line: "Captured refinement: '<paraphrase>' — wired as <action> of <feature> roadmap entry."
 
+#### Hook reinforcement
+
+A PostToolUse hook scoped to `mcp__bicameral__bicameral_preflight` injects a
+`<system-reminder>` after every preflight call that surfaces ≥1 decision. The
+reminder lists each surfaced `decision_id` + description and templates this
+step's two-call sequence with the IDs filled in. The reminder is conditional
+("IF your prompt contradicts a surfaced decision …") — preflight has no view
+of the user's prompt, so the hook over-fires; the LLM is the gate. Mirrors the
+UserPromptSubmit verb-classifier pattern that elevates `bicameral.preflight`
+above default tool selection. Source: `scripts/hooks/post_preflight_capture_reminder.py`;
+wired by `setup_wizard._install_claude_hooks` and the e2e harness's
+`materialize_settings_with_hooks`.
+
 ### 6. Honor blocking hints (guided mode vs normal mode)
 
 The agent's `guided_mode` setting controls whether action hints are

--- a/tests/e2e/_harness_setup.py
+++ b/tests/e2e/_harness_setup.py
@@ -53,7 +53,7 @@ def materialize_settings_with_hooks(
     mcp_config_path: pathlib.Path,
     mcp_root: pathlib.Path,
 ) -> pathlib.Path:
-    """Write a project-style ``settings.json`` carrying the three hooks
+    """Write a project-style ``settings.json`` carrying the four hooks
     bicameral's setup-wizard installs in real projects. The PostToolUse and
     UserPromptSubmit commands are byte-exact strings imported from
     ``setup_wizard`` — single source of truth, no drift.
@@ -70,6 +70,10 @@ def materialize_settings_with_hooks(
     Hooks installed:
       - PostToolUse/Bash: bicameral-sync listens for "new commit detected"
         output to auto-fire ``link_commit``.
+      - PostToolUse/bicameral_preflight: collision-capture reminder fires
+        when preflight surfaces ≥1 decision, templating the Step 5.6
+        ingest(agent_session) + resolve_collision call so the agent
+        captures user refinements that contradict surfaced decisions.
       - SessionEnd: spawns a subprocess running
         ``/bicameral:capture-corrections --auto-ingest`` (with the test
         MCP config) to scan the just-ended session for uningested
@@ -81,8 +85,10 @@ def materialize_settings_with_hooks(
     if str(mcp_root) not in sys.path:
         sys.path.insert(0, str(mcp_root))
     from setup_wizard import (  # noqa: E402
+        _BICAMERAL_COLLISION_CAPTURE_REMINDER_COMMAND,
         _BICAMERAL_POST_COMMIT_COMMAND,
         _BICAMERAL_PREFLIGHT_REMINDER_COMMAND,
+        _BICAMERAL_PREFLIGHT_TOOL_NAME,
         _build_session_end_command,
     )
 
@@ -94,7 +100,16 @@ def materialize_settings_with_hooks(
                 {
                     "matcher": "Bash",
                     "hooks": [{"type": "command", "command": _BICAMERAL_POST_COMMIT_COMMAND}],
-                }
+                },
+                {
+                    "matcher": _BICAMERAL_PREFLIGHT_TOOL_NAME,
+                    "hooks": [
+                        {
+                            "type": "command",
+                            "command": _BICAMERAL_COLLISION_CAPTURE_REMINDER_COMMAND,
+                        }
+                    ],
+                },
             ],
             "SessionEnd": [
                 {

--- a/tests/e2e/run_e2e_flows.py
+++ b/tests/e2e/run_e2e_flows.py
@@ -43,6 +43,15 @@ MCP_CONFIG_TEMPLATE = E2E_ROOT / "bicameral.mcp.json"
 RESULTS_DIR = pathlib.Path(__file__).resolve().parents[2] / "test-results" / "e2e"
 RESULTS_DIR.mkdir(parents=True, exist_ok=True)
 
+# Wall-clock cap for a single `claude -p` flow invocation. Was 300s; CI
+# repeatedly tripped that limit on Flow 2 (the longest flow — chained
+# preflight → ingest(agent_session) → resolve_collision sequence after the
+# #154 hook landed). Last clean dev-branch Flow 2 measured 289.7s — only
+# ~3% headroom on the old cap. Bumped to 600s to give the post-hook
+# sequence plenty of margin without inflating the recording job's wall
+# beyond what GitHub Actions tolerates.
+CLAUDE_SESSION_TIMEOUT_S = 600
+
 # Persistent ledger shared across the 5 flow sessions in a single run, wiped
 # at the start of each run so flow-1 seeds → flow-2 refines → flow-3 reflects
 # → flow-4 captures → flow-5 ratifies, all against the same ledger state.
@@ -482,7 +491,7 @@ def run_claude_session(
         cwd=DESKTOP_REPO_PATH,
         capture_output=True,
         text=True,
-        timeout=300,
+        timeout=CLAUDE_SESSION_TIMEOUT_S,
     )
 
     transcript_path.write_text(proc.stdout, encoding="utf-8")
@@ -1216,7 +1225,7 @@ def main() -> int:
                     flow_id=spec.flow_id,
                     prompt_file=spec.prompt_file,
                     verdict="ERROR",
-                    body="claude CLI session timed out (>300s)",
+                    body=f"claude CLI session timed out (>{CLAUDE_SESSION_TIMEOUT_S}s)",
                     category=spec.category,
                     advisory=spec.advisory,
                 )

--- a/tests/test_post_preflight_capture_hook.py
+++ b/tests/test_post_preflight_capture_hook.py
@@ -83,6 +83,29 @@ def test_emits_reminder_when_decisions_surfaced():
     assert "supersede" in ctx and "keep_both" in ctx and "link_parent" in ctx
 
 
+def test_reminder_is_unconditional_not_judgment_gated():
+    """The reminder must instruct mechanical capture, NOT condition on the
+    agent's own judgment of whether the prompt 'really' contradicts. An
+    earlier conditional phrasing let the agent skip capture on borderline
+    prompts even when preflight surfaced relevant decisions. Lock the
+    unconditional posture in so future edits don't quietly regress it.
+    """
+    stdin = _make_stdin(
+        fired=True,
+        decisions=[{"decision_id": "decision:abc", "description": "Some prior decision"}],
+    )
+    _, out, _ = _run_hook(stdin)
+    ctx = _hook_output(json.loads(out))["additionalContext"]
+    # Affirmative imperative present.
+    assert "BEFORE any code edits, you MUST capture" in ctx
+    assert "do NOT judge" in ctx
+    # Negative: must not gate on the agent's own contradiction judgment, and
+    # must not give an explicit escape hatch for "compatible" prompts.
+    assert "If your current prompt CONTRADICTS" not in ctx
+    assert "If your prompt is COMPATIBLE" not in ctx
+    assert "ignore this and proceed normally" not in ctx
+
+
 def _assert_silent(out: str) -> None:
     """No envelope written. Tolerate fully-empty stdout or `{}`."""
     if not out.strip():

--- a/tests/test_post_preflight_capture_hook.py
+++ b/tests/test_post_preflight_capture_hook.py
@@ -4,9 +4,15 @@ The hook is invoked as a subprocess by Claude Code on every PostToolUse
 matching ``mcp__bicameral__bicameral_preflight``. Tests run it the same
 way to exercise stdin/stdout exactly as production does.
 
-The hook emits plain stdout text (no envelope) — the same shape the
-existing PostToolUse/Bash hook uses. Claude Code appends the hook's
-stdout to the tool result the agent sees on the next turn.
+Claude Code 2.x requires PostToolUse hook output shaped as
+``{"hookSpecificOutput": {"hookEventName": "PostToolUse",
+"additionalContext": "..."}}``. Plain stdout from PostToolUse hooks is
+silently dropped to the debug log (per
+https://code.claude.com/docs/en/hooks — only UserPromptSubmit /
+UserPromptExpansion / SessionStart treat raw stdout as agent-visible
+context). These tests assert against the envelope shape — anything else
+is a broken contract regardless of whether the hook process exits
+cleanly.
 """
 
 from __future__ import annotations
@@ -44,8 +50,18 @@ def _make_stdin(*, fired: bool, decisions: list[dict], response_as_string: bool 
     return json.dumps(payload)
 
 
+def _hook_output(parsed: dict) -> dict:
+    """Extract hookSpecificOutput.additionalContext, asserting envelope shape."""
+    assert "hookSpecificOutput" in parsed, (
+        f"hook must emit hookSpecificOutput envelope (Claude Code 2.x contract); got {parsed!r}"
+    )
+    inner = parsed["hookSpecificOutput"]
+    assert inner.get("hookEventName") == "PostToolUse"
+    return inner
+
+
 def test_emits_reminder_when_decisions_surfaced():
-    """fired=True with ≥1 decision → reminder containing each decision_id + Step 5.6 template."""
+    """fired=True with ≥1 decision → envelope with reminder containing each decision_id + Step 5.6 template."""
     stdin = _make_stdin(
         fired=True,
         decisions=[
@@ -55,30 +71,40 @@ def test_emits_reminder_when_decisions_surfaced():
     )
     rc, out, _ = _run_hook(stdin)
     assert rc == 0
-    assert "<system-reminder>" in out
-    assert "decision:abc123" in out
-    assert "decision:def456" in out
-    assert "Drag-and-drop to reorder commits" in out
-    assert "bicameral.ingest" in out
-    assert "agent_session" in out
-    assert "bicameral.resolve_collision" in out
-    assert "supersede" in out and "keep_both" in out and "link_parent" in out
+    inner = _hook_output(json.loads(out))
+    ctx = inner["additionalContext"]
+    assert "<system-reminder>" in ctx
+    assert "decision:abc123" in ctx
+    assert "decision:def456" in ctx
+    assert "Drag-and-drop to reorder commits" in ctx
+    assert "bicameral.ingest" in ctx
+    assert "agent_session" in ctx
+    assert "bicameral.resolve_collision" in ctx
+    assert "supersede" in ctx and "keep_both" in ctx and "link_parent" in ctx
+
+
+def _assert_silent(out: str) -> None:
+    """No envelope written. Tolerate fully-empty stdout or `{}`."""
+    if not out.strip():
+        return
+    parsed = json.loads(out)
+    assert "hookSpecificOutput" not in parsed
 
 
 def test_silent_when_fired_false():
-    """fired=False → no output."""
+    """fired=False → no envelope."""
     stdin = _make_stdin(fired=False, decisions=[])
     rc, out, _ = _run_hook(stdin)
     assert rc == 0
-    assert out.strip() == ""
+    _assert_silent(out)
 
 
 def test_silent_when_decisions_empty():
-    """fired=True but decisions=[] → no output (nothing to contradict)."""
+    """fired=True but decisions=[] → no envelope (nothing to contradict)."""
     stdin = _make_stdin(fired=True, decisions=[])
     rc, out, _ = _run_hook(stdin)
     assert rc == 0
-    assert out.strip() == ""
+    _assert_silent(out)
 
 
 def test_handles_response_as_json_string():
@@ -90,8 +116,8 @@ def test_handles_response_as_json_string():
     )
     rc, out, _ = _run_hook(stdin)
     assert rc == 0
-    assert "decision:xyz" in out
-    assert "<system-reminder>" in out
+    inner = _hook_output(json.loads(out))
+    assert "decision:xyz" in inner["additionalContext"]
 
 
 def test_silent_when_tool_name_does_not_match():
@@ -103,14 +129,14 @@ def test_silent_when_tool_name_does_not_match():
     }
     rc, out, _ = _run_hook(json.dumps(payload))
     assert rc == 0
-    assert out.strip() == ""
+    _assert_silent(out)
 
 
 def test_handles_malformed_stdin():
-    """Non-JSON stdin returns rc 0 with no output — never blocks user."""
+    """Non-JSON stdin returns rc 0 with no envelope — never blocks user."""
     rc, out, _ = _run_hook("this is not JSON at all {[}")
     assert rc == 0
-    assert out.strip() == ""
+    _assert_silent(out)
 
 
 def test_handles_missing_tool_response():
@@ -118,7 +144,7 @@ def test_handles_missing_tool_response():
     payload = {"tool_name": PREFLIGHT_TOOL_NAME, "tool_input": {}}
     rc, out, _ = _run_hook(json.dumps(payload))
     assert rc == 0
-    assert out.strip() == ""
+    _assert_silent(out)
 
 
 def test_idempotent_on_double_fire():

--- a/tests/test_post_preflight_capture_hook.py
+++ b/tests/test_post_preflight_capture_hook.py
@@ -1,0 +1,133 @@
+"""Functionality tests for scripts/hooks/post_preflight_capture_reminder.py.
+
+The hook is invoked as a subprocess by Claude Code on every PostToolUse
+matching ``mcp__bicameral__bicameral_preflight``. Tests run it the same
+way to exercise stdin/stdout exactly as production does.
+
+The hook emits plain stdout text (no envelope) — the same shape the
+existing PostToolUse/Bash hook uses. Claude Code appends the hook's
+stdout to the tool result the agent sees on the next turn.
+"""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+HOOK_SCRIPT = REPO_ROOT / "scripts" / "hooks" / "post_preflight_capture_reminder.py"
+
+PREFLIGHT_TOOL_NAME = "mcp__bicameral__bicameral_preflight"
+
+
+def _run_hook(stdin_text: str) -> tuple[int, str, str]:
+    """Invoke the hook with stdin_text on stdin; return (rc, stdout, stderr)."""
+    proc = subprocess.run(
+        [sys.executable, str(HOOK_SCRIPT)],
+        input=stdin_text,
+        capture_output=True,
+        text=True,
+        timeout=10,
+    )
+    return proc.returncode, proc.stdout, proc.stderr
+
+
+def _make_stdin(*, fired: bool, decisions: list[dict], response_as_string: bool = False) -> str:
+    response = {"fired": fired, "decisions": decisions}
+    payload = {
+        "tool_name": PREFLIGHT_TOOL_NAME,
+        "tool_input": {"topic": "reorder commits", "file_paths": ["app/src/lib/git/reorder.ts"]},
+        "tool_response": json.dumps(response) if response_as_string else response,
+    }
+    return json.dumps(payload)
+
+
+def test_emits_reminder_when_decisions_surfaced():
+    """fired=True with ≥1 decision → reminder containing each decision_id + Step 5.6 template."""
+    stdin = _make_stdin(
+        fired=True,
+        decisions=[
+            {"decision_id": "decision:abc123", "description": "Drag-and-drop to reorder commits"},
+            {"decision_id": "decision:def456", "description": "Cherry-pick across branches"},
+        ],
+    )
+    rc, out, _ = _run_hook(stdin)
+    assert rc == 0
+    assert "<system-reminder>" in out
+    assert "decision:abc123" in out
+    assert "decision:def456" in out
+    assert "Drag-and-drop to reorder commits" in out
+    assert "bicameral.ingest" in out
+    assert "agent_session" in out
+    assert "bicameral.resolve_collision" in out
+    assert "supersede" in out and "keep_both" in out and "link_parent" in out
+
+
+def test_silent_when_fired_false():
+    """fired=False → no output."""
+    stdin = _make_stdin(fired=False, decisions=[])
+    rc, out, _ = _run_hook(stdin)
+    assert rc == 0
+    assert out.strip() == ""
+
+
+def test_silent_when_decisions_empty():
+    """fired=True but decisions=[] → no output (nothing to contradict)."""
+    stdin = _make_stdin(fired=True, decisions=[])
+    rc, out, _ = _run_hook(stdin)
+    assert rc == 0
+    assert out.strip() == ""
+
+
+def test_handles_response_as_json_string():
+    """tool_response can arrive as a JSON-encoded string; reminder still fires."""
+    stdin = _make_stdin(
+        fired=True,
+        decisions=[{"decision_id": "decision:xyz", "description": "Some constraint"}],
+        response_as_string=True,
+    )
+    rc, out, _ = _run_hook(stdin)
+    assert rc == 0
+    assert "decision:xyz" in out
+    assert "<system-reminder>" in out
+
+
+def test_silent_when_tool_name_does_not_match():
+    """Hook only fires for bicameral_preflight; other tools → silent."""
+    payload = {
+        "tool_name": "Bash",
+        "tool_input": {"command": "git commit"},
+        "tool_response": {"fired": True, "decisions": [{"decision_id": "x", "description": "y"}]},
+    }
+    rc, out, _ = _run_hook(json.dumps(payload))
+    assert rc == 0
+    assert out.strip() == ""
+
+
+def test_handles_malformed_stdin():
+    """Non-JSON stdin returns rc 0 with no output — never blocks user."""
+    rc, out, _ = _run_hook("this is not JSON at all {[}")
+    assert rc == 0
+    assert out.strip() == ""
+
+
+def test_handles_missing_tool_response():
+    """Payload without tool_response → silent (no contradiction signal)."""
+    payload = {"tool_name": PREFLIGHT_TOOL_NAME, "tool_input": {}}
+    rc, out, _ = _run_hook(json.dumps(payload))
+    assert rc == 0
+    assert out.strip() == ""
+
+
+def test_idempotent_on_double_fire():
+    """Same input twice produces identical output (no state leak)."""
+    stdin = _make_stdin(
+        fired=True,
+        decisions=[{"decision_id": "decision:abc", "description": "Some decision"}],
+    )
+    rc1, out1, _ = _run_hook(stdin)
+    rc2, out2, _ = _run_hook(stdin)
+    assert rc1 == rc2 == 0
+    assert out1 == out2


### PR DESCRIPTION
## Summary

Step 5.6 of `skills/bicameral-preflight` (added by #163) instructs the agent to ingest a refinement with `source=agent_session` and call `resolve_collision` when the user's prompt contradicts a surfaced decision. Skill-instruction adherence isn't reliable — e2e Flow 2a fails on **dev** with *"saw 0 ingest call(s), none with agent_session"* even though preflight surfaced the right seed. #163 closed #154 on paper but left it open in CI.

This PR uses the same shape that closed #146: a Claude Code hook that bypasses skill adherence by injecting a `<system-reminder>` into the agent's next-turn context. #146 used UserPromptSubmit + a verb classifier; this PR uses **PostToolUse scoped to `mcp__bicameral__bicameral_preflight`**, with the "contradiction signal" being "preflight returned ≥1 decision."

The reminder is **conditional** (*"IF your prompt contradicts ..."*) because preflight has no view of the user prompt; the LLM gates applicability. Symmetric to the UserPromptSubmit hook that over-fires on any implementation verb and lets the skill be the gate.

Closes #154.

## What's in this PR

- `scripts/hooks/post_preflight_capture_reminder.py` — new hook. Reads `{tool_name, tool_input, tool_response}` from stdin; if `tool_name == mcp__bicameral__bicameral_preflight` and `tool_response.fired` and `tool_response.decisions`, prints a `<system-reminder>` listing each surfaced `decision_id` + `description` and templating the Step 5.6 ingest+resolve_collision call.
- `tests/test_post_preflight_capture_hook.py` — 8 cases: fired, silent-when-not-fired, silent-when-decisions-empty, response-as-JSON-string, silent-on-other-tool, malformed-stdin, missing-tool_response, idempotent-on-double-fire.
- `pyproject.toml` — `bicameral-mcp-collision-capture-reminder` console script.
- `setup_wizard.py` — `_BICAMERAL_COLLISION_CAPTURE_REMINDER_COMMAND` + `_BICAMERAL_PREFLIGHT_TOOL_NAME` constants; new PostToolUse entry merged into `_install_claude_hooks`. Self-healing replace-not-skip strategy matches existing pattern.
- `tests/e2e/_harness_setup.py` — second PostToolUse entry materialized alongside the existing `Bash` matcher.
- `.claude/settings.json` — dogfood entry invoking the source script directly via `python3` (mirrors the existing UserPromptSubmit dogfood line).
- `skills/bicameral-preflight/SKILL.md` — `#### Hook reinforcement` subsection under Step 5.6 documenting the new behavior.

## Validation

- `ruff check .` — clean (216 files).
- `ruff format --check .` — clean (216 files).
- `pytest tests/test_post_preflight_capture_hook.py tests/test_preflight_hook.py tests/test_preflight_intent.py` — 19/19 PASS.
- Setup-wizard byte-stability: ran `_install_claude_hooks` 3× on a fresh repo; resulting `settings.json` byte-identical between runs (self-healing semantic, intentional per CHANGELOG #v0.10.3).
- Harness materializer smoke test: `materialize_settings_with_hooks` produces both PostToolUse matchers (`Bash`, `mcp__bicameral__bicameral_preflight`) with the right commands.

## Test plan

- [ ] CI: `e2e assertions (auto)` — Flow 2a flips ⚠️ FAIL → ✅ PASS without other code changes.
- [ ] CI: `ruff + mypy` passes.
- [ ] CI: `MCP Regression Suite` (ubuntu + windows) passes.
- [ ] Verify Flow 2 transcript shows the new system-reminder injected after `bicameral_preflight` returns, followed by `bicameral_ingest(source=agent_session)` and `bicameral_resolve_collision`.

## Out of scope

- Server-side contradiction detection in preflight (deliberately removed in v0.9.3 per `handlers/ingest.py:262-263`).
- Flow 4 path-X-(b) — separate gap tracked under #156, requires a transcript-queue redesign.
- Wiring `resolve_collision` into `/bicameral:capture-corrections` (the SessionEnd subprocess) for missed-in-session contradictions — that's a skill-file change inside the spawned subprocess, separate concern.

## Branch strategy

Lands on `dev`. `triage-from-dev` (PR #165) rebases on top to pick this up before #165 merges to `main`.