### PR TITLE
test(e2e): Flow 1 asserter feature-area relax + Bash post-commit hook envelope

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -6,7 +6,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "python3 -c \"import json,sys,re; d=json.load(sys.stdin); c=d.get('tool_input',{}).get('command',''); ops=('git commit','git merge ','git pull','git rebase --continue'); [print('bicameral: git write-op detected — call bicameral.link_commit(commit_hash=\\'HEAD\\') now to sync the decision ledger') for _ in [1] if any(op in c for op in ops)]\""
+            "command": "python3 scripts/hooks/post_commit_sync_reminder.py"
           }
         ]
       }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -56,6 +56,7 @@ test = [
 bicameral-mcp = "server:cli_main"
 bicameral-mcp-classify = "cli.classify:main"
 bicameral-mcp-preflight-reminder = "scripts.hooks.preflight_reminder:main"
+bicameral-mcp-post-commit-sync-reminder = "scripts.hooks.post_commit_sync_reminder:main"
 
 [tool.hatch.build.targets.wheel]
 packages = ["."]

--- a/scripts/hooks/post_commit_sync_reminder.py
+++ b/scripts/hooks/post_commit_sync_reminder.py
@@ -1,0 +1,82 @@
+"""PostToolUse hook for the ``Bash`` tool — git write-op detector.
+
+When the agent runs ``git commit`` / ``git merge`` / ``git pull`` /
+``git rebase --continue``, inject a system-reminder telling the agent to
+call ``/bicameral:sync`` so the decision ledger picks up the new HEAD,
+runs compliance checks, and produces authoritative reflected/drifted
+verdicts before the next user turn.
+
+Replaces the plain-stdout one-liner ``_BICAMERAL_POST_COMMIT_COMMAND``
+that previously lived inline in ``setup_wizard.py``. Per Claude Code
+2.x hook docs (https://code.claude.com/docs/en/hooks), plain stdout
+from PostToolUse hooks is silently dropped to the debug log — only
+UserPromptSubmit / UserPromptExpansion / SessionStart treat raw stdout
+as agent-visible context. Symptom: the agent committed but never
+followed through to call ``link_commit`` / ``/bicameral:sync`` because
+the reminder never reached the model. Fix: emit the structured
+envelope ``{"hookSpecificOutput": {"hookEventName": "PostToolUse",
+"additionalContext": "..."}}``.
+
+The reminder text preserves the canonical ``"bicameral: new commit
+detected"`` phrase — the ``bicameral-sync`` skill watches for that
+exact prefix as one of its trigger signals.
+
+Errors are swallowed silently (exit 0, empty response) so a broken
+hook never blocks a user.
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+
+BASH_TOOL_NAME = "Bash"
+
+# Substrings that mark a git write-op against HEAD that the agent should
+# follow up with /bicameral:sync. Exact phrasing matches the legacy
+# inline command's tuple so behavior is byte-identical except for the
+# stdout envelope.
+WRITE_OP_MARKERS: tuple[str, ...] = (
+    "git commit",
+    "git merge ",
+    "git pull",
+    "git rebase --continue",
+)
+
+REMINDER_TEXT = (
+    "bicameral: new commit detected — run /bicameral:sync to resolve "
+    "compliance and get authoritative reflected/drifted status"
+)
+
+
+def _is_git_write_op(command: str) -> bool:
+    return any(marker in command for marker in WRITE_OP_MARKERS)
+
+
+def main() -> int:
+    try:
+        payload = json.load(sys.stdin)
+    except (json.JSONDecodeError, ValueError):
+        return 0
+    if not isinstance(payload, dict):
+        return 0
+    if payload.get("tool_name") != BASH_TOOL_NAME:
+        return 0
+    tool_input = payload.get("tool_input") or {}
+    command = tool_input.get("command", "") if isinstance(tool_input, dict) else ""
+    if not isinstance(command, str) or not _is_git_write_op(command):
+        return 0
+    json.dump(
+        {
+            "hookSpecificOutput": {
+                "hookEventName": "PostToolUse",
+                "additionalContext": REMINDER_TEXT,
+            }
+        },
+        sys.stdout,
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/setup_wizard.py
+++ b/setup_wizard.py
@@ -394,18 +394,19 @@ def _build_session_end_command(mcp_config_path: str | None = None) -> str:
 _BICAMERAL_SESSION_END_COMMAND = _build_session_end_command()
 
 # Fires after every Bash tool use. When the command is a git write-op
-# (commit / merge / pull / rebase --continue), prints a trigger line that
-# causes the agent to invoke /bicameral:sync — running the full
-# link_commit → compliance check flow so status is authoritative immediately.
-_BICAMERAL_POST_COMMIT_COMMAND = (
-    'python3 -c "'
-    "import json,sys; "
-    "d=json.load(sys.stdin); "
-    "c=d.get('tool_input',{}).get('command',''); "
-    "ops=('git commit','git merge ','git pull','git rebase --continue'); "
-    "[print('bicameral: new commit detected — run /bicameral:sync to resolve compliance and get authoritative reflected/drifted status') "
-    'for _ in [1] if any(op in c for op in ops)]"'
-)
+# (commit / merge / pull / rebase --continue), emits a hookSpecificOutput
+# envelope whose additionalContext nudges the agent to invoke
+# /bicameral:sync — running the full link_commit → compliance check
+# flow so status is authoritative immediately.
+#
+# Was a plain-stdout python -c one-liner. Per Claude Code 2.x hook docs
+# (https://code.claude.com/docs/en/hooks), plain stdout from PostToolUse
+# is dropped to the debug log — only UserPromptSubmit / UserPromptExpansion
+# / SessionStart treat raw stdout as agent-visible context. Symptom: the
+# agent committed but never followed through with link_commit because
+# the reminder never reached the model. Console script writes the proper
+# envelope; source: scripts/hooks/post_commit_sync_reminder.py.
+_BICAMERAL_POST_COMMIT_COMMAND = "bicameral-mcp-post-commit-sync-reminder"
 
 # UserPromptSubmit hook: deterministic regex over a verb list elevates
 # bicameral.preflight above the agent's default tool-selection priority

--- a/tests/e2e/run_e2e_flows.py
+++ b/tests/e2e/run_e2e_flows.py
@@ -612,9 +612,49 @@ def _ingest_items(call: dict) -> list[dict]:
     return p.get("decisions") or p.get("mappings") or []
 
 
+# Feature-area binding sets for Flow 1. Each seeded decision can legitimately
+# anchor to any of several files in the desktop/desktop tree — the asserter
+# checks that *some* file in each area is bound, not which specific one.
+# Previously the asserter required the exact paths "cherry-pick.ts" and
+# "reorder.ts"; LLM nondeterminism on borderline cases (e.g. binding the
+# UI-layer commit-list.tsx instead of the git-layer reorder.ts) flaked the
+# test even though the functional outcome — drift detection has a code
+# anchor for each feature — was satisfied.
+#
+# The "Improved commit history" decision bundles four ops (drag-to-reorder,
+# drag-to-squash, amend, branch-from), so any of the files backing those is
+# a legitimate anchor. cherry-pick has both lib and UI surfaces and either
+# is acceptable.
+_CHERRY_PICK_AREA_PATHS: tuple[str, ...] = (
+    "cherry-pick.ts",
+    "cherry-pick.tsx",
+)
+_COMMIT_HISTORY_AREA_PATHS: tuple[str, ...] = (
+    # git-layer (canonical anchors for drift on the actual operations)
+    "/git/reorder.ts",
+    "/git/squash.ts",
+    "/git/commit.ts",
+    # ui-layer (legitimate when the decision is framed as a UX feature)
+    "/history/commit-list.tsx",
+    "/history/commit-list-item.tsx",
+    "/multi-commit-operation/reorder.tsx",
+    "/multi-commit-operation/squash.tsx",
+    "/dispatcher/dispatcher.ts",
+    # models / store layer (when bound as data-shape contracts)
+    "/models/multi-commit-operation.ts",
+    "/models/retry-actions.ts",
+    "/stores/app-store.ts",
+)
+
+
+def _bound_to_area(bind_targets: list[str], area_paths: tuple[str, ...]) -> bool:
+    """Return True iff any bound path matches any acceptable substring for the area."""
+    return any(any(sub in p for sub in area_paths) for p in bind_targets)
+
+
 def assert_flow_1(calls: list[dict]) -> tuple[bool, str]:
-    """Flow 1: PM ingests the seed roadmap decisions, anchors the cherry-pick
-    decision to cherry-pick.ts and the reorder decision to reorder.ts, and
+    """Flow 1: PM ingests the seed roadmap decisions, anchors at least one
+    file in each of the cherry-pick and commit-history feature areas, and
     ratifies. Subsequent flows depend on a CLEAN, RATIFIED, BOUND ledger as
     their baseline.
 
@@ -623,6 +663,13 @@ def assert_flow_1(calls: list[dict]) -> tuple[bool, str]:
     separate ``bicameral.bind`` call for code that already exists. A
     follow-up ``bicameral.bind`` is reserved for abstract decisions whose
     code doesn't exist yet. This asserter accepts EITHER path.
+
+    The check is feature-area-scoped, not file-scoped: any of the files
+    listed in ``_CHERRY_PICK_AREA_PATHS`` / ``_COMMIT_HISTORY_AREA_PATHS``
+    counts as a legitimate anchor for the corresponding decision. The
+    earlier exact-filename check ("cherry-pick.ts" + "reorder.ts" only)
+    flaked when the LLM picked an equally valid UI-layer file like
+    ``commit-list.tsx`` for the bundled commit-history decision.
     """
     bcalls = _bicameral_tool_calls(calls)
     names = [c["name"].split("__")[-1] for c in bcalls]
@@ -662,17 +709,23 @@ def assert_flow_1(calls: list[dict]) -> tuple[bool, str]:
             if path:
                 bind_targets.append(path)
 
-    has_cp = any("cherry-pick.ts" in p for p in bind_targets)
-    has_reorder = any("reorder.ts" in p for p in bind_targets)
-    if not (has_cp and has_reorder):
+    has_cp_area = _bound_to_area(bind_targets, _CHERRY_PICK_AREA_PATHS)
+    has_commit_history_area = _bound_to_area(bind_targets, _COMMIT_HISTORY_AREA_PATHS)
+    if not (has_cp_area and has_commit_history_area):
         missing = [
-            f
-            for f, present in (("cherry-pick.ts", has_cp), ("reorder.ts", has_reorder))
+            label
+            for label, present in (
+                ("cherry-pick area", has_cp_area),
+                ("commit-history area", has_commit_history_area),
+            )
             if not present
         ]
         return False, (
-            f"bind missing target(s): {missing}; checked ingest.mappings[].code_regions "
-            f"and bicameral.bind calls; saw bound paths: {bind_targets}; sequence: {names}"
+            f"bind missing feature area(s): {missing}; checked "
+            f"ingest.mappings[].code_regions and bicameral.bind calls; saw bound "
+            f"paths: {bind_targets}; expected at least one path per missing area "
+            f"matching cherry-pick: {list(_CHERRY_PICK_AREA_PATHS)} or "
+            f"commit-history: {list(_COMMIT_HISTORY_AREA_PATHS)}; sequence: {names}"
         )
 
     # Ratify: PM blesses the just-ingested decisions. Flow 5 walks the
@@ -686,7 +739,8 @@ def assert_flow_1(calls: list[dict]) -> tuple[bool, str]:
 
     binding_path = "inline code_regions" if not bind_calls else "inline + follow-up bind"
     return True, (
-        f"ingest({total_items} items, {binding_path}) → cherry-pick.ts + reorder.ts bound; "
+        f"ingest({total_items} items, {binding_path}) → cherry-pick + commit-history "
+        f"feature areas bound (paths: {bind_targets}); "
         f"ratify({len(ratify_calls)}); sequence: {names}"
     )
 

--- a/tests/test_e2e_asserters.py
+++ b/tests/test_e2e_asserters.py
@@ -1,0 +1,176 @@
+"""Unit tests for the e2e flow asserters.
+
+Run the asserter functions in isolation against synthetic tool-call lists.
+Lets us pin behaviour like "Flow 1 accepts any commit-history-area file as
+a legitimate anchor for the bundled reorder/squash/amend/branch-from
+decision" without paying for a full claude-CLI e2e cycle.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+E2E_DIR = Path(__file__).resolve().parent.parent / "tests" / "e2e"
+if str(E2E_DIR) not in sys.path:
+    sys.path.insert(0, str(E2E_DIR))
+
+# Importing the orchestrator triggers env-var checks (DESKTOP_REPO_PATH etc.)
+# and CLI presence checks that we don't want to fire in unit tests. Stub them
+# before import so the module loads without bailing out.
+import os  # noqa: E402
+
+os.environ.setdefault("DESKTOP_REPO_PATH", str(Path(__file__).resolve().parent))
+os.environ.setdefault("PATH", os.environ.get("PATH", ""))
+
+import shutil  # noqa: E402
+
+_orig_which = shutil.which
+
+
+def _which_stub(name: str, *args, **kwargs):
+    if name in ("claude", "bicameral-mcp"):
+        return f"/stub/{name}"
+    return _orig_which(name, *args, **kwargs)
+
+
+shutil.which = _which_stub  # type: ignore[assignment]
+try:
+    import run_e2e_flows  # noqa: E402
+finally:
+    shutil.which = _orig_which  # type: ignore[assignment]
+
+
+def _ingest_call(decisions: list[dict]) -> dict:
+    return {
+        "name": "mcp__bicameral__bicameral_ingest",
+        "input": {"payload": {"decisions": decisions}},
+    }
+
+
+def _ratify_call(decision_id: str) -> dict:
+    return {
+        "name": "mcp__bicameral__bicameral_ratify",
+        "input": {"decision_id": decision_id},
+    }
+
+
+def _seed_calls(commit_history_anchor: str) -> list[dict]:
+    """Standard Flow 1 sequence: ingest the 3 seed decisions with inline
+    bindings, then ratify each. ``commit_history_anchor`` is the file path
+    chosen for the bundled commit-history decision — varied across tests
+    to confirm the asserter accepts any legitimate area path.
+    """
+    decisions = [
+        {
+            "description": "High-signal notifications",
+            "code_regions": [{"file_path": "app/src/lib/stores/notifications-store.ts"}],
+        },
+        {
+            "description": "Improved commit history",
+            "code_regions": [{"file_path": commit_history_anchor}],
+        },
+        {
+            "description": "Cherry-pick between branches",
+            "code_regions": [{"file_path": "app/src/lib/git/cherry-pick.ts"}],
+        },
+    ]
+    return [
+        _ingest_call(decisions),
+        _ratify_call("decision:1"),
+        _ratify_call("decision:2"),
+        _ratify_call("decision:3"),
+    ]
+
+
+# ── Flow 1: feature-area binding ────────────────────────────────────────
+
+
+def test_flow1_passes_with_canonical_git_layer_anchor():
+    """The previously-required exact path — must still pass."""
+    calls = _seed_calls(commit_history_anchor="app/src/lib/git/reorder.ts")
+    ok, detail = run_e2e_flows.assert_flow_1(calls)
+    assert ok, f"Flow 1 should pass with canonical reorder.ts anchor; detail: {detail}"
+
+
+def test_flow1_passes_with_ui_layer_anchor():
+    """Previously failing case — agent picks UI-layer commit-list.tsx for the
+    bundled commit-history decision. Now accepted as a legitimate anchor."""
+    calls = _seed_calls(commit_history_anchor="app/src/ui/history/commit-list.tsx")
+    ok, detail = run_e2e_flows.assert_flow_1(calls)
+    assert ok, f"Flow 1 should accept commit-list.tsx as commit-history anchor; detail: {detail}"
+
+
+def test_flow1_passes_with_dispatcher_anchor():
+    """Dispatcher also backs the bundled ops (amend, branch-from)."""
+    calls = _seed_calls(commit_history_anchor="app/src/ui/dispatcher/dispatcher.ts")
+    ok, detail = run_e2e_flows.assert_flow_1(calls)
+    assert ok, f"Flow 1 should accept dispatcher.ts as commit-history anchor; detail: {detail}"
+
+
+def test_flow1_passes_with_squash_anchor():
+    """Bundled decision includes drag-to-squash; squash.ts is a legitimate anchor."""
+    calls = _seed_calls(commit_history_anchor="app/src/lib/git/squash.ts")
+    ok, detail = run_e2e_flows.assert_flow_1(calls)
+    assert ok, f"Flow 1 should accept squash.ts as commit-history anchor; detail: {detail}"
+
+
+def test_flow1_fails_when_commit_history_unbound():
+    """Bind something far from the commit-history area — asserter still fails."""
+    calls = _seed_calls(commit_history_anchor="app/src/lib/some-unrelated-file.ts")
+    ok, detail = run_e2e_flows.assert_flow_1(calls)
+    assert not ok, f"Flow 1 must fail when no commit-history-area file is bound; detail: {detail}"
+    assert "commit-history area" in detail
+
+
+def test_flow1_fails_when_cherry_pick_unbound():
+    """Replace cherry-pick.ts with something unrelated — asserter fails."""
+    decisions = [
+        {
+            "description": "High-signal notifications",
+            "code_regions": [{"file_path": "app/src/lib/stores/notifications-store.ts"}],
+        },
+        {
+            "description": "Improved commit history",
+            "code_regions": [{"file_path": "app/src/lib/git/reorder.ts"}],
+        },
+        {
+            "description": "Cherry-pick between branches",
+            "code_regions": [{"file_path": "app/src/lib/some-other-thing.ts"}],
+        },
+    ]
+    calls = [_ingest_call(decisions), _ratify_call("d1"), _ratify_call("d2"), _ratify_call("d3")]
+    ok, detail = run_e2e_flows.assert_flow_1(calls)
+    assert not ok
+    assert "cherry-pick area" in detail
+
+
+def test_flow1_accepts_cherry_pick_tsx():
+    """UI-layer cherry-pick.tsx is also a legitimate cherry-pick anchor."""
+    decisions = [
+        {
+            "description": "High-signal notifications",
+            "code_regions": [{"file_path": "app/src/lib/stores/notifications-store.ts"}],
+        },
+        {
+            "description": "Improved commit history",
+            "code_regions": [{"file_path": "app/src/lib/git/reorder.ts"}],
+        },
+        {
+            "description": "Cherry-pick between branches",
+            "code_regions": [{"file_path": "app/src/ui/multi-commit-operation/cherry-pick.tsx"}],
+        },
+    ]
+    calls = [_ingest_call(decisions), _ratify_call("d1"), _ratify_call("d2"), _ratify_call("d3")]
+    ok, detail = run_e2e_flows.assert_flow_1(calls)
+    assert ok, f"Flow 1 should accept cherry-pick.tsx; detail: {detail}"
+
+
+def test_flow1_fails_without_ratify():
+    """Even if bindings are fine, missing ratify still fails the asserter."""
+    calls = _seed_calls(commit_history_anchor="app/src/lib/git/reorder.ts")
+    # Drop the three ratify calls.
+    calls = [c for c in calls if "ratify" not in c["name"]]
+    ok, detail = run_e2e_flows.assert_flow_1(calls)
+    assert not ok
+    assert "ratify" in detail.lower()

--- a/tests/test_post_commit_sync_hook.py
+++ b/tests/test_post_commit_sync_hook.py
@@ -1,0 +1,135 @@
+"""Functionality tests for scripts/hooks/post_commit_sync_reminder.py.
+
+The hook is invoked as a subprocess by Claude Code on every PostToolUse
+matching ``Bash``. Tests run it the same way to exercise stdin/stdout
+exactly as production does.
+
+Claude Code 2.x requires PostToolUse hook output shaped as
+``{"hookSpecificOutput": {"hookEventName": "PostToolUse",
+"additionalContext": "..."}}``. Plain stdout from PostToolUse hooks is
+silently dropped to the debug log (per
+https://code.claude.com/docs/en/hooks). These tests assert against the
+envelope shape — anything else is a broken contract.
+"""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+HOOK_SCRIPT = REPO_ROOT / "scripts" / "hooks" / "post_commit_sync_reminder.py"
+
+
+def _run_hook(stdin_text: str) -> tuple[int, str, str]:
+    proc = subprocess.run(
+        [sys.executable, str(HOOK_SCRIPT)],
+        input=stdin_text,
+        capture_output=True,
+        text=True,
+        timeout=10,
+    )
+    return proc.returncode, proc.stdout, proc.stderr
+
+
+def _make_stdin(*, tool_name: str = "Bash", command: str = "") -> str:
+    return json.dumps({"tool_name": tool_name, "tool_input": {"command": command}})
+
+
+def _hook_output(parsed: dict) -> dict:
+    """Extract hookSpecificOutput.additionalContext, asserting envelope shape."""
+    assert "hookSpecificOutput" in parsed, (
+        f"hook must emit hookSpecificOutput envelope (Claude Code 2.x contract); got {parsed!r}"
+    )
+    inner = parsed["hookSpecificOutput"]
+    assert inner.get("hookEventName") == "PostToolUse"
+    return inner
+
+
+def _assert_silent(out: str) -> None:
+    """No envelope written. Tolerate fully-empty stdout or `{}`."""
+    if not out.strip():
+        return
+    parsed = json.loads(out)
+    assert "hookSpecificOutput" not in parsed
+
+
+def test_emits_reminder_on_git_commit():
+    rc, out, _ = _run_hook(_make_stdin(command="git commit -m 'feat: add foo'"))
+    assert rc == 0
+    inner = _hook_output(json.loads(out))
+    ctx = inner["additionalContext"]
+    assert "bicameral: new commit detected" in ctx
+    assert "/bicameral:sync" in ctx
+
+
+def test_emits_reminder_on_git_merge():
+    rc, out, _ = _run_hook(_make_stdin(command="git merge feature/foo --no-ff"))
+    assert rc == 0
+    inner = _hook_output(json.loads(out))
+    assert "bicameral: new commit detected" in inner["additionalContext"]
+
+
+def test_emits_reminder_on_git_pull():
+    rc, out, _ = _run_hook(_make_stdin(command="git pull origin main"))
+    assert rc == 0
+    inner = _hook_output(json.loads(out))
+    assert "bicameral: new commit detected" in inner["additionalContext"]
+
+
+def test_emits_reminder_on_git_rebase_continue():
+    rc, out, _ = _run_hook(_make_stdin(command="git rebase --continue"))
+    assert rc == 0
+    inner = _hook_output(json.loads(out))
+    assert "bicameral: new commit detected" in inner["additionalContext"]
+
+
+def test_silent_on_read_only_git_command():
+    """git status, git log, git diff, etc. → silent."""
+    for cmd in ["git status", "git log -10", "git diff HEAD", "git branch -a"]:
+        rc, out, _ = _run_hook(_make_stdin(command=cmd))
+        assert rc == 0
+        _assert_silent(out)
+
+
+def test_silent_on_non_bash_tool():
+    """Hook only fires for Bash; other tools → silent."""
+    rc, out, _ = _run_hook(_make_stdin(tool_name="Edit", command="git commit"))
+    assert rc == 0
+    _assert_silent(out)
+
+
+def test_silent_on_non_git_bash_command():
+    rc, out, _ = _run_hook(_make_stdin(command="ls -la"))
+    assert rc == 0
+    _assert_silent(out)
+
+
+def test_handles_malformed_stdin():
+    rc, out, _ = _run_hook("this is not JSON at all {[}")
+    assert rc == 0
+    _assert_silent(out)
+
+
+def test_handles_missing_tool_input():
+    payload = json.dumps({"tool_name": "Bash"})
+    rc, out, _ = _run_hook(payload)
+    assert rc == 0
+    _assert_silent(out)
+
+
+def test_handles_non_dict_tool_input():
+    payload = json.dumps({"tool_name": "Bash", "tool_input": "git commit"})
+    rc, out, _ = _run_hook(payload)
+    assert rc == 0
+    _assert_silent(out)
+
+
+def test_idempotent_on_double_fire():
+    stdin = _make_stdin(command="git commit -m 'whatever'")
+    rc1, out1, _ = _run_hook(stdin)
+    rc2, out2, _ = _run_hook(stdin)
+    assert rc1 == rc2 == 0
+    assert out1 == out2


### PR DESCRIPTION
Bundles two independent fixes that together stabilize the e2e job on \`dev\`:

1. **Flow 1 asserter relaxed** — exact-filename gate (\`reorder.ts\` AND \`cherry-pick.ts\` both bound) replaced with a feature-area gate (any file in the relevant area counts as a legitimate anchor). Fixes the LLM-nondeterminism flake where the agent picks UI-layer \`commit-list.tsx\` instead of git-layer \`reorder.ts\` for the bundled drag-to-reorder/squash/amend/branch-from decision.

2. **Bash post-commit PostToolUse hook now uses hookSpecificOutput envelope** — the inline \`python3 -c\` one-liner in \`setup_wizard.py\` printed \"bicameral: new commit detected …\" to plain stdout, which Claude Code 2.x silently drops to the debug log (per https://code.claude.com/docs/en/hooks). Symptom: the agent commits in Flow 3 but never follows through with \`link_commit\` because the reminder never reached the model. Fix: move the inline command to a proper script file emitting \`{hookSpecificOutput: {hookEventName: \"PostToolUse\", additionalContext: \"...\"}}\`.

Originally opened as PRs #171 + #169; combined here per request.

## Why bundle

Both changes are needed for Flow 3's ledger assertion to reliably PASS:
- Asserter relax stops Flow 1 from cascading into Flow 3 when the agent picks a non-canonical anchor.
- Bash hook envelope makes the agent reliably call \`link_commit\` after Flow 3's git commit so compliance_check rows actually get written.

Either one in isolation could still red-light the e2e job; together they remove both flake sources from the post-Flow-2a gauntlet.

## What's in this PR

### Flow 1 asserter (\`tests/e2e/run_e2e_flows.py\`)

Each seeded decision must have ≥1 bound path matching one of an acceptable substring set:

- **cherry-pick area**: \`cherry-pick.ts\`, \`cherry-pick.tsx\`
- **commit-history area**: \`/git/reorder.ts\`, \`/git/squash.ts\`, \`/git/commit.ts\`, \`/history/commit-list.tsx\`, \`/history/commit-list-item.tsx\`, \`/multi-commit-operation/{reorder,squash}.tsx\`, \`/dispatcher/dispatcher.ts\`, \`/models/{multi-commit-operation,retry-actions}.ts\`, \`/stores/app-store.ts\`

### Asserter unit tests (\`tests/test_e2e_asserters.py\`)

8 cases — canonical \`reorder.ts\`, UI-layer \`commit-list.tsx\` (previously flaky), dispatcher / squash anchors, \`cherry-pick.tsx\`, negative cases (unrelated file → fail with clear \`commit-history area\` / \`cherry-pick area\` detail), missing ratify.

### Post-commit hook (\`scripts/hooks/post_commit_sync_reminder.py\`)

Reads \`{tool_name, tool_input}\` from stdin; if \`tool_name == Bash\` and the command contains \`git commit\` / \`git merge \` / \`git pull\` / \`git rebase --continue\`, emits the envelope. Reminder text preserves the canonical \"bicameral: new commit detected\" prefix verbatim so the \`bicameral-sync\` skill's existing trigger keeps matching.

### Hook unit tests (\`tests/test_post_commit_sync_hook.py\`)

11 cases — each git write-op verb, read-only git, non-Bash tool, non-git Bash, malformed stdin, missing/non-dict \`tool_input\`, idempotent.

### Wiring

- \`pyproject.toml\` — \`bicameral-mcp-post-commit-sync-reminder\` console script.
- \`setup_wizard.py\` — \`_BICAMERAL_POST_COMMIT_COMMAND\` now references the console script. Existing \`_install_claude_hooks\` merge logic unchanged.
- \`.claude/settings.json\` — dogfood entry invokes the source script via \`python3\`.

## Validation

- \`ruff check .\` — clean (217 files).
- \`ruff format --check .\` — clean (217 files).
- \`pytest tests/test_e2e_asserters.py tests/test_post_commit_sync_hook.py tests/test_preflight_hook.py\` — 24/24 PASS.
- Setup-wizard byte-stability across repeated \`_install_claude_hooks\` calls.

## Test plan

- [ ] CI: \`e2e assertions (auto)\` — Flow 1 PASSes regardless of which feature-area file the agent picked; Flow 3 ledger assertion (compliance_check rows written) reliably PASSes.
- [ ] CI: \`ruff + mypy\` passes.
- [ ] CI: \`MCP Regression Suite\` (ubuntu + windows) passes.

## Companion PR

#168 — adds the resolve_collision PostToolUse hook for Flow 2a (#154), bumps the 300s flow timeout, and uses the same envelope shape this PR establishes for the Bash hook.