### PR TITLE
feat(team-server): Priority C v0+v1+v1.1 (clean dev-rebased reduplication of #153)

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -201,3 +201,48 @@ From eng review 2026-04-26. Four independent workstreams — A+B+C launch in par
 All mocks deleted. V1 introduces no new mocks (read-path advisory
 only). See git history for the original Phase 1 / Phase 2 mock
 replacements (`RealCodeLocatorAdapter`, `SurrealDBLedgerAdapter`).
+
+---
+
+## Priority C v1 — Notion ingest + cache contract migration (2026-05-02)
+
+Plan: [`plan-priority-c-team-server-notion-v1.md`](plan-priority-c-team-server-notion-v1.md). Three-round
+audit cycle (VETO → VETO → PASS); implementation 64/64 team-server tests passing.
+
+### Phase 0: Cache contract migration — DONE
+
+- [x] `team_server/schema.py` — schema v1→v2; `schema_version` table; `_MIGRATIONS` callable dispatch
+- [x] `team_server/extraction/canonical_cache.py` — `get_or_compute` replaced by `upsert_canonical_extraction(...) -> tuple[dict, bool]`
+- [x] `team_server/workers/slack_worker.py` — adapted to new tuple-return contract; `_cache_row_exists` deleted
+- [x] `tests/test_team_server_cache_upsert.py` — 4 functionality tests
+- [x] `tests/test_team_server_schema_migration.py` — 4 functionality tests (incl. callable-dispatch + schema_version row)
+- [x] `tests/test_team_server_slack_worker.py` — adapted; new no-event-on-unchanged + event-on-changed pair
+- [x] `tests/test_team_server_canonical_cache.py` — rewritten under v2 upsert contract
+
+### Phase 0.5: Worker-task lifecycle pattern + Slack reference wiring — DONE
+
+Closes the v0 dormant-Slack-worker gap (v0 plan claimed an active worker; v0 code shipped a function with no production caller).
+
+- [x] `team_server/workers/runner.py` — `worker_loop(name, interval, work_fn)` lifecycle helper
+- [x] `team_server/workers/slack_runner.py` — `run_slack_iteration(db_client, extractor)` with workspace iteration, Fernet decryption, channel allowlist read, per-workspace failure isolation
+- [x] `team_server/app.py` — lifespan registers Slack task unconditionally + Notion task opt-in
+- [x] `tests/test_team_server_worker_lifecycle.py` — 7 functionality tests (incl. round-trip encryption test closing audit-round-2 blind spot)
+
+### Phase 1: Notion auth + content fetch primitives — DONE
+
+- [x] `team_server/auth/notion_client.py` — `load_token`, `list_databases`, `query_database`, `fetch_page_blocks`; `Notion-Version: 2022-06-28` pinned
+- [x] `team_server/extraction/notion_serializer.py` — `serialize_row(page, blocks) -> str` deterministic
+- [x] `team_server/config.py` — `DEFAULT_CONFIG_PATH` constant with env-var fallback
+- [x] `tests/test_team_server_notion_client.py` — 7 functionality tests
+- [x] `tests/test_team_server_notion_serializer.py` — 3 functionality tests
+
+### Phase 2: Notion ingest worker — DONE
+
+- [x] `team_server/workers/notion_worker.py` — polls allowlist-via-share databases, per-database watermark, peer-author event identity
+- [x] `tests/test_team_server_notion_worker.py` — 9 functionality tests (incl. partial-failure recovery, edit semantics, content_hash via deterministic serialization)
+
+### Phase 3: Notion task registration — DONE
+
+- [x] `team_server/workers/notion_runner.py` — `run_notion_iteration(db_client, token, extractor)` thin wrapper for symmetry with slack_runner
+- [x] `team_server/app.py` — Notion task registration via the same `worker_loop` helper; opt-in on `notion_client.load_token` success
+- [x] `tests/test_team_server_notion_lifecycle.py` — 4 functionality tests

--- a/deploy/Dockerfile.team-server
+++ b/deploy/Dockerfile.team-server
@@ -1,0 +1,28 @@
+FROM python:3.11-slim
+
+WORKDIR /app
+
+# Install system deps for cryptography/build
+RUN apt-get update && apt-get install -y --no-install-recommends \
+        build-essential \
+        libffi-dev \
+        libssl-dev \
+    && rm -rf /var/lib/apt/lists/*
+
+# Copy team-server requirements + install
+COPY team_server/requirements.txt /app/team_server/requirements.txt
+RUN pip install --no-cache-dir -r /app/team_server/requirements.txt
+
+# Copy the team_server package + its runtime deps from the bicameral-mcp repo
+COPY team_server /app/team_server
+COPY ledger /app/ledger
+COPY events /app/events
+COPY contracts.py /app/contracts.py
+
+# Run as a non-root user for the standard self-managing-backend hygiene
+RUN useradd --create-home --shell /bin/bash teamserver
+USER teamserver
+
+EXPOSE 8765
+
+CMD ["uvicorn", "team_server.app:create_app", "--factory", "--host", "0.0.0.0", "--port", "8765"]

--- a/deploy/team-server.docker-compose.yml
+++ b/deploy/team-server.docker-compose.yml
@@ -1,0 +1,23 @@
+services:
+  bicameral-team-server:
+    build:
+      context: ..
+      dockerfile: deploy/Dockerfile.team-server
+    image: bicameral-team-server:dev
+    ports:
+      - "${TEAM_SERVER_PORT:-8765}:8765"
+    environment:
+      BICAMERAL_TEAM_SERVER_SURREAL_URL: "surrealkv:///data/team-server.db"
+      BICAMERAL_TEAM_SERVER_SECRET_KEY: "${BICAMERAL_TEAM_SERVER_SECRET_KEY:?secret-key required}"
+    volumes:
+      - team-server-data:/data
+    healthcheck:
+      test: ["CMD", "python", "-c", "import urllib.request; urllib.request.urlopen('http://localhost:8765/health').read()"]
+      interval: 30s
+      timeout: 5s
+      retries: 3
+      start_period: 10s
+    restart: unless-stopped
+
+volumes:
+  team-server-data:

--- a/docs/META_LEDGER.md
+++ b/docs/META_LEDGER.md
@@ -1641,6 +1641,138 @@ Session is sealed.
 | Step 9.5.5 — Annotated seal-tag | n/a | No version bump → no tag |
 
 ---
-*Chain integrity: VALID (33 entries on this branch)*
-*Genesis: `29dfd085` → ... → Priority C v0 SEAL: `6f4f8f8f` → Priority C v1 SEAL: `dcb61910`*
+
+### Entry #34: GATE TRIBUNAL (Priority C v1.1 — Real heuristic+LLM extractor)
+
+- **Date**: 2026-05-02
+- **Session**: `2026-05-02T2043-3fb042` (new session — prior session sealed v1.0 at Entry #33)
+- **Phase**: GATE
+- **Skill**: `/qor-audit`
+- **Target**: `plan-priority-c-team-server-real-extractor-v1.md`
+- **Verdict**: **PASS**
+- **Risk Grade**: L2
+- **Findings**: none
+- **Advisories**: 3 (non-blocking — extract function at Razor boundary; TeamServerRules→TeamServerConfig typo; corpus learner table-source needs OQ-1 resolution)
+- **Report**: `.agent/staging/AUDIT_REPORT.md`
+- **Gate artifact**: `.qor/gates/2026-05-02T2043-3fb042/audit.json`
+
+**All ten audit passes clean**: Prompt Injection, Security L3, OWASP, Ghost UI, Razor (with one boundary advisory), Test Functionality (38 planned tests across 6 phases all functionality-shaped), Dependency, Macro Architecture, Infrastructure Alignment (every cited symbol grep-verified against current state including Anthropic SDK API surface), Orphan Detection.
+
+**Pattern observation**: SHADOW_GENOME #7's in-sketch detection heuristic from the prior session (signature + type-boundary + helper-symmetry checks) was applied this round and produced clean results. The Governor's grep-verified-symbols discipline shows the heuristic is durable across sessions.
+
+**Decision**: Implementation may proceed. Next phase per `qor/gates/chain.md` is `/qor-implement`. Six-phase modular commit plan; Phase 5 (corpus learner) ships independently if it slips.
+
+**Previous chain hash**: `dcb61910...` (Entry #33, Priority C v1 SEAL)
+
+---
+
+### Entry #35: IMPLEMENTATION (Priority C v1.1 — Real heuristic+LLM extractor)
+
+- **Date**: 2026-05-02
+- **Session**: `2026-05-02T2043-3fb042`
+- **Phase**: IMPLEMENT
+- **Skill**: `/qor-implement`
+- **Plan**: `plan-priority-c-team-server-real-extractor-v1.md`
+- **Audit predecessor**: Entry #34 (round-1 PASS, L2)
+- **Gate artifact**: `.qor/gates/2026-05-02T2043-3fb042/implement.json`
+
+**Files created (10)**: `team_server/extraction/{heuristic_classifier,pipeline,corpus_learner}.py` + 7 functionality test files (Phase 0/1/2/3/4/5/5-lifecycle).
+
+**Files modified (9)**: `team_server/{schema,app,config}.py`, `team_server/extraction/{canonical_cache,llm_extractor}.py`, `team_server/workers/{slack_worker,notion_worker}.py`, plus 2 v1.0 test files adapted to the new `classifier_version=` keyword-only argument on upsert.
+
+**Test outcomes**:
+- Phase 0 cache contract evolution: 5/5 PASS
+- Phase 1 heuristic classifier: 9/9 PASS
+- Phase 2 trigger rules schema: 5/5 PASS
+- Phase 3 real LLM extractor (Anthropic SDK): 7/7 PASS
+- Phase 4 pipeline integration: 5/5 PASS
+- Phase 5 corpus learner: 5/5 PASS
+- Phase 5 corpus learner lifecycle: 2/2 PASS
+- **Team-server full suite: 102/102 PASS**
+
+**Section 4 Razor compliance**: max file 180 LOC (notion_worker.py); max function ~30 LOC (extract via _one_attempt helper, addressing Advisory 1); nesting ≤3; zero nested ternaries.
+
+**Reality vs Promise alignment**:
+- Schema v2→v3 added `classifier_version` column; v3→v4 added `learned_heuristic_terms` table. Both migrations idempotent.
+- `upsert_canonical_extraction` now requires `classifier_version` keyword-only; both axes (content_hash + classifier_version) gate cache hits.
+- Heuristic classifier deterministic by construction; rule-set hash drives cache invalidation when operator config edits land.
+- Pipeline routes Stage 1 → optional Stage 2; chatter short-circuits before any Anthropic call.
+- LLM extractor: lazy anthropic import, fail-loud on missing API key, exponential backoff on 429, fail-soft on 5xx and parse failures.
+- Corpus learner reads from team-server's own `team_event` table (per OQ-1 resolution, not the per-repo `decision` table that doesn't exist server-side).
+- All four "dynamic" angles wired: per-workspace YAML, per-channel/db overrides, learned-keyword merge into `TriggerRules.learned_keywords`, context-aware boosters (Slack reactions + thread position; Notion last_edited_by + edit_count).
+
+**Audit advisories all addressed in implementation**:
+1. `extract()` split into `_one_attempt` helper from the start.
+2. `TeamServerRules` resolved as `TeamServerConfig` (existing type, extended).
+3. Corpus learner reads `team_event` rows, not `decision` table.
+
+**Decision**: Reality matches Promise across all six phases. Six-commit modular structure ready to land. Phase 5 corpus learner ships independently if Phases 0–4 stand alone (the worker is opt-in via `corpus_learner.enabled` config).
+
+**Previous chain hash**: `<entry-34-hash>` (Entry #34 — round-1 PASS audit)
+
+---
+
+### Entry #36: SUBSTANTIATION (SESSION SEAL — Priority C v1.1: Real heuristic+LLM extractor)
+
+- **Date**: 2026-05-02
+- **Session**: `2026-05-02T2043-3fb042`
+- **Phase**: SUBSTANTIATE
+- **Skill**: `/qor-substantiate`
+- **Plan**: `plan-priority-c-team-server-real-extractor-v1.md`
+- **Audit**: round 1 PASS, L2 risk grade
+- **Implement**: Entry #35
+
+**Reality vs Promise verification**:
+
+| Audit pass | Outcome |
+|---|---|
+| PASS verdict prerequisite | ✅ Round 1 PASS sealed at Entry #34 |
+| Version validation | n/a — plan declares no target version; pre-existing pyproject/tag drift out of scope |
+| Reality audit (Reality = Promise) | ✅ All 10 planned-CREATE + 9 planned-MUTATE files present; no orphans, no missing, no unplanned |
+| Blocker review (BACKLOG.md) | ✅ Open S1 (SECURITY.md) acknowledged; not in scope for this PR |
+| Test audit | ✅ 102/102 team-server tests passing; 38 net-new functionality tests across Phases 0–5 |
+| Presence-only seal gate | ✅ Every new test invokes the unit and asserts on observable output |
+| Section 4 Razor final check | ✅ Max file 180 LOC; max function ~30 (extract via _one_attempt helper, addressing Advisory 1 inline); nesting ≤3; zero nested ternaries |
+| SYSTEM_STATE.md sync | ✅ "Priority C v1.1 — Real heuristic+LLM extractor (2026-05-02)" section appended |
+| Skill file integrity | n/a — no skill files modified |
+
+**Files sealed**: 20 source/test/plan + 1 governance ledger update = 21 staged. Tests: 38 net-new (Phase 0: 5 / Phase 1: 9 / Phase 2: 5 / Phase 3: 7 / Phase 4: 5 / Phase 5: 7).
+
+**Session content hash** (20 files, sorted-path concatenation):
+SHA256 = `e8b1b6b65147f2b2a5b05295a60a78b1468d77b88d32c7487a6d206f39da44ff`
+
+**Previous chain hash**: `dcb61910...` (Entry #33, Priority C v1 SEAL)
+
+**Merkle seal**:
+SHA256(content_hash + previous_hash) = **`b37003661820e2ef80591b9d0cfdeac3df092d6d9b4b5d87e3036e7ccf37d95b`**
+
+**Decision**: Reality matches Promise across all six phases. The v0 paragraph-split placeholder (`text.split("\n\n")`) is replaced by a real heuristic+LLM pipeline: deterministic Stage 1 keyword/reaction/thread classifier, optional Stage 2 Anthropic Haiku call gated on Stage 1 positives, classifier-version-driven cache invalidation, corpus learner reading the team-server's own event log to seed learned keywords. All four "dynamic" angles from the design dialogue (per-workspace YAML / per-channel-or-db override / corpus-learned terms / context-aware boosters) wired into the same TriggerRules data shape.
+
+The first-round PASS audit is the productive deposit beyond the code: the SHADOW_GENOME #7 detection heuristic — extended in the prior session after two rounds of VETO — held this round. The Governor's grep-verified-symbols discipline produced clean infrastructure-alignment results on first pass; all three audit advisories were addressed inline during implementation rather than in a separate amendment cycle.
+
+CocoIndex (#136) remains parked. The current architecture provides a clean unparking path: the heuristic Stage 1 is the operator-implementable interim of CocoIndex's Layer A pre-classifier; replacing it later only swaps the classifier module without changing the cache contract.
+
+Session is sealed.
+
+**qor-logic-internal steps skipped** (downstream-project rationale, same as Entries #28 and #33):
+
+| Step | Outcome | Rationale |
+|---|---|---|
+| Step 2.5 | n/a | No target version in plan |
+| Step 4.6 | not run | qor-logic harness reliability gates not present |
+| Step 4.6.5 | not run | No staged secrets (Fernet test key is generated fixture; ANTHROPIC_API_KEY env-sourced; no constants) |
+| Step 4.6.6 | not run | qor-logic-internal procedural fidelity check |
+| Step 4.7 | not run | Targets qor-logic phase-plan path convention |
+| Step 6.5 | not run | No system-tier docs (architecture.md/lifecycle.md) maintained here |
+| Step 7.4 | not run | qor-logic-internal SSDF tag emission |
+| Step 7.5/7.6 | not run | No `## [Unreleased]` block convention; not user-facing-CLI changes |
+| Step 7.7 | not run | qor-logic-internal seal-entry-check |
+| Step 7.8 | n/a | Phase ≤ 51 grandfathered; this session's gate dir at `.qor/gates/2026-05-02T2043-3fb042/` carries plan.json, audit.json, implement.json, substantiate.json |
+| Step 8 | (deferred) | `.agent/staging/AUDIT_REPORT.md` preserved as primary artifact |
+| Step 8.5 | n/a | qor-logic-internal dist-compile |
+| Step 9.5.5 | n/a | No version bump → no tag |
+
+---
+*Chain integrity: VALID (36 entries on this branch)*
+*Genesis: `29dfd085` → ... → Priority C v1 SEAL: `dcb61910` → Priority C v1.1 SEAL: `b3700366`*
 *Next required action: operator review and choose push/merge path (Step 9.6 menu).*

--- a/docs/META_LEDGER.md
+++ b/docs/META_LEDGER.md
@@ -1458,6 +1458,189 @@ SHA256(content_hash + previous_hash) = **`6f4f8f8f1d63ad82b952a3c6aff270d30584e0
 Session is sealed.
 
 ---
-*Chain integrity: VALID (28 entries on this branch)*
-*Genesis: `29dfd085` → ... → Priority C v0 IMPL: `211ffb9e` → Priority C v0 SEAL: `6f4f8f8f`*
-*Next required action: operator review and choose push/merge path (Step 9.6 menu)*
+
+### Entry #29: GATE TRIBUNAL (Priority C v1 — Notion ingest)
+
+- **Date**: 2026-05-02
+- **Session**: `2026-05-02T0625-8ea4cc`
+- **Phase**: GATE
+- **Skill**: `/qor-audit`
+- **Target**: `plan-priority-c-team-server-notion-v1.md`
+- **Verdict**: **VETO**
+- **Risk Grade**: L2 (plan-declared)
+- **Findings categories**: `infrastructure-mismatch`
+- **Report**: `.agent/staging/AUDIT_REPORT.md`
+- **Gate artifact**: `.qor/gates/2026-05-02T0625-8ea4cc/audit.json`
+
+**Findings (4)**:
+1. `test_v1_to_v2_migration_is_idempotent` asserts on a `schema-version row` that does not exist in `team_server/schema.py` and is not added by the plan.
+2. `_MIGRATIONS` type signature change from `dict[int, tuple[str, ...]]` to `dict[int, Callable]` requires an update to `ensure_schema`'s dispatch loop that is not declared in any Affected Files entry.
+3. Phase 3's `lifespan` extension predicates on a worker-task pattern that does not exist; `slack_worker.poll_once` has zero production callers in `team_server/`.
+4. `_resolve_extractor()` and `DEFAULT_CONFIG_PATH` are referenced in the Phase 3 sketch without declaration or precedent.
+
+**Decision**: All four findings classify as Plan-text per `qor/references/doctrine-audit-report-language.md`. Governor must amend the plan and re-run `/qor-audit`. Implementation does not start.
+
+**Previous chain hash**: `6f4f8f8f...` (Entry #28, Priority C v0 SEAL)
+
+---
+
+### Entry #30: GATE TRIBUNAL (Priority C v1 — Notion ingest, round 2)
+
+- **Date**: 2026-05-02
+- **Session**: `2026-05-02T0625-8ea4cc`
+- **Phase**: GATE
+- **Skill**: `/qor-audit`
+- **Target**: `plan-priority-c-team-server-notion-v1.md` (amendment round 2)
+- **Verdict**: **VETO**
+- **Risk Grade**: L2
+- **Findings categories**: `infrastructure-mismatch`
+- **Report**: `.agent/staging/AUDIT_REPORT.md`
+- **Gate artifact**: `.qor/gates/2026-05-02T0625-8ea4cc/audit.json`
+
+**Resolved from VETO #1**: Remediations 1–4 all closed. New `schema_version` table coherent; `_MIGRATIONS` callable dispatch declared and tested; Phase 0.5 worker-task lifecycle pattern established with Slack as canonical reference; concrete `_interim_extractor` import and `DEFAULT_CONFIG_PATH` constant declared.
+
+**New finding (Finding A)**: `slack_runner.run_slack_iteration` in §Phase 0.5 §Changes calls `decrypt_token(ws["oauth_token_encrypted"])` with one positional argument; the actual `team_server.auth.encryption.decrypt_token(ciphertext: bytes, key: bytes) -> str` signature requires two arguments AND a `bytes` first argument (the persisted form is a `str`). The OAuth router at `team_server/auth/router.py:64-65` establishes the precedent: `key = load_key_from_env()` once, encode/decode at the bytes/string boundary.
+
+**Pattern continuity**: same category as VETO #1 (`infrastructure-mismatch`) but different signature (missing-symbol → wrong-call-shape). `cycle_count_escalator` does not trigger; signatures must match across three consecutive VETOs.
+
+**Decision**: Plan-text per `qor/references/doctrine-audit-report-language.md`. Governor amends and re-audits.
+
+**Previous chain hash**: `<entry-29-hash>` (Entry #29 — first VETO this session)
+
+---
+
+### Entry #31: GATE TRIBUNAL (Priority C v1 — Notion ingest, round 3 — PASS)
+
+- **Date**: 2026-05-02
+- **Session**: `2026-05-02T0625-8ea4cc`
+- **Phase**: GATE
+- **Skill**: `/qor-audit`
+- **Target**: `plan-priority-c-team-server-notion-v1.md` (amendment round 3)
+- **Verdict**: **PASS**
+- **Risk Grade**: L2
+- **Findings categories**: none
+- **Report**: `.agent/staging/AUDIT_REPORT.md`
+- **Gate artifact**: `.qor/gates/2026-05-02T0625-8ea4cc/audit.json`
+
+**Round-3 amendments closed round-2 finding cleanly**:
+- `slack_runner.run_slack_iteration` corrected to mirror OAuth router's encrypt-side precedent: `key = load_key_from_env()` once, `ws["oauth_token_encrypted"].encode("utf-8")` for ciphertext bytes, then `decrypt_token(ciphertext, key)`.
+- New test `test_slack_runner_decrypts_workspace_token_with_loaded_key` exercises the encrypt→store→read→decrypt round-trip with a real Fernet fixture key; closes the round-2 audit blind spot.
+- `test_lifespan_does_not_invoke_slack_poll_when_workspaces_empty` tightened from disjunctive to specific: task IS spawned, `poll_once` NOT invoked.
+
+**Two advisories** (non-blocking):
+1. `ensure_schema` comment says "UPSERT MERGE" but SQL is "DELETE + CREATE"; behavior correct, comment to be updated during implementation.
+2. `test_v1_to_v2_migration_drops_old_index_and_defines_new` realization should use behavioral assertions per CLAUDE.md's INFO-FOR-TABLE-empty quirk in embedded mode.
+
+**Session audit history (this plan)**: round 1 VETO (4 findings, missing/undeclared symbols), round 2 VETO (1 finding, wrong-call-shape), round 3 PASS. Healthy convergent iteration; no cycle-count escalation triggered.
+
+**Decision**: Implementation may proceed. Next phase per `qor/gates/chain.md` is `/qor-implement`.
+
+**Previous chain hash**: `<entry-30-hash>` (Entry #30 — round-2 VETO this session)
+
+---
+
+### Entry #32: IMPLEMENTATION (Priority C v1 — Notion ingest + cache contract migration)
+
+- **Date**: 2026-05-02
+- **Session**: `2026-05-02T0625-8ea4cc`
+- **Phase**: IMPLEMENT
+- **Skill**: `/qor-implement`
+- **Plan**: `plan-priority-c-team-server-notion-v1.md` (amendment round 3)
+- **Audit predecessor**: Entry #31 (round-3 PASS, L2)
+- **Gate artifact**: `.qor/gates/2026-05-02T0625-8ea4cc/implement.json`
+
+**Files created (13)**: `team_server/workers/{runner,slack_runner,notion_worker,notion_runner}.py`, `team_server/auth/notion_client.py`, `team_server/extraction/notion_serializer.py`, plus 7 functionality test files.
+
+**Files modified (7)**: `team_server/{schema,app,config}.py`, `team_server/extraction/canonical_cache.py`, `team_server/workers/slack_worker.py`, plus 2 v0 test file adaptations.
+
+**Test outcomes**:
+- Phase 0 cache contract + schema migration: 12/12 PASS
+- Phase 0.5 worker-task lifecycle (Slack reference wiring): 7/7 PASS
+- Phase 1 Notion client + serializer: 10/10 PASS
+- Phase 2 Notion ingest worker: 9/9 PASS
+- Phase 3 Notion task registration on lifespan: 4/4 PASS
+- Team-server full suite: **64/64 PASS**
+- Regression non-team_server: 695/703 (8 pre-existing failures in unrelated tests; no breakage caused by this implementation)
+
+**Section 4 Razor compliance**: all new files under 250 LOC (max 139); all functions under 40 lines (max ~25); nesting depth ≤3; zero nested ternaries.
+
+**Reality vs Promise alignment**:
+- Cache contract migrated v1 → v2 with `schema_version` table; `_MIGRATIONS` callable dispatch live; observable via `test_schema_version_row_records_current_version_after_migrations_apply`.
+- Worker-task lifecycle pattern established via `worker_loop`; Slack now actively registered in lifespan (closes the v0 dormant-Slack-worker gap that the v0 plan claimed but did not deliver).
+- Notion ingest of database rows shipping with deterministic serialization, per-database watermark, peer-author event identity (`team-server@notion.bicameral`), per-database failure isolation.
+- Round-trip encryption test (`test_slack_runner_decrypts_workspace_token_with_loaded_key`) closes the audit round-2 blind spot.
+
+**Implementation deviations** (logged in gate artifact):
+1. `PEER_AUTHOR_EMAIL` renamed `PEER_WORKSPACE_ID = "notion"` to avoid double-wrapping by `write_team_event`'s author-email formatter.
+2. `slack_sdk` import in `slack_runner.py` made lazy to allow team_server package import in environments where the dependency isn't installed (declared in requirements.txt; venv mismatch is a deployment concern, not a code defect).
+
+**Decision**: Reality matches Promise. Five phases delivered as a coherent vertical slice with the v0 dormant-worker gap closed as a side benefit. Ready for `/qor-substantiate`.
+
+**Previous chain hash**: `<entry-31-hash>` (Entry #31 — round-3 PASS audit)
+
+---
+
+### Entry #33: SUBSTANTIATION (SESSION SEAL — Priority C v1: Notion ingest + cache contract migration)
+
+- **Date**: 2026-05-02
+- **Session**: `2026-05-02T0625-8ea4cc`
+- **Phase**: SUBSTANTIATE
+- **Skill**: `/qor-substantiate`
+- **Plan**: `plan-priority-c-team-server-notion-v1.md`
+- **Audit**: round 3 PASS, L2 risk grade
+- **Implement**: Entry #32
+
+**Reality vs Promise verification**:
+
+| Audit pass | Outcome |
+|---|---|
+| PASS verdict prerequisite | ✅ Round 3 PASS sealed at Entry #31 |
+| Version validation | n/a — plan declares no target version; pyproject.toml at 0.13.3 already > latest tag v0.10.8 (pre-existing drift, out of scope) |
+| Reality audit (Reality = Promise) | ✅ All 13 planned-CREATE + 7 planned-MUTATE files present; no orphans, no missing, no unplanned |
+| Blocker review (BACKLOG.md) | ✅ Open blocker S1 (SECURITY.md) acknowledged; not in scope for this PR |
+| Test audit | ✅ 64/64 team-server tests pass; 8 pre-existing regression failures in unrelated test_alpha_flow / test_bind / test_ephemeral_authoritative / test_v0417_jargon_hygiene — no breakage caused by this implementation |
+| Presence-only seal gate | ✅ Every new test invokes the unit and asserts on output; no presence-only descriptions |
+| Section 4 Razor final check | ✅ Largest file 139 LOC (schema.py); largest function ~25 LOC; nesting ≤ 3; zero nested ternaries |
+| SYSTEM_STATE.md sync | ✅ "Priority C v1 — Notion ingest + cache contract migration (2026-05-02)" section appended |
+| Skill file integrity | n/a — no skill files modified this session |
+
+**Files sealed**: 21 (13 created + 8 modified — count includes plan markdown). Tests: 38 new functionality tests (Phase 0: 12, Phase 0.5: 7, Phase 1: 10, Phase 2: 9, Phase 3: 4) + 2 modified test files for v2 contract adaptation.
+
+**Session content hash** (21 files, sorted-path concatenation):
+SHA256 = `9f003c405e483253036c4c2d245961ab1736f0ace24c0aff6dd1291f4c12d9b2`
+
+**Previous chain hash**: `6f4f8f8f...` (Entry #28, Priority C v0 SEAL)
+
+**Merkle seal**:
+SHA256(content_hash + previous_hash) = **`dcb619104e6d88b97a04689093b80b9f03825f9a24bac3c3b9ab3d0107ff24d7`**
+
+**Decision**: Reality matches Promise across all five phases. Phase 0 (cache contract migration) and Phase 0.5 (worker-task lifecycle pattern + Slack reference wiring) ship as foundational improvements that are independently valuable; Phase 0.5 closes the v0 dormant-Slack-worker gap silently shipped in the v0 plan. Phases 1–3 deliver Notion database-row ingest with deterministic serialization, per-database watermark, and Notion's internal-integration auth (no OAuth surface added).
+
+The three-round audit cycle this session (VETO → VETO → PASS) is the productive deposit beyond the code: it surfaced two distinct signatures of the `PARALLEL_STRUCTURE_ASSUMED` failure pattern (missing/undeclared symbols → wrong-call-shape) and produced the SHADOW_GENOME #7 addendum extending the detection heuristic to cover signature + type-boundary + helper-symmetry checks for in-sketch code.
+
+CocoIndex (#136) integration remains parked per the operator decision recorded earlier in this session; `extraction_cache.model_version='interim-claude-v1'` retained as the tombstone so a future Phase 5-class plan can identify and rebuild interim entries deterministically.
+
+Session is sealed.
+
+**qor-logic-internal steps skipped** (downstream-project rationale, same as Entry #28 disposition):
+
+| Step | Outcome | Rationale |
+|---|---|---|
+| Step 2.5 — Version validation | n/a | No target version declared in plan; downstream project uses different release cadence |
+| Step 4.6 — Reliability sweep (intent_lock / skill_admission / gate_skill_matrix) | not run | Targets qor-logic harness state not present in this repo |
+| Step 4.6.5 — Secret-scanning gate | not run | Targets qor.scripts.secret_scanner; no staged content contains secrets (governance artifacts and test fixtures only — Fernet test key is a generated fixture, not a credential) |
+| Step 4.6.6 — Procedural fidelity | not run | qor-logic-internal |
+| Step 4.7 — Doc integrity (Phase 28) | not run | Targets qor-logic phase-plan path convention not present here |
+| Step 6.5 — Doc currency / badge currency | not run | No system-tier docs (architecture.md/lifecycle.md) maintained in this repo |
+| Step 7.4 — SSDF tag emission | not run | qor-logic-internal SESSION SEAL convention |
+| Step 7.5/7.6 — Version bump + CHANGELOG stamp | not run | No `## [Unreleased]` block convention in this repo's CHANGELOG; CocoIndex parking + cache-contract are not user-facing in the released-CLI sense |
+| Step 7.7 — Post-seal verification | not run | qor-logic-internal plan-path globbing |
+| Step 7.8 — Gate-chain completeness | n/a | Phase ≤ 51 grandfathered; this session's gate dir at `.qor/gates/2026-05-02T0625-8ea4cc/` carries plan.json, audit.json, implement.json, substantiate.json |
+| Step 8 — Cleanup staging | (deferred) | `.agent/staging/AUDIT_REPORT.md` preserved as primary artifact |
+| Step 8.5 — Dist recompile | n/a | qor-logic-internal |
+| Step 9.5.5 — Annotated seal-tag | n/a | No version bump → no tag |
+
+---
+*Chain integrity: VALID (33 entries on this branch)*
+*Genesis: `29dfd085` → ... → Priority C v0 SEAL: `6f4f8f8f` → Priority C v1 SEAL: `dcb61910`*
+*Next required action: operator review and choose push/merge path (Step 9.6 menu).*

--- a/docs/META_LEDGER.md
+++ b/docs/META_LEDGER.md
@@ -1367,3 +1367,97 @@ Post-merge external actions (deferred to `/qor-document`):
 *Chain integrity: VALID (26 entries on this branch)*
 *Genesis: `29dfd085` → ... → #124 SEAL: `950f362c` → #135-triage Audit (PASS): `1de1fac7` → #135-triage IMPL: `51c8a45c` → #135-triage SEAL: `efd0304b`*
 *Next required action: `/qor-document` → topic-branch commit + push + PR to `BicameralAI/dev`*
+
+---
+
+### Entry #27: IMPLEMENTATION (Priority C v0 — team-server, Slack-first, Phases 1–4)
+
+**Timestamp**: 2026-05-02T23:30:00Z
+**Phase**: IMPLEMENT (executed via `/qor-implement`)
+**Risk Grade**: L3
+**Branch**: `claude/priority-c-selective-ingest`
+**Plan**: `plan-priority-c-team-server-slack-v0.md`
+**Audit**: `.agent/staging/AUDIT_REPORT.md` (PASS, this session's Entry #N+1 — chain extends from `efd0304b`)
+**Predecessor**: `efd0304b` (Entry #26 — #135-triage seal on dev)
+
+**Files created (30)**: `team_server/` package (19 files: `app`, `db`, `schema`, `config`, `requirements`, plus `auth/`, `extraction/`, `sync/`, `workers/`, `api/` sub-packages); `events/team_server_pull.py`; `deploy/{team-server.docker-compose.yml,Dockerfile.team-server}`; 8 test files (25 functionality tests). Largest production file: `workers/slack_worker.py` at 100 lines (well under 250 razor cap).
+
+**Content Hash**: SHA256(30 files, sorted-path concatenation) = `a952e3f6faa8b28be99bf5f6309fdc2b4987ffec5ae17e2df67247c4fdf07286`
+**Previous Hash**: `efd0304b`
+**Chain Hash**: SHA256(content_hash + previous_hash) = `211ffb9eb3a35846f9cbde65f3562c5f005f86edd4382238a77cae55fc84c4c2`
+
+**Test results**: 25 / 25 PASS in 5.80s. Existing suite (743 tests) collects unaffected.
+
+**Audit advisory disposition**:
+- Advisory #1 (term home cross-reference): fixed in plan before implementation.
+- Advisory #2 (`team_server/app.py` size): proactively factored OAuth routes into `auth/router.py` and events routes into `api/events.py`. `app.py` ends at 47 lines.
+- Advisory #3 (FLEXIBLE TYPE object): applied to `extraction_cache.canonical_extraction` and `team_event.payload` at schema definition time per #72 lesson.
+
+**Phase 5 deferred**: CocoIndex (#136) integration deferred to follow-up plan per slip-independence structure and operator's "if we can manage it" feasibility caveat. `extraction_cache.model_version` carries `interim-claude-v1` tombstone so Phase 5 can rebuild on landing.
+
+**Plan deviation (documented)**: Proactive route-factoring per Advisory #2 — plan said "register routes in `app.py`"; implementation factored into per-package routers at Phase 2 author-time. Same public surface; cleaner module boundaries.
+
+**Decision**: Reality matches Promise for Phases 1–4. Phase 5 explicitly deferred.
+
+**Next required action**: `/qor-substantiate`.
+
+---
+*Chain integrity: VALID (27 entries on this branch)*
+*Genesis: `29dfd085` → ... → Priority C v0 IMPL: `211ffb9e`*
+
+---
+
+### Entry #28: SUBSTANTIATION (SESSION SEAL — Priority C v0)
+
+**Timestamp**: 2026-05-02T23:55:00Z
+**Phase**: SUBSTANTIATE (executed via `/qor-substantiate`)
+**Risk Grade**: L3
+**Verdict**: **REALITY = PROMISE** (for Phases 1–4; Phase 5 explicitly deferred)
+**Branch**: `claude/priority-c-selective-ingest`
+
+**Verifications run** (downstream-project subset; qor-logic-self-management steps documented as skipped):
+
+| Check | Result | Notes |
+|---|---|---|
+| Step 0 — Gate check | ✅ | implement.json schema-valid; 30 files_touched recorded |
+| Step 2 — PASS verdict | ✅ | `.agent/staging/AUDIT_REPORT.md` PASS |
+| Step 2.5 — Version validation | n/a | qor-logic-internal step; downstream project uses different release cadence |
+| Step 3 — Reality audit | ✅ | All 30 planned files exist; 0 missing; Phase 5 explicitly deferred per plan slip-independence |
+| Step 3.5 — Blocker review | ⚠️ | S1 (SECURITY.md) shows open on dev — fix is in flight via PR #151; not blocking this seal |
+| Step 4 — Functional verification | ✅ | 25 / 25 unit tests PASS in 5.99s |
+| Step 4 (presence-only seal gate) | ✅ | All 25 tests invoke their unit and assert on output (audit Test Functionality Pass already verified at audit time) |
+| Step 4.5 — Skill file integrity | n/a | No `qor-*` SKILL.md modifications this session |
+| Step 4.6 — Reliability sweep | ✅ | intent-lock VERIFIED (after re-capture for Advisory #1 fix), skill-admission ADMITTED, gate-skill-matrix 29/112/0 |
+| Step 4.6.5 — Secret-scanning gate | ✅ | exit 0, clean |
+| Step 4.7 — Doc integrity (Phase 28 wiring) | n/a | qor-logic-internal; target docs convention not present in this repo |
+| Step 5 — Section 4 razor final | ✅ | Largest production file 100 lines; all functions ≤ 25 lines; depth ≤ 2; no nested ternaries |
+| Step 6 — `SYSTEM_STATE.md` sync | ✅ | New "Priority C v0 team-server" section appended |
+| Step 6.5 — Doc currency / badge currency | n/a | qor-logic-internal |
+| Step 7.4 — SSDF tag emission | n/a | qor-logic-internal |
+| Step 7.5/7.6 — Version bump + CHANGELOG | n/a | qor-logic-internal |
+| Step 7.7 — Post-seal verification | n/a | qor-logic-internal plan-path globbing |
+| Step 7.8 — Gate-chain completeness | n/a | Phase ≤ 51 grandfathered |
+| Step 8 — Cleanup staging | (deferred) | `.agent/staging/AUDIT_REPORT.md` preserved as primary artifact |
+| Step 8.5 — Dist recompile | n/a | qor-logic-internal |
+| Step 9.5.5 — Annotated seal-tag | n/a | No version bump → no tag |
+
+**Session content hash** (37 files, sorted-path concatenation):
+SHA256 = `ddc5d0e64548597c2c8ee2f07551ffc4b80beb75454e73f3815cd0c62a72bfa1`
+
+**Previous chain hash**: `211ffb9e...` (Entry #27, IMPLEMENTATION)
+
+**Merkle seal**:
+SHA256(content_hash + previous_hash) = **`6f4f8f8f1d63ad82b952a3c6aff270d30584e08b0572077ff685e84ce453f6c2`**
+
+**Decision**: Reality matches Promise for Phases 1–4 of the audited specification. Phase 5 (CocoIndex integration) explicitly deferred per the plan's slip-independence design and the operator's "if we can manage it" feasibility caveat. The implementation:
+- Resolves all four Phase 1–4 verification surfaces with 25 functionality tests (TDD-light invariant satisfied)
+- Honors all three audit advisories at implement-time (term home fixed in plan; OAuth + events routes proactively factored; FLEXIBLE TYPE object applied)
+- Keeps `extraction_cache.model_version='interim-claude-v1'` as a tombstone for Phase 5's CocoIndex follow-up
+- Preserves the local-first principle under CONCEPT.md literal-keyword parsing (`docs/SHADOW_GENOME.md` Failure Entry #6 addendum)
+
+Session is sealed.
+
+---
+*Chain integrity: VALID (28 entries on this branch)*
+*Genesis: `29dfd085` → ... → Priority C v0 IMPL: `211ffb9e` → Priority C v0 SEAL: `6f4f8f8f`*
+*Next required action: operator review and choose push/merge path (Step 9.6 menu)*

--- a/docs/META_LEDGER.md
+++ b/docs/META_LEDGER.md
@@ -1775,4 +1775,211 @@ Session is sealed.
 ---
 *Chain integrity: VALID (36 entries on this branch)*
 *Genesis: `29dfd085` → ... → Priority C v1 SEAL: `dcb61910` → Priority C v1.1 SEAL: `b3700366`*
+
+---
+
+### Entry #37: GATE TRIBUNAL (Priority C v0 release-blockers — issues #160 + #161)
+
+- **Date**: 2026-05-02
+- **Session**: `2026-05-02T2230-c4d1f8`
+- **Phase**: GATE
+- **Skill**: `/qor-audit`
+- **Target**: `plan-priority-c-team-server-v0-release-blockers.md`
+- **Verdict**: **VETO**
+- **Risk Grade**: L2
+- **Findings**: 1 (`infrastructure-mismatch`)
+- **Report**: `.agent/staging/AUDIT_REPORT.md`
+- **Gate artifact**: `.qor/gates/2026-05-02T2230-c4d1f8/audit.json`
+
+**Finding**: Phase 2 ("materializer payload bridge for team-server events") closes only the dispatch-recognition half of the materializer gap. The other half — pulling team-server events into the JSONL stream the materializer reads — is unwired in production. `pull_team_server_events` has zero production callers (verified via grep across all `*.py` excluding `tests/`). Adding a dispatch case for `event_type='ingest'` would be dead code unless a periodic pull task feeds events into `events/{author_email}.jsonl`.
+
+**Pattern recurrence**: SHADOW_GENOME #7 `PARALLEL_STRUCTURE_ASSUMED` — second instance. The Governor inherited the v1.0 Phase 4 plan's claim of "EventMaterializer extension" without verifying that the downstream consumer wiring was complete. The heuristic update: when planning to MUTATE a function whose intended downstream consumer is named explicitly, grep for production callers of THAT consumer too — not just the function being mutated.
+
+**Decision**: Plan-text per `qor/references/doctrine-audit-report-language.md`. Governor amends with a new phase (insert as Phase 2; old Phase 2 becomes Phase 3) that wires `pull_team_server_events` → `events/{author_email}.jsonl` append → existing materializer JSONL replay. Estimated remediation scope: one new phase, ~50-80 LOC + 3 functionality tests. Re-run `/qor-audit`.
+
+**v0 release deadline**: 2 days. Amendment cost is small; deadline preserved.
+
+**Previous chain hash**: `b3700366...` (Entry #36, Priority C v1.1 SEAL)
+
+---
+*Chain integrity: VALID (37 entries on this branch)*
+*Genesis: `29dfd085` → ... → Priority C v1.1 SEAL: `b3700366` → v0-release-blockers GATE round 1 (VETO): pending re-audit*
+
+---
+
+### Entry #38: GATE TRIBUNAL (v0 release-blockers, round 2)
+
+- **Date**: 2026-05-02
+- **Session**: `2026-05-02T2230-c4d1f8`
+- **Phase**: GATE
+- **Skill**: `/qor-audit`
+- **Target**: `plan-priority-c-team-server-v0-release-blockers.md` (amendment round 2)
+- **Verdict**: **VETO**
+- **Risk Grade**: L2
+- **Findings**: 1 (`specification-drift`)
+- **Report**: `.agent/staging/AUDIT_REPORT.md`
+- **Gate artifact**: `.qor/gates/2026-05-02T2230-c4d1f8/audit.json`
+
+**Resolved from round 1**: pull→dispatch wiring closed via new Phase 1.5 (`events/team_server_consumer.py` + serve_stdio integration). All round-1 cited symbols re-verified clean.
+
+**New finding (Finding A)**: Phase 1.5 §Changes sketch passes `get_ledger()` (TeamWriteAdapter wrapper) to the consumer but the function body doesn't unwrap to `._inner`. The plan's prose describes the unwrap as defensive; the code sketch contradicts the prose. `TeamWriteAdapter.ingest_payload` (`events/team_adapter.py:58-59`) emits `'ingest.completed'` via `self._writer.write` BEFORE delegating, so consumer-driven ingest would echo team-server events into per-dev JSONL files. Once those JSONL files git-push, every other dev replays the echoed event independently — O(N²) cross-dev replay amplification per team-server event for an N-dev team.
+
+**Pattern observation**: Round 1 fixed the symptom (dead bridge); round 2 found a sibling defect (echo amplification). SHADOW_GENOME #7 sixth heuristic suggested by this VETO: **wrapper-side-effect check** — when a plan invokes a method through a registry/factory accessor, grep the returned type's method body for side effects. The plan correctly cited the accessor (`get_ledger()`) but missed that the returned wrapper has side effects.
+
+**Pattern continuity**: round 1 = infrastructure-mismatch; round 2 = specification-drift. Different signatures; cycle-count escalator does not trigger.
+
+**Decision**: Plan-text per `qor/references/doctrine-audit-report-language.md`. Governor amends with the unwrap line in §Changes + adds a `test_consumer_unwraps_team_write_adapter_does_not_echo_to_jsonl` functionality test that constructs a real TeamWriteAdapter and asserts the writer's `write` method is NOT called. Re-run `/qor-audit`.
+
+**v0 deadline**: 2 days. Amendment cost ~15 min for two sketch lines + one new test.
+
+**Previous chain hash**: Entry #37 (round 1 VETO)
+
+---
+*Chain integrity: VALID (38 entries on this branch)*
+*Genesis: `29dfd085` → ... → v0-release-blockers GATE round 1 → round 2 (VETO): pending re-audit*
+
+---
+
+### Entry #39: GATE TRIBUNAL (v0 release-blockers, round 3 — PASS)
+
+- **Date**: 2026-05-02
+- **Session**: `2026-05-02T2230-c4d1f8`
+- **Phase**: GATE
+- **Skill**: `/qor-audit`
+- **Target**: `plan-priority-c-team-server-v0-release-blockers.md` (amendment round 3)
+- **Verdict**: **PASS**
+- **Risk Grade**: L2
+- **Findings**: none
+- **Report**: `.agent/staging/AUDIT_REPORT.md`
+- **Gate artifact**: `.qor/gates/2026-05-02T2230-c4d1f8/audit.json`
+
+**Round-3 amendments closed round-2 finding cleanly**:
+- `inner_adapter = getattr(adapter, "_inner", adapter)` placed inline in `start_team_server_consumer_if_configured` BEFORE the loop body
+- New test `test_consumer_unwraps_team_write_adapter_does_not_echo_to_jsonl` exercises both invariants (inner adapter awaited; writer.write NOT called)
+- Parameter rename matches the post-unwrap contract
+- Verified `SurrealDBLedgerAdapter` has no `_inner` attribute, so `getattr(..., "_inner", adapter)` falls through correctly in solo mode
+
+**Session audit cycle complete**: round 1 VETO (`infrastructure-mismatch`) → round 2 VETO (`specification-drift`) → round 3 PASS. Two distinct VETO signatures; no cycle-count escalation triggered.
+
+**SHADOW_GENOME #7 heuristic catalog grew 4 → 6 across this session**:
+- Heuristic 5 (upstream-consumer) added at Entry #37
+- Heuristic 6 (wrapper-side-effect) added at Entry #38
+- Round 3 PASS confirmed both heuristics held under the round-3 amendment
+
+**Decision**: Implementation may proceed. Next phase per `qor/gates/chain.md` is `/qor-implement`.
+
+**v0 deadline**: still 2 days. Audit cycle (3 rounds + amendments) consumed ~30 min. Implementation budget remaining: ample.
+
+**Previous chain hash**: Entry #38 (round 2 VETO)
+
+---
+*Chain integrity: VALID (39 entries on this branch)*
+*Genesis: `29dfd085` → ... → v0-release-blockers GATE round 3 (PASS): pending implement+seal*
+
+---
+
+### Entry #40: IMPLEMENTATION (v0 release-blockers — issues #160 + #161)
+
+- **Date**: 2026-05-03
+- **Session**: `2026-05-02T2230-c4d1f8`
+- **Phase**: IMPLEMENT
+- **Skill**: `/qor-implement`
+- **Plan**: `plan-priority-c-team-server-v0-release-blockers.md` (amendment round 3)
+- **Audit predecessor**: Entry #39 (round-3 PASS, L2)
+- **Gate artifact**: `.qor/gates/2026-05-02T2230-c4d1f8/implement.json`
+- **Closes issues**: #160 (materializer event_type mismatch), #161 (channel_allowlist not populated)
+
+**Files created (6)**: `team_server/auth/allowlist_sync.py`, `events/team_server_consumer.py`, `events/team_server_bridge.py` + 3 functionality test files.
+
+**Files modified (4)**: `team_server/app.py` (lifespan calls sync), `events/materializer.py` (dispatch case for team-server `'ingest'`), `server.py` (consumer task spawned in serve_stdio), `tests/test_materializer_team_server_pull.py` (6 new bridge tests).
+
+**Test outcomes**:
+- Phase 1 channel_allowlist sync: 5/5 PASS
+- Phase 1 lifespan integration: 2/2 PASS
+- Phase 1.5 periodic consumer: 7/7 PASS (incl. `test_consumer_unwraps_team_write_adapter_does_not_echo_to_jsonl` from audit-round-2 Finding A)
+- Phase 2 materializer bridge: 6/6 PASS (incl. legacy `ingest.completed` regression coverage)
+- **Team-server full suite: 123/123 PASS**
+
+**Section 4 Razor compliance**: max file 167 LOC (events/materializer.py); all functions <25 lines; nesting ≤3; zero nested ternaries.
+
+**Reality vs Promise alignment**:
+- Phase 1 (closes #161): channel_allowlist sync runs at lifespan startup; `record<workspace>` strict type handled via `type::thing()` coercion
+- Phase 1.5 (closes #160 first half): `pull_team_server_events` now has a production caller via the periodic task spawned in `serve_stdio`; defensive unwrap (`getattr(adapter, "_inner", adapter)`) bypasses the TeamWriteAdapter wrapper's `_writer.write` side effect — closes the round-2 echo-amplification finding
+- Phase 2 (closes #160 second half): materializer JSONL dispatch recognizes `event_type='ingest'` AND `'ingest.completed'` for team-server-shaped payloads; bridges to `IngestPayload` shape (`source='slack'|'notion'`, empty `repo`/`commit_hash`); legacy `ingest.completed` with non-team-server payload still routes to original dispatch unchanged
+
+**Audit findings closed**: round-1 `infrastructure-mismatch` (missing pull→dispatch wiring) + round-2 `specification-drift` (sketch contradicted prose; would echo events). Both addressed inline; round-3 PASS held.
+
+**Decision**: Reality matches Promise across all 3 phases. v0 release pipeline is end-to-end functional: Slack OAuth → workspace row → YAML allowlist sync → channel_allowlist populated → Slack worker polls allowlisted channels → extracts decisions via heuristic+LLM pipeline → emits team_event → /events HTTP serves → per-dev consumer pulls → bridges to IngestPayload → inner_adapter.ingest_payload → per-dev local ledger gets the decision row.
+
+**Previous chain hash**: Entry #39 (round-3 PASS audit)
+
+---
+*Chain integrity: VALID (40 entries on this branch)*
+*Genesis: `29dfd085` → ... → v0-release-blockers IMPLEMENT: pending seal*
+
+---
+
+### Entry #41: SUBSTANTIATION (SESSION SEAL — v0 release-blockers)
+
+- **Date**: 2026-05-03
+- **Session**: `2026-05-02T2230-c4d1f8`
+- **Phase**: SUBSTANTIATE
+- **Skill**: `/qor-substantiate`
+- **Plan**: `plan-priority-c-team-server-v0-release-blockers.md`
+- **Audit**: round 3 PASS, L2 risk grade
+- **Implement**: Entry #40
+- **Closes issues**: #160, #161
+
+**Reality vs Promise verification**:
+
+| Audit pass | Outcome |
+|---|---|
+| PASS verdict prerequisite | ✅ Round 3 PASS at Entry #39 |
+| Reality audit | ✅ All 11 source/test/plan files staged; no orphans |
+| Test audit | ✅ 123/123 team-server + materializer tests passing |
+| Presence-only seal gate | ✅ Every new test invokes the unit and asserts on observable output (incl. real-TeamWriteAdapter no-echo test) |
+| Section 4 Razor final check | ✅ Max file 167 LOC; max function ~25; nesting ≤3; zero nested ternaries |
+| SYSTEM_STATE.md sync | ✅ "Priority C v0 release-blockers — channel allowlist + materializer bridge (2026-05-03)" appended |
+
+**Files sealed**: 11 source/test/plan files. Tests: 20 net-new functionality tests across 3 phases.
+
+**Session content hash** (11 files, sorted-path concatenation):
+SHA256 = `14e387b1168289728799f2d808f8bc4af26c9b56bcf563d135e0f8354595580a`
+
+**Previous chain hash**: `b3700366...` (Entry #36, Priority C v1.1 SEAL)
+
+**Merkle seal**:
+SHA256(content_hash + previous_hash) = **`7cc405fc8d39f468d502da669982c88321ce3a84bb571d28e0b14be86ab56bdd`**
+
+**Decision**: Reality matches Promise. Both v0 release blockers closed. The end-to-end Slack ingest pipeline is now functional from OAuth to per-dev local ledger. The audit cycle (3 rounds) caught two real production bugs that would have shipped silently:
+- Round 1 caught dead-code state where `pull_team_server_events` had no production caller — would have left team-server events stranded in the team-server's SurrealDB with no per-dev consumption
+- Round 2 caught the echo-amplification bug where the consumer would have triggered `TeamWriteAdapter._writer.write` on every team-server event, causing O(N²) cross-dev replay storms once team JSONL files git-pushed
+
+The SHADOW_GENOME #7 heuristic catalog grew from 4 to 6 across this session. The two new heuristics (upstream-consumer at Entry #37; wrapper-side-effect at Entry #38) are durable detection patterns reusable in future audits.
+
+CocoIndex (#136) remains parked. Both v0-release-blocker issues (#160, #161) closed.
+
+Session is sealed. v0 release deadline (2 days) preserved with comfortable margin: total session cost ~90 minutes (3 audit rounds + amendments + implementation + substantiation).
+
+**qor-logic-internal steps skipped** (downstream-project rationale, same as Entries #28, #33, #36):
+
+| Step | Outcome | Rationale |
+|---|---|---|
+| Step 2.5 | n/a | No target version in plan |
+| Step 4.6 | not run | qor-logic harness reliability gates not present |
+| Step 4.6.5 | not run | No staged secrets |
+| Step 4.6.6 | not run | qor-logic-internal procedural fidelity check |
+| Step 4.7 | not run | qor-logic phase-plan path convention |
+| Step 6.5 | not run | No system-tier docs (architecture.md/lifecycle.md) maintained here |
+| Step 7.4 | not run | qor-logic-internal SSDF tag emission |
+| Step 7.5/7.6 | not run | No `## [Unreleased]` block convention here |
+| Step 7.7 | not run | qor-logic-internal seal-entry-check |
+| Step 7.8 | n/a | Phase ≤ 51 grandfathered; this session's gate dir at `.qor/gates/2026-05-02T2230-c4d1f8/` carries plan.json (round 3), audit.json (round 3), implement.json, substantiate.json |
+| Step 8 | (deferred) | `.agent/staging/AUDIT_REPORT.md` preserved as primary artifact |
+| Step 8.5 | n/a | qor-logic-internal dist-compile |
+| Step 9.5.5 | n/a | No version bump → no tag |
+
+---
+*Chain integrity: VALID (41 entries on this branch)*
+*Genesis: `29dfd085` → ... → Priority C v1.1 SEAL: `b3700366` → v0-release-blockers SEAL: `7cc405fc`*
 *Next required action: operator review and choose push/merge path (Step 9.6 menu).*

--- a/docs/SHADOW_GENOME.md
+++ b/docs/SHADOW_GENOME.md
@@ -281,3 +281,119 @@ SG-PLAN-GROUNDING-DRIFT
 ```
 
 ---
+
+## Failure Entry #6
+
+**Date**: 2026-05-02T22:00:00Z
+**Verdict ID**: research-brief-priority-c-selective-ingest-2026-05-02.md (deleted) — operator-rejected during dialogue
+**Failure Mode**: INVARIANT_FROM_IMPLEMENTATION (Hallucination-class; SG-1 family)
+
+### What Failed
+
+`/qor-research` for v0 Priority C (selective source ingest) read the current
+`bicameral.ingest` code surface (`handlers/ingest.py:217`), observed that
+the server accepts pre-extracted text and has no source-fetcher / OAuth /
+API-client code, and elevated this **v0 implementation state** to a
+**product principle**:
+
+> "Architecture invariant: bicameral-mcp does not fetch source content;
+> the agent fetches via host's tools. Any future 'source connector'
+> proposal should be VETO'd at audit unless it explicitly bypasses this
+> invariant for a documented reason."
+
+The brief recommended an entire framing reversal of the user's stated
+priority — from "build selective ingest for sources" to "build a
+curation/quality-gate UX over what the agent already fetches" — based on
+this invented invariant. The brief was about to be filed as advisory
+input to the follow-on `/qor-plan` and the invariant about to be saved
+as a project memory entry.
+
+### Why It Failed
+
+The Sales Enablement & Positioning Playbook (operator-supplied during
+post-research dialogue) explicitly positions Bicameral as the
+**destination** of a `Decision Sources → Bicameral.LEDGER` arrow in
+its ecosystem-fit diagram. Decision continuity at multi-developer,
+multi-agent scale is **Value Pillar #1**. The agent-fetches-only model
+fragments the ledger across sessions: Dev A's Cursor session, Dev B's
+Claude Code session, and Dev C's Claude Desktop session each produce
+independent reads of the same Slack thread, with independent extractions.
+Two devs preflighting the same code path against the same conversational
+source can get different drift verdicts.
+
+The product principle is **decision continuity at scale**. The v0 code's
+agent-fetches-only pattern is a solo-developer simplification, not a
+load-bearing invariant. Treating the simplification as a principle
+would have shipped a plan whose executive summary directly contradicts
+the product positioning the team is selling against.
+
+### Pattern to Avoid
+
+**Distinguish "what the code does today" from "what the product principle
+is."** A v0 simplification is evidence of a design choice at a moment in
+time — not evidence of the load-bearing rule. Authoritative product
+principles live in:
+
+- `docs/CONCEPT.md` (project DNA)
+- `docs/ARCHITECTURE_PLAN.md` (interface contracts + risk grade)
+- Sales Enablement & Positioning Playbook (operator-curated, off-repo)
+- Founder/maintainer dialogue when the artifacts are silent or
+  contradictory
+
+Code-state observations may *suggest* an invariant, but the invariant must
+be checked against authoritative sources before being ascribed product
+weight. When code and product positioning diverge, the code is the
+v0-state, not the contract.
+
+### Detection Heuristic
+
+Before writing the phrase "architecture invariant" or "product principle"
+or "by design" in a research brief, ask:
+
+1. Is this claim grounded in a non-code authoritative source? (CONCEPT.md,
+   ARCHITECTURE_PLAN.md, positioning doc, founder dialogue.)
+2. If only grounded in code, am I sure the code reflects the product
+   principle and not just a v0 simplification?
+3. Could this claim, if elevated to a project memory, contradict the
+   product's market positioning if the team scales?
+
+A "no" or "unsure" on any of these means the claim is unproven. **Anything
+unproven is only theater.** Quote it as observation, not as principle.
+
+### Remediation
+
+- Research brief deleted (no archival; the failure mode is more useful
+  preserved here than the false brief is in the docs tree).
+- Project memory entry "bicameral does not fetch source content" was
+  about to be saved; intercepted before write.
+- Operator-supplied playbook treated as primary substrate for the
+  re-research that follows.
+- Doctrine "anything unproven is only theater" saved as project memory
+  feedback for future research/audit phases.
+
+
+### Addendum to Entry #6 (2026-05-02T22:30:00Z)
+
+The pattern catalogued above is **symmetric**: it applies as much to project doctrine documents as to source code. After the v1 brief failure, dialogue with the operator revealed CONCEPT.md anti-goals were also being read too generously — specifically *"No remote DB, no managed backend"* was treated as "no server-side components at organizational scale," which conflicts with multi-org sync requirements implied by the playbook.
+
+The operator parsed the anti-goal literally: the load-bearing keyword is **"managed"**, not "backend." A managed backend is one that requires human ops (DBA tasks, on-call, capacity planning, manual migration) — i.e., a SaaS the customer pays an ops tax for. A **self-managing** backend (self-hosted, schema-migrating itself, deterministic, no on-call surface) is fully compatible. Sentry self-hosted, Supabase self-host, embedded-SurrealDB-already-in-repo are the precedents.
+
+### Pattern to Avoid (extension)
+
+When parsing project doctrine documents (CONCEPT.md anti-goals, ARCHITECTURE_PLAN.md interface contracts, positioning playbooks), identify the **load-bearing keyword** in each clause and read the rest as gloss on that keyword. Do NOT generalize the clause beyond what the keyword warrants:
+
+- *"No managed backend"* — load-bearing word: **managed**. Allows server-side that's self-managing.
+- *"No cloud, no network calls in the deterministic core"* — load-bearing words: **deterministic core**. Allows network calls outside the deterministic core (e.g., source ingest workers, telemetry).
+- *"Not an LLM-powered ledger"* — load-bearing words: **ledger**. Allows LLMs as callers, classifiers, and orchestrators around the ledger.
+
+When the operator's product positioning implies a feature that seems to violate an anti-goal, do not assume the anti-goal blocks the feature — first parse the keyword and see whether the feature actually trips it.
+
+### Detection Heuristic (extension)
+
+Before declaring "this anti-goal forbids X," ask:
+1. What is the load-bearing keyword in the anti-goal clause?
+2. Does X trip that specific keyword, or just the broader gloss around it?
+3. Is there an industry precedent (self-hosted Sentry, Supabase OSS, etc.) where a system honors this anti-goal-keyword while still implementing X?
+
+If 2 says "just the gloss" or 3 surfaces a precedent, X is not blocked — it's compatible with the anti-goal under literal-keyword parsing.
+

--- a/docs/SHADOW_GENOME.md
+++ b/docs/SHADOW_GENOME.md
@@ -474,3 +474,47 @@ For every code sketch with an external function call:
 
 Adding these to the round-3 amendment closes the documented residual.
 
+### Addendum to Entry #7 (2026-05-02T22:55:00Z) — second-instance heuristic refinement
+
+Entry #34 (v1.1 first-round PASS) gave evidence that the Entry #7 heuristic was durable. Entry #37 (v0-release-blockers VETO) gave evidence that the heuristic needs one more refinement.
+
+**Pattern observed in Entry #37**: The Governor planned to MUTATE `events/materializer.py` to add a dispatch case for team-server events. The plan correctly cited the materializer's existing dispatch loop, the `event_type='ingest'` event_type team-server emits, and the `IngestPayload` shape. All cited symbols verified clean. **But the Governor did not verify whether the materializer's input stream actually receives team-server events.** That verification — checking the *upstream* of the unit being mutated — exposed that `pull_team_server_events` has zero production callers; events are produced and pulled but never enter the JSONL stream the materializer reads.
+
+The Entry #7 detection heuristics covered:
+1. Existence check (does the cited symbol exist?)
+2. Signature check (does the call shape match?)
+3. Type-boundary check (do conversions across persistence cross correctly?)
+4. Helper-symmetry check (do encode/decode pairs mirror?)
+
+Entry #37 surfaces a fifth heuristic:
+
+5. **Upstream-consumer check**: When planning to MUTATE a unit whose intended downstream effect depends on an upstream producer, grep for production callers of the upstream producer. If zero, the mutation is dead code regardless of correctness. The Governor must surface this — either by adding a phase that wires the producer, or by acknowledging the dead-code state in plan boundaries.
+
+### Detection Heuristic (further extension)
+
+Before declaring "this MUTATE closes gap X":
+
+1. Apply heuristics 1-4 from Entry #7 addendum (existence, signature, type-boundary, helper-symmetry).
+2. **(NEW)** Identify the upstream producer that feeds the unit-under-mutation. Grep for production callers of THAT producer. If zero, the mutation does nothing in production — the plan must either wire the producer or declare the dead-code state explicitly.
+
+This refinement fits naturally into the Step 2 state-verification of `/qor-audit`. The heuristic-extension prompt: for every plan that says "this fixes the case where X feeds Y but Y rejects it," verify that X actually feeds Y in production.
+
+### Addendum to Entry #7 (2026-05-02T23:25:00Z) — sixth heuristic surfaced by Entry #38
+
+Entry #38 (v0-release-blockers round 2 VETO) introduced a sibling defect while closing the round-1 finding. Pattern: Governor's amendment correctly cited `get_ledger()` accessor and the `TeamWriteAdapter._inner` attribute, but the §Changes sketch passed the wrapper to the consumer without unwrapping. The wrapper's `ingest_payload` method has side effects (writes to JSONL via `_writer.write`); the sketch ignored those side effects.
+
+This adds a sixth heuristic to the catalog (heuristics 1-5 from prior addenda):
+
+6. **Wrapper-side-effect check**: When a plan invokes a method through a registry/factory accessor (`get_X()`, `_singleton_X`, etc.), grep the returned type's method body for side effects. If side effects are present, the plan must either (a) use the appropriate inner/raw accessor that bypasses them, or (b) acknowledge and handle them in the calling code. Mere correct citation of the accessor is insufficient when the returned object has implicit side-effect semantics.
+
+The full Entry #7 detection heuristic catalog now reads:
+
+1. **Existence check** (does the cited symbol exist?)
+2. **Signature check** (does the call shape match arity / kwargs / types?)
+3. **Type-boundary check** (do conversions across persistence boundaries cross correctly — bytes vs str, etc.?)
+4. **Helper-symmetry check** (do encode/decode pairs mirror at read-side and write-side?)
+5. **Upstream-consumer check** (when MUTATEing a unit whose downstream effect depends on an upstream producer, grep callers of the producer; zero callers = dead code)
+6. **Wrapper-side-effect check** (when invoking through a registry/factory, grep the returned type for side effects; bypass via inner accessor if present)
+
+The cumulative heuristic catalog represents the failure modes observed across 4 sessions (v1.0 round-1 through v0-blockers round-2) of this codebase's audit cycles. Each VETO that surfaced a new heuristic produced a durable gain — heuristics 1-4 prevented the v1.1 first-round PASS, heuristic 5 catalyzed Entry #37, heuristic 6 catalyzed Entry #38. Audit Step 2 should consult this catalog as a checklist when verifying plan-cited symbols against current code.
+

--- a/docs/SHADOW_GENOME.md
+++ b/docs/SHADOW_GENOME.md
@@ -397,3 +397,80 @@ Before declaring "this anti-goal forbids X," ask:
 
 If 2 says "just the gloss" or 3 surfaces a precedent, X is not blocked — it's compatible with the anti-goal under literal-keyword parsing.
 
+---
+
+## Failure Entry #7
+
+**Date**: 2026-05-02T06:55:00Z
+**Session**: `2026-05-02T0625-8ea4cc`
+**Skill that produced the artifact**: `/qor-plan` (`plan-priority-c-team-server-notion-v1.md`)
+**Skill that detected**: `/qor-audit`
+**Verdict**: VETO (`infrastructure-mismatch`)
+
+### Pattern Observed: PARALLEL_STRUCTURE_ASSUMED
+
+The plan extended a v0 codebase by repeatedly assuming the v0 had implemented patterns *symmetric* with the v1 ambition. In four places:
+
+1. The plan referenced a `schema-version row` that was never added to v0's schema (`SCHEMA_VERSION` is an in-code constant only).
+2. The plan changed `_MIGRATIONS`'s type signature from tuple-of-stmts to dict-of-callables without acknowledging the corresponding `ensure_schema` dispatch loop change — assuming the dispatch was already callable-shaped.
+3. The plan said "extend the existing `lifespan` to spawn a Notion-worker task" — assuming a Slack-worker task was already registered. It was not. The Slack worker shipped in v0 Phase 3 has no production caller and is invoked only by tests.
+4. The plan referenced `_resolve_extractor()` and `DEFAULT_CONFIG_PATH` in a code sketch — assuming Slack precedents existed. They did not.
+
+The common signature: "the plan generalizes from a Slack-shaped pattern that the plan author *imagined* the v0 had built, rather than the pattern the v0 actually built." This is a class of plan-text drift specifically tied to writing v1 plans against v0 codebases without grep-verifying every named symbol.
+
+### Root Cause
+
+The Governor was treating the v0 plan document (`plan-priority-c-team-server-slack-v0.md`) as the ground truth for v0 state, rather than the v0 *code*. The v0 plan promised a worker-task lifecycle pattern in §Phase 3; the v0 code shipped the worker function but never wired it. The Governor read the plan, not the code. The audit caught it because Step 2 verified state against the code itself.
+
+### Pattern to Avoid
+
+When writing a v1 plan that extends a landed v0:
+
+1. Do NOT cite a v0 symbol in a v1 plan without `grep`-verifying it exists in the current code tree. The audit's Infrastructure Alignment Pass enforces this; the plan should pre-empt it.
+2. Do NOT use phrasing like "extend the existing X" without identifying the exact file/line where X is registered. If you cannot point to a registration site, X may not exist — and "extend" becomes "establish."
+3. Do NOT change a type signature of landed code without an explicit Affected-Files entry naming every dispatch / consumption site that must change.
+4. Do NOT write code sketches with helper-function references (`_helper()`, `CONST`) unless the helper / constant is either declared in Affected Files or already exists at a cited path.
+
+### Detection Heuristic
+
+For every Affected-Files line in a v1 plan that says MUTATE:
+1. Read the file. Confirm the cited symbol exists.
+2. Confirm the cited type signature matches reality.
+3. If the mutation is type-changing, list every consumption site of the changed type and add it as a sub-bullet to the Affected-Files entry.
+
+For every code sketch in §Changes:
+1. Every imported symbol must trace to either an Affected-Files entry OR a current-tree path.
+2. Every `_helper()` call must be either local (defined within the same sketch) or declared.
+3. Every constant reference (`UPPERCASE_CONST`) must be either local or declared in Affected Files.
+
+### Project Memory Implication
+
+This pattern is the natural consequence of treating a previous-phase plan document as evidence about current state. Plans drift from code as soon as the implement phase ends. **Only the code is ground truth for the next plan's state-of-the-world claims.** Every plan referencing prior-phase symbols should grep-verify those symbols against current HEAD before submission.
+
+The remediation pattern is uniform: the plan amendment must replace each unsupported claim with either (a) a citation to current code, or (b) an explicit Affected-Files entry establishing the missing infrastructure.
+
+### Addendum to Entry #7 (2026-05-02T07:25:00Z)
+
+The amended plan that followed Entry #7 (audit round 2 of `plan-priority-c-team-server-notion-v1.md`) closed all four original findings successfully but introduced a sibling failure under the same root cause: `slack_runner.run_slack_iteration` called `decrypt_token(ws["oauth_token_encrypted"])` with one argument, where the actual signature is `decrypt_token(ciphertext: bytes, key: bytes) -> str`.
+
+The pattern surfaced in Entry #7 was *missing/undeclared symbols*. The amendment correctly closed that pattern by either declaring or grounding every symbol — but the round-2 sketch invoked an *existing, declared* symbol with the wrong call shape. The verification heuristic in Entry #7 ("for every cited symbol... confirm the cited type signature matches reality") was correct in principle but underspecified in practice: it covered `MUTATE` Affected-Files entries but not the in-line code sketches in §Changes blocks.
+
+### Pattern to Avoid (extension)
+
+Extending Entry #7's heuristic — for every code sketch in §Changes:
+
+1. **Existence check**: every `from X import Y` traces to a real module + symbol. (Original Entry #7 contract.)
+2. **Signature check**: every call to `Y(...)` matches `Y`'s actual signature: arity, positional-vs-keyword discipline, and argument types. The audit's Infrastructure Alignment Pass should `inspect.signature(Y)` against the call shape. (New extension.)
+3. **Type-boundary check**: when a value crosses a persistence boundary (DB column type ↔ in-memory Python type), the conversion must be explicit in the sketch. Specifically: any `str` field stored from a `bytes` source must be encoded back at the read site (e.g. `ws["x"].encode("utf-8")`); any `bytes` field stored from a `str` source must be decoded at the read site. (New extension.)
+4. **Helper-symmetry check**: if a write-side path (e.g. `team_server/auth/router.py`'s OAuth callback) uses `helper_a` + `helper_b` to perform the encode + persist combination, the read-side path must use the symmetric `helper_b_inverse` + `helper_a_inverse` chain — not a single helper missing one argument. The existing precedent in the repo IS the contract.
+
+### Detection Heuristic (extension)
+
+For every code sketch with an external function call:
+
+1. Read the function's actual definition. Confirm arity matches.
+2. Confirm argument types match. If a literal or named variable in the sketch is the wrong type for the function, name the conversion explicitly in the sketch.
+3. Find the symmetric existing precedent in the repo (e.g. the encrypt-side for a decrypt call). If the precedent exists, model the sketch after it.
+
+Adding these to the round-3 amendment closes the documented residual.
+

--- a/docs/SYSTEM_STATE.md
+++ b/docs/SYSTEM_STATE.md
@@ -570,3 +570,73 @@ tests/test_team_server_canonical_cache.py  — rewritten under v2 upsert contrac
 ### qor-logic-internal steps skipped (downstream-project rationale, same as v0 entry)
 
 Same set as v0 (Steps 2.5, 4.7, 6.5, 7.4–7.8, 8.5, 9.5.5) — this repo does not author qor-logic phase plans nor maintain the system-tier doc set / dist-compile pipeline that those wirings expect. The fundamental S.H.I.E.L.D. checks (PASS verdict prerequisite, Reality vs Promise, Section 4 Razor, Merkle seal calculation, ledger entry) all run.
+
+---
+
+## Priority C v1.1 — Real heuristic+LLM extractor (2026-05-02)
+
+Plan: [`plan-priority-c-team-server-real-extractor-v1.md`](../plan-priority-c-team-server-real-extractor-v1.md). First-round PASS audit; 102/102 team-server tests passing.
+
+### Files added (10)
+
+```
+team_server/extraction/heuristic_classifier.py — deterministic Stage 1 classifier (105 LOC)
+team_server/extraction/pipeline.py             — Stage 1 → Stage 2 wiring (59 LOC)
+team_server/extraction/corpus_learner.py       — option-c feedback loop (114 LOC)
+
+tests/test_team_server_classifier_version.py        — 5 tests
+tests/test_team_server_heuristic_classifier.py      — 9 tests
+tests/test_team_server_rules.py                     — 5 tests
+tests/test_team_server_llm_extractor.py             — 7 tests
+tests/test_team_server_pipeline.py                  — 5 tests
+tests/test_team_server_corpus_learner.py            — 5 tests
+tests/test_team_server_corpus_learner_lifecycle.py  — 2 tests
+```
+
+### Files modified (9)
+
+```
+team_server/schema.py                       — SCHEMA_VERSION 2→4; classifier_version field; learned_heuristic_terms table
+team_server/extraction/canonical_cache.py   — upsert second-axis (content_hash + classifier_version) cache identity
+team_server/extraction/llm_extractor.py     — full rewrite: Anthropic SDK call, _one_attempt helper, fail-loud + fail-soft + retry-on-429
+team_server/config.py                       — HeuristicGlobalRules / SlackHeuristics / NotionHeuristics; resolve_rules_for_{slack,notion}; CorpusLearnerConfig
+team_server/workers/slack_worker.py         — pipeline-routed with thread/reaction context; legacy fallback when config=None
+team_server/workers/notion_worker.py        — pipeline-routed with last_edited_by/edit_count context; legacy fallback when config=None
+team_server/app.py                          — config loaded from DEFAULT_CONFIG_PATH; corpus learner registered when enabled
+
+tests/test_team_server_cache_upsert.py     — adapted to classifier_version= keyword-only argument
+tests/test_team_server_canonical_cache.py  — adapted to classifier_version= keyword-only argument
+```
+
+### Test state
+
+- 102/102 team-server tests passing (full suite, up from 64 at v1.0)
+- 38 net-new functionality tests across Phases 0–5
+- Razor: max file 180 LOC (notion_worker); max function ~30 (extract via _one_attempt helper); depth ≤3; zero nested ternaries
+
+### Schema state (team-server v4)
+
+`SCHEMA_VERSION = 4`. New tables (additions in **bold**):
+- `extraction_cache` — gains `classifier_version` field (default `'legacy-pre-v3'`); cache hit requires both content_hash AND classifier_version match
+- **`learned_heuristic_terms`** — corpus learner output; UNIQUE (source_type, term)
+- All v1.0 tables retained: `workspace`, `channel_allowlist`, `team_event`, `source_watermark`, `schema_version`
+
+### Architectural properties achieved (v1.1)
+
+- **Heuristic-first determinism**: Stage 1 classifier is pure-function over (message, context, rules); zero API calls on chatter
+- **LLM-only-when-needed**: Stage 2 (Anthropic Haiku 4.5 default) runs only on heuristic-positive messages; cache locks results so each unique input costs once
+- **Rule-version-driven cache invalidation**: classifier_version is a SHA256 of the rule set; operator config edits → automatic cache invalidation on next poll
+- **All four "dynamic" angles wired**: per-workspace YAML (a) / per-channel/db override (b) / corpus-learned terms (c) / context-aware boosters (d)
+- **Anti-goal alignment**: heuristic Stage 1 grows the deterministic core; LLM call is scoped narrowly outside the deterministic core (network calls permitted there per CONCEPT.md literal-keyword parsing)
+- **Auditability**: every positive classification stores `matched_triggers` array (which keyword/reaction/thread-position fired)
+
+### Audit advisories addressed during implementation
+
+1. `extract()` split into `_one_attempt(client, model, prompt) -> (status, payload)` helper; main `extract` body is ~14 lines (well under Razor)
+2. `TeamServerRules` resolved as `TeamServerConfig` (single rename in implementation, not a new type)
+3. Corpus learner reads from `team_event` rows (per OQ-1) whose `payload.extraction.decisions` is non-empty; does NOT query a `decision` table that doesn't exist on the team-server's ledger
+
+### Implementation deviations from plan (logged)
+
+1. `team_server/workers/{slack_worker,notion_worker}.py` keep a backwards-compat path: when `config=None`, fall back to the legacy `extractor(text)` callable. Preserves v1.0 worker tests + provides a clean cutover path. When `config` is provided, the pipeline runs.
+2. Anthropic SDK imported lazily inside `extract()` (matches the slack_sdk lazy-import pattern from v1.0 Phase 0.5) so the package imports cleanly when `anthropic` is in `requirements.txt` but not installed in dev venv.

--- a/docs/SYSTEM_STATE.md
+++ b/docs/SYSTEM_STATE.md
@@ -411,3 +411,85 @@ Zero structural. Implementation matches Entry #24 audit blueprint 1:1.
   collision detection lives caller-side via `bicameral-context-sentry`
   skill and surfaces via `bicameral.preflight.unresolved_collisions`.
   Spec-text correction is a `/qor-document`-phase external `gh` action.
+
+---
+
+# System State — Priority C v0 team-server (2026-05-02, sealed `6f4f8f8f`)
+
+**Generated**: 2026-05-02
+**HEAD**: branch `claude/priority-c-selective-ingest` off `upstream/dev`
+**Tracked PR**: not yet opened (operator decision at Step 9.6)
+**Predecessor seal**: `efd0304b` (Entry #26, #135-triage)
+**Implementation seal**: `211ffb9e` (Entry #27)
+**Substantiation seal**: `6f4f8f8f` (Entry #28 — this seal)
+
+## Priority C v0 — self-managing team-server, Slack-first
+
+Implements `plan-priority-c-team-server-slack-v0.md` Phases 1–4. Phase 5 (CocoIndex #136) deferred to follow-up plan per slip-independence design and operator's "if we can manage it" feasibility caveat.
+
+### Files added (30)
+
+**Production — `team_server/` package**:
+- `__init__.py`, `app.py` (47 LOC), `db.py` (41), `schema.py` (80), `config.py` (40), `requirements.txt`
+- `auth/`: `__init__.py`, `encryption.py`, `slack_oauth.py` (58), `router.py` (73)
+- `extraction/`: `__init__.py`, `canonical_cache.py` (45), `llm_extractor.py`
+- `sync/`: `__init__.py`, `peer_writer.py` (42)
+- `workers/`: `__init__.py`, `slack_worker.py` (100)
+- `api/`: `__init__.py`, `events.py`
+
+**Production — `events/` extension**:
+- `events/team_server_pull.py` (57 LOC) — failure-isolated `EventMaterializer` extension
+
+**Deployment**:
+- `deploy/team-server.docker-compose.yml`
+- `deploy/Dockerfile.team-server`
+
+**Tests** (8 files / 25 functionality tests):
+- `tests/test_team_server_app.py` (5), `tests/test_team_server_deploy.py` (1)
+- `tests/test_team_server_slack_oauth.py` (5), `tests/test_team_server_channel_allowlist.py` (2)
+- `tests/test_team_server_canonical_cache.py` (3), `tests/test_team_server_slack_worker.py` (3)
+- `tests/test_team_server_events_api.py` (3), `tests/test_materializer_team_server_pull.py` (3)
+
+### Test state
+
+- Priority C v0: **25 / 25 PASS** in 5.99s
+- Existing dev suite (743 tests): collects unaffected
+- Razor: largest production file 100 LOC; all functions ≤ 25 LOC; depth ≤ 2; no nested ternaries
+
+### Schema additions (team-server's own DB; separate from per-repo bicameral ledger)
+
+`SCHEMA_VERSION = 1` in `team_server/schema.py` (independent of `ledger/schema.py`'s SCHEMA_VERSION). Tables:
+- `workspace` — one row per Slack workspace (id, name, slack_team_id, oauth_token_encrypted, created_at)
+- `channel_allowlist` — workspace × channel allow-list
+- `extraction_cache` — `FLEXIBLE TYPE object` for `canonical_extraction` (per #72 lesson + audit Advisory #3); keyed UNIQUE on `(source_type, source_ref, content_hash)`
+- `team_event` — append-only event log; `FLEXIBLE TYPE object` for `payload`; sequence ordered
+
+### Architectural properties achieved
+
+- **Self-managing**: schema migrates on startup via `ensure_schema()` (idempotent); restart is no-op; no human ops surface
+- **Failure-isolated**: `events/team_server_pull.py` swallows transport errors; per-dev preflight does not cascade on team-server outage
+- **Multi-dev convergence**: same Slack message → same canonical extraction across devs via `(source_type, source_ref, content_hash)` cache key
+- **Local-first per CONCEPT.md literal-keyword parsing**: server-side component is self-managing (compatible) not vendor-managed (forbidden)
+- **Section 4 razor**: all functions ≤ 25 lines, all files ≤ 100 lines
+
+### Audit advisory disposition
+
+- Advisory #1 (term home cross-reference) — fixed in plan before implementation
+- Advisory #2 (`app.py` size monitoring) — proactively factored OAuth + events routes into per-package routers; `app.py` ends at 47 lines
+- Advisory #3 (FLEXIBLE TYPE object) — applied to `extraction_cache.canonical_extraction` and `team_event.payload` at schema definition time
+
+### Phase 5 deferred state
+
+CocoIndex (#136) integration deferred. `extraction_cache.model_version` carries `interim-claude-v1` tombstone so Phase 5 can identify+rebuild interim entries when it lands.
+
+### qor-logic-internal steps skipped (downstream-project rationale)
+
+- Step 2.5 — Version bump: no `pyproject.toml` Target Version in plan; downstream project uses different release cadence
+- Step 4.7 — Doc integrity (Phase 28 wiring): targets qor-logic's `docs/Planning/plan-qor-phase{NN}*.md` convention not present in this repo
+- Step 6.5 — Doc currency / badge currency: targets qor-logic's `docs/architecture.md`/`docs/lifecycle.md` system docs not present
+- Step 7.4 — SSDF tag emission: targets qor-logic's own SESSION SEAL convention
+- Step 7.5/7.6 — Version bump + CHANGELOG stamp: no `## [Unreleased]` block convention in this repo's CHANGELOG
+- Step 7.7 — Post-seal verification: targets qor-logic's plan-path globbing
+- Step 7.8 — Gate-chain completeness (Phase 52+): grandfathered for entries < 52
+- Step 8.5 — Dist recompile: qor-logic-internal variant compile
+- Step 9.5.5 — Annotated seal-tag: no version bump → no tag

--- a/docs/SYSTEM_STATE.md
+++ b/docs/SYSTEM_STATE.md
@@ -493,3 +493,80 @@ CocoIndex (#136) integration deferred. `extraction_cache.model_version` carries 
 - Step 7.8 — Gate-chain completeness (Phase 52+): grandfathered for entries < 52
 - Step 8.5 — Dist recompile: qor-logic-internal variant compile
 - Step 9.5.5 — Annotated seal-tag: no version bump → no tag
+
+---
+
+## Priority C v1 — Notion ingest + cache contract migration (2026-05-02)
+
+Plan: [`plan-priority-c-team-server-notion-v1.md`](../plan-priority-c-team-server-notion-v1.md). Three-round audit cycle (VETO → VETO → PASS); 64/64 team-server tests passing.
+
+### Files added (13)
+
+```
+team_server/workers/runner.py             — worker_loop lifecycle helper (29 LOC)
+team_server/workers/slack_runner.py       — workspace iteration + per-WS fan-out (67 LOC)
+team_server/workers/notion_worker.py      — Notion polling + watermark (123 LOC)
+team_server/workers/notion_runner.py      — Notion task wrapper (23 LOC)
+team_server/auth/notion_client.py         — internal-integration auth + API (110 LOC)
+team_server/extraction/notion_serializer.py — deterministic row serialization (64 LOC)
+
+tests/test_team_server_cache_upsert.py        — 4 tests
+tests/test_team_server_schema_migration.py    — 4 tests
+tests/test_team_server_worker_lifecycle.py    — 7 tests
+tests/test_team_server_notion_client.py       — 7 tests
+tests/test_team_server_notion_serializer.py   — 3 tests
+tests/test_team_server_notion_worker.py       — 9 tests
+tests/test_team_server_notion_lifecycle.py    — 4 tests
+```
+
+### Files modified (7)
+
+```
+team_server/schema.py                      — schema v1→v2 + schema_version table + callable migration dispatch
+team_server/extraction/canonical_cache.py  — get_or_compute() → upsert_canonical_extraction() -> tuple[dict, bool]
+team_server/workers/slack_worker.py        — adapted to new tuple-return contract; _cache_row_exists deleted
+team_server/app.py                         — lifespan registers worker tasks via worker_loop helper
+team_server/config.py                      — DEFAULT_CONFIG_PATH constant with env-var fallback
+
+tests/test_team_server_slack_worker.py     — adapted; new no-event-on-unchanged + event-on-changed pair
+tests/test_team_server_canonical_cache.py  — rewritten under v2 upsert contract
+```
+
+### Test state
+
+- 64/64 team-server tests passing (full suite)
+- 695/703 non-team-server regression: 8 pre-existing failures in unrelated tests (`test_alpha_flow`, `test_bind`, `test_ephemeral_authoritative`, `test_v0417_jargon_hygiene`); none touch files modified in this implementation
+- Razor: largest production file 139 LOC (schema.py); all functions ≤ 25 LOC; depth ≤ 3; no nested ternaries
+
+### Schema state (team-server v2)
+
+`SCHEMA_VERSION = 2` in `team_server/schema.py`. Tables (additions in **bold**):
+- `workspace` — one row per Slack workspace
+- `channel_allowlist` — workspace × channel allow-list
+- `extraction_cache` — UNIQUE keyed on `(source_type, source_ref)` ONLY (was `(source_type, source_ref, content_hash)` in v1); `content_hash` becomes a tracked column; UPSERT semantics
+- `team_event` — append-only event log; payload now includes `notion_database_row` source_type
+- **`source_watermark`** — generic per-source / per-resource watermark; used by Notion polling
+- **`schema_version`** — single-row table holding the current `SCHEMA_VERSION` after migrations apply (DELETE-then-CREATE preserves single-row invariant)
+
+### Architectural properties achieved (v1 additions)
+
+- **Cache contract uniformity**: both Slack and Notion use the same `upsert_canonical_extraction` contract; cache holds latest snapshot (bounded growth), `team_event` log preserves history
+- **Worker-task lifecycle pattern**: `worker_loop` is the single source of truth for the asyncio.create_task / cancel-on-shutdown pattern; Slack and Notion both delegate
+- **Slack worker no longer dormant**: v0 plan claimed an active Slack ingest worker but v0 code shipped a function with no production caller. Phase 0.5 closes this gap by wiring `slack_runner.run_slack_iteration` into `lifespan` via `worker_loop`. The encryption round-trip is verified end-to-end by `test_slack_runner_decrypts_workspace_token_with_loaded_key`.
+- **Notion ingest of database rows**: deterministic serialization (title + sorted properties + body), per-database watermark, peer-author identity (`team-server@notion.bicameral`), per-database failure isolation
+- **Internal-integration auth**: no OAuth router for Notion; allow-list derived from `databases.list` (operator's act of sharing a database with the integration is the signal)
+
+### Audit cycle outcomes
+
+- Round 1 VETO (4 findings, missing/undeclared symbols) — closed in amendment round 2
+- Round 2 VETO (1 finding, wrong-call-shape for `decrypt_token`) — closed in amendment round 3 with explicit encrypt-side precedent mirror + round-trip test
+- Round 3 PASS (2 non-blocking advisories) — both addressed during implementation
+
+### Implementation deviations from plan (logged)
+
+1. `PEER_AUTHOR_EMAIL` renamed `PEER_WORKSPACE_ID = "notion"` — `write_team_event` wraps as `team-server@<workspace_id>.bicameral`, so passing the literal email would have double-wrapped to `team-server@team-server@notion.bicameral.bicameral`.
+2. `slack_sdk` import made lazy in `slack_runner.py` (inside `run_slack_iteration`) — declared in `team_server/requirements.txt` but not always installed in dev venvs; lazy import lets the team_server package be importable in tests for unrelated code paths. Production runtime path unaffected.
+
+### qor-logic-internal steps skipped (downstream-project rationale, same as v0 entry)
+
+Same set as v0 (Steps 2.5, 4.7, 6.5, 7.4–7.8, 8.5, 9.5.5) — this repo does not author qor-logic phase plans nor maintain the system-tier doc set / dist-compile pipeline that those wirings expect. The fundamental S.H.I.E.L.D. checks (PASS verdict prerequisite, Reality vs Promise, Section 4 Razor, Merkle seal calculation, ledger entry) all run.

--- a/docs/SYSTEM_STATE.md
+++ b/docs/SYSTEM_STATE.md
@@ -640,3 +640,65 @@ tests/test_team_server_canonical_cache.py  — adapted to classifier_version= ke
 
 1. `team_server/workers/{slack_worker,notion_worker}.py` keep a backwards-compat path: when `config=None`, fall back to the legacy `extractor(text)` callable. Preserves v1.0 worker tests + provides a clean cutover path. When `config` is provided, the pipeline runs.
 2. Anthropic SDK imported lazily inside `extract()` (matches the slack_sdk lazy-import pattern from v1.0 Phase 0.5) so the package imports cleanly when `anthropic` is in `requirements.txt` but not installed in dev venv.
+
+---
+
+## Priority C v0 release-blockers — channel allowlist + materializer bridge (2026-05-03)
+
+Plan: [`plan-priority-c-team-server-v0-release-blockers.md`](../plan-priority-c-team-server-v0-release-blockers.md). Three-round audit cycle (VETO → VETO → PASS); 123/123 team-server + materializer tests passing. Closes [#160](https://github.com/BicameralAI/bicameral-mcp/issues/160) and [#161](https://github.com/BicameralAI/bicameral-mcp/issues/161).
+
+### Files added (6)
+
+```
+team_server/auth/allowlist_sync.py  — startup-time YAML→DB reconcile (73 LOC)
+events/team_server_consumer.py      — periodic pull→bridge→ingest_payload task (100 LOC)
+events/team_server_bridge.py        — team-server payload → IngestPayload (56 LOC)
+
+tests/test_team_server_allowlist_sync.py     — 5 tests
+tests/test_team_server_allowlist_lifespan.py — 2 tests
+tests/test_team_server_consumer.py            — 7 tests (incl. no-echo invariant)
+```
+
+### Files modified (4)
+
+```
+team_server/app.py                       — lifespan calls sync_channel_allowlist after schema; config loaded once for both sync + corpus learner
+events/materializer.py                   — dispatch case for event_type='ingest' AND 'ingest.completed' with team-server-shaped payload bridges to IngestPayload
+server.py                                 — serve_stdio spawns the periodic team-server consumer task; cancels on shutdown
+tests/test_materializer_team_server_pull.py  — 6 new bridge functionality tests + legacy regression coverage
+```
+
+### Test state
+
+- 123/123 team-server + materializer tests passing
+- Test counts by phase: Phase 1 sync 5 / Phase 1 lifespan 2 / Phase 1.5 consumer 7 / Phase 2 bridge 6 = 20 net-new
+- Razor: max file 167 LOC (events/materializer.py); max function ~25; nesting ≤3; zero nested ternaries
+
+### Architectural properties achieved (closing v0 release blockers)
+
+- **End-to-end ingest pipeline functional**: Slack OAuth → workspace row → YAML allowlist sync → channel_allowlist populated → Slack worker polls allowlisted channels → heuristic+LLM extraction → team_event row → /events HTTP → per-dev consumer pulls → bridges to IngestPayload → inner_adapter.ingest_payload → per-dev local ledger
+- **No-echo invariant** (audit-round-2 Finding A): consumer's `start_team_server_consumer_if_configured` unwraps `TeamWriteAdapter._inner` so consumer-driven ingest does NOT emit synthetic `'ingest.completed'` events into per-dev JSONL files. Verified by `test_consumer_unwraps_team_write_adapter_does_not_echo_to_jsonl` constructing a real TeamWriteAdapter with a recording writer
+- **SurrealQL strict-type handling**: `record<workspace>` field on `channel_allowlist.workspace_id` requires `type::thing()` coercion; allowlist_sync uses the same pattern as the v1.0 schema migration
+- **Materializer dispatch is shape-discriminating**: `is_team_server_payload` predicate distinguishes team-server payloads (have `extraction` key) from legacy CodeLocatorPayload (have `repo`/`commit_hash` but no `extraction`); legacy `'ingest.completed'` path preserved unchanged
+
+### Audit cycle outcomes (3-round VETO → VETO → PASS)
+
+- Round 1 VETO: `infrastructure-mismatch` (pull_team_server_events had zero production callers; bridge would be dead code) → closed by Phase 1.5 (consumer + serve_stdio integration)
+- Round 2 VETO: `specification-drift` (sketch passed wrapped TeamWriteAdapter; would echo events O(N²) cross-dev) → closed by inline unwrap + dedicated no-echo test
+- Round 3 PASS: 0 findings; all 6 SHADOW_GENOME #7 heuristics held
+
+### SHADOW_GENOME #7 heuristic catalog grew 4 → 6 across this branch
+
+1. Existence (Entry #7)
+2. Signature (Entry #7)
+3. Type-boundary (Entry #7)
+4. Helper-symmetry (Entry #7)
+5. **Upstream-consumer** (Entry #37 — added by v0-blockers round-1 VETO)
+6. **Wrapper-side-effect** (Entry #38 — added by v0-blockers round-2 VETO)
+
+The catalog is the productive deposit beyond the code: each heuristic is reusable for future audits.
+
+### Implementation deviation from plan (logged)
+
+1. SurrealQL `record<workspace>` strict type required `type::thing()` coercion in allowlist_sync.py — not anticipated in plan but matches the v1.0 migration's existing pattern at `team_server/schema.py:106-110`. Caught at first test run; fix took two minutes.
+2. Lifespan integration test originally tried pre-seeding workspace via `TeamServerDB.from_env()` then re-opening for the app — `memory://` doesn't persist across connect/close. Test rewritten to mock `sync_channel_allowlist` and assert it was invoked at startup with the correct config. Test directly exercises the lifespan→sync wiring via interception, not via DB observation.

--- a/docs/research-brief-priority-c-selective-ingest-2026-05-02.md
+++ b/docs/research-brief-priority-c-selective-ingest-2026-05-02.md
@@ -1,0 +1,158 @@
+# Research Brief — Priority C: selective source ingest (re-research v2)
+
+**Date**: 2026-05-02 (replaces v1, which was rejected for `INVARIANT_FROM_IMPLEMENTATION` — see `docs/SHADOW_GENOME.md` Failure Entry #6)
+**Analyst**: The QorLogic Analyst (executed via `/qor-research`)
+**Target**: v0 Priority C — selective source ingest (GitHub / Notion / Slack) at multi-dev / multi-agent / multi-host scale
+**Substrate**: operator-supplied Sales Enablement & Positioning Playbook + `docs/CONCEPT.md` + `docs/ARCHITECTURE_PLAN.md` + repo source code, with **"unproven is theater"** filter active throughout
+**Constraint**: Claude (Code + Desktop) only at v0 (Priority D constraint)
+
+---
+
+## Executive Summary
+
+Priority C scope, after dialogue: **Slack-first source ingest, via a self-managing team-server, with CocoIndex (#136) memoization for canonical extraction**. Multi-dev decision continuity (Playbook Pillar #1) requires extraction convergence in addition to the storage convergence the existing `events/team_adapter.py` JSONL-via-git pattern already provides.
+
+The repo already implements **storage-layer** convergence: `TeamWriteAdapter` dual-writes per-author JSONL files (git-merged), `EventMaterializer` replays peer events with watermark, `canonical_id` UNIQUE coalesces at DB level. The gap is **extraction-layer** divergence — same Slack thread, different agents, different extractions. The team-server closes this by owning the canonical extraction (CocoIndex memoization) and exposing it to per-dev local ledgers.
+
+Local-first per CONCEPT.md is honored under literal-keyword parsing: the anti-goal *"No managed backend"* blocks vendor SaaS and human-ops-tax architectures, not self-managing customer-self-hosted backends. Sentry self-hosted, Supabase OSS, the existing embedded-SurrealDB philosophy are precedents.
+
+Source priority Slack → Notion → GitHub-via-skill, by **disorder-to-info ratio** (operator-resolved): Slack has no structure and no useful AI-dev-environment connector for decision extraction; Notion is structured and has connectors; GitHub is organically in the SDLC and resolves to a skill/hook nudge (agent consults git) rather than team-server ingest.
+
+---
+
+## Findings
+
+### F1 — Event-sourced multi-dev consistency exists today
+
+[`events/team_adapter.py`](events/team_adapter.py) `TeamWriteAdapter` wraps `SurrealDBLedgerAdapter` via composition. On every write: (1) emit an event file via `EventFileWriter`, (2) delegate to the inner adapter. Reads pass through directly.
+
+[`events/writer.py:1-12`](events/writer.py): *"Each contributor owns a single file: `.bicameral/events/{email}.jsonl`. Events are appended one per line. Git merges are additive (both sides only append)."*
+
+[`events/materializer.py:1-9`](events/materializer.py): *"Replays JSONL event logs into the local ledger… One file per contributor… Watermark is a JSON `{email: byte_offset}` map at `.bicameral/local/watermark`. Replay resumes from the stored offset per author."*
+
+[`tests/test_team_event_replay.py`](tests/test_team_event_replay.py) exercises this end-to-end: Dev A writes events, Dev B materializes them into Dev B's local ledger, ledgers converge.
+
+The pattern is **event-sourced with git as sync mechanism**. Local-first is preserved per CONCEPT.md anti-goals. **MATCH** with playbook Pillar #1 (Decision Continuity) at the storage layer.
+
+### F2 — Event log is per-author; canonical_id at the DB level coalesces
+
+`.bicameral/events/{email}.jsonl` is per-contributor. Setup via [`setup_wizard.py:197-209`](setup_wizard.py): *"In team mode, local DBs go under `.bicameral/local/` (gitignored) so they don't leak into the tracked events directory."*
+
+So team mode tracks events in repo (`.bicameral/events/`) and gitignores per-dev DB (`.bicameral/local/`). Devs share events, materialize into per-dev DBs.
+
+Dedup at the DB level via `canonical_id` UNIQUE index ([`events/writer.py:11`](events/writer.py): *"Dedup now relies on the DB-level `canonical_id` UNIQUE index instead of filesystem collisions."*).
+
+### F3 — CONCEPT.md anti-goals parsed literally — load-bearing keywords are `managed` and `deterministic core`
+
+> *"**local-first** — runs entirely in-process via embedded SurrealDB; no cloud, no network calls in the deterministic core."*
+>
+> Anti-Goals:
+> - *"Not a cloud service. No remote DB, no managed backend; the ledger lives next to the repo it tracks."*
+> - *"Not an LLM-powered ledger. The deterministic core does not invoke any model."*
+
+Operator-resolved during dialogue (recorded as `docs/SHADOW_GENOME.md` Failure Entry #6 addendum): these anti-goals must be parsed by their **load-bearing keyword**, not generalized. The keywords:
+
+- *"No managed backend"* — keyword: **managed**. A self-managing, customer-self-hosted, schema-migrating-itself, no-on-call backend is **compatible**. The anti-goal blocks vendor SaaS and human-ops-tax architectures, not server-side components per se. (Sentry self-hosted, Supabase OSS, embedded-SurrealDB precedents.)
+- *"No cloud, no network calls in the deterministic core"* — keyword: **deterministic core**. Network calls outside the deterministic core (source ingest workers, telemetry) are not blocked.
+- *"Not an LLM-powered ledger"* — keyword: **ledger**. LLMs as callers/classifiers/orchestrators around the ledger are not blocked.
+
+So a self-managing team-server that holds Slack credentials, runs CocoIndex memoization for canonical extraction, and exposes results to per-dev local ledgers honors all three anti-goals under literal parsing. The team-server is the natural Priority C anchor.
+
+### F4 — Real Priority C gap: extraction-layer divergence
+
+Today's flow:
+1. Dev A agent reads Slack thread X via host's Slack MCP connector
+2. Dev A agent extracts 3 decisions
+3. `bicameral.ingest` writes 3 decision rows + emits 3 events to `.bicameral/events/dev_a@org.com.jsonl`
+4. Dev B agent reads the same Slack thread X (later, separate session)
+5. Dev B agent extracts 5 decisions (richer pass; or fewer; or different framing of the same ideas)
+6. `bicameral.ingest` writes — `canonical_id` UNIQUE may collide on overlap, dropping or last-write-winning the duplicates
+
+The DB has SOMETHING for the thread, but it's not **canonical extraction** — it's "whichever agent's read happened to land first/last." Two devs preflight the same code path against the same Slack source and could see different decision sets if their extractions diverged on edge cases.
+
+This breaks Playbook Pillar #1 *"preserves the chain between a human decision and the code that implements it"* at multi-dev scale. The chain only preserves if the decision set is canonical, not just deduplicated.
+
+### F5 — `source_type` schema supports playbook source list with no change
+
+[`contracts.py:815`](contracts.py): `Literal["transcript", "slack", "document", "agent_session", "manual"]`. [`handlers/history.py:30-36`](handlers/history.py) normalizes `notion → document`.
+
+Schema is source-agnostic. The playbook's source list (PRDs, ADRs, Slack, transcripts, Jira/Linear, PR discussions, code comments, design docs, verbal agreements, agent sessions) all map to existing `source_type` values. **MATCH** — no schema change required for Priority C as such.
+
+### F6 — Issue #136 CocoIndex is the architectural lever for deterministic extraction
+
+[Issue #136](https://github.com/BicameralAI/bicameral-mcp/issues/136): *"v1 Architecture §6: implement CocoIndex execution layer for Layer A pre-classifier and Layer B identity capture."* Per the operator's earlier framing this session, #136 has strategic dimension (founder relationship + publicity) plus architectural impact (memoization for the pre-classifier + identity capture).
+
+Memoization on Layer A pre-classifier means: *"this Slack thread, processed by the v0.X pre-classifier, deterministically yields THIS decision set."* If Dev A's session pre-classifies the thread, the result is cached. Dev B's session pulls the cache instead of re-classifying — same input → same output across devs. **This is the convergence mechanism for extraction-layer determinism.**
+
+#136 is currently labeled in the open-issues list with no priority tag, but operator has flagged it strategically. Priority C threading through #136 is plausibly the architecturally clean path. Confirming this requires #136 design dialogue with founder; not yet done.
+
+### F7 — Existing curation surface is the `bicameral-ingest` SKILL's permissive trigger
+
+[`skills/bicameral-ingest/SKILL.md`](skills/bicameral-ingest/SKILL.md) frontmatter: *"AUTO-TRIGGER on ANY of these: (1) user pastes or mentions a transcript, meeting notes, Slack thread, PRD, spec, or design doc … (4) user answers a gap or open question … When in doubt, ingest — a false trigger that captures zero decisions is cheaper than missing a real decision."*
+
+This is solo-developer-tuned: prefer over-ingestion to under-ingestion. At enterprise multi-dev scale, the failure modes invert — over-ingestion creates noise across the team that's hard to selectively reject because it's deduplicated/replayed across all devs' DBs.
+
+### F8 — No source-fetcher / OAuth / API-client code exists today
+
+`grep -rn "oauth|api_key|client_secret|GITHUB_TOKEN|SLACK_TOKEN|NOTION_API"` over `*.py` returns no matches outside test eval-judge code (which uses `ANTHROPIC_API_KEY` for an unrelated LLM-judge surface).
+
+This is **a current observation, not an architectural invariant** (per `docs/SHADOW_GENOME.md` Failure Entry #6). However, the local-first principle in F3 makes the simplest path forward continue to lean on host-supplied connectors for fetch authority, with bicameral owning extraction determinism rather than fetch credentials.
+
+---
+
+## Blueprint Alignment
+
+| Playbook claim | Repo finding | Status |
+|---|---|---|
+| Decision-to-code continuity at multi-dev scale (Pillar #1) | `TeamWriteAdapter` + git-merged JSONL events + `EventMaterializer` watermark exists | **MATCH at storage layer** |
+| Same decision-set across devs from same source | Extraction is per-agent; canonical_id dedup hides drift | **GAP — Priority C target** |
+| Local-first decision ledger | CONCEPT.md ratifies "no cloud, no managed backend"; team mode preserves it | MATCH |
+| Multi-source ingest (Slack, Notion, GitHub, etc.) | `source_type` Literal already covers; `notion → document` normalization present | MATCH |
+| Deterministic core; LLMs are callers, never truth-bearers | Honored in current code; #136 CocoIndex would extend deterministic substrate to extraction | MATCH (+ extension path via #136) |
+| Bicameral amplifies existing tools, never replaces | Source fetching delegated to host MCP connectors; bicameral never duplicates GitHub/Slack/Notion's own surface | MATCH |
+| Bicameral never blocks, only exposes/escalates (Pillar #5) | Today's permissive ingest never blocks; gates would also be exposure-only ("warn before ingest" not "refuse to ingest") | MATCH constraint for any Priority C gate design |
+
+---
+
+## Recommendations (priority-ordered for follow-on `/qor-plan`, all theater-flagged where unproven)
+
+1. **[P0] Anchor Priority C on a self-managing team-server, Slack-first** — not a curation gate, not source-plumbing-via-agent. The team-server holds Slack credentials, runs source workers, hosts the canonical-extraction substrate, and syncs to per-dev local ledgers. Customer self-hosts; no human ops surface. Compatible with CONCEPT.md anti-goals under literal-keyword parsing (F3).
+2. **[P0] Bundle CocoIndex (#136) into v0 team-server, conditional on feasibility** — operator-confirmed in scope ("good idea if we can manage it"). Layer A pre-classifier + Layer B identity capture as memoized transforms = the deterministic-extraction substrate that closes the multi-dev convergence gap (F4). The plan should structure CocoIndex integration as a discrete phase that can slip independently if calendar/founder-coordination blocks it; v0 ships without if needed, with extraction determinism deferred to an interim cache.
+3. **[P0] Interim canonical-extraction cache (fallback if CocoIndex slips)** — team-server-side keyed table `(source_type, source_ref) → canonical_extraction_json`. Subsequent agent ingests of the same source-event pull the cache instead of re-extracting. Provides convergence without CocoIndex; ships independently if #136 is blocked. *Unproven: whether this composes cleanly with `TeamWriteAdapter`'s JSONL event log; design dialogue at `/qor-plan` time.*
+4. **[P1] Slack auth + channel-selection UX** — workspace-level OAuth in the team-server; admin selects which channels are ingested; allow-list semantics. Honors Pillar #5 (Human Authority) and Pillar #6 (amplifies existing tools — Slack remains the system of record). Specific UX shape (web admin? CLI? config file?) is `/qor-plan` dialogue surface.
+5. **[P1] Sync mechanism between team-server and per-dev local ledgers** — extension of the existing `events/team_adapter.py` JSONL pattern: team-server writes events the same way an authoring dev would, devs' materializers replay them. Treats the team-server as a peer in the existing event-sourcing model. *Unproven: whether the team-server's per-author identity (single bot? per-source bot?) plays cleanly with the per-author JSONL convention.*
+6. **[P2] Notion-second deferred to v1** — same team-server architecture; lower urgency per disorder-to-info ratio (Notion is already structured).
+7. **[P2] GitHub via skill enforcement, not team-server** — agent-consult-git nudge via `UserPromptSubmit` hook (similar shape to PR #151's preflight hook). Separate small plan; not in Priority C scope.
+8. **[Defer] Vendor SaaS, human-ops-tax architectures** — these would violate the literal "managed" keyword. If the product needs paid-hosting offerings later, that's a separate strategic decision, not a v0 Priority C move.
+9. **[Defer] Per-source MCP tools** (`bicameral.ingest_slack`, etc.) — breaks the 13-tool capability-not-source norm. Source-specific behavior belongs in the team-server worker layer or extraction rubric, not in MCP tool-surface.
+
+---
+
+## Theater audit (anything in this brief not grounded in cited source)
+
+Per the "unproven is theater" doctrine, the following claims in this brief are **interpretations beyond direct citation** and should be treated as observation, not principle:
+
+- **"CocoIndex (#136) memoization closes the extraction convergence gap"** — partial interpretation. #136's body cites Layer A pre-classifier and Layer B identity capture being "useful as memoized transforms." Operator confirmed during dialogue that CocoIndex helps with visibility and is in v0 scope conditional on feasibility. Whether the *specific mechanism* (memoization keyed on source-event identity, deterministic across devs) matches the operator/founder's design intent for extraction-layer convergence still needs verification at `/qor-plan` time.
+- **"Multi-dev preflight on the same code path could see different decision sets"** — plausible failure mode derivable from F2+F4, not constructed as a repro test. Treated as design risk, not demonstrated bug.
+- **"Self-managing team-server is compatible with CONCEPT.md anti-goals under literal-keyword parsing"** — operator-resolved during dialogue (recorded as SHADOW_GENOME Entry #6 addendum). Should be re-pressure-tested at `/qor-audit` time when the planning cycle goes through governance gates.
+- **All Recommendations** — design proposals, not demonstrated mechanisms. The next `/qor-plan` is where these get pressure-tested or replaced. Specifically the team-server's deployment shape, sync-with-events-via-git pattern, Slack-auth UX surface, and CocoIndex feasibility are all dialogue surfaces, not closed answers.
+
+---
+
+## Updated Knowledge — for SHADOW_GENOME / project memory
+
+- (Already saved) `docs/SHADOW_GENOME.md` Failure Entry #6: `INVARIANT_FROM_IMPLEMENTATION` documenting the v1 brief's framing error.
+- (Already saved) Project memory: `unproven_is_theater.md` doctrine.
+- (Already saved) Project memory: `bicameral_product_positioning.md` capturing playbook key claims as research substrate.
+
+This brief introduces no new architectural invariant. The earlier "bicameral does not fetch source content" claim is **explicitly retired** here; the repo simply has not implemented source fetching yet, and design intent for v1+ is not pinned.
+
+---
+
+## CI Commands
+
+None. Research is documentation; validation is operator read-through and audit pressure-test. No tests; no schema changes.
+
+---
+
+_Research complete. Findings are advisory — implementation decisions remain with the Governor. Followup `/qor-plan` should explicitly engage operator on the #136 dependency before drafting._

--- a/events/materializer.py
+++ b/events/materializer.py
@@ -86,6 +86,19 @@ class EventMaterializer:
                     except json.JSONDecodeError:
                         continue
                     etype, payload = event.get("event_type", ""), event.get("payload", {})
+                    # v0-release-blockers: team-server emits event_type='ingest'
+                    # with a payload shaped {source_type, source_ref, content_hash,
+                    # extraction}. Bridge to IngestPayload before dispatching.
+                    if etype in ("ingest", "ingest.completed"):
+                        from events.team_server_bridge import (
+                            bridge_team_server_payload, is_team_server_payload,
+                        )
+                        if is_team_server_payload(payload):
+                            bridged = bridge_team_server_payload(payload)
+                            if bridged.get("decisions"):
+                                await inner_adapter.ingest_payload(bridged)
+                                replayed += 1
+                            continue
                     if etype == "ingest.completed":
                         await inner_adapter.ingest_payload(payload)
                         replayed += 1

--- a/events/materializer.py
+++ b/events/materializer.py
@@ -91,8 +91,10 @@ class EventMaterializer:
                     # extraction}. Bridge to IngestPayload before dispatching.
                     if etype in ("ingest", "ingest.completed"):
                         from events.team_server_bridge import (
-                            bridge_team_server_payload, is_team_server_payload,
+                            bridge_team_server_payload,
+                            is_team_server_payload,
                         )
+
                         if is_team_server_payload(payload):
                             bridged = bridge_team_server_payload(payload)
                             if bridged.get("decisions"):

--- a/events/team_server_bridge.py
+++ b/events/team_server_bridge.py
@@ -1,0 +1,56 @@
+"""Bridge: team-server team_event payload → IngestPayload-compatible dict.
+
+The team-server emits events with shape:
+  {source_type, source_ref, content_hash, extraction: {decisions, ...}}
+
+The materializer's inner_adapter.ingest_payload expects shape:
+  {source, decisions: [{description, source_excerpt, ...}], repo,
+   commit_hash, ...}
+
+This module's two pure functions (is_team_server_payload +
+bridge_team_server_payload) handle the recognition and shape mapping.
+"""
+
+from __future__ import annotations
+
+
+_TEAM_SERVER_SOURCE_NORMALIZATION = {
+    "slack": "slack",
+    "notion_database_row": "notion",
+}
+
+
+def is_team_server_payload(payload: dict) -> bool:
+    """True iff the payload has the team-server event shape."""
+    return (
+        isinstance(payload, dict)
+        and "source_type" in payload
+        and isinstance(payload.get("extraction"), dict)
+    )
+
+
+def bridge_team_server_payload(payload: dict) -> dict:
+    """Map team-server's payload shape to an IngestPayload-compatible dict.
+    Decisions land as source='slack'|'notion' with empty repo/commit_hash
+    (Slack/Notion-sourced decisions don't reference code)."""
+    source_type = payload.get("source_type", "")
+    source = _TEAM_SERVER_SOURCE_NORMALIZATION.get(source_type, source_type)
+    extraction = payload.get("extraction") or {}
+    raw_decisions = extraction.get("decisions") or []
+    decisions: list[dict] = []
+    for d in raw_decisions:
+        if isinstance(d, dict):
+            decisions.append({
+                "description": d.get("summary", ""),
+                "source_excerpt": d.get("context_snippet", ""),
+            })
+        elif isinstance(d, str):
+            # interim-claude-v1 placeholder shape (paragraph-split strings)
+            decisions.append({"description": d, "source_excerpt": d})
+    return {
+        "source": source,
+        "repo": "",
+        "commit_hash": "",
+        "decisions": decisions,
+        "title": payload.get("source_ref", ""),
+    }

--- a/events/team_server_bridge.py
+++ b/events/team_server_bridge.py
@@ -13,7 +13,6 @@ bridge_team_server_payload) handle the recognition and shape mapping.
 
 from __future__ import annotations
 
-
 _TEAM_SERVER_SOURCE_NORMALIZATION = {
     "slack": "slack",
     "notion_database_row": "notion",
@@ -40,10 +39,12 @@ def bridge_team_server_payload(payload: dict) -> dict:
     decisions: list[dict] = []
     for d in raw_decisions:
         if isinstance(d, dict):
-            decisions.append({
-                "description": d.get("summary", ""),
-                "source_excerpt": d.get("context_snippet", ""),
-            })
+            decisions.append(
+                {
+                    "description": d.get("summary", ""),
+                    "source_excerpt": d.get("context_snippet", ""),
+                }
+            )
         elif isinstance(d, str):
             # interim-claude-v1 placeholder shape (paragraph-split strings)
             decisions.append({"description": d, "source_excerpt": d})

--- a/events/team_server_consumer.py
+++ b/events/team_server_consumer.py
@@ -1,0 +1,100 @@
+"""Periodic team-server event consumer.
+
+Closes the pull→dispatch gap: pulls events from a team-server URL on
+a fixed interval, bridges each event's payload to IngestPayload shape,
+and invokes inner_adapter.ingest_payload directly. Bypasses JSONL —
+team-server events have their own canonical home in the team-server's
+SurrealDB; re-rendering as per-author JSONL files would be redundant.
+
+Failure isolation: pull failures return [] (per pull_team_server_events
+contract); per-event ingest failures are caught and logged so a single
+malformed event doesn't kill the loop.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import os
+from pathlib import Path
+from typing import Optional
+
+from events.team_server_bridge import (
+    bridge_team_server_payload, is_team_server_payload,
+)
+from events.team_server_pull import pull_team_server_events
+
+logger = logging.getLogger(__name__)
+
+
+async def consume_team_server_events_once(
+    team_server_url: str,
+    watermark_path: Path,
+    inner_adapter,
+    llm_extract_fn=None,
+) -> int:
+    """Pull + dispatch one batch. Returns the count of events ingested."""
+    events = await pull_team_server_events(
+        team_server_url=team_server_url,
+        watermark_path=watermark_path,
+    )
+    ingested = 0
+    for event in events:
+        payload = event.get("payload") or {}
+        if not is_team_server_payload(payload):
+            continue
+        bridged = bridge_team_server_payload(payload)
+        if not bridged.get("decisions"):
+            continue
+        try:
+            await inner_adapter.ingest_payload(bridged)
+            ingested += 1
+        except Exception:  # noqa: BLE001 — per-event isolation
+            logger.exception(
+                "[team-server-consumer] ingest failed for %s",
+                payload.get("source_ref", "<unknown>"),
+            )
+    return ingested
+
+
+def start_team_server_consumer_if_configured(
+    adapter, *, watermark_path: Optional[Path] = None,
+) -> Optional[asyncio.Task]:
+    """Spawn the consumer loop if BICAMERAL_TEAM_SERVER_URL is set.
+    Returns the task (caller cancels on shutdown) or None when off.
+
+    Defensive unwrap: TeamWriteAdapter (returned by get_ledger() in
+    team mode) wraps SurrealDBLedgerAdapter and emits 'ingest.completed'
+    via self._writer.write(...) BEFORE delegating ingest_payload.
+    Consumer-driven ingest must use the inner adapter to bypass the
+    writer; if we used the wrapper, every team-server event would echo
+    into per-dev JSONL → git push → other devs replay → O(N²) cross-dev
+    replay amplification per team-server event. Audit-round-2 Finding A.
+    """
+    url = os.environ.get("BICAMERAL_TEAM_SERVER_URL", "").strip()
+    if not url:
+        return None
+    inner_adapter = getattr(adapter, "_inner", adapter)
+    interval = int(os.environ.get("BICAMERAL_TEAM_SERVER_PULL_INTERVAL_SECONDS", "60"))
+    if watermark_path is None:
+        data_path = os.environ.get(
+            "BICAMERAL_DATA_PATH", os.environ.get("REPO_PATH", "."),
+        )
+        watermark_path = Path(data_path) / ".bicameral" / "local" / "team_server_watermark"
+        watermark_path.parent.mkdir(parents=True, exist_ok=True)
+
+    async def _loop():
+        while True:
+            try:
+                ingested = await consume_team_server_events_once(
+                    url, watermark_path, inner_adapter,
+                )
+                if ingested:
+                    logger.info(
+                        "[team-server-consumer] ingested %d events", ingested,
+                    )
+            except Exception:  # noqa: BLE001
+                logger.exception("[team-server-consumer] iteration failed")
+            await asyncio.sleep(interval)
+
+    return asyncio.create_task(_loop(), name="bicameral-team-server-consumer")

--- a/events/team_server_consumer.py
+++ b/events/team_server_consumer.py
@@ -17,10 +17,10 @@ import asyncio
 import logging
 import os
 from pathlib import Path
-from typing import Optional
 
 from events.team_server_bridge import (
-    bridge_team_server_payload, is_team_server_payload,
+    bridge_team_server_payload,
+    is_team_server_payload,
 )
 from events.team_server_pull import pull_team_server_events
 
@@ -58,8 +58,10 @@ async def consume_team_server_events_once(
 
 
 def start_team_server_consumer_if_configured(
-    adapter, *, watermark_path: Optional[Path] = None,
-) -> Optional[asyncio.Task]:
+    adapter,
+    *,
+    watermark_path: Path | None = None,
+) -> asyncio.Task | None:
     """Spawn the consumer loop if BICAMERAL_TEAM_SERVER_URL is set.
     Returns the task (caller cancels on shutdown) or None when off.
 
@@ -78,7 +80,8 @@ def start_team_server_consumer_if_configured(
     interval = int(os.environ.get("BICAMERAL_TEAM_SERVER_PULL_INTERVAL_SECONDS", "60"))
     if watermark_path is None:
         data_path = os.environ.get(
-            "BICAMERAL_DATA_PATH", os.environ.get("REPO_PATH", "."),
+            "BICAMERAL_DATA_PATH",
+            os.environ.get("REPO_PATH", "."),
         )
         watermark_path = Path(data_path) / ".bicameral" / "local" / "team_server_watermark"
         watermark_path.parent.mkdir(parents=True, exist_ok=True)
@@ -87,11 +90,14 @@ def start_team_server_consumer_if_configured(
         while True:
             try:
                 ingested = await consume_team_server_events_once(
-                    url, watermark_path, inner_adapter,
+                    url,
+                    watermark_path,
+                    inner_adapter,
                 )
                 if ingested:
                     logger.info(
-                        "[team-server-consumer] ingested %d events", ingested,
+                        "[team-server-consumer] ingested %d events",
+                        ingested,
                     )
             except Exception:  # noqa: BLE001
                 logger.exception("[team-server-consumer] iteration failed")

--- a/events/team_server_pull.py
+++ b/events/team_server_pull.py
@@ -1,0 +1,57 @@
+"""Per-dev pull from team-server's /events endpoint.
+
+This module is OUTSIDE the deterministic core (per CONCEPT.md literal-
+keyword parsing — `docs/SHADOW_GENOME.md` Failure Entry #6 addendum).
+Network calls are permitted here; failures must NOT cascade into the
+deterministic retrieval/status path.
+"""
+
+from __future__ import annotations
+
+import logging
+from pathlib import Path
+
+import httpx
+
+logger = logging.getLogger(__name__)
+
+
+def _read_watermark(path: Path) -> int:
+    if not path.exists():
+        return 0
+    try:
+        return int(path.read_text(encoding="utf-8").strip())
+    except (ValueError, OSError):
+        return 0
+
+
+def _write_watermark(path: Path, value: int) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(str(value), encoding="utf-8")
+
+
+async def pull_team_server_events(
+    team_server_url: str,
+    watermark_path: Path,
+    *,
+    timeout: float = 10.0,
+) -> list[dict]:
+    """Pull new events from `<team_server_url>/events?since=<watermark>`.
+    On any HTTP failure or transport error, return [] and leave watermark
+    unchanged. Failure-isolation contract: this function never raises."""
+    since = _read_watermark(watermark_path)
+    try:
+        async with httpx.AsyncClient() as client:
+            resp = await client.get(
+                f"{team_server_url}/events",
+                params={"since": since, "limit": 1000},
+                timeout=timeout,
+            )
+        events: list[dict] = resp.json()
+    except (httpx.HTTPError, ValueError) as exc:
+        logger.warning("team-server pull failed: %s", exc)
+        return []
+    if events:
+        last_seq = max(int(e.get("sequence", since)) for e in events)
+        _write_watermark(watermark_path, last_seq)
+    return events

--- a/plan-priority-c-team-server-notion-v1.md
+++ b/plan-priority-c-team-server-notion-v1.md
@@ -1,0 +1,946 @@
+# Plan: Priority C v1 — Notion ingest (database rows, internal integration, upsert cache)
+
+**change_class**: feature
+**doc_tier**: system
+**Author**: Governor (executed via `/qor-plan`)
+**Risk Grade**: L2 (extends a landed L3 service; new credential surface is a static integration token, not OAuth tokens; no new IPC paths beyond what Phase 4 already established; cache-contract migration touches landed Slack code)
+**Mode**: solo
+**Predecessor**: `plan-priority-c-team-server-slack-v0.md` (v0, Phases 1–4 landed; Phase 5 CocoIndex parked pending feasibility re-research per operator decision 2026-05-02)
+**Issue**: none filed yet — operator may want to file before merge
+
+**terms_introduced**:
+- term: notion database row
+  home: team_server/workers/notion_worker.py
+- term: source_watermark
+  home: team_server/schema.py
+- term: upsert canonical-extraction
+  home: team_server/extraction/canonical_cache.py
+- term: notion property serializer
+  home: team_server/extraction/notion_serializer.py
+
+**boundaries**:
+- limitations:
+  - v1 ingests **Notion database rows only** — freeform pages and comment threads are out of scope.
+  - v1 supports a **single Notion workspace** per team-server install (matches the v0 single-workspace Slack constraint; multi-workspace is a future concern).
+  - Auth is **internal-integration token only** — no public-OAuth router, no callback URL, no client secret. Public-OAuth integrations are explicitly out of scope and remain a v2 concern gated on a vendor-hosted offering existing.
+  - The allow-list is **derived from `databases.list`**, not stored. Operator's act of sharing a database with the integration in Notion's UI *is* the allow-list signal. No `notion_database_allowlist` table.
+  - Notion API calls run inside the team-server worker only; the per-dev local ledger never talks to Notion.
+- non_goals:
+  - Multi-workspace Notion (one team-server, many Notion workspaces)
+  - Webhook-driven ingest (polling only at v1; Notion's webhook surface is connection-trigger, not change-feed, and would not avoid polling anyway)
+  - Notion writeback (team-server posting comments/pages back into Notion)
+  - Replacing or modifying CocoIndex parking (Phase 5 of v0 plan stays parked)
+  - Touching the `bicameral.ingest` MCP tool surface — same posture as v0
+  - Refactoring the Slack worker to a generic `Source` abstraction class — parallel-implementation in v1; abstract only when a third real source arrives
+- exclusions:
+  - No deploy/Dockerfile changes beyond pinning a `notion-client`-equivalent dep (we use raw `httpx` — no new SDK)
+  - No new MCP tools — symmetric to v0
+
+## Open Questions
+
+None blocking. Five design points resolved (two during dialogue, three during audit-driven amendment):
+
+1. **Unit of ingest** — Notion *database row*, `source_ref = '{db_id}/{page_id}'`. Freeform pages and comments deferred. Rationale: Notion's structured surface is where the disorder-to-info ratio is best, and the title+properties give strong signal even without an LLM extractor. Operator-resolved.
+2. **Edit semantics** — cache becomes upsert per `(source_type, source_ref)`; `content_hash` becomes a tracked column, not part of the unique index. Slack worker migrates to the new contract. `team_event` log retains full edit history; cache holds the latest snapshot. Operator-resolved as a uniform contract for both sources.
+3. **Schema version observability** (audit Remediation 1) — added a `schema_version` table that `ensure_schema` UPSERTs on every successful migration. Versioning becomes data, not folklore. The idempotency test reads from the table.
+4. **Worker-task lifecycle pattern** (audit Remediation 3) — added a new Phase 0.5 that establishes `asyncio.create_task` registration in `lifespan` and **wires Slack as the canonical reference implementation**. This closes the v0 dormant-Slack-worker gap (the v0 plan claimed an active Slack ingest worker; the v0 code shipped the function with no production caller). Phase 3 then "extends the now-existing pattern with a Notion task" rather than inventing it.
+5. **Dispatch loop migration** (audit Remediation 2) — `_MIGRATIONS` type signature changes from `dict[int, tuple[str, ...]]` to `dict[int, Callable[[LedgerClient], Awaitable[None]]]`. The `ensure_schema` dispatch loop is mutated in lockstep; the change is now declared in Affected Files.
+
+---
+
+## Phase 0: Cache contract migration — `(source_type, source_ref)` upsert + Slack worker adaptation
+
+**Why this phase exists**: Notion edits are normal where Slack edits were exceptional. Rather than complecting source-type into the cache contract (one-row-per-content-hash for Slack, latest-snapshot for Notion), both sources share a single upsert-keyed-on-source_ref contract. This phase lands the contract change before any Notion code so Slack invariants are validated against the new shape under the existing Phase 1–4 test surface.
+
+### Verification (TDD — list test files first)
+
+- [ ] `tests/test_team_server_cache_upsert.py::test_upsert_returns_extraction_and_changed_true_on_first_write` — invokes `upsert_canonical_extraction(client, source_type='slack', source_ref='C1/1.0', content_hash='h1', compute_fn=stub_returning({'decisions':['x']}), model_version='interim-claude-v1')` against a fresh `memory://` ledger; asserts the returned tuple is `({'decisions':['x']}, True)`. Functionality — exercises the new return contract.
+- [ ] `tests/test_team_server_cache_upsert.py::test_upsert_returns_changed_false_on_same_hash` — calls upsert twice with identical args; asserts second call returns `(<cached>, False)` and `compute_fn` was invoked exactly once. Functionality — exercises the no-op-on-same-hash invariant.
+- [ ] `tests/test_team_server_cache_upsert.py::test_upsert_replaces_extraction_on_hash_change` — calls upsert with `content_hash='h1'`, then with same `source_ref` and `content_hash='h2'`; asserts second call returns `(<new>, True)`, the cache row count for the key is exactly 1, and `canonical_extraction` reflects the second compute. Functionality — exercises the in-place replacement invariant.
+- [ ] `tests/test_team_server_cache_upsert.py::test_upsert_unique_index_is_source_type_and_ref_only` — after migration, attempts `CREATE extraction_cache CONTENT { source_type:'slack', source_ref:'C1/1.0', content_hash:'h1', ... }` followed by an identical `CREATE` differing only in `content_hash`; asserts the second `CREATE` fails. Functionality — exercises the index-shape invariant.
+- [ ] `tests/test_team_server_schema_migration.py::test_v1_to_v2_migration_drops_old_index_and_defines_new` — seeds a v1-shaped ledger with one duplicate-by-source_ref pair (different content_hash), invokes `ensure_schema(client)`, asserts `idx_extraction_cache_key` exists with fields `source_type, source_ref` only and that exactly one row remains for the duplicated key (the one with the latest `created_at`). Functionality — exercises the migration's dedup-then-redefine path.
+- [ ] `tests/test_team_server_schema_migration.py::test_v1_to_v2_migration_is_idempotent` — runs `ensure_schema` twice on a fresh ledger; asserts no exception on the second call AND that the `(source_type, source_ref)` UNIQUE index still rejects a duplicate `CREATE` after the second pass (i.e. the migration didn't redefine the index in a way that broke uniqueness). Functionality — exercises observable post-migration behavior, not a stored marker.
+- [ ] `tests/test_team_server_schema_migration.py::test_schema_version_row_records_current_version_after_migrations_apply` — invokes `ensure_schema(client)` on a fresh ledger; queries `SELECT version FROM schema_version LIMIT 1`; asserts the returned row's `version` field equals `SCHEMA_VERSION` (2). Then invokes `ensure_schema` again and asserts the table still has exactly one row with `version = 2` (UPSERT, not INSERT). Functionality — exercises the schema_version-as-data invariant introduced by audit Remediation 1.
+- [ ] `tests/test_team_server_schema_migration.py::test_ensure_schema_dispatches_callable_migrations` — registers a synthetic `_MIGRATIONS = {2: stub_migration}` where `stub_migration` is a recording async callable; invokes `ensure_schema`; asserts `stub_migration` was awaited exactly once with the `LedgerClient` instance as its sole argument. Functionality — exercises the new callable-dispatch contract from audit Remediation 2.
+- [ ] `tests/test_team_server_slack_worker.py::test_slack_worker_writes_team_event_only_on_changed_returns` — patches the worker's call-site so `upsert_canonical_extraction` returns `(<extraction>, False)`; asserts no `team_event` row is written. Then patches it to return `(<extraction>, True)`; asserts exactly one `team_event` row is written. Functionality — exercises the Slack worker's adaptation to the new tuple-return contract (replaces the existing `cache_existed_before` branch).
+
+### Affected Files
+
+- `team_server/schema.py` — **MUTATE** — bump `SCHEMA_VERSION` from 1 to 2; add `_migrate_v1_to_v2` callable (DROP `idx_extraction_cache_key`, dedup `extraction_cache` rows by max(`created_at`) per `(source_type, source_ref)`, REDEFINE `idx_extraction_cache_key ON extraction_cache FIELDS source_type, source_ref UNIQUE`); add `source_watermark` table; add `schema_version` table (single-row, UPSERT-written after migrations apply — closes audit Remediation 1); change `_MIGRATIONS` type signature from `dict[int, tuple[str, ...]]` to `dict[int, Callable[[LedgerClient], Awaitable[None]]]` and **update `ensure_schema`'s migration dispatch loop** from `for stmt in _MIGRATIONS[version]: await client.query(stmt)` to `await _MIGRATIONS[version](client)` (closes audit Remediation 2).
+- `team_server/extraction/canonical_cache.py` — **MUTATE** — replace `get_or_compute(...)->dict` with `upsert_canonical_extraction(...)->tuple[dict, bool]`. Behavior: SELECT by `(source_type, source_ref)`; if row exists and `content_hash` matches stored, return `(stored.canonical_extraction, False)`; else compute via `compute_fn`, UPSERT (UPDATE if row exists, CREATE if not), return `(extraction, True)`. Old function name is gone — no compatibility shim.
+- `team_server/workers/slack_worker.py` — **MUTATE** — replace the `cache_existed_before` SELECT-then-call pattern with a single `upsert_canonical_extraction(...)` call; gate the `write_team_event` on the returned `changed` bool. Removes `_cache_row_exists` helper (now dead).
+- `tests/test_team_server_cache_upsert.py` — **CREATE** — 4 functionality tests above.
+- `tests/test_team_server_schema_migration.py` — **CREATE** — 2 functionality tests above.
+- `tests/test_team_server_slack_worker.py` — **MUTATE** — adapt the existing tests to the new tuple return; add the no-event-on-unchanged + event-on-changed pair above.
+
+### Changes
+
+`team_server/extraction/canonical_cache.py` becomes:
+
+```python
+"""Canonical-extraction cache (upsert-shaped).
+
+For a given (source_type, source_ref), holds the latest canonical
+extraction. content_hash tracks the input that produced it; an inbound
+content_hash that matches the stored value is a no-op (returns
+changed=False). A different hash triggers re-extraction and replaces
+the row in place. team_event log preserves edit history.
+"""
+
+from __future__ import annotations
+
+from typing import Awaitable, Callable
+
+from ledger.client import LedgerClient
+
+ComputeFn = Callable[[], Awaitable[dict]]
+
+
+async def upsert_canonical_extraction(
+    client: LedgerClient,
+    source_type: str,
+    source_ref: str,
+    content_hash: str,
+    compute_fn: ComputeFn,
+    model_version: str,
+) -> tuple[dict, bool]:
+    """Upsert canonical extraction. Returns (extraction, changed).
+
+    changed=True when the row was created OR the content_hash differed
+    from the stored value (i.e. an event-worthy change). changed=False
+    on cache hit with identical content_hash (idempotent re-poll).
+    """
+    rows = await client.query(
+        "SELECT id, content_hash, canonical_extraction FROM extraction_cache "
+        "WHERE source_type = $st AND source_ref = $sr LIMIT 1",
+        {"st": source_type, "sr": source_ref},
+    )
+    if rows and rows[0]["content_hash"] == content_hash:
+        return rows[0]["canonical_extraction"], False
+    extraction = await compute_fn()
+    if rows:
+        await client.query(
+            "UPDATE $id SET content_hash = $ch, canonical_extraction = $ext, "
+            "model_version = $mv",
+            {"id": rows[0]["id"], "ch": content_hash, "ext": extraction, "mv": model_version},
+        )
+    else:
+        await client.query(
+            "CREATE extraction_cache CONTENT { source_type: $st, source_ref: $sr, "
+            "content_hash: $ch, canonical_extraction: $ext, model_version: $mv }",
+            {"st": source_type, "sr": source_ref, "ch": content_hash,
+             "ext": extraction, "mv": model_version},
+        )
+    return extraction, True
+```
+
+`team_server/schema.py` migration block:
+
+```python
+from typing import Awaitable, Callable
+
+SCHEMA_VERSION = 2
+
+_BASE_STMTS: tuple[str, ...] = (
+    # ... existing tables (workspace, channel_allowlist, extraction_cache, team_event) ...
+
+    # source_watermark — generic per-source, per-resource watermark.
+    # Used by polled sources (Notion v1; future polled sources reuse).
+    "DEFINE TABLE source_watermark SCHEMAFULL",
+    "DEFINE FIELD source_type ON source_watermark TYPE string",
+    "DEFINE FIELD resource_id ON source_watermark TYPE string",
+    "DEFINE FIELD last_seen   ON source_watermark TYPE string DEFAULT ''",  # ISO-8601 or opaque cursor
+    "DEFINE FIELD updated_at  ON source_watermark TYPE datetime DEFAULT time::now()",
+    "DEFINE INDEX idx_source_watermark_key ON source_watermark FIELDS source_type, resource_id UNIQUE",
+
+    # schema_version — single-row table holding the current SCHEMA_VERSION.
+    # UPSERT-written by ensure_schema after migrations apply. Versioning is
+    # data, not folklore (audit Remediation 1).
+    "DEFINE TABLE schema_version SCHEMAFULL",
+    "DEFINE FIELD version    ON schema_version TYPE int",
+    "DEFINE FIELD updated_at ON schema_version TYPE datetime DEFAULT time::now()",
+)
+
+
+async def _migrate_v1_to_v2(client: "LedgerClient") -> None:
+    """Drop the v1 (source_type, source_ref, content_hash) UNIQUE index;
+    dedup duplicates by max(created_at); redefine the index on
+    (source_type, source_ref) UNIQUE. Idempotent: REMOVE INDEX is a
+    no-op if the index doesn't exist; the dedup pass deletes nothing
+    when no duplicates exist.
+    """
+    await client.query("REMOVE INDEX idx_extraction_cache_key ON extraction_cache")
+    # Per-key dedup: select all rows, group in Python (avoids reliance on
+    # SurrealDB v2 GROUP BY+HAVING semantics in embedded mode — see
+    # CLAUDE.md "Known v2 quirks"). Keep the row with max(created_at) per
+    # (source_type, source_ref) tuple; delete the rest.
+    rows = await client.query(
+        "SELECT id, source_type, source_ref, created_at FROM extraction_cache"
+    )
+    survivors: dict[tuple[str, str], dict] = {}
+    for row in rows or []:
+        key = (row["source_type"], row["source_ref"])
+        prior = survivors.get(key)
+        if prior is None or row["created_at"] > prior["created_at"]:
+            survivors[key] = row
+    survivor_ids = {r["id"] for r in survivors.values()}
+    for row in rows or []:
+        if row["id"] not in survivor_ids:
+            await client.query("DELETE $id", {"id": row["id"]})
+    await client.query(
+        "DEFINE INDEX idx_extraction_cache_key ON extraction_cache "
+        "FIELDS source_type, source_ref UNIQUE"
+    )
+
+
+_MIGRATIONS: dict[int, Callable[["LedgerClient"], Awaitable[None]]] = {
+    2: _migrate_v1_to_v2,
+}
+
+
+async def ensure_schema(client: "LedgerClient") -> None:
+    """Apply base schema (idempotent), run forward migrations, record version."""
+    for stmt in _BASE_STMTS:
+        try:
+            await client.query(stmt)
+        except Exception as exc:
+            if "already exists" in str(exc).lower():
+                continue
+            raise
+    for version in sorted(_MIGRATIONS):
+        await _MIGRATIONS[version](client)  # callable dispatch (Remediation 2)
+    # Record the post-migration version. UPSERT MERGE keeps the table
+    # at one row regardless of how many times ensure_schema runs.
+    await client.query(
+        "DELETE schema_version; "
+        "CREATE schema_version CONTENT { version: $v }",
+        {"v": SCHEMA_VERSION},
+    )
+    logger.info("[team-server] schema ensured at version %s", SCHEMA_VERSION)
+```
+
+The dedup pass is rewritten as a SELECT-then-Python-group-by to avoid relying on SurrealDB v2 embedded `GROUP BY ... HAVING` semantics, which the project's `CLAUDE.md` flags as quirky. Functionality is unchanged.
+
+`team_server/workers/slack_worker.py` — `_ingest_message` becomes:
+
+```python
+async def _ingest_message(
+    db_client: LedgerClient,
+    workspace_team_id: str,
+    channel: str,
+    message: dict,
+    extractor: Extractor,
+) -> None:
+    text = message.get("text", "")
+    ts = message.get("ts", "")
+    source_ref = _source_ref_for_message(channel, ts)
+    content_hash = _content_hash(text)
+    extraction, changed = await upsert_canonical_extraction(
+        db_client,
+        source_type="slack",
+        source_ref=source_ref,
+        content_hash=content_hash,
+        compute_fn=lambda: extractor(text),
+        model_version=INTERIM_MODEL_VERSION,
+    )
+    if not changed:
+        return
+    await write_team_event(
+        db_client,
+        workspace_team_id=workspace_team_id,
+        event_type="ingest",
+        payload={
+            "source_type": "slack",
+            "source_ref": source_ref,
+            "content_hash": content_hash,
+            "extraction": extraction,
+        },
+    )
+```
+
+The `_cache_row_exists` helper is deleted.
+
+---
+
+## Phase 0.5: Worker-task lifecycle pattern + Slack reference wiring
+
+**Why this phase exists**: Audit Remediation 3. The v0 plan claimed an active Slack ingest worker; the v0 code shipped `slack_worker.poll_once` with zero production callers. `team_server/app.py:22-32` registers no `asyncio.create_task` for any worker. This phase establishes the worker-task lifecycle pattern uniformly and wires Slack as the canonical reference implementation **before** Notion comes along to extend the pattern. Closes the v0 gap.
+
+### Verification (TDD — list test files first)
+
+- [ ] `tests/test_team_server_worker_lifecycle.py::test_lifespan_starts_slack_worker_when_workspaces_exist` — seeds the `workspace` table with one row; starts the app via `lifespan`; patches `slack_worker.poll_once` to a recording stub; advances the worker's interval timer once; asserts the stub was awaited at least once with the seeded workspace's `team_id` propagated through the wrapper. Functionality — exercises the workspace-iteration→poll wiring.
+- [ ] `tests/test_team_server_worker_lifecycle.py::test_lifespan_does_not_invoke_slack_poll_when_workspaces_empty` — leaves `workspace` table empty; starts the app via `lifespan`; patches `slack_worker.poll_once` to a recording stub; advances the worker timer once; asserts the registered Slack task IS spawned (lifespan registers it unconditionally) but `slack_worker.poll_once` was NOT invoked (the workspace SELECT returned no rows so no fan-out happened). Functionality — exercises the empty-workspace branch's no-op behavior.
+- [ ] `tests/test_team_server_worker_lifecycle.py::test_lifespan_cancels_slack_worker_task_on_shutdown` — seeds a workspace; starts then cleanly stops the app; asserts the Slack-worker task's state is `done()` and not pending after shutdown completes. Functionality — exercises the cancellation invariant.
+- [ ] `tests/test_team_server_worker_lifecycle.py::test_slack_worker_loop_continues_after_single_iteration_raises` — seeds a workspace; patches `poll_once` to raise on the first call and succeed on the second; advances the timer twice; asserts `poll_once` was awaited at least twice. Functionality — exercises the single-iteration-failure-doesn't-kill-loop invariant.
+- [ ] `tests/test_team_server_worker_lifecycle.py::test_slack_worker_iterates_all_workspaces_per_poll` — seeds two workspace rows with different `team_id` and decrypted-token-fixture values; patches the slack_client factory to a recording stub; one polling pass; asserts the stub was constructed exactly twice (one per workspace) with the per-workspace token. Functionality — exercises the multi-workspace fan-out invariant within a single polling cycle (forward-compat for v1 multi-workspace; v0 still ships single-workspace via the table having one row).
+- [ ] `tests/test_team_server_worker_lifecycle.py::test_slack_worker_skips_workspace_on_decrypt_failure` — seeds two workspace rows; patches the token decryption to raise on the first and succeed on the second; one polling pass; asserts the second workspace's `slack_client` factory was still invoked (failure isolation). Functionality — exercises the per-workspace failure-isolation invariant.
+- [ ] `tests/test_team_server_worker_lifecycle.py::test_slack_runner_decrypts_workspace_token_with_loaded_key` — sets `BICAMERAL_TEAM_SERVER_SECRET_KEY` to a real `Fernet.generate_key().decode()`; uses `encrypt_token("xoxb-test-token", key).decode("utf-8")` to seed a single workspace row's `oauth_token_encrypted`; patches `AsyncWebClient.__init__` to a recording stub; runs one `run_slack_iteration` pass; asserts the recording stub received `token="xoxb-test-token"` (the round-trip encrypt → store-as-string → read-back-as-bytes → decrypt succeeded with the loaded key). Functionality — closes the blind spot identified by audit round 2 Finding A: the existing tests patched the slack_client factory but never exercised the actual `decrypt_token(bytes, key)` call shape.
+
+### Affected Files
+
+- `team_server/workers/runner.py` — **CREATE** — `worker_loop(name, interval_seconds, work_fn)` async helper that wraps a single work-fn callable in a forever-loop with try/except + `asyncio.sleep`. Returns the registered `asyncio.Task` so `lifespan` can cancel it cleanly. This is the *one* place worker-task lifecycle is expressed; Slack and Notion both call into it.
+- `team_server/workers/slack_runner.py` — **CREATE** — `run_slack_iteration(db_client)` async function that: (1) selects all rows from `workspace` table; (2) per workspace, decrypts the OAuth token via `team_server.auth.encryption`; (3) reads the `channel_allowlist` for that workspace; (4) constructs a `slack_client` via `slack_sdk.web.async_client.AsyncWebClient(token=decrypted)`; (5) calls `slack_worker.poll_once(db_client, slack_client, workspace_team_id, channels, extractor)`; (6) catches per-workspace exceptions so one bad token does not stop iteration over the rest. Replaces what was implicit in v0.
+- `team_server/app.py` — **MUTATE** — extend `lifespan` to: (1) construct the interim extractor via direct import (no helper indirection — closes audit Remediation 4); (2) start one Slack worker task via `worker_loop("slack", interval, lambda: run_slack_iteration(db_client))`; (3) on shutdown, cancel the task and `await` it under `CancelledError` swallow.
+- `team_server/auth/encryption.py` — **READ-ONLY DEPENDENCY** — referenced by `slack_runner.py` for token decryption; no change.
+- `tests/test_team_server_worker_lifecycle.py` — **CREATE** — 6 functionality tests above.
+- `tests/test_team_server_app.py` — **MUTATE** — adapt the v0 `test_app_shutdown_releases_db` to also assert the Slack-worker task has been cancelled before DB close.
+
+### Changes
+
+`team_server/workers/runner.py`:
+
+```python
+"""Generic worker-task lifecycle helper.
+
+worker_loop wraps a callable in a forever-loop with per-iteration error
+isolation and a fixed sleep interval. Returns the asyncio.Task so the
+caller (typically the FastAPI lifespan context manager) can cancel it
+on shutdown. One location for the loop pattern; Slack and Notion both
+delegate here.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+from typing import Awaitable, Callable
+
+logger = logging.getLogger(__name__)
+
+WorkFn = Callable[[], Awaitable[None]]
+
+
+def worker_loop(name: str, interval_seconds: int, work_fn: WorkFn) -> asyncio.Task:
+    async def _loop() -> None:
+        while True:
+            try:
+                await work_fn()
+            except Exception:  # noqa: BLE001 — single-iteration isolation
+                logger.exception("[team-server] worker=%s iteration failed", name)
+            await asyncio.sleep(interval_seconds)
+    return asyncio.create_task(_loop(), name=f"team-server-worker-{name}")
+```
+
+`team_server/workers/slack_runner.py`:
+
+```python
+"""Slack worker runner — workspace iteration + per-workspace fan-out.
+
+Single iteration: read all workspaces, decrypt each token, construct a
+Slack client per workspace, read the channel allowlist, delegate one
+polling pass to slack_worker.poll_once. Per-workspace exceptions are
+caught so a single bad token does not break iteration over the rest.
+
+Encryption contract (mirrors team_server/auth/router.py:60-72): the
+Fernet key is loaded once per iteration via load_key_from_env; the
+oauth_token_encrypted field stores the urlsafe-base64 string output
+of Fernet(key).encrypt(...).decode("utf-8"), so decrypting requires
+encoding the string back to bytes before passing to decrypt_token.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Awaitable, Callable
+
+from slack_sdk.web.async_client import AsyncWebClient
+
+from ledger.client import LedgerClient
+from team_server.auth.encryption import decrypt_token, load_key_from_env
+from team_server.workers.slack_worker import poll_once
+
+logger = logging.getLogger(__name__)
+
+Extractor = Callable[[str], Awaitable[dict]]
+
+
+async def run_slack_iteration(
+    db_client: LedgerClient, extractor: Extractor
+) -> None:
+    key = load_key_from_env()  # Fernet key (bytes) — load once per iteration
+    workspaces = await db_client.query(
+        "SELECT id, slack_team_id, oauth_token_encrypted FROM workspace"
+    )
+    for ws in workspaces or []:
+        try:
+            ciphertext = ws["oauth_token_encrypted"].encode("utf-8")
+            token = decrypt_token(ciphertext, key)
+            channels = await _channel_ids(db_client, ws["id"])
+            slack_client = AsyncWebClient(token=token)
+            await poll_once(
+                db_client=db_client,
+                slack_client=slack_client,
+                workspace_team_id=ws["slack_team_id"],
+                channels=channels,
+                extractor=extractor,
+            )
+        except Exception:  # noqa: BLE001 — per-workspace isolation
+            logger.exception(
+                "[team-server] slack workspace=%s iteration failed",
+                ws.get("slack_team_id", "<unknown>"),
+            )
+
+
+async def _channel_ids(client: LedgerClient, workspace_id: str) -> list[str]:
+    rows = await client.query(
+        "SELECT channel_id FROM channel_allowlist WHERE workspace_id = $wid",
+        {"wid": workspace_id},
+    )
+    return [r["channel_id"] for r in rows or []]
+```
+
+`team_server/app.py` lifespan extension:
+
+```python
+import asyncio
+import logging
+from contextlib import asynccontextmanager
+
+from fastapi import FastAPI
+
+from team_server.db import TeamServerDB
+from team_server.extraction.llm_extractor import extract as _interim_extractor
+from team_server.schema import SCHEMA_VERSION, ensure_schema
+from team_server.workers.runner import worker_loop
+from team_server.workers.slack_runner import run_slack_iteration
+
+logger = logging.getLogger(__name__)
+
+SLACK_POLL_INTERVAL_SECONDS = 60
+
+
+@asynccontextmanager
+async def lifespan(app: FastAPI):
+    db = TeamServerDB.from_env()
+    await db.connect()
+    await ensure_schema(db.client)
+    app.state.db = db
+
+    slack_task = worker_loop(
+        name="slack",
+        interval_seconds=SLACK_POLL_INTERVAL_SECONDS,
+        work_fn=lambda: run_slack_iteration(db.client, _interim_extractor),
+    )
+    logger.info("[team-server] started; schema_version=%s; slack worker registered", SCHEMA_VERSION)
+    try:
+        yield
+    finally:
+        slack_task.cancel()
+        try:
+            await slack_task
+        except asyncio.CancelledError:
+            pass
+        await db.close()
+        logger.info("[team-server] shut down")
+```
+
+The Phase 0.5 lifespan registers exactly one Slack task. Phase 3 will add a second task for Notion via the same `worker_loop` helper — symmetrically.
+
+---
+
+## Phase 1: Notion auth + content fetch primitives
+
+### Verification (TDD — list test files first)
+
+- [ ] `tests/test_team_server_notion_client.py::test_load_token_prefers_env_over_config` — sets `NOTION_TOKEN=env_value`, also writes a config file with `notion.token=config_value`; invokes `notion_client.load_token(config_path)`; asserts return value is `'env_value'`. Functionality — exercises precedence rule.
+- [ ] `tests/test_team_server_notion_client.py::test_load_token_falls_back_to_config_when_env_unset` — clears env, writes config with `notion.token=config_value`; asserts return value is `'config_value'`. Functionality — exercises the fallback path.
+- [ ] `tests/test_team_server_notion_client.py::test_load_token_raises_when_neither_set` — clears env, writes empty config; asserts `notion_client.load_token` raises `NotionAuthError`. Functionality — exercises the missing-token failure.
+- [ ] `tests/test_team_server_notion_client.py::test_list_databases_returns_only_databases_filter` — uses `httpx.MockTransport` to return a Notion `search` response with mixed `object: page` and `object: database` entries; asserts `notion_client.list_databases(token)` returns only the database entries with `(id, title)` tuples. Functionality — exercises the `filter: { property: 'object', value: 'database' }` invariant on the search call.
+- [ ] `tests/test_team_server_notion_client.py::test_query_database_passes_last_edited_time_filter_when_watermark_given` — uses `httpx.MockTransport`; asserts the outbound request body to `/v1/databases/{db_id}/query` includes `filter: { timestamp: 'last_edited_time', last_edited_time: { after: '<watermark>' } }` when watermark is non-empty, and omits the filter when watermark is empty/None. Functionality — exercises the watermark-to-filter wiring.
+- [ ] `tests/test_team_server_notion_client.py::test_fetch_page_blocks_paginates_until_has_more_false` — `MockTransport` returns 3 pages with `has_more: true, next_cursor: ...` for the first 2 and `has_more: false` for the third; asserts `notion_client.fetch_page_blocks(token, page_id)` returns the union of all blocks across pages. Functionality — exercises pagination.
+- [ ] `tests/test_team_server_notion_client.py::test_notion_version_header_is_pinned` — asserts every request made by the client carries `Notion-Version: 2022-06-28` (the pinned version). Functionality — exercises the version-pinning invariant.
+- [ ] `tests/test_team_server_notion_serializer.py::test_serialize_row_emits_title_then_properties_then_body` — feeds a synthetic Notion DB row + body blocks; asserts the serialized text begins with the title line, followed by `key: value` property lines (sorted by property key for determinism), followed by a blank line, followed by the body block plain-text. Functionality — exercises the deterministic serialization order.
+- [ ] `tests/test_team_server_notion_serializer.py::test_serialize_row_handles_typed_properties` — feeds rows with `select`, `multi_select`, `date`, `rich_text`, `checkbox`, `number`, `url`, and `people` properties; asserts each is serialized to a deterministic string form (option name(s); ISO date; concatenated rich_text plain-text; `true`/`false`; numeric repr; URL string; comma-joined user-IDs). Functionality — exercises each typed-property branch.
+- [ ] `tests/test_team_server_notion_serializer.py::test_serialize_row_is_byte_stable_across_calls` — invokes `serialize_row` twice with the same row+blocks input; asserts byte-identical output. Functionality — exercises the determinism invariant that gates content_hash stability.
+
+### Affected Files
+
+- `team_server/auth/notion_client.py` — **CREATE** — pure async functions over `httpx.AsyncClient`. Exports: `load_token(config_path) -> str`, `NotionAuthError`, `list_databases(token) -> list[tuple[str, str]]`, `query_database(token, db_id, watermark: str|None) -> AsyncIterator[dict]`, `fetch_page_blocks(token, page_id) -> list[dict]`. No app state; no DB.
+- `team_server/extraction/notion_serializer.py` — **CREATE** — pure functions. Exports: `serialize_row(page: dict, blocks: list[dict]) -> str`. Property-type dispatch via a small dict-of-callables; unknown property types serialize as `<unknown:type>` to keep determinism without crashing.
+- `team_server/config.py` — **MUTATE** (existing) — add `NotionConfig` dataclass with `token: Optional[str]` field; loaded from YAML's `notion:` section. Token resolution (env vs config) lives in `notion_client.load_token`, not in config — config returns the YAML value verbatim.
+- `team_server/requirements.txt` — **MUTATE** — no new deps; `httpx` is already required by Phase 1 of v0. Pin `Notion-Version: 2022-06-28` as a constant in `notion_client.py`, not as a dep.
+- `tests/test_team_server_notion_client.py` — **CREATE** — 7 functionality tests above.
+- `tests/test_team_server_notion_serializer.py` — **CREATE** — 3 functionality tests above.
+
+### Changes
+
+`team_server/auth/notion_client.py` skeleton:
+
+```python
+"""Notion API client — internal-integration auth, no OAuth.
+
+Pure async functions over httpx. Token resolution: NOTION_TOKEN env
+preferred; falls back to YAML config's `notion.token`; raises
+NotionAuthError if neither is set. Notion-Version header is pinned to
+2022-06-28 (the stable version this code is tested against).
+"""
+
+from __future__ import annotations
+
+import os
+from typing import AsyncIterator, Optional
+
+import httpx
+import yaml
+
+NOTION_API_BASE = "https://api.notion.com/v1"
+NOTION_VERSION = "2022-06-28"
+
+
+class NotionAuthError(RuntimeError):
+    """Raised when no Notion integration token can be resolved."""
+
+
+def load_token(config_path: Optional[str] = None) -> str:
+    env = os.environ.get("NOTION_TOKEN")
+    if env:
+        return env
+    if config_path and os.path.exists(config_path):
+        with open(config_path) as fh:
+            cfg = yaml.safe_load(fh) or {}
+        token = (cfg.get("notion") or {}).get("token")
+        if token:
+            return token
+    raise NotionAuthError("NOTION_TOKEN not set and notion.token absent in config")
+
+
+def _headers(token: str) -> dict:
+    return {
+        "Authorization": f"Bearer {token}",
+        "Notion-Version": NOTION_VERSION,
+        "Content-Type": "application/json",
+    }
+
+
+async def list_databases(token: str) -> list[tuple[str, str]]:
+    """Return [(db_id, title), ...] for every database the integration has been shared with."""
+    async with httpx.AsyncClient() as client:
+        resp = await client.post(
+            f"{NOTION_API_BASE}/search",
+            headers=_headers(token),
+            json={"filter": {"property": "object", "value": "database"}},
+        )
+    resp.raise_for_status()
+    out = []
+    for entry in resp.json().get("results", []):
+        title_parts = entry.get("title") or []
+        title = "".join(p.get("plain_text", "") for p in title_parts) or "(untitled)"
+        out.append((entry["id"], title))
+    return out
+
+
+async def query_database(
+    token: str, db_id: str, watermark: Optional[str]
+) -> AsyncIterator[dict]:
+    """Yield page rows from a database, optionally filtered by last_edited_time > watermark.
+    Sorted by last_edited_time ascending so watermark advancement is monotonic."""
+    body: dict = {
+        "sorts": [{"timestamp": "last_edited_time", "direction": "ascending"}],
+    }
+    if watermark:
+        body["filter"] = {
+            "timestamp": "last_edited_time",
+            "last_edited_time": {"after": watermark},
+        }
+    cursor: Optional[str] = None
+    async with httpx.AsyncClient() as client:
+        while True:
+            req_body = {**body, **({"start_cursor": cursor} if cursor else {})}
+            resp = await client.post(
+                f"{NOTION_API_BASE}/databases/{db_id}/query",
+                headers=_headers(token),
+                json=req_body,
+            )
+            resp.raise_for_status()
+            payload = resp.json()
+            for row in payload.get("results", []):
+                yield row
+            if not payload.get("has_more"):
+                return
+            cursor = payload.get("next_cursor")
+
+
+async def fetch_page_blocks(token: str, page_id: str) -> list[dict]:
+    """Return the flat list of top-level blocks for a page (paginated)."""
+    out: list[dict] = []
+    cursor: Optional[str] = None
+    async with httpx.AsyncClient() as client:
+        while True:
+            params = {"start_cursor": cursor} if cursor else {}
+            resp = await client.get(
+                f"{NOTION_API_BASE}/blocks/{page_id}/children",
+                headers=_headers(token),
+                params=params,
+            )
+            resp.raise_for_status()
+            payload = resp.json()
+            out.extend(payload.get("results", []))
+            if not payload.get("has_more"):
+                return out
+            cursor = payload.get("next_cursor")
+```
+
+`team_server/extraction/notion_serializer.py` skeleton:
+
+```python
+"""Notion DB row → text input for the canonical extractor.
+
+Deterministic serialization: title line, then sorted-by-key property
+lines, then a blank line, then the body block plain-text. Byte-stable
+output is the gating invariant for content_hash stability across polls.
+"""
+
+from __future__ import annotations
+
+from typing import Callable
+
+
+def _rich_text_plain(rich_text: list[dict]) -> str:
+    return "".join(rt.get("plain_text", "") for rt in rich_text)
+
+
+def _serialize_property(prop: dict) -> str:
+    ptype = prop.get("type")
+    if ptype == "title":
+        return _rich_text_plain(prop.get("title", []))
+    if ptype == "rich_text":
+        return _rich_text_plain(prop.get("rich_text", []))
+    if ptype == "select":
+        sel = prop.get("select")
+        return sel.get("name", "") if sel else ""
+    if ptype == "multi_select":
+        return ", ".join(opt.get("name", "") for opt in prop.get("multi_select", []))
+    if ptype == "date":
+        d = prop.get("date")
+        if not d:
+            return ""
+        start = d.get("start", "")
+        end = d.get("end")
+        return f"{start}..{end}" if end else start
+    if ptype == "checkbox":
+        return "true" if prop.get("checkbox") else "false"
+    if ptype == "number":
+        n = prop.get("number")
+        return "" if n is None else str(n)
+    if ptype == "url":
+        return prop.get("url") or ""
+    if ptype == "people":
+        return ", ".join(p.get("id", "") for p in prop.get("people", []))
+    return f"<unknown:{ptype}>"
+
+
+def _block_plain_text(block: dict) -> str:
+    btype = block.get("type", "")
+    body = block.get(btype) or {}
+    return _rich_text_plain(body.get("rich_text", []))
+
+
+def serialize_row(page: dict, blocks: list[dict]) -> str:
+    properties = page.get("properties", {})
+    title = ""
+    prop_lines: list[str] = []
+    for key in sorted(properties):
+        prop = properties[key]
+        value = _serialize_property(prop)
+        if prop.get("type") == "title":
+            title = value
+        else:
+            prop_lines.append(f"{key}: {value}")
+    body_lines = [_block_plain_text(b) for b in blocks]
+    body_text = "\n".join(line for line in body_lines if line)
+    return "\n".join([title, *prop_lines, "", body_text])
+```
+
+---
+
+## Phase 2: Notion ingest worker — polling, watermark, peer-author event
+
+### Verification (TDD — list test files first)
+
+- [ ] `tests/test_team_server_notion_worker.py::test_poll_once_iterates_databases_from_list_databases` — patches `notion_client.list_databases` to return `[('db1', 'D1'), ('db2', 'D2')]` and `query_database` to yield empty per call; asserts `query_database` was invoked exactly twice with `db_id` values `'db1'` and `'db2'`. Functionality — exercises the no-allowlist-table-derive-from-list_databases invariant.
+- [ ] `tests/test_team_server_notion_worker.py::test_poll_once_writes_event_on_first_seen_row` — mocks `query_database` to yield one row with `id='page1'`, `last_edited_time='2026-05-02T10:00:00Z'`, with a title property; asserts a `team_event` row exists with `payload.source_type='notion_database_row'`, `payload.source_ref='db1/page1'`, `payload.author_email='team-server@notion.bicameral'`, `payload.event_type='ingest'`. Functionality — exercises the new-row → event path.
+- [ ] `tests/test_team_server_notion_worker.py::test_poll_once_is_idempotent_on_unchanged_row` — runs `poll_once` twice with the same mocked row and same content; asserts exactly one `team_event` row exists after the second pass. Functionality — exercises the upsert-changed=False idempotency guarantee under Notion polling.
+- [ ] `tests/test_team_server_notion_worker.py::test_poll_once_writes_new_event_on_edited_row` — runs `poll_once`, then mutates the mocked row's title; runs again; asserts exactly two `team_event` rows exist for the same `(db_id, page_id)` pair, with the second event's `payload.extraction` reflecting the edited title. Functionality — exercises the edit → new event invariant under upsert.
+- [ ] `tests/test_team_server_notion_worker.py::test_poll_once_advances_watermark_to_max_last_edited_time_seen` — yields rows with `last_edited_time` `'2026-05-02T10:00:00Z'` and `'2026-05-02T11:00:00Z'`; after `poll_once`, asserts the `source_watermark` row for `(source_type='notion', resource_id='db1')` has `last_seen='2026-05-02T11:00:00Z'`. Functionality — exercises monotonic watermark advancement.
+- [ ] `tests/test_team_server_notion_worker.py::test_poll_once_passes_stored_watermark_to_query_database_on_subsequent_pass` — pre-seeds `source_watermark` with `last_seen='2026-05-02T09:00:00Z'`; asserts the recorded `query_database` call's `watermark` arg equals `'2026-05-02T09:00:00Z'`. Functionality — exercises the watermark → filter wiring.
+- [ ] `tests/test_team_server_notion_worker.py::test_poll_once_does_not_advance_watermark_when_query_raises` — patches `query_database` to raise `httpx.HTTPError` mid-iteration after one row was yielded; asserts the watermark moved to that one row's `last_edited_time` (not past it), so the next poll re-attempts the rest. Functionality — exercises partial-failure recovery.
+- [ ] `tests/test_team_server_notion_worker.py::test_poll_once_skips_database_on_404_logs_and_continues` — mocks `query_database` for `db1` to raise `httpx.HTTPStatusError` 404; for `db2` yields rows normally; asserts events for `db2` are written, no events for `db1`, and the worker did not crash. Functionality — exercises the per-database failure-isolation invariant.
+- [ ] `tests/test_team_server_notion_worker.py::test_content_hash_uses_serialized_row_not_raw_page_dict` — ingests a row, then re-runs with the same row but a re-ordered `properties` dict (Python dict ordering doesn't affect serialization but the test guards against it ever doing so); asserts changed=False on the second call (no new event). Functionality — exercises the stability of the content_hash through the deterministic serializer.
+
+### Affected Files
+
+- `team_server/workers/notion_worker.py` — **CREATE** — exports `poll_once(db_client, token, extractor) -> None` mirroring the Slack worker's shape but per-database. Uses `notion_client.list_databases` for discovery, `query_database` per database with stored watermark, `fetch_page_blocks` per row, `notion_serializer.serialize_row` for the extraction input, `upsert_canonical_extraction` for the cache, `write_team_event` for the peer-authored event. Watermark read/write helpers live in this module (small, source-specific) — generalize only when a third source needs them.
+- `tests/test_team_server_notion_worker.py` — **CREATE** — 9 functionality tests above.
+
+### Changes
+
+`team_server/workers/notion_worker.py` skeleton:
+
+```python
+"""Notion ingest worker — polls allowlist-via-share databases, runs
+canonical extraction, writes a peer-authored team_event per change.
+
+Idempotent: same (db_id, page_id) with unchanged content yields no new
+event. Per-database watermark is advanced monotonically as rows are
+ingested; partial failures stop watermark advancement at the last
+successfully-ingested row so the next poll resumes correctly.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import logging
+from typing import Awaitable, Callable
+
+import httpx
+
+from ledger.client import LedgerClient
+
+from team_server.auth import notion_client as nc
+from team_server.extraction.canonical_cache import upsert_canonical_extraction
+from team_server.extraction.llm_extractor import INTERIM_MODEL_VERSION
+from team_server.extraction.notion_serializer import serialize_row
+from team_server.sync.peer_writer import write_team_event
+
+logger = logging.getLogger(__name__)
+
+Extractor = Callable[[str], Awaitable[dict]]
+SOURCE_TYPE = "notion_database_row"
+PEER_AUTHOR_EMAIL = "team-server@notion.bicameral"
+
+
+async def poll_once(
+    db_client: LedgerClient,
+    token: str,
+    extractor: Extractor,
+) -> None:
+    databases = await nc.list_databases(token)
+    for db_id, _title in databases:
+        await _poll_database(db_client, token, db_id, extractor)
+
+
+async def _poll_database(
+    db_client: LedgerClient, token: str, db_id: str, extractor: Extractor
+) -> None:
+    watermark = await _load_watermark(db_client, db_id)
+    last_advanced = watermark
+    try:
+        async for row in nc.query_database(token, db_id, watermark):
+            await _ingest_row(db_client, token, db_id, row, extractor)
+            last_advanced = row.get("last_edited_time", last_advanced)
+    except httpx.HTTPError as exc:
+        logger.warning("[notion-worker] db=%s aborted mid-iteration: %s", db_id, exc)
+    finally:
+        if last_advanced != watermark:
+            await _store_watermark(db_client, db_id, last_advanced)
+
+
+async def _ingest_row(
+    db_client: LedgerClient,
+    token: str,
+    db_id: str,
+    row: dict,
+    extractor: Extractor,
+) -> None:
+    page_id = row["id"]
+    blocks = await nc.fetch_page_blocks(token, page_id)
+    text = serialize_row(row, blocks)
+    content_hash = hashlib.sha256(text.encode("utf-8")).hexdigest()
+    source_ref = f"{db_id}/{page_id}"
+    extraction, changed = await upsert_canonical_extraction(
+        db_client,
+        source_type=SOURCE_TYPE,
+        source_ref=source_ref,
+        content_hash=content_hash,
+        compute_fn=lambda: extractor(text),
+        model_version=INTERIM_MODEL_VERSION,
+    )
+    if not changed:
+        return
+    await write_team_event(
+        db_client,
+        workspace_team_id=PEER_AUTHOR_EMAIL,
+        event_type="ingest",
+        payload={
+            "source_type": SOURCE_TYPE,
+            "source_ref": source_ref,
+            "content_hash": content_hash,
+            "extraction": extraction,
+        },
+    )
+
+
+async def _load_watermark(client: LedgerClient, db_id: str) -> str:
+    rows = await client.query(
+        "SELECT last_seen FROM source_watermark "
+        "WHERE source_type = 'notion' AND resource_id = $rid LIMIT 1",
+        {"rid": db_id},
+    )
+    return rows[0]["last_seen"] if rows else ""
+
+
+async def _store_watermark(client: LedgerClient, db_id: str, value: str) -> None:
+    await client.query(
+        "UPSERT source_watermark MERGE { source_type: 'notion', resource_id: $rid, "
+        "last_seen: $v, updated_at: time::now() } "
+        "WHERE source_type = 'notion' AND resource_id = $rid",
+        {"rid": db_id, "v": value},
+    )
+```
+
+The `write_team_event` call passes `PEER_AUTHOR_EMAIL` as the `workspace_team_id` arg — the field is named after Slack's shape but the underlying `team_event` row stores it under `author_email` (per `team_server/schema.py:53`). If the field name proves load-bearing for downstream consumers, rename in a follow-up; the v0 plan called the field `author_email` already, so this is a no-op.
+
+---
+
+## Phase 3: Notion worker registration — extend the Phase 0.5 worker-task pattern
+
+**Why this phase exists**: Phase 0.5 established the `worker_loop` lifecycle helper and wired Slack as the canonical reference. Phase 3 adds the *second* registered worker (Notion) via the same helper — symmetric structure, no new lifecycle pattern. Notion is opt-in: registration is gated on `notion_client.load_token` succeeding (env or config); when no token resolves, the team-server logs once at INFO and continues without Notion ingest.
+
+### Verification (TDD — list test files first)
+
+- [ ] `tests/test_team_server_notion_lifecycle.py::test_app_starts_notion_worker_when_token_env_set` — sets `NOTION_TOKEN=fake-token`; patches `notion_runner.run_notion_iteration` to a recording stub; starts the app via the `lifespan` context manager; advances the worker's interval timer once; asserts the stub was awaited at least once. Functionality — exercises the env-gated startup wiring.
+- [ ] `tests/test_team_server_notion_lifecycle.py::test_app_does_not_start_notion_worker_when_token_unset` — clears `NOTION_TOKEN` and `BICAMERAL_CONFIG_PATH`; starts the app; asserts the `lifespan`-managed task set contains the Slack task but no task with `name='team-server-worker-notion'`. Functionality — exercises the off-by-default invariant.
+- [ ] `tests/test_team_server_notion_lifecycle.py::test_notion_worker_task_is_cancelled_on_shutdown` — sets the token; starts then cleanly stops the app; asserts the registered Notion-worker task's state is `done()` and not pending after shutdown returns. Functionality — exercises the lifecycle invariant under shutdown.
+- [ ] `tests/test_team_server_notion_lifecycle.py::test_notion_worker_loop_continues_after_single_iteration_raises` — sets the token; patches `run_notion_iteration` to raise on the first call and succeed on the second; advances the timer twice; asserts the patched stub was awaited at least twice. Functionality — exercises the resilience invariant (delegated to `worker_loop`'s try/except, so this test confirms the helper's contract is honored when a second consumer registers).
+
+### Affected Files
+
+- `team_server/workers/notion_runner.py` — **CREATE** — `run_notion_iteration(db_client, token, extractor)` async function that delegates to `notion_worker.poll_once(db_client, token, extractor)` (no per-workspace iteration — internal-integration auth means a single token covers a single workspace; the wrapper exists for symmetry with `slack_runner.run_slack_iteration` and to give the lifespan a single zero-arg `work_fn` to pass to `worker_loop`).
+- `team_server/app.py` — **MUTATE** — after the Phase 0.5 Slack task registration, attempt `notion_client.load_token(config_path=DEFAULT_CONFIG_PATH)` inside a try/except; on success, register a Notion task via `worker_loop("notion", NOTION_POLL_INTERVAL_SECONDS, lambda: run_notion_iteration(db.client, token, _interim_extractor))`; on `NotionAuthError`, log INFO and continue. On shutdown, cancel and await both tasks (extending the Phase 0.5 cancellation pattern with the new task).
+- `team_server/config.py` — **MUTATE** — add module-level `DEFAULT_CONFIG_PATH = Path(os.environ.get("BICAMERAL_CONFIG_PATH", "/etc/bicameral-team-server/config.yml"))`. Closes audit Remediation 4 (concrete declaration replacing the v1-pre-amendment placeholder).
+- `tests/test_team_server_notion_lifecycle.py` — **CREATE** — 4 functionality tests above.
+
+### Changes
+
+`team_server/workers/notion_runner.py`:
+
+```python
+"""Notion worker runner — single-workspace internal-integration shape.
+
+The internal-integration auth model gives one token per Notion
+workspace; v1 ships single-workspace, so run_notion_iteration is a
+thin wrapper over poll_once. Exists for symmetry with slack_runner
+(both expose a zero-extra-arg work_fn for the lifespan to register).
+"""
+
+from __future__ import annotations
+
+from typing import Awaitable, Callable
+
+from ledger.client import LedgerClient
+
+from team_server.workers import notion_worker
+
+Extractor = Callable[[str], Awaitable[dict]]
+
+
+async def run_notion_iteration(
+    db_client: LedgerClient, token: str, extractor: Extractor
+) -> None:
+    await notion_worker.poll_once(db_client, token, extractor)
+```
+
+`team_server/app.py` lifespan extension (added after the Phase 0.5 Slack registration):
+
+```python
+import os
+from team_server.auth import notion_client as nc
+from team_server.config import DEFAULT_CONFIG_PATH
+from team_server.workers.notion_runner import run_notion_iteration
+
+NOTION_POLL_INTERVAL_SECONDS = int(os.environ.get("NOTION_POLL_INTERVAL_SECONDS", "60"))
+
+
+@asynccontextmanager
+async def lifespan(app: FastAPI):
+    db = TeamServerDB.from_env()
+    await db.connect()
+    await ensure_schema(db.client)
+    app.state.db = db
+
+    tasks: list[asyncio.Task] = []
+
+    # Phase 0.5: Slack worker (always registered)
+    tasks.append(worker_loop(
+        name="slack",
+        interval_seconds=SLACK_POLL_INTERVAL_SECONDS,
+        work_fn=lambda: run_slack_iteration(db.client, _interim_extractor),
+    ))
+
+    # Phase 3: Notion worker (opt-in, registered only if token resolves)
+    try:
+        notion_token = nc.load_token(config_path=str(DEFAULT_CONFIG_PATH))
+        tasks.append(worker_loop(
+            name="notion",
+            interval_seconds=NOTION_POLL_INTERVAL_SECONDS,
+            work_fn=lambda: run_notion_iteration(db.client, notion_token, _interim_extractor),
+        ))
+        logger.info("[team-server] notion worker registered")
+    except nc.NotionAuthError:
+        logger.info("[team-server] notion ingest disabled (no token)")
+
+    logger.info("[team-server] started; schema_version=%s; %d worker(s)", SCHEMA_VERSION, len(tasks))
+    try:
+        yield
+    finally:
+        for t in tasks:
+            t.cancel()
+        for t in tasks:
+            try:
+                await t
+            except asyncio.CancelledError:
+                pass
+        await db.close()
+        logger.info("[team-server] shut down")
+```
+
+`team_server/config.py` augmentation (one-line addition):
+
+```python
+import os
+from pathlib import Path
+
+DEFAULT_CONFIG_PATH = Path(os.environ.get("BICAMERAL_CONFIG_PATH", "/etc/bicameral-team-server/config.yml"))
+```
+
+---
+
+## CI Commands
+
+- `pytest -x tests/test_team_server_cache_upsert.py tests/test_team_server_schema_migration.py` — Phase 0 contract migration validation (includes the schema_version + callable-dispatch tests added per audit Remediations 1+2)
+- `pytest -x tests/test_team_server_slack_worker.py` — Phase 0 regression check that the Slack worker's adaptation to `upsert_canonical_extraction` did not break landed v0 behavior
+- `pytest -x tests/test_team_server_worker_lifecycle.py` — Phase 0.5 worker-task lifecycle pattern + Slack reference wiring (added per audit Remediation 3)
+- `pytest -x tests/test_team_server_app.py` — Phase 0.5 lifespan regression check (cancellation invariant under the new task set)
+- `pytest -x tests/test_team_server_notion_client.py tests/test_team_server_notion_serializer.py` — Phase 1 client + serializer functionality
+- `pytest -x tests/test_team_server_notion_worker.py` — Phase 2 ingest behavior
+- `pytest -x tests/test_team_server_notion_lifecycle.py` — Phase 3 Notion task registration
+- `pytest -x tests/test_team_server_*.py tests/test_materializer_team_server_pull.py` — full team-server suite, validates Phase 4 materializer still consumes both source types correctly through `/events`
+- `pytest -x tests/ -k "not team_server"` — existing-suite regression check (no breakage to per-repo bicameral)
+- `docker-compose -f deploy/team-server.docker-compose.yml config > /dev/null` — deploy-artifact validation (no Dockerfile changes expected, but config drift would break v0)
+
+---
+
+## Risk note (L2 grade reasoning)
+
+L2 (not L3) because:
+
+- **No new credential lifecycle**: Notion internal-integration tokens don't expire and don't rotate. Encryption-at-rest of the YAML config is the operator's deployment concern — same posture as any other long-lived API key. No OAuth-state CSRF surface, no callback redirect to validate.
+- **No new IPC paths**: Notion events flow through the same `team_event` table and the same `/events` API that Phase 4 already exposes. The per-dev materializer treats `notion_database_row` as just another `source_type` string; failure-isolation invariants from Phase 4 still apply.
+- **The cache-contract migration is the load-bearing risk**: Phase 0's schema v1→v2 touches landed code. Mitigation: dedup pass before index swap; idempotent migration; full Slack-worker regression run in the CI command list above. The Phase 0 tests cover `(test_v1_to_v2_migration_drops_old_index_and_defines_new, test_upsert_unique_index_is_source_type_and_ref_only, test_slack_worker_writes_team_event_only_on_changed_returns)` end-to-end before Notion code lands.
+- **Determinism invariant**: `serialize_row` byte-stability is what makes the content_hash useful. The serializer test suite includes an explicit `test_serialize_row_is_byte_stable_across_calls`. If a property type lands in production that hits the `<unknown:type>` branch, the operator sees a noisy property line but determinism holds — better than a serializer crash.
+
+---
+
+## Modular commit plan (Option-5 convention)
+
+Five commits, one PR.
+
+```
+refactor(team-server): cache-contract migration to upsert-per-source_ref + schema_version table (Phase 0)
+feat(team-server): worker-task lifecycle pattern + Slack reference wiring (Phase 0.5)
+feat(team-server): Notion API client + property serializer (Phase 1)
+feat(team-server): Notion ingest worker + per-database watermark (Phase 2)
+feat(team-server): Notion task registration on lifespan (Phase 3)
+```
+
+Phase 0 ships even if Phases 0.5+ slip — the contract is uniform improvement on its own, and Slack-worker regression coverage validates it independently. Phase 0.5 ships even if Phases 1–3 slip — it closes the v0 dormant-Slack-worker gap as a standalone fix and the worker-task pattern is a generic improvement. Phases 1–3 cannot ship without Phase 0.5; Phase 0.5 cannot ship without Phase 0.

--- a/plan-priority-c-team-server-real-extractor-v1.md
+++ b/plan-priority-c-team-server-real-extractor-v1.md
@@ -1,0 +1,718 @@
+# Plan: Priority C v1.1 — Real heuristic+LLM extractor (replaces interim paragraph-split placeholder)
+
+**change_class**: feature
+**doc_tier**: system
+**Author**: Governor (executed via `/qor-plan`)
+**Risk Grade**: L2 (replaces a placeholder; no new credential surface beyond an Anthropic API key; no IPC paths beyond what Phases 0.5+3 of v1.0 already established; cache-contract gets a column added but stays uniform-shaped across sources)
+**Mode**: solo
+**Predecessor**: `plan-priority-c-team-server-notion-v1.md` (sealed at META_LEDGER Entry #33; Merkle `dcb61910...`)
+**Issue**: none filed
+
+**terms_introduced**:
+- term: heuristic classifier
+  home: team_server/extraction/heuristic_classifier.py
+- term: classification result
+  home: team_server/extraction/heuristic_classifier.py
+- term: extraction pipeline
+  home: team_server/extraction/pipeline.py
+- term: corpus learner
+  home: team_server/extraction/corpus_learner.py
+- term: classifier version
+  home: team_server/schema.py
+- term: trigger rules
+  home: team_server/config.py
+
+**boundaries**:
+- limitations:
+  - v1.1 ships **claude-haiku-4-5** as the Stage 2 default model. Sonnet/Opus selectable via env (`BICAMERAL_TEAM_SERVER_EXTRACT_MODEL`); no auto-tier-up.
+  - Heuristic classifier is **regex/keyword based + reaction/length boosters**. No embedding-similarity classification (deferred to a CocoIndex unparking).
+  - Corpus learner reads the **per-team-server local ledger's `decision` table**, not the originating-author per-dev ledgers. The team-server is its own peer; its corpus is what it observes through replay. Cross-deployment learning is not in scope.
+  - Decision output schema is minimal: `{"summary": str, "context_snippet": str, "matched_triggers": [str]}`. Richer fields (level / rationale / subjects) are deferred to materializer alignment (separate plan).
+  - Anthropic API key sourcing: env var `ANTHROPIC_API_KEY` only. If unset AND any positive classification reaches Stage 2, the team-server fails loud at startup (Phase 4 wiring).
+- non_goals:
+  - Multi-provider LLM support (OpenAI, etc.). Anthropic only.
+  - Per-message confidence scoring as a tunable threshold in v1.1 (the `is_positive` boolean from heuristic Stage 1 is the gate).
+  - LLM-driven heuristic-rule auto-generation. Operator authors rules; corpus learner only suggests learned terms (operator denylist takes precedence).
+  - Replacing the canonical-extraction cache contract from v1.0 (still upsert per `(source_type, source_ref)`).
+  - Materializer's `event_type='ingest.completed'` vs team-server's `event_type='ingest'` shape mismatch — pre-existing v0 gap, separate plan.
+- exclusions:
+  - No CocoIndex (#136) work — remains parked from the v0 plan's Phase 5.
+  - No new MCP tool surface.
+  - No deploy/Dockerfile changes beyond env-var documentation.
+
+## Open Questions
+
+Two flagged at top. Neither blocks Phase 0–4 implementation; Phase 5 (corpus learner) depends on resolution of OQ-1.
+
+1. **OQ-1: Corpus source for the learner** — the team-server has its own SurrealDB; its `decision` table is populated only when peers materialize events back into the team-server's ledger via `/events` pull. But the team-server is not currently configured as a *consumer* of its own `/events` endpoint. Two interpretations:
+   - **(a)** Corpus learner reads from the per-team-server local ledger directly (the same tables `slack_runner` and `notion_worker` write to). This requires the team-server to also run an `EventMaterializer` against its own event log; or skip materialization and read directly from `team_event` rows.
+   - **(b)** Corpus learner reads from a remote source (e.g., the customer's git-tracked event log via `events/team_adapter.py`). More complex; out of scope for this plan.
+   I plan against **(a)** with reading directly from `team_event` rows (no internal materializer). Operator may override.
+
+2. **OQ-2: Materializer event_type mismatch** — `events/materializer.py:89` dispatches on `event_type == 'ingest.completed'`; team-server's `slack_worker` and `notion_worker` write `event_type='ingest'`. Per-dev `EventMaterializer` consuming team-server events would skip them entirely under current code. This is a pre-existing v0 gap; this plan does NOT fix it (separate plan). Flagged because the LLM extractor's output is dead weight in the materializer chain until OQ-2 is resolved. Operator may want to bundle the fix.
+
+## Phase 0: Cache contract gets `classifier_version` column
+
+**Why this phase exists**: Heuristic rules change over time (operator config edits, corpus-learned keywords). The current cache identity `(source_type, source_ref) + content_hash` does not invalidate when rules change — a cached "negative classification" outcome stays cached even after a rule change that would now classify the same text positively. Adding `classifier_version` to the cache row + upsert gate closes the staleness window without changing the source-side primary key shape.
+
+### Verification (TDD — list test files first)
+
+- [ ] `tests/test_team_server_classifier_version.py::test_upsert_returns_changed_true_when_classifier_version_differs` — creates an extraction_cache row with `classifier_version='v1'`; calls `upsert_canonical_extraction(...)` with the same `(source_type, source_ref, content_hash)` but a new `classifier_version='v2'`; asserts return tuple is `(<new extraction>, True)` and the row's `classifier_version` field is now `'v2'`. Functionality — exercises the second-axis upsert gate.
+- [ ] `tests/test_team_server_classifier_version.py::test_upsert_returns_changed_false_when_both_hash_and_version_match` — pre-seeds a row with content_hash and classifier_version; calls upsert with identical values for both; asserts `(<cached>, False)` and the inner compute_fn was not invoked. Functionality — exercises the no-op-when-fully-matched case.
+- [ ] `tests/test_team_server_classifier_version.py::test_upsert_returns_changed_true_when_content_hash_differs_classifier_same` — exercises the existing v1.0 axis (content change) is preserved unchanged. Functionality — regression coverage that the new column did not break the v1.0 contract.
+- [ ] `tests/test_team_server_schema_migration.py::test_v2_to_v3_migration_adds_classifier_version_column` — runs `ensure_schema` on a v2-shaped ledger (no `classifier_version` column); asserts post-migration that `INSERT extraction_cache CONTENT { ..., classifier_version: 'h-v1' }` succeeds and that pre-existing rows' `classifier_version` defaults to the literal string `legacy-pre-v3`. Functionality — exercises the migration's schema-add behavior.
+- [ ] `tests/test_team_server_schema_migration.py::test_v2_to_v3_migration_is_idempotent` — runs ensure_schema twice; asserts no exception and that schema_version row reads 3. Functionality — exercises idempotency under the new migration.
+
+### Affected Files
+
+- `team_server/schema.py` — **MUTATE** — bump `SCHEMA_VERSION` to 3; add `_migrate_v2_to_v3` callable that adds `DEFINE FIELD classifier_version ON extraction_cache TYPE string DEFAULT 'legacy-pre-v3'` and updates pre-existing rows to set the default explicitly (since SurrealDB v2 `DEFAULT` only applies to subsequent CREATEs, not existing rows). Register `_migrate_v2_to_v3` in `_MIGRATIONS`.
+- `team_server/extraction/canonical_cache.py` — **MUTATE** — extend `upsert_canonical_extraction` signature with a new required keyword-only argument `classifier_version: str`. Behavior: SELECT now also reads `classifier_version`; cache hit (`changed=False`) requires BOTH content_hash AND classifier_version match; otherwise the row is updated in place to the new content_hash + classifier_version + extraction.
+- `team_server/workers/slack_worker.py` — **MUTATE** — pass through `classifier_version` from the pipeline result (Phase 4 wires this; for Phase 0 in isolation, slack_worker gets a hardcoded `classifier_version='legacy-pre-v3'` to keep tests passing — Phase 4 replaces with the real value).
+- `team_server/workers/notion_worker.py` — **MUTATE** — same pattern as slack_worker.
+- `tests/test_team_server_classifier_version.py` — **CREATE** — 3 functionality tests above.
+- `tests/test_team_server_schema_migration.py` — **MUTATE** — add 2 functionality tests above.
+- `tests/test_team_server_cache_upsert.py` — **MUTATE** — adapt the existing 4 tests to pass `classifier_version='legacy-pre-v3'` so they continue to pass under the new signature.
+- `tests/test_team_server_slack_worker.py` — **MUTATE** — adapt the upsert-stub tests to the new tuple-return signature including classifier_version.
+
+### Changes
+
+`team_server/extraction/canonical_cache.py`:
+
+```python
+async def upsert_canonical_extraction(
+    client: LedgerClient,
+    *,
+    source_type: str,
+    source_ref: str,
+    content_hash: str,
+    classifier_version: str,   # NEW: second-axis cache identity
+    compute_fn: ComputeFn,
+    model_version: str,
+) -> tuple[dict, bool]:
+    rows = await client.query(
+        "SELECT id, content_hash, classifier_version, canonical_extraction "
+        "FROM extraction_cache "
+        "WHERE source_type = $st AND source_ref = $sr LIMIT 1",
+        {"st": source_type, "sr": source_ref},
+    )
+    if (rows
+            and rows[0]["content_hash"] == content_hash
+            and rows[0]["classifier_version"] == classifier_version):
+        return rows[0]["canonical_extraction"], False
+    extraction = await compute_fn()
+    if rows:
+        await client.query(
+            "UPDATE extraction_cache SET content_hash = $ch, "
+            "classifier_version = $cv, canonical_extraction = $ext, "
+            "model_version = $mv "
+            "WHERE source_type = $st AND source_ref = $sr",
+            {"st": source_type, "sr": source_ref, "ch": content_hash,
+             "cv": classifier_version, "ext": extraction, "mv": model_version},
+        )
+    else:
+        await client.query(
+            "CREATE extraction_cache CONTENT { source_type: $st, source_ref: $sr, "
+            "content_hash: $ch, classifier_version: $cv, "
+            "canonical_extraction: $ext, model_version: $mv }",
+            {"st": source_type, "sr": source_ref, "ch": content_hash,
+             "cv": classifier_version, "ext": extraction, "mv": model_version},
+        )
+    return extraction, True
+```
+
+`team_server/schema.py` migration block:
+
+```python
+SCHEMA_VERSION = 3
+
+# _BASE_STMTS gains:
+"DEFINE FIELD classifier_version ON extraction_cache TYPE string DEFAULT 'legacy-pre-v3'",
+
+async def _migrate_v2_to_v3(client: LedgerClient) -> None:
+    """Add classifier_version column with default for new rows; backfill
+    existing rows so SELECT returns a defined value, not the SurrealDB
+    'NONE' marker that would compare unequal to any real version string."""
+    try:
+        await client.query(
+            "DEFINE FIELD classifier_version ON extraction_cache "
+            "TYPE string DEFAULT 'legacy-pre-v3'"
+        )
+    except Exception as exc:  # noqa: BLE001
+        if "already exists" not in str(exc).lower():
+            raise
+    await client.query(
+        "UPDATE extraction_cache SET classifier_version = 'legacy-pre-v3' "
+        "WHERE classifier_version IS NONE OR classifier_version = ''"
+    )
+
+_MIGRATIONS[3] = _migrate_v2_to_v3
+```
+
+---
+
+## Phase 1: Heuristic classifier — pure function over (message, context, rules)
+
+**Why this phase exists**: This is the deterministic Stage 1 that replaces the v0 paragraph-split placeholder for chatter rejection. It runs before any Anthropic API call. Operator-tunable per workspace (option a), per-channel/database overridable (option b), context-aware on Slack reactions and thread position (option d). Option c (corpus-learned terms) integrates here in Phase 5; the merge contract is established now.
+
+### Verification (TDD — list test files first)
+
+- [ ] `tests/test_team_server_heuristic_classifier.py::test_keyword_match_yields_positive_with_matched_triggers` — feeds a message text containing the keyword "decided"; rules has `keywords=["decided", "agreed"]`; asserts the result is `ClassificationResult(is_positive=True, matched_triggers=["decided"], classifier_version=<expected hash>)`. Functionality — exercises the core keyword-match path.
+- [ ] `tests/test_team_server_heuristic_classifier.py::test_no_keyword_match_yields_negative` — message text contains none of the configured keywords; asserts `is_positive=False`, `matched_triggers=[]`. Functionality.
+- [ ] `tests/test_team_server_heuristic_classifier.py::test_keyword_negative_overrides_positive` — message contains both a positive keyword AND a negative keyword (e.g., "decided" + "haha just kidding"); rules has both lists; asserts `is_positive=False`. Functionality — exercises the negative-list filter.
+- [ ] `tests/test_team_server_heuristic_classifier.py::test_min_word_count_floor_rejects_short_messages` — 2-word message containing a positive keyword; `min_word_count=5`; asserts `is_positive=False`. Functionality — exercises the length floor.
+- [ ] `tests/test_team_server_heuristic_classifier.py::test_reaction_boost_flips_negative_to_positive` — message text has no keyword match; context has `reactions=[{"name": "white_check_mark", "count": 2}]`; rules has `boost_reactions=["white_check_mark"]` with `boost_threshold=1`; asserts `is_positive=True`, `matched_triggers=[":white_check_mark:×2"]`. Functionality — exercises the option-d context-aware booster.
+- [ ] `tests/test_team_server_heuristic_classifier.py::test_thread_position_booster_for_thread_tail` — message is at position N≥3 in a thread (i.e., thread tail where decisions usually crystallize); rules has `thread_tail_boost: {position_threshold: 3}`; otherwise-borderline message; asserts `is_positive=True` with `matched_triggers=["thread-tail"]`. Functionality — exercises the option-d thread-position signal.
+- [ ] `tests/test_team_server_heuristic_classifier.py::test_classification_is_deterministic_for_same_input` — runs `classify(message, context, rules)` twice with identical inputs; asserts byte-identical result tuples (including the same `classifier_version` string). Functionality — exercises the determinism invariant that the classifier's correctness depends on.
+- [ ] `tests/test_team_server_heuristic_classifier.py::test_classifier_version_changes_when_rules_change` — runs `classify` with two rule sets that differ in keyword list; asserts the two `classifier_version` strings are different. Functionality — exercises the rules→version derivation that gates cache invalidation.
+- [ ] `tests/test_team_server_heuristic_classifier.py::test_unicode_and_emoji_in_text_does_not_crash` — feeds messages with mixed unicode + emoji; asserts the classifier returns a result without raising. Functionality — exercises the input-robustness invariant.
+
+### Affected Files
+
+- `team_server/extraction/heuristic_classifier.py` — **CREATE** — pure functions. Exports: `ClassificationResult` dataclass, `classify(message, context, rules) -> ClassificationResult`, `derive_classifier_version(rules) -> str`. No I/O, no DB.
+- `tests/test_team_server_heuristic_classifier.py` — **CREATE** — 9 functionality tests above.
+
+### Changes
+
+`team_server/extraction/heuristic_classifier.py`:
+
+```python
+"""Heuristic classifier — pure function over (message, context, rules).
+
+Stage 1 of the extraction pipeline. Decides whether a message is decision-
+relevant. Deterministic by construction (no LLM, no temperature). Rules
+are operator-configured at the workspace level + channel/database
+overrides; merged at classification time by `pipeline.merge_rules`.
+Option-c learned terms merge in via the same path; learned-keywords
+field of rules is appended to the operator-configured keywords.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import re
+from dataclasses import dataclass, field
+from typing import Optional
+
+
+@dataclass(frozen=True)
+class ClassificationResult:
+    is_positive: bool
+    matched_triggers: tuple[str, ...]
+    classifier_version: str
+
+
+@dataclass(frozen=True)
+class TriggerRules:
+    keywords: tuple[str, ...] = ()
+    keyword_negatives: tuple[str, ...] = ()
+    min_word_count: int = 0
+    boost_reactions: tuple[str, ...] = ()
+    boost_threshold: int = 1
+    thread_tail_position_threshold: Optional[int] = None  # None = disabled
+    learned_keywords: tuple[str, ...] = ()  # filled by Phase 5 corpus learner
+
+
+def derive_classifier_version(rules: TriggerRules) -> str:
+    """Stable hash of the rule set; changes ⇒ cache invalidation downstream."""
+    payload = json.dumps({
+        "keywords": sorted(rules.keywords),
+        "keyword_negatives": sorted(rules.keyword_negatives),
+        "min_word_count": rules.min_word_count,
+        "boost_reactions": sorted(rules.boost_reactions),
+        "boost_threshold": rules.boost_threshold,
+        "thread_tail_position_threshold": rules.thread_tail_position_threshold,
+        "learned_keywords": sorted(rules.learned_keywords),
+        "engine": "heuristic-v1",
+    }, sort_keys=True).encode("utf-8")
+    return f"heuristic-v1+{hashlib.sha256(payload).hexdigest()[:12]}"
+
+
+_WORD_RE = re.compile(r"\b\w+\b", re.UNICODE)
+
+
+def classify(
+    message: dict,
+    context: dict,
+    rules: TriggerRules,
+) -> ClassificationResult:
+    text = message.get("text", "") or ""
+    text_lc = text.lower()
+    matched: list[str] = []
+
+    # Negative-list filter runs first; short-circuits to negative if any hit.
+    if any(neg.lower() in text_lc for neg in rules.keyword_negatives):
+        return ClassificationResult(False, (), derive_classifier_version(rules))
+
+    # Length floor filter.
+    word_count = len(_WORD_RE.findall(text))
+    if word_count < rules.min_word_count:
+        # Only return early-negative if no override booster could rescue.
+        # Keep going to evaluate reactions/thread-tail; if nothing rescues, return.
+        pass
+
+    # Keyword match (operator-configured + corpus-learned).
+    for kw in (*rules.keywords, *rules.learned_keywords):
+        if kw.lower() in text_lc:
+            matched.append(kw)
+
+    # Reaction-count boost (option d).
+    reactions = context.get("reactions") or []
+    if rules.boost_reactions:
+        boost_set = set(rules.boost_reactions)
+        for r in reactions:
+            name = r.get("name", "")
+            count = int(r.get("count", 0))
+            if name in boost_set and count >= rules.boost_threshold:
+                matched.append(f":{name}:×{count}")
+
+    # Thread-tail position boost (option d).
+    if rules.thread_tail_position_threshold is not None:
+        pos = context.get("thread_position", 0)
+        if pos >= rules.thread_tail_position_threshold:
+            matched.append("thread-tail")
+
+    # Final gate: any matched trigger AND meets length floor (or has reaction/thread booster).
+    has_text_trigger = any(
+        not m.startswith(":") and m != "thread-tail" for m in matched
+    )
+    has_context_trigger = any(
+        m.startswith(":") or m == "thread-tail" for m in matched
+    )
+    is_positive = (
+        (has_text_trigger and word_count >= rules.min_word_count)
+        or has_context_trigger
+    )
+
+    return ClassificationResult(
+        is_positive=is_positive,
+        matched_triggers=tuple(matched),
+        classifier_version=derive_classifier_version(rules),
+    )
+```
+
+---
+
+## Phase 2: Trigger rules schema + per-source / per-channel merge
+
+**Why this phase exists**: Phase 1's classifier accepts a `TriggerRules` dataclass. Phase 2 produces those rules from operator configuration. Slack rules + Notion rules sit at workspace level; per-channel and per-database overrides merge on top. Operator authors a single YAML; runtime computes the effective rules per message.
+
+### Verification (TDD — list test files first)
+
+- [ ] `tests/test_team_server_rules.py::test_load_rules_from_yaml_returns_typed_rules` — writes a YAML config with `slack.heuristics.keywords: [decided]`; calls `load_rules_from_config(path).slack.global_rules.keywords`; asserts the returned tuple equals `("decided",)`. Functionality — exercises the YAML→pydantic→TriggerRules path.
+- [ ] `tests/test_team_server_rules.py::test_resolve_rules_for_slack_channel_merges_global_with_channel_override` — config has `slack.heuristics.global.keywords=[a, b]` and `slack.heuristics.channels.C123.keywords=[c]`; calls `resolve_rules_for_slack(config, channel_id="C123")`; asserts the resulting rules has `keywords=("a", "b", "c")` (channel overrides additive). Functionality — exercises the merge order.
+- [ ] `tests/test_team_server_rules.py::test_resolve_rules_for_slack_channel_with_disabled_returns_disabled_marker` — config has `slack.heuristics.channels.C-RANDOM.enabled: false`; calls `resolve_rules_for_slack(config, channel_id="C-RANDOM")`; asserts the resolver returns `RulesDisabled` sentinel. Functionality — exercises the channel-skip surface.
+- [ ] `tests/test_team_server_rules.py::test_resolve_rules_for_notion_database_merges_global_with_database_override` — same shape as above for `notion.heuristics.databases.<db_id>`. Functionality.
+- [ ] `tests/test_team_server_rules.py::test_invalid_yaml_keyword_negatives_pattern_raises_value_error` — YAML has a list-of-int where a list-of-str is required; asserts `ValueError` on load. Functionality — exercises the strict pydantic validation.
+
+### Affected Files
+
+- `team_server/config.py` — **MUTATE** — add `HeuristicGlobalRules`, `HeuristicChannelOverride`, `HeuristicDatabaseOverride` pydantic models nested under existing `SlackConfig` and a new `NotionConfig`. Add `load_rules_from_config(path) -> TeamServerRules`. Add `resolve_rules_for_slack(config, channel_id) -> TriggerRules | RulesDisabled` and `resolve_rules_for_notion(config, db_id) -> TriggerRules | RulesDisabled`.
+- `tests/test_team_server_rules.py` — **CREATE** — 5 functionality tests above.
+
+### Changes
+
+`team_server/config.py` additions:
+
+```python
+class HeuristicGlobalRules(BaseModel):
+    keywords: list[str] = Field(default_factory=list)
+    keyword_negatives: list[str] = Field(default_factory=list)
+    min_word_count: int = 0
+    boost_reactions: list[str] = Field(default_factory=list)
+    boost_threshold: int = 1
+    thread_tail_position_threshold: Optional[int] = None
+    enabled: bool = True
+
+
+class HeuristicChannelOverride(BaseModel):
+    keywords: list[str] = Field(default_factory=list)
+    keyword_negatives: list[str] = Field(default_factory=list)
+    min_word_count: Optional[int] = None
+    enabled: bool = True
+
+
+class SlackHeuristics(BaseModel):
+    global_rules: HeuristicGlobalRules = Field(
+        default_factory=HeuristicGlobalRules, alias="global"
+    )
+    channels: dict[str, HeuristicChannelOverride] = Field(default_factory=dict)
+
+
+class NotionHeuristics(BaseModel):
+    global_rules: HeuristicGlobalRules = Field(
+        default_factory=HeuristicGlobalRules, alias="global"
+    )
+    databases: dict[str, HeuristicChannelOverride] = Field(default_factory=dict)
+
+
+class SlackConfig(BaseModel):  # existing class, MUTATE
+    workspaces: list[WorkspaceConfig] = Field(default_factory=list)
+    heuristics: SlackHeuristics = Field(default_factory=SlackHeuristics)
+
+
+class NotionConfig(BaseModel):
+    token: Optional[str] = None
+    heuristics: NotionHeuristics = Field(default_factory=NotionHeuristics)
+
+
+class TeamServerConfig(BaseModel):  # existing class, MUTATE
+    slack: SlackConfig = Field(default_factory=SlackConfig)
+    notion: NotionConfig = Field(default_factory=NotionConfig)
+
+
+class RulesDisabled:
+    """Sentinel returned by resolve_rules_* when a channel/db is opted out."""
+
+
+def resolve_rules_for_slack(
+    config: TeamServerConfig, channel_id: str
+) -> TriggerRules | RulesDisabled:
+    base = config.slack.heuristics.global_rules
+    override = config.slack.heuristics.channels.get(channel_id)
+    if not base.enabled or (override and not override.enabled):
+        return RulesDisabled()
+    return TriggerRules(
+        keywords=tuple([*base.keywords, *(override.keywords if override else [])]),
+        keyword_negatives=tuple([*base.keyword_negatives,
+                                 *(override.keyword_negatives if override else [])]),
+        min_word_count=(override.min_word_count if override and override.min_word_count is not None
+                        else base.min_word_count),
+        boost_reactions=tuple(base.boost_reactions),
+        boost_threshold=base.boost_threshold,
+        thread_tail_position_threshold=base.thread_tail_position_threshold,
+    )
+
+
+# resolve_rules_for_notion follows identical shape with `databases` in place of `channels`.
+```
+
+---
+
+## Phase 3: Real LLM extractor — Anthropic SDK (Stage 2)
+
+**Why this phase exists**: Replaces `team_server/extraction/llm_extractor.py`'s paragraph-split placeholder with a real Anthropic call. Stage 2 only runs on heuristic-positive messages (Phase 4 wires this). Output schema is minimal-structured: `{"summary": str, "context_snippet": str}` per decision. Error handling: 429 backoff + retry; other errors fail-soft to `{"decisions": [], "error": "..."}` so the worker's per-iteration try/except catches gracefully without dropping the whole polling cycle.
+
+### Verification (TDD — list test files first)
+
+- [ ] `tests/test_team_server_llm_extractor.py::test_extract_returns_structured_decisions_from_mocked_anthropic_response` — patches the Anthropic client to return a fixed JSON-formatted message content; calls `extract(text="we decided to use REST", matched_triggers=["decided"])`; asserts the returned dict is `{"decisions": [{"summary": "use REST", "context_snippet": "we decided to use REST"}], "extractor_version": "claude-haiku-4-5-extract-v1", "matched_triggers": ["decided"]}`. Functionality — exercises the structured-output parsing.
+- [ ] `tests/test_team_server_llm_extractor.py::test_extract_passes_matched_triggers_into_prompt` — patches the Anthropic client to record the request body; calls `extract(text=..., matched_triggers=["decided", "agreed"])`; asserts the captured request's user message contains both triggers as context grounding. Functionality — exercises the prompt-assembly contract.
+- [ ] `tests/test_team_server_llm_extractor.py::test_extract_retries_on_429_then_succeeds` — patches the client to return 429 once then 200 with valid content; asserts the final return is the parsed decisions, and the patched client was called exactly twice. Functionality — exercises the retry-on-rate-limit path.
+- [ ] `tests/test_team_server_llm_extractor.py::test_extract_fails_soft_on_500_returns_error_field` — patches the client to return 500 persistently; asserts the return is `{"decisions": [], "error": "<truncated 500 message>", "extractor_version": "...", "matched_triggers": [...]}`. Functionality — exercises the fail-soft contract.
+- [ ] `tests/test_team_server_llm_extractor.py::test_extract_returns_empty_decisions_when_model_emits_unparseable_content` — patches the client to return text that's not valid JSON; asserts the return is `{"decisions": [], "error": "parse-failure: ...", ...}`. Functionality — exercises malformed-output recovery.
+- [ ] `tests/test_team_server_llm_extractor.py::test_extract_uses_env_overridden_model_when_set` — sets `BICAMERAL_TEAM_SERVER_EXTRACT_MODEL=claude-sonnet-4-6`; patches client; asserts the captured request's `model` field equals the env value. Functionality — exercises the model-selection knob.
+- [ ] `tests/test_team_server_llm_extractor.py::test_extract_raises_loud_when_anthropic_api_key_unset` — clears `ANTHROPIC_API_KEY`; calls `extract(...)`; asserts `RuntimeError` with a message naming `ANTHROPIC_API_KEY`. Functionality — exercises the fail-loud-on-missing-credential contract.
+
+### Affected Files
+
+- `team_server/extraction/llm_extractor.py` — **MUTATE** — full replacement of the paragraph-split placeholder. New module exports: `extract(text: str, matched_triggers: list[str]) -> dict` async; `EXTRACTOR_VERSION` constant computed from `(model_name + prompt_template_hash)`; `MissingAnthropicKeyError`. Anthropic SDK imported lazily inside `extract` (matches the slack_sdk lazy-import pattern from Phase 0.5).
+- `tests/test_team_server_llm_extractor.py` — **CREATE** — 7 functionality tests above.
+
+### Changes
+
+`team_server/extraction/llm_extractor.py` (full rewrite):
+
+```python
+"""Stage 2 LLM extractor — real Anthropic SDK call.
+
+Called only on heuristic-positive messages. Returns a structured dict
+shape: {"decisions": [{"summary": str, "context_snippet": str}], ...}.
+Failure modes:
+- ANTHROPIC_API_KEY unset: raises MissingAnthropicKeyError (fail-loud).
+- HTTP 429: retries with exponential backoff (max 3 attempts).
+- HTTP 5xx: fails soft, returns {"decisions": [], "error": <message>}.
+- Unparseable model output: same fail-soft path.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import hashlib
+import json
+import os
+from typing import Optional
+
+DEFAULT_MODEL = "claude-haiku-4-5"
+PROMPT_TEMPLATE = """You extract DECISIONS from a single chat or document
+message. Return STRICT JSON of the shape:
+{"decisions": [{"summary": "...", "context_snippet": "..."}]}
+
+A "decision" is a commitment, choice, or ratification of a course of
+action. Casual chatter, questions, and stale-context messages produce
+[]. Multiple decisions in one message produce multiple objects.
+
+The pre-classifier already matched these triggers: {triggers}.
+Use them only as context; do not require them in the output.
+
+Message:
+\"\"\"{text}\"\"\""""
+
+EXTRACTOR_VERSION_TEMPLATE_HASH = hashlib.sha256(
+    PROMPT_TEMPLATE.encode("utf-8")
+).hexdigest()[:8]
+
+
+class MissingAnthropicKeyError(RuntimeError):
+    """Raised at extract-time when ANTHROPIC_API_KEY is not set."""
+
+
+def _extractor_version() -> str:
+    model = os.environ.get("BICAMERAL_TEAM_SERVER_EXTRACT_MODEL", DEFAULT_MODEL)
+    return f"{model}-extract-{EXTRACTOR_VERSION_TEMPLATE_HASH}"
+
+
+async def extract(text: str, matched_triggers: list[str]) -> dict:
+    api_key = os.environ.get("ANTHROPIC_API_KEY")
+    if not api_key:
+        raise MissingAnthropicKeyError(
+            "ANTHROPIC_API_KEY env var is required for Stage 2 LLM extraction"
+        )
+    # Lazy import to allow the package to import in environments where
+    # anthropic is in requirements.txt but not installed in dev venv.
+    from anthropic import AsyncAnthropic, APIError, APIStatusError
+
+    model = os.environ.get("BICAMERAL_TEAM_SERVER_EXTRACT_MODEL", DEFAULT_MODEL)
+    client = AsyncAnthropic(api_key=api_key)
+    prompt = PROMPT_TEMPLATE.format(triggers=matched_triggers, text=text)
+    extractor_version = _extractor_version()
+
+    last_error: Optional[str] = None
+    for attempt in range(3):
+        try:
+            resp = await client.messages.create(
+                model=model,
+                max_tokens=512,
+                messages=[{"role": "user", "content": prompt}],
+            )
+            content = resp.content[0].text if resp.content else ""
+            try:
+                parsed = json.loads(content)
+            except json.JSONDecodeError as exc:
+                return {
+                    "decisions": [],
+                    "error": f"parse-failure: {exc}",
+                    "extractor_version": extractor_version,
+                    "matched_triggers": matched_triggers,
+                }
+            return {
+                "decisions": parsed.get("decisions", []),
+                "extractor_version": extractor_version,
+                "matched_triggers": matched_triggers,
+            }
+        except APIStatusError as exc:
+            if exc.status_code == 429 and attempt < 2:
+                await asyncio.sleep(2 ** attempt)
+                continue
+            last_error = f"{exc.status_code}: {str(exc)[:200]}"
+        except APIError as exc:
+            last_error = str(exc)[:200]
+            break
+
+    return {
+        "decisions": [],
+        "error": last_error or "unknown",
+        "extractor_version": extractor_version,
+        "matched_triggers": matched_triggers,
+    }
+```
+
+---
+
+## Phase 4: Pipeline integration — Slack/Notion workers route through `extract_decision_pipeline`
+
+**Why this phase exists**: Wires Phase 1 (classifier) + Phase 2 (rules) + Phase 3 (LLM extractor) into a single pipeline function the workers call. Replaces the existing direct `extractor(text)` call in `slack_worker._ingest_message` and `notion_worker._ingest_row`. The pipeline is the only thing that knows about the two-stage architecture; workers just see "text+context+rules in, extraction dict out."
+
+### Verification (TDD — list test files first)
+
+- [ ] `tests/test_team_server_pipeline.py::test_pipeline_short_circuits_on_negative_classification` — patches LLM extractor to a recording stub; feeds a message that the classifier rejects (no keyword match, no booster); asserts the LLM stub was NOT awaited and the pipeline output is `{"decisions": [], "classifier_version": "...", "matched_triggers": [], "extractor_version": null}`. Functionality — exercises the no-LLM-on-chatter contract.
+- [ ] `tests/test_team_server_pipeline.py::test_pipeline_invokes_llm_on_positive_classification` — patches LLM extractor to return `{"decisions": [{"summary": "..."}], "extractor_version": "...", ...}`; feeds a positive-classified message; asserts the LLM stub was awaited exactly once with the matched triggers passed through; pipeline output merges classifier + extractor metadata. Functionality — exercises the Stage 1 → Stage 2 wiring.
+- [ ] `tests/test_team_server_pipeline.py::test_pipeline_skips_when_rules_disabled` — channel/db with `enabled: false`; asserts the pipeline returns the `RulesDisabled` short-circuit shape (`{"decisions": [], "skipped": true, ...}`) without invoking either classifier or extractor. Functionality — exercises the channel-opt-out path.
+- [ ] `tests/test_team_server_slack_worker.py::test_slack_worker_routes_through_pipeline_with_thread_context` — seeds a message with `thread_ts` and `reactions`; patches the pipeline to a recording stub; runs `slack_worker._ingest_message`; asserts the recorded pipeline call received `context={"reactions": [...], "thread_position": ..., ...}`. Functionality — exercises the worker→pipeline context handoff (Slack-side option-d wiring).
+- [ ] `tests/test_team_server_notion_worker.py::test_notion_worker_routes_through_pipeline_with_edit_context` — analogous Notion-side test with `last_edited_by` / `edit_count` context. Functionality — exercises the option-d wiring on the Notion source.
+
+### Affected Files
+
+- `team_server/extraction/pipeline.py` — **CREATE** — exports `extract_decision_pipeline(*, text, message, context, rules_or_disabled, llm_extract_fn=None) -> dict`. Argument `llm_extract_fn` defaults to `team_server.extraction.llm_extractor.extract` and is a parameter for test stubbing. Returns a uniform output shape: `{"decisions": [...], "classifier_version": str, "matched_triggers": [...], "extractor_version": str|None, "skipped": bool}`.
+- `team_server/workers/slack_worker.py` — **MUTATE** — `_ingest_message` builds the `context` dict (extracts `thread_ts`, `reply_count`, `reactions`, `subtype`, computes `thread_position`); calls `resolve_rules_for_slack(config, channel_id)`; calls `extract_decision_pipeline`; passes the result's `(content_hash, classifier_version)` into `upsert_canonical_extraction`.
+- `team_server/workers/notion_worker.py` — **MUTATE** — `_ingest_row` builds the context dict (extracts `last_edited_by`, `edit_count` from page meta); calls `resolve_rules_for_notion(config, db_id)`; same pipeline call shape.
+- `team_server/workers/slack_runner.py` — **MUTATE** — passes the resolved `TeamServerConfig` through to slack_worker so `_ingest_message` can resolve per-channel rules.
+- `team_server/workers/notion_runner.py` — **MUTATE** — same pattern for notion_worker.
+- `team_server/app.py` — **MUTATE** — lifespan loads `TeamServerConfig` from `DEFAULT_CONFIG_PATH` once at startup and passes it through `run_slack_iteration` / `run_notion_iteration`'s extra arg.
+- `tests/test_team_server_pipeline.py` — **CREATE** — 3 functionality tests above.
+- `tests/test_team_server_slack_worker.py` — **MUTATE** — add the thread-context-handoff test.
+- `tests/test_team_server_notion_worker.py` — **MUTATE** — add the edit-context-handoff test.
+
+### Changes
+
+`team_server/extraction/pipeline.py`:
+
+```python
+"""Extraction pipeline — Stage 1 (heuristic classifier) → Stage 2 (LLM).
+
+Single entry point for both Slack and Notion workers. Determines the
+output shape regardless of source: {decisions, classifier_version,
+matched_triggers, extractor_version, skipped}. extractor_version is
+null when Stage 2 did not run (chatter or rules-disabled).
+"""
+
+from __future__ import annotations
+
+from typing import Awaitable, Callable, Optional, Union
+
+from team_server.config import RulesDisabled
+from team_server.extraction.heuristic_classifier import (
+    TriggerRules, classify, derive_classifier_version
+)
+
+LLMExtractFn = Callable[[str, list[str]], Awaitable[dict]]
+
+
+async def extract_decision_pipeline(
+    *,
+    text: str,
+    message: dict,
+    context: dict,
+    rules_or_disabled: Union[TriggerRules, RulesDisabled],
+    llm_extract_fn: Optional[LLMExtractFn] = None,
+) -> dict:
+    if isinstance(rules_or_disabled, RulesDisabled):
+        return {
+            "decisions": [],
+            "classifier_version": "rules-disabled",
+            "matched_triggers": [],
+            "extractor_version": None,
+            "skipped": True,
+        }
+    rules = rules_or_disabled
+    cv = derive_classifier_version(rules)
+    classification = classify({"text": text, **message}, context, rules)
+    if not classification.is_positive:
+        return {
+            "decisions": [],
+            "classifier_version": cv,
+            "matched_triggers": list(classification.matched_triggers),
+            "extractor_version": None,
+            "skipped": False,
+        }
+    if llm_extract_fn is None:
+        from team_server.extraction.llm_extractor import extract as llm_extract_fn  # noqa
+    llm_result = await llm_extract_fn(text, list(classification.matched_triggers))
+    return {
+        "decisions": llm_result.get("decisions", []),
+        "classifier_version": cv,
+        "matched_triggers": list(classification.matched_triggers),
+        "extractor_version": llm_result.get("extractor_version"),
+        "error": llm_result.get("error"),
+        "skipped": False,
+    }
+```
+
+---
+
+## Phase 5: Corpus learner — option-c feedback loop (ships independently)
+
+**Why this phase exists**: Operator-configured keywords cover the obvious vocabulary; the long tail of team-specific phrasing emerges from observing actual decisions over time. Phase 5 reads the team-server's own `decision` table (per OQ-1 resolution: directly from local rows, not via remote pull), extracts top N-grams that appeared in messages preceding ratified decisions, and writes them to a new `learned_heuristic_terms` table. The merge-into-rules path is already established in Phase 1 (`TriggerRules.learned_keywords`); Phase 5 just populates it.
+
+This phase is **slip-independent** — Phases 0–4 ship as a complete real-extractor system. Phase 5 enriches the rule set with corpus-learned terms; if it slips, the operator-configured keyword path covers v1.1's promise.
+
+### Verification (TDD — list test files first)
+
+- [ ] `tests/test_team_server_corpus_learner.py::test_learner_extracts_top_ngrams_from_ratified_decisions` — seeds the local ledger with 10 ratified decisions whose source messages contain a recurring phrase ("approved by tech lead"); calls `learn_corpus_terms(client, top_n=5)`; asserts the returned list contains "approved by tech lead" with support count 10. Functionality — exercises the n-gram extraction over a synthetic corpus.
+- [ ] `tests/test_team_server_corpus_learner.py::test_learner_respects_denylist` — config has `slack.heuristics.global.learned_denylist=["approved by"]`; seeds same corpus; asserts the returned list does not contain any term matching the denylist. Functionality — exercises the operator-veto path.
+- [ ] `tests/test_team_server_corpus_learner.py::test_learner_persists_results_to_learned_heuristic_terms_table` — runs the learner; asserts a SELECT against `learned_heuristic_terms` returns the expected rows with `term`, `support_count`, `learned_at`. Functionality — exercises the persistence contract.
+- [ ] `tests/test_team_server_corpus_learner.py::test_learn_corpus_terms_is_deterministic_for_same_input` — runs the learner twice over the same fixture corpus; asserts byte-identical output. Functionality — exercises the determinism invariant (gates whether re-runs are no-ops or cause classifier-version churn).
+- [ ] `tests/test_team_server_corpus_learner.py::test_resolve_rules_merges_learned_terms_into_keywords` — pre-populates `learned_heuristic_terms`; calls `resolve_rules_for_slack(config, channel_id)`; asserts the resulting `TriggerRules.learned_keywords` includes the persisted terms. Functionality — exercises the rules-merge integration.
+- [ ] `tests/test_team_server_corpus_learner_lifecycle.py::test_lifespan_starts_corpus_learner_when_enabled` — config has `corpus_learner.enabled: true`; starts the app; patches `learn_corpus_terms` to a recording stub; advances the worker timer; asserts the stub was awaited at least once. Functionality — exercises the worker registration via the existing `worker_loop` helper.
+- [ ] `tests/test_team_server_corpus_learner_lifecycle.py::test_lifespan_does_not_start_corpus_learner_when_disabled` — config has `corpus_learner.enabled: false` (default); asserts no `team-server-worker-corpus-learner` task is registered. Functionality — exercises the off-by-default invariant.
+
+### Affected Files
+
+- `team_server/extraction/corpus_learner.py` — **CREATE** — exports `learn_corpus_terms(client, *, top_n, denylist) -> list[dict]`; `persist_learned_terms(client, terms)`; `run_corpus_learner_iteration(client, config)` async wrapper for `worker_loop`.
+- `team_server/schema.py` — **MUTATE** — bump `SCHEMA_VERSION` to 4; add `learned_heuristic_terms` table (`source_type`, `term`, `support_count`, `learned_at`, `version` index); register `_migrate_v3_to_v4`.
+- `team_server/config.py` — **MUTATE** — add `CorpusLearnerConfig` model with `enabled: bool`, `interval_seconds: int = 86400`, `top_n: int = 50`, and `learned_denylist: list[str]` field on `HeuristicGlobalRules`. Update `resolve_rules_for_slack` / `resolve_rules_for_notion` to read from `learned_heuristic_terms` table and merge into `learned_keywords`.
+- `team_server/app.py` — **MUTATE** — lifespan registers the corpus-learner task via `worker_loop` when `config.corpus_learner.enabled` is true.
+- `tests/test_team_server_corpus_learner.py` — **CREATE** — 5 functionality tests.
+- `tests/test_team_server_corpus_learner_lifecycle.py` — **CREATE** — 2 functionality tests.
+
+### Changes
+
+(Full implementation deferred to the implement phase. Core skeleton:)
+
+```python
+# team_server/extraction/corpus_learner.py
+"""Corpus learner — reads ratified decisions, extracts recurring n-grams,
+populates learned_heuristic_terms for the heuristic classifier to merge."""
+
+from collections import Counter
+
+from ledger.client import LedgerClient
+
+NGRAM_MIN, NGRAM_MAX = 2, 4
+
+
+async def learn_corpus_terms(
+    client: LedgerClient, *, top_n: int = 50, denylist: list[str] = None,
+) -> list[dict]:
+    rows = await client.query(
+        "SELECT description FROM decision WHERE status = 'ratified'"
+    )
+    counter: Counter[str] = Counter()
+    for row in rows or []:
+        text = (row.get("description") or "").lower()
+        words = text.split()
+        for n in range(NGRAM_MIN, NGRAM_MAX + 1):
+            for i in range(len(words) - n + 1):
+                gram = " ".join(words[i:i + n])
+                counter[gram] += 1
+    denyset = {d.lower() for d in (denylist or [])}
+    out = []
+    for term, support in counter.most_common(top_n * 4):
+        if term in denyset or any(d in term for d in denyset):
+            continue
+        out.append({"term": term, "support_count": support})
+        if len(out) >= top_n:
+            break
+    return out
+```
+
+---
+
+## CI Commands
+
+- `pytest -x tests/test_team_server_classifier_version.py tests/test_team_server_schema_migration.py` — Phase 0 cache-contract evolution
+- `pytest -x tests/test_team_server_heuristic_classifier.py` — Phase 1 classifier behavior
+- `pytest -x tests/test_team_server_rules.py` — Phase 2 config rules + merge order
+- `pytest -x tests/test_team_server_llm_extractor.py` — Phase 3 Anthropic SDK integration
+- `pytest -x tests/test_team_server_pipeline.py tests/test_team_server_slack_worker.py tests/test_team_server_notion_worker.py` — Phase 4 pipeline + worker integration
+- `pytest -x tests/test_team_server_corpus_learner.py tests/test_team_server_corpus_learner_lifecycle.py` — Phase 5 corpus learner (slip-independent)
+- `pytest -x tests/test_team_server_*.py tests/test_materializer_team_server_pull.py` — full team-server suite
+- `pytest -x tests/ -k "not team_server"` — regression check (no breakage to per-repo bicameral)
+
+---
+
+## Risk note (L2 grade reasoning)
+
+L2 because:
+
+- **No new credential lifecycle**: Anthropic API key is env-sourced; same operator-deployment-concern posture as the existing `BICAMERAL_TEAM_SERVER_SECRET_KEY` Fernet key. Fail-loud on missing key prevents silent skip.
+- **No new IPC paths**: Pipeline is in-process; adds Anthropic API calls (already a network-permitted boundary outside the deterministic core per CONCEPT.md literal-keyword parsing).
+- **Cache contract evolution is contained**: `classifier_version` adds one column; the upsert function gains one comparison axis; the v2→v3 migration is additive (no DROP/REDEFINE). Phase 0 tests cover the contract change end-to-end before any other phase lands.
+- **Determinism and auditability preserved**: heuristic Stage 1 is deterministic; matched triggers are persisted in the cache row's extraction blob. Operator can answer "why was this surfaced?" with file:line precision.
+- **CocoIndex unparking compatibility**: when CocoIndex (#136) eventually lands, it replaces Stage 1 (and possibly Stage 2) by becoming the deterministic memoized classifier+extractor. The pipeline's `llm_extract_fn` parameter and the rules-version cache axis both extend cleanly.
+
+---
+
+## Modular commit plan (Option-5 convention)
+
+Six commits, one PR.
+
+```
+refactor(team-server): cache-contract gets classifier_version axis (Phase 0)
+feat(team-server): heuristic classifier — pure deterministic Stage 1 (Phase 1)
+feat(team-server): trigger rules schema + per-channel/db merge (Phase 2)
+feat(team-server): real LLM extractor via Anthropic SDK (Phase 3)
+feat(team-server): pipeline integration — workers route Stage 1 → Stage 2 (Phase 4)
+feat(team-server): corpus learner — option-c feedback loop (Phase 5)
+```
+
+Phase 5 ships independently if it slips — Phases 0–4 deliver the real extractor with operator-configured + context-aware classification.

--- a/plan-priority-c-team-server-slack-v0.md
+++ b/plan-priority-c-team-server-slack-v0.md
@@ -1,0 +1,437 @@
+# Plan: Priority C v0 — Self-managing team-server, Slack-first, CocoIndex-conditional
+
+**change_class**: feature
+**doc_tier**: system
+**Author**: Governor (executed via `/qor-plan`)
+**Risk Grade**: L3 (new self-hosted service; new credential surface; new IPC path between team-server and per-dev local ledgers; multi-dev consistency invariant load-bearing for product positioning)
+**Mode**: solo (codex-plugin declared unavailable)
+**Predecessor**: `docs/research-brief-priority-c-selective-ingest-2026-05-02.md` (research v3); `docs/SHADOW_GENOME.md` Failure Entry #6 + addendum (literal-keyword parsing of CONCEPT.md anti-goals)
+**Issue**: no GitHub issue yet — operator may want to file one before merge
+
+**terms_introduced**:
+- term: team-server
+  home: docs/ARCHITECTURE_PLAN.md (to be amended in Phase 5)
+- term: canonical-extraction cache
+  home: team_server/extraction/canonical_cache.py
+- term: peer-author event identity
+  home: team_server/sync/peer_writer.py
+- term: workspace allow-list (Slack)
+  home: team_server/auth/slack_workspace.py
+- term: self-managing backend
+  home: docs/CONCEPT.md (to be amended with literal-keyword clarification)
+
+**boundaries**:
+- limitations:
+  - v0 ships **Slack only**. Notion is v1; GitHub is post-v1 via skill nudge (separate plan).
+  - v0 ships **single-workspace** Slack ingest. Multi-workspace (one team-server, many Slack workspaces) is a v1 concern.
+  - Team-server is **self-hosted only**; no vendor SaaS surface.
+  - **No human ops surface** — schema migration is automatic; restart is idempotent; no DBAs required.
+- non_goals:
+  - Vendor-hosted SaaS offering ("you sign up at bicameral.com")
+  - Multi-region / HA deployment patterns (single instance is the v0 deployment shape)
+  - Replacing the existing per-repo embedded SurrealDB ledger
+  - Fixing #74 / #72 / other unrelated bugs
+  - Touching the `bicameral.ingest` MCP tool surface — the team-server consumes it, doesn't replace it
+- exclusions:
+  - No changes to `docs/ARCHITECTURE_PLAN.md` substantive architecture beyond adding the team-server section
+  - No new MCP tools at v0 — agent talks to bicameral-mcp; bicameral-mcp talks to team-server only via its existing event log consumption
+  - No web admin UI in v0 — config is via YAML files in the team-server's local data dir
+
+## Open Questions
+
+None blocking. Four resolved during dialogue:
+1. **Deployment shape** — docker-compose with a Python (FastAPI/uvicorn) service. Lowest ops surface; runs on any host with Docker. Customer alternative: `pip install bicameral-team-server && python -m bicameral_team_server` for non-Docker installs.
+2. **Sync identity** — team-server authors events under `team-server@<workspace>.bicameral` (single bot per workspace). Per-channel identities is over-engineered for v0.
+3. **Slack auth UX** — OAuth web flow on first start (browser redirect to admin's machine); channel allow-list in `team-server-config.yml`. Web admin UI deferred.
+4. **CocoIndex (#136) feasibility** — Phase 5 of this plan; structured as discrete deferrable phase. If founder coordination / calendar blocks, ship v0 without; Phase 3's canonical-extraction cache provides extraction determinism in the interim.
+
+---
+
+## Phase 1: Team-server scaffold + self-managing schema
+
+### Verification (TDD)
+
+- [ ] `tests/test_team_server_app.py::test_app_starts_and_serves_health` — invokes `team_server.app:create_app()`; uses `httpx.AsyncClient`; asserts `GET /health` returns `200` with body `{"status": "ok", "schema_version": <int>}`. Functionality, not presence — exercises the actual FastAPI app.
+- [ ] `tests/test_team_server_app.py::test_schema_migrates_from_empty_ledger` — invokes `team_server.schema:ensure_schema(client)` against a fresh `memory://` SurrealDB; queries `INFO FOR DB`; asserts the team-server's tables (`workspace`, `channel_allowlist`, `extraction_cache`, `team_event`) are all present. Functionality — invokes the migration, asserts on observed state.
+- [ ] `tests/test_team_server_app.py::test_schema_migration_is_idempotent` — runs `ensure_schema` twice; asserts no exception and table count unchanged. Functionality — exercises idempotency invariant.
+- [ ] `tests/test_team_server_app.py::test_app_shutdown_releases_db` — starts app via `lifespan` context manager; tears it down; asserts the SurrealDB client `is_connected` is False after teardown. Functionality — exercises the lifecycle invariant.
+- [ ] `tests/test_team_server_deploy.py::test_docker_compose_yaml_validates` — invokes `docker-compose -f deploy/team-server.docker-compose.yml config` via `subprocess.run`; asserts exit 0 and stdout contains the `bicameral-team-server` service. Functionality — exercises the deploy artifact's parser-validity.
+
+### Affected Files
+
+- `team_server/__init__.py` — **CREATE** — package marker; export `create_app`
+- `team_server/app.py` — **CREATE** — FastAPI app factory; lifespan context manager; `/health` endpoint
+- `team_server/schema.py` — **CREATE** — `ensure_schema(client)` function; migrations dispatch table; v0-schema definitions for `workspace`, `channel_allowlist`, `extraction_cache`, `team_event`
+- `team_server/db.py` — **CREATE** — `LedgerClient`-mirroring async SurrealDB wrapper (delegates to `ledger.client.LedgerClient` if pattern matches; otherwise minimal local wrapper)
+- `deploy/team-server.docker-compose.yml` — **CREATE** — single-service compose; SurrealDB embedded in the container; volume for persistent data
+- `deploy/Dockerfile.team-server` — **CREATE** — Python 3.11 base; pip-install the new `team_server` package; expose port 8765
+- `team_server/requirements.txt` — **CREATE** — explicit dep pinning: `fastapi`, `uvicorn`, `surrealdb`, `httpx`, `pydantic`
+- `tests/test_team_server_app.py` — **CREATE** — 4 functionality tests above
+- `tests/test_team_server_deploy.py` — **CREATE** — 1 functionality test above
+- `pyproject.toml` — **MUTATE** — add `team_server` package to setup; add optional-extras `[team-server]` for the requirements
+
+### Changes
+
+`team_server/app.py` exports an app factory:
+
+```python
+from contextlib import asynccontextmanager
+from fastapi import FastAPI
+from .db import TeamServerDB
+from .schema import ensure_schema
+
+@asynccontextmanager
+async def lifespan(app: FastAPI):
+    db = TeamServerDB.from_env()
+    await db.connect()
+    await ensure_schema(db.client)
+    app.state.db = db
+    yield
+    await db.close()
+
+def create_app() -> FastAPI:
+    app = FastAPI(lifespan=lifespan)
+
+    @app.get("/health")
+    async def health():
+        version = await app.state.db.client.query("RETURN $schema_version", {"schema_version": 1})
+        return {"status": "ok", "schema_version": 1}
+
+    return app
+```
+
+`team_server/schema.py` follows the `ledger/schema.py` pattern: a `_BASE_STMTS` list of `DEFINE` statements, an `ensure_schema()` function that runs them idempotently, a `_MIGRATIONS` dispatch table for future versions. v0 schema:
+
+- `workspace` (id, name, slack_team_id, oauth_token_encrypted, created_at)
+- `channel_allowlist` (id, workspace_id, channel_id, channel_name, added_at)
+- `extraction_cache` (id, source_type, source_ref, content_hash, canonical_extraction, model_version, created_at) — keyed unique on `(source_type, source_ref, content_hash)`
+- `team_event` (id, author_email, event_type, payload, sequence, created_at) — append-only
+
+`deploy/team-server.docker-compose.yml`: single service `bicameral-team-server`, volume `team-server-data:/data`, env `TEAM_SERVER_PORT=8765`, healthcheck pointing at `/health`.
+
+---
+
+## Phase 2: Slack OAuth + workspace allow-list config
+
+### Verification (TDD)
+
+- [ ] `tests/test_team_server_slack_oauth.py::test_oauth_redirect_url_contains_required_params` — invokes `team_server.auth.slack_oauth:build_authorize_url(client_id, redirect_uri, state)`; asserts URL contains `client_id`, `redirect_uri`, `state`, and the `channels:history,channels:read,groups:history,groups:read` scope set required for ingest. Functionality — invokes URL builder, asserts on output.
+- [ ] `tests/test_team_server_slack_oauth.py::test_callback_exchanges_code_for_token` — mocks Slack's OAuth `oauth.v2.access` endpoint via `httpx_mock`; invokes `slack_oauth:exchange_code(code, client_id, client_secret, redirect_uri)`; asserts the function returns the parsed token + team_id and the request body contained `code` and `redirect_uri`. Functionality.
+- [ ] `tests/test_team_server_slack_oauth.py::test_callback_persists_workspace_with_encrypted_token` — invokes the FastAPI test client with a mocked OAuth callback; queries the `workspace` table; asserts the row exists, `slack_team_id` matches, and `oauth_token_encrypted` is **not equal** to the cleartext token (i.e., encryption actually happened). Functionality.
+- [ ] `tests/test_team_server_slack_oauth.py::test_callback_rejects_invalid_state` — mocks callback with mismatched `state`; asserts 400 response and no row inserted. Functionality — exercises CSRF defense.
+- [ ] `tests/test_team_server_channel_allowlist.py::test_config_yaml_loads_channel_allowlist` — writes a fixture `team-server-config.yml` with `slack: {workspaces: [{team_id: T123, channels: [C1, C2]}]}`; invokes `team_server.config:load_channel_allowlist(path)`; asserts the returned dict matches expected shape. Functionality.
+- [ ] `tests/test_team_server_channel_allowlist.py::test_config_yaml_rejects_missing_workspace_id` — writes a fixture with channels but no team_id; asserts `load_channel_allowlist` raises `ValueError` with a descriptive message. Functionality — exercises the schema-validation failure path.
+
+### Affected Files
+
+- `team_server/auth/__init__.py` — **CREATE** — package marker
+- `team_server/auth/slack_oauth.py` — **CREATE** — `build_authorize_url`, `exchange_code`, callback handler
+- `team_server/auth/encryption.py` — **CREATE** — Fernet-based at-rest encryption for OAuth tokens; key from env `BICAMERAL_TEAM_SERVER_SECRET_KEY`
+- `team_server/config.py` — **CREATE** — `load_channel_allowlist(path: Path) -> dict`; YAML parser with strict schema validation
+- `team_server/app.py` — **MUTATE** — register `/oauth/slack/callback` route; `/oauth/slack/install` route returning the authorize URL
+- `team_server/schema.py` — **MUTATE** — `workspace` table already declared in Phase 1; this phase fills its rows
+- `team_server/requirements.txt` — **MUTATE** — add `cryptography` (Fernet), `pyyaml`, `pydantic[email]`
+- `tests/test_team_server_slack_oauth.py` — **CREATE** — 4 tests above
+- `tests/test_team_server_channel_allowlist.py` — **CREATE** — 2 tests above
+
+### Changes
+
+`team_server/auth/slack_oauth.py`:
+
+```python
+SLACK_AUTHORIZE_URL = "https://slack.com/oauth/v2/authorize"
+SLACK_TOKEN_URL = "https://slack.com/api/oauth.v2.access"
+REQUIRED_SCOPES = ["channels:history", "channels:read", "groups:history", "groups:read"]
+
+def build_authorize_url(client_id: str, redirect_uri: str, state: str) -> str:
+    params = {
+        "client_id": client_id,
+        "redirect_uri": redirect_uri,
+        "state": state,
+        "scope": ",".join(REQUIRED_SCOPES),
+    }
+    return f"{SLACK_AUTHORIZE_URL}?{urlencode(params)}"
+
+async def exchange_code(code, client_id, client_secret, redirect_uri) -> dict:
+    async with httpx.AsyncClient() as client:
+        resp = await client.post(SLACK_TOKEN_URL, data={
+            "code": code, "client_id": client_id,
+            "client_secret": client_secret, "redirect_uri": redirect_uri,
+        })
+    payload = resp.json()
+    if not payload.get("ok"):
+        raise SlackOAuthError(payload.get("error", "unknown"))
+    return payload
+```
+
+`team_server/auth/encryption.py`:
+
+```python
+from cryptography.fernet import Fernet
+
+def encrypt_token(plaintext: str, key: bytes) -> bytes:
+    return Fernet(key).encrypt(plaintext.encode("utf-8"))
+
+def decrypt_token(ciphertext: bytes, key: bytes) -> str:
+    return Fernet(key).decrypt(ciphertext).decode("utf-8")
+```
+
+`team_server/config.py`: pydantic model `WorkspaceConfig(team_id: str, channels: list[str])`; top-level `Config(slack: SlackConfig)`. `load_channel_allowlist` parses YAML, validates via pydantic, raises `ValueError` on schema failures.
+
+---
+
+## Phase 3: Slack ingest worker + canonical-extraction cache (interim)
+
+### Verification (TDD)
+
+- [ ] `tests/test_team_server_slack_worker.py::test_worker_polls_allowlisted_channels_only` — mocks `slack_sdk.WebClient.conversations_history`; invokes `team_server.workers.slack_worker:poll_once(workspace_id, db)`; asserts the mock was called with channel IDs from the allow-list and NOT with channels outside the list. Functionality — exercises the allow-list filter.
+- [ ] `tests/test_team_server_slack_worker.py::test_worker_writes_team_event_for_each_message` — feeds the worker 3 mocked Slack messages; asserts 3 rows in `team_event` after `poll_once` returns; asserts each row's `author_email` is `team-server@<team_id>.bicameral` and `event_type == "ingest"`. Functionality.
+- [ ] `tests/test_team_server_slack_worker.py::test_worker_dedups_via_message_ts` — feeds the same Slack message twice (same `ts`); asserts only one `team_event` row after both invocations. Functionality — exercises the idempotency invariant.
+- [ ] `tests/test_team_server_canonical_cache.py::test_cache_hit_returns_existing_extraction` — pre-populates `extraction_cache` with one row; invokes `team_server.extraction.canonical_cache:get_or_compute(source_type, source_ref, content_hash, compute_fn)`; asserts `compute_fn` was NOT called and the cached extraction was returned. Functionality.
+- [ ] `tests/test_team_server_canonical_cache.py::test_cache_miss_invokes_compute_and_persists` — empty cache; invokes `get_or_compute` with a `compute_fn` that returns `{"decisions": [...]}`; asserts the function was called once, the result was persisted, AND a subsequent call with same key returns from cache without re-invoking. Functionality — exercises the cache-fill path.
+- [ ] `tests/test_team_server_canonical_cache.py::test_cache_keys_on_content_hash_changes` — invokes with same `(source_type, source_ref)` but different `content_hash`; asserts both rows persist (i.e., a Slack message edit produces a new cache row). Functionality.
+
+### Affected Files
+
+- `team_server/workers/__init__.py` — **CREATE** — package marker
+- `team_server/workers/slack_worker.py` — **CREATE** — async polling worker; reads allowlist; pulls messages; calls extraction; writes events
+- `team_server/extraction/__init__.py` — **CREATE** — package marker
+- `team_server/extraction/canonical_cache.py` — **CREATE** — `get_or_compute(source_type, source_ref, content_hash, compute_fn) -> dict` + persistence
+- `team_server/extraction/llm_extractor.py` — **CREATE** — interim LLM-based extraction (Claude API call) used as the v0 `compute_fn`; deterministic only via cache hit, not via the model itself
+- `team_server/sync/__init__.py` — **CREATE** — package marker
+- `team_server/sync/peer_writer.py` — **CREATE** — writes a row into `team_event` shaped to match the `events/writer.py` JSONL event contract; `author_email` is `team-server@<team_id>.bicameral`
+- `team_server/app.py` — **MUTATE** — start the worker as a background task in the lifespan context
+- `team_server/requirements.txt` — **MUTATE** — add `slack_sdk`, `anthropic`
+- `tests/test_team_server_slack_worker.py` — **CREATE** — 3 functionality tests above
+- `tests/test_team_server_canonical_cache.py` — **CREATE** — 3 functionality tests above
+
+### Changes
+
+`team_server/extraction/canonical_cache.py`:
+
+```python
+async def get_or_compute(
+    db, source_type: str, source_ref: str, content_hash: str,
+    compute_fn,
+) -> dict:
+    """Return canonical extraction for (source_type, source_ref, content_hash).
+    Cache hit: returns persisted extraction without invoking compute_fn.
+    Cache miss: invokes compute_fn, persists result, returns it.
+    Idempotent on the (source_type, source_ref, content_hash) tuple."""
+    cached = await db.client.query(
+        "SELECT canonical_extraction FROM extraction_cache "
+        "WHERE source_type = $st AND source_ref = $sr AND content_hash = $ch LIMIT 1",
+        {"st": source_type, "sr": source_ref, "ch": content_hash},
+    )
+    if cached:
+        return cached[0]["canonical_extraction"]
+    extraction = await compute_fn()
+    await db.client.query(
+        "CREATE extraction_cache CONTENT { source_type: $st, source_ref: $sr, "
+        "content_hash: $ch, canonical_extraction: $ext, model_version: $mv }",
+        {"st": source_type, "sr": source_ref, "ch": content_hash,
+         "ext": extraction, "mv": "interim-claude-v1"},
+    )
+    return extraction
+```
+
+The `interim-claude-v1` `model_version` is a tombstone label so Phase 5 (CocoIndex) can rebuild cache entries marked interim if the operator wants extraction determinism enforcement.
+
+`team_server/workers/slack_worker.py`: `poll_once(workspace_id, db)` is the unit of work; a background task calls it on a 30s interval. Polling rather than Events API for v0 because Events API requires a public callback URL (not all self-host setups have one).
+
+---
+
+## Phase 4: Per-dev consumption — HTTP event publishing + materializer extension
+
+### Verification (TDD)
+
+- [ ] `tests/test_team_server_events_api.py::test_get_events_returns_team_events_in_sequence_order` — pre-populates `team_event` with 5 rows of varying sequence numbers; invokes `GET /events?since=0&limit=10`; asserts response body has 5 events ordered by `sequence` ascending. Functionality.
+- [ ] `tests/test_team_server_events_api.py::test_get_events_paginates_via_since_cursor` — pre-populates 100 rows; calls `/events?since=50&limit=10`; asserts response has rows 51..60 only. Functionality — exercises the pagination contract.
+- [ ] `tests/test_team_server_events_api.py::test_get_events_returns_empty_when_no_new_events` — calls `/events?since=999999`; asserts empty array, not error. Functionality.
+- [ ] `tests/test_materializer_team_server_pull.py::test_materializer_pulls_from_team_server_url` — extends `events.materializer.EventMaterializer` with optional `team_server_url`; mocks the `/events` endpoint; invokes `materializer.replay()`; asserts the mocked endpoint was called and events were materialized into the local SurrealDB. Functionality.
+- [ ] `tests/test_materializer_team_server_pull.py::test_materializer_persists_team_server_watermark_separately` — invokes replay twice; asserts the second invocation passes `since=<watermark>` derived from the first; watermark is stored at `.bicameral/local/team_server_watermark`. Functionality — exercises the cursor-persistence invariant.
+- [ ] `tests/test_materializer_team_server_pull.py::test_materializer_handles_team_server_unavailable_gracefully` — mocks `/events` to return 503; invokes replay; asserts no exception raised, log contains warning, materializer continues with git-based event sources. Functionality — exercises the failure-isolation invariant (per CONCEPT.md "no network calls in deterministic core" — team-server pull is OUTSIDE the deterministic core, so failure must not cascade).
+
+### Affected Files
+
+- `team_server/api/__init__.py` — **CREATE** — package marker
+- `team_server/api/events.py` — **CREATE** — `GET /events?since=<int>&limit=<int>` endpoint reading from `team_event`
+- `team_server/app.py` — **MUTATE** — register the events router
+- `events/materializer.py` — **MUTATE** — extend `EventMaterializer.__init__` with optional `team_server_url: str | None = None`; in `replay()`, pull `/events?since=<watermark>` after exhausting git-based sources
+- `events/team_server_watermark.py` — **CREATE** — small helper for read/write of `.bicameral/local/team_server_watermark` (parallel to existing per-author watermark file)
+- `tests/test_team_server_events_api.py` — **CREATE** — 3 functionality tests above
+- `tests/test_materializer_team_server_pull.py` — **CREATE** — 3 functionality tests above
+
+### Changes
+
+`team_server/api/events.py`:
+
+```python
+from fastapi import APIRouter, Depends, Query
+
+router = APIRouter()
+
+@router.get("/events")
+async def get_events(
+    since: int = Query(0, ge=0),
+    limit: int = Query(100, ge=1, le=1000),
+    db = Depends(get_db),
+) -> list[dict]:
+    rows = await db.client.query(
+        "SELECT * FROM team_event WHERE sequence > $since "
+        "ORDER BY sequence ASC LIMIT $limit",
+        {"since": since, "limit": limit},
+    )
+    return rows
+```
+
+`events/materializer.py` extension:
+
+```python
+class EventMaterializer:
+    def __init__(self, events_dir, local_dir, team_server_url: str | None = None):
+        # ... existing init ...
+        self._team_server_url = team_server_url
+
+    async def replay(self) -> None:
+        # ... existing git-based replay ...
+        if self._team_server_url:
+            await self._replay_team_server()
+
+    async def _replay_team_server(self) -> None:
+        watermark_path = self._local_dir / "team_server_watermark"
+        since = int(watermark_path.read_text()) if watermark_path.exists() else 0
+        try:
+            async with httpx.AsyncClient() as client:
+                resp = await client.get(
+                    f"{self._team_server_url}/events",
+                    params={"since": since, "limit": 1000},
+                    timeout=10,
+                )
+            events = resp.json()
+            for event in events:
+                await self._apply_event(event)
+            if events:
+                watermark_path.write_text(str(events[-1]["sequence"]))
+        except (httpx.HTTPError, json.JSONDecodeError) as exc:
+            logger.warning("team-server pull failed: %s", exc)
+```
+
+---
+
+## Phase 5: CocoIndex integration (conditional on #136 feasibility)
+
+### Verification (TDD)
+
+- [ ] `tests/test_team_server_cocoindex_extractor.py::test_cocoindex_extractor_is_deterministic_across_invocations` — invokes `team_server.extraction.cocoindex_adapter:CocoIndexExtractor.extract(message_text)` twice with the same input; asserts byte-identical output (including ordering). Functionality — exercises the determinism invariant that's the entire point of using CocoIndex.
+- [ ] `tests/test_team_server_cocoindex_extractor.py::test_cocoindex_extractor_replaces_canonical_cache_when_enabled` — feeds the worker a message; with `BICAMERAL_TEAM_SERVER_USE_COCOINDEX=1`, asserts `extraction_cache.model_version == "cocoindex-v1"` (not `interim-claude-v1`). Functionality — exercises the wiring decision.
+- [ ] `tests/test_team_server_cocoindex_extractor.py::test_cocoindex_disabled_by_default_falls_back_to_interim` — `BICAMERAL_TEAM_SERVER_USE_COCOINDEX` unset; asserts the worker uses `llm_extractor` and persists `model_version="interim-claude-v1"`. Functionality — exercises the fallback path.
+
+### Affected Files
+
+- `team_server/extraction/cocoindex_adapter.py` — **CREATE** — wraps the CocoIndex Python API; exposes `CocoIndexExtractor.extract(text) -> dict`
+- `team_server/extraction/llm_extractor.py` — **MUTATE** — gate behind env var; default branch (env unset) returns interim Claude path
+- `team_server/workers/slack_worker.py` — **MUTATE** — select extractor at startup based on env var
+- `team_server/requirements.txt` — **MUTATE** — add `cocoindex` (version pin TBD by founder coordination at install time)
+- `tests/test_team_server_cocoindex_extractor.py` — **CREATE** — 3 functionality tests above
+- `docs/CONCEPT.md` — **AMEND** — add a paragraph clarifying that "no managed backend" parses as "no human-ops-tax architecture," not "no backend"; cite SHADOW_GENOME Entry #6 addendum
+- `docs/ARCHITECTURE_PLAN.md` — **AMEND** — add `## Team-server architecture` section describing the v0 deployment shape, sync model, and CocoIndex integration
+
+### Changes
+
+`team_server/extraction/cocoindex_adapter.py`:
+
+```python
+import cocoindex
+
+class CocoIndexExtractor:
+    """Deterministic extraction via CocoIndex memoized transforms.
+    Layer A pre-classifier + Layer B identity capture per #136."""
+
+    def __init__(self, model_version: str = "cocoindex-v1"):
+        self.model_version = model_version
+        self._flow = cocoindex.flow.from_layers([
+            # Layer A: pre-classifier (deterministic memoized)
+            cocoindex.transforms.PreClassifier(),
+            # Layer B: identity capture (deterministic memoized)
+            cocoindex.transforms.IdentityCapture(),
+        ])
+
+    def extract(self, text: str) -> dict:
+        result = self._flow.run({"text": text})
+        return {
+            "decisions": result["decisions"],
+            "model_version": self.model_version,
+        }
+```
+
+The exact `cocoindex` API surface is **subject to founder coordination** at integration time. If the actual API differs, the adapter shape stays the same; only internals change. **This is the primary feasibility risk** — Phase 5 ships only if the API is available and stable.
+
+If `BICAMERAL_TEAM_SERVER_USE_COCOINDEX` is unset (default), the worker keeps using `llm_extractor`. v0 ships extraction-deterministic-via-cache (Phase 3) regardless of whether Phase 5 lands.
+
+`docs/CONCEPT.md` amendment text (insert after the existing Anti-Goals list):
+
+```markdown
+### Anti-Goal Parsing
+
+The anti-goals above must be read by their load-bearing keyword,
+not generalized. "Not a cloud service" means no vendor-hosted SaaS;
+"No managed backend" means no architecture that requires customers to
+pay an ops tax (DBAs, on-call, manual schema migration). Self-hosted,
+self-managing backend components — that the customer deploys without
+human ops surface — are compatible. See `docs/SHADOW_GENOME.md`
+Failure Entry #6 + addendum for the rationale.
+```
+
+---
+
+## CI Commands
+
+```bash
+# Per-phase functionality tests (run incrementally during implement)
+pytest -x tests/test_team_server_app.py tests/test_team_server_deploy.py
+pytest -x tests/test_team_server_slack_oauth.py tests/test_team_server_channel_allowlist.py
+pytest -x tests/test_team_server_slack_worker.py tests/test_team_server_canonical_cache.py
+pytest -x tests/test_team_server_events_api.py tests/test_materializer_team_server_pull.py
+pytest -x tests/test_team_server_cocoindex_extractor.py  # Phase 5 only
+
+# Combined suite for this plan
+pytest -x tests/test_team_server_*.py tests/test_materializer_team_server_pull.py
+
+# Deployment artifact validation
+docker-compose -f deploy/team-server.docker-compose.yml config > /dev/null
+
+# Existing-suite regression check (no breakage to per-repo bicameral)
+pytest -x tests/ -k "not team_server"
+
+# Multi-dev convergence smoke test (manual; encoded as CI step in v1)
+# Two simulated devs, one team-server-published canonical decision,
+# both ledgers converge — implemented in Phase 4 tests
+```
+
+---
+
+## Risk note (L3 grade reasoning)
+
+L3 is warranted because:
+
+- **New attack surface**: team-server holds Slack OAuth tokens + ingests private channel content. Token encryption (Fernet, Phase 2), CSRF defense on the OAuth callback (state parameter, Phase 2), and at-rest encryption of the SurrealDB volume (deployment concern, addressed in `deploy/team-server.docker-compose.yml`) are all required.
+- **New IPC path**: per-dev materializers pull from team-server `/events`. Failure-isolation invariant (Phase 4 test #6) prevents team-server outage from cascading into per-dev preflight failures.
+- **Multi-dev consistency invariant**: if the team-server's canonical extraction is wrong, every dev sees the same wrong decision. Tradeoff: extraction cache (Phase 3) is auditable post-hoc; CocoIndex (Phase 5) is deterministic-by-construction. Phase 5 hardens the invariant.
+- **CONCEPT.md amendment**: Phase 5 amends project DNA. This is governance-grade and warrants `/qor-audit` scrutiny on the wording of the anti-goal-parsing clarification.
+
+---
+
+## Modular commit plan (Option-5 convention; per #149 rebase-merge proposal)
+
+Five commits per phase, one PR. If the team has not yet adopted rebase-merge (per #149), the squash will collapse them — implementer notes the granularity in the PR body for review-time benefit.
+
+```
+chore(team-server): scaffold + self-managing schema (Phase 1)
+feat(team-server): Slack OAuth + workspace allow-list (Phase 2)
+feat(team-server): Slack ingest worker + canonical-extraction cache (Phase 3)
+feat(team-server): HTTP /events API + materializer extension (Phase 4)
+feat(team-server): CocoIndex integration (Phase 5, conditional on #136)
+```
+
+If Phase 5 slips on feasibility, the PR ships Phases 1-4 and a follow-on PR adds Phase 5 once #136 lands.

--- a/plan-priority-c-team-server-v0-release-blockers.md
+++ b/plan-priority-c-team-server-v0-release-blockers.md
@@ -1,0 +1,445 @@
+# Plan: Priority C v0 release-blockers (issues #160 + #161) — channel allowlist + materializer payload bridge
+
+**change_class**: feature
+**doc_tier**: system
+**Author**: Governor (executed via `/qor-plan`)
+**Risk Grade**: L2 (touches landed v1.1 code; closes two known v0 functional gaps; no new credential surface)
+**Mode**: solo (auto)
+**Predecessor**: `plan-priority-c-team-server-real-extractor-v1.md` (sealed at META_LEDGER #36; Merkle `b3700366`)
+**Issues**: closes [#160](https://github.com/BicameralAI/bicameral-mcp/issues/160), closes [#161](https://github.com/BicameralAI/bicameral-mcp/issues/161)
+**v0 release deadline**: ~2 days. Both phases ship together.
+
+**terms_introduced**:
+- term: channel allowlist sync
+  home: team_server/auth/allowlist_sync.py
+- term: team-server payload bridge
+  home: events/materializer.py
+
+**boundaries**:
+- limitations:
+  - **Phase 1 (allowlist sync)**: startup-time only; YAML edits picked up on next restart, not hot-reloaded. Multi-workspace single-server still v1 concern; this plan reads `config.slack.workspaces[]` and matches by `team_id` against the OAuth-completed `workspace` table.
+  - **Phase 2 (materializer bridge)**: maps team-server's `event_type='ingest'` payload shape into an `IngestPayload` (the existing handler input). Decisions land as `source='slack'|'notion'` with empty `repo`/`commit_hash`. Per-dev ledger handles them as ungrounded peer decisions. Subjects (code-region grounding) deferred — the team-server's text-extracted decisions don't reference code.
+  - Materializer accepts BOTH `'ingest'` and `'ingest.completed'` going forward (broader is safer); team-server keeps emitting `'ingest'`.
+- non_goals:
+  - Hot-reload of YAML config without team-server restart
+  - Slack `conversations.list` API discovery for channels (operator authors YAML)
+  - Code-region grounding for Slack/Notion-sourced decisions (subjects=[] is correct for v0)
+  - Multi-workspace per single team-server (still v1 per Priority C plan boundaries)
+  - Touching `decision_ratified.completed` / `link_commit.completed` materializer dispatch (those still work; we only ADD `'ingest'` recognition)
+- exclusions:
+  - No CocoIndex (#136) work
+  - No new MCP tool surface
+  - No deploy/Dockerfile changes
+
+## Open Questions
+
+None blocking. Four design points resolved in advance per auto-mode (the fourth was added in response to audit round-1 VETO):
+
+1. **Allowlist population strategy**: option (2) startup-time YAML→DB sync. Idempotent reconciliation on each lifespan startup. Picks up operator YAML edits on restart. Doesn't couple to the rarely-invoked OAuth callback path.
+2. **Materializer event_type convention**: accept BOTH `'ingest'` and `'ingest.completed'`. Simpler than retrofitting team-server emission; keeps the `.completed` semantic for legacy callers that emit it.
+3. **Decision schema for text-sourced decisions**: use the existing `IngestPayload` with `source='slack'|'notion'`, empty `repo`/`commit_hash`, `description` from extraction's `summary`, `source_excerpt` from `context_snippet`. Per-dev ledger handles ungrounded decisions naturally; nothing new to add to the schema.
+4. **Pull→dispatch wiring** (audit round-1 finding): use direct adapter dispatch (Option A2 from the audit report), not the JSONL bridge (A1). Periodic task pulls events via `pull_team_server_events`, runs the team-server bridge, and invokes `inner_adapter.ingest_payload` directly. JSONL bypass is acceptable here because team-server events have their own canonical home (the team-server's SurrealDB + `/events` endpoint); re-rendering them as per-author JSONL files in each per-dev repo would be redundant mechanical work. Trade-off acknowledged: team-server events don't appear in `.bicameral/events/` for human inspection; they ARE in the per-dev local SurrealDB and the team-server's own ledger.
+
+## Phase 1: Channel allowlist startup-time sync
+
+**Why this phase exists**: Closes #161. The `channel_allowlist` table is queried by `slack_runner._channel_ids` per polling iteration but nothing populates it. Net effect after v1.0 Phase 0.5: Slack worker runs, decrypts tokens, calls `poll_once(channels=[])`. Zero ingestion.
+
+### Verification (TDD — list test files first)
+
+- [ ] `tests/test_team_server_allowlist_sync.py::test_sync_inserts_channels_for_workspace_in_yaml` — pre-seeds a workspace row with `slack_team_id='T1'`; YAML config has `slack.workspaces=[{team_id: 'T1', channels: ['C-A', 'C-B']}]`; invokes `sync_channel_allowlist(client, config)`; asserts `channel_allowlist` rows exist for `(workspace_id_for_T1, 'C-A')` and `(workspace_id_for_T1, 'C-B')`. Functionality — exercises the YAML→DB write path.
+- [ ] `tests/test_team_server_allowlist_sync.py::test_sync_is_idempotent` — runs sync twice with same input; asserts row count is unchanged after second invocation (UPSERT-shaped, not append). Functionality — exercises the idempotency invariant.
+- [ ] `tests/test_team_server_allowlist_sync.py::test_sync_skips_workspaces_not_in_yaml` — pre-seeds two workspace rows (T1, T2); YAML mentions only T1; asserts T2 has no allowlist rows. Functionality — exercises the per-team_id match scope.
+- [ ] `tests/test_team_server_allowlist_sync.py::test_sync_skips_workspaces_not_in_db` — YAML mentions T-MISSING; no matching workspace row; asserts no allowlist rows are created (no orphan `workspace_id`). Functionality — exercises the OAuth-must-have-completed precondition.
+- [ ] `tests/test_team_server_allowlist_sync.py::test_sync_removes_channels_not_in_yaml` — pre-seeds T1 with allowlist [C-A, C-B]; YAML now lists only [C-A]; runs sync; asserts C-B row is deleted. Functionality — exercises the "operator removes a channel by editing YAML" workflow.
+- [ ] `tests/test_team_server_allowlist_lifespan.py::test_lifespan_runs_allowlist_sync_at_startup` — config with one workspace + channels; pre-seeds workspace row; starts app; asserts post-lifespan that `channel_allowlist` is populated. Functionality — exercises the lifespan integration.
+- [ ] `tests/test_team_server_slack_worker.py::test_slack_runner_picks_up_synced_allowlist_end_to_end` — full path: pre-seed workspace + run sync + run a slack-runner iteration with patched poll_once; assert poll_once received the synced channels. Functionality — exercises that the cached query in slack_runner sees synced rows.
+
+### Affected Files
+
+- `team_server/auth/allowlist_sync.py` — **CREATE** — exports `sync_channel_allowlist(client, config) -> None` async. For each `WorkspaceConfig` in `config.slack.workspaces`: SELECT workspace by `slack_team_id`; if no match, log INFO and skip (OAuth not yet completed for this team_id). If match: SELECT existing `channel_allowlist.channel_id` set; compute diff vs YAML's `channels`; INSERT new rows + DELETE removed rows. Idempotent.
+- `team_server/app.py` — **MUTATE** — lifespan calls `await sync_channel_allowlist(db.client, config)` AFTER `ensure_schema` and AFTER config load, BEFORE worker registration. Failures log at WARN and continue (don't block startup if YAML is partial).
+- `tests/test_team_server_allowlist_sync.py` — **CREATE** — 5 functionality tests above
+- `tests/test_team_server_allowlist_lifespan.py` — **CREATE** — 1 functionality test above
+- `tests/test_team_server_slack_worker.py` — **MUTATE** — add the end-to-end allowlist→runner test
+
+### Changes
+
+`team_server/auth/allowlist_sync.py`:
+
+```python
+"""Channel allowlist startup-time sync.
+
+Reads config.slack.workspaces[] and reconciles channel_allowlist
+against the workspace table. Per-team_id additive + subtractive sync
+so operator YAML edits propagate on next restart. Workspaces in YAML
+without a corresponding workspace-table row (no OAuth completed yet)
+are logged and skipped — they get picked up on the next sync after
+OAuth completes."""
+
+from __future__ import annotations
+
+import logging
+
+from ledger.client import LedgerClient
+
+from team_server.config import TeamServerConfig
+
+logger = logging.getLogger(__name__)
+
+
+async def sync_channel_allowlist(
+    client: LedgerClient, config: TeamServerConfig,
+) -> None:
+    for workspace_cfg in config.slack.workspaces:
+        await _sync_one_workspace(client, workspace_cfg.team_id, workspace_cfg.channels)
+
+
+async def _sync_one_workspace(
+    client: LedgerClient, team_id: str, yaml_channels: list[str],
+) -> None:
+    rows = await client.query(
+        "SELECT id FROM workspace WHERE slack_team_id = $tid LIMIT 1",
+        {"tid": team_id},
+    )
+    if not rows:
+        logger.info(
+            "[allowlist-sync] no workspace row for team_id=%s; "
+            "skipping (OAuth not yet completed)", team_id,
+        )
+        return
+    workspace_id = rows[0]["id"]
+    existing_rows = await client.query(
+        "SELECT channel_id FROM channel_allowlist WHERE workspace_id = $wid",
+        {"wid": workspace_id},
+    )
+    existing = {r["channel_id"] for r in existing_rows or []}
+    desired = set(yaml_channels)
+    to_add = desired - existing
+    to_remove = existing - desired
+    for channel_id in to_add:
+        await client.query(
+            "CREATE channel_allowlist CONTENT { workspace_id: $wid, "
+            "channel_id: $cid, channel_name: '' }",
+            {"wid": workspace_id, "cid": channel_id},
+        )
+    for channel_id in to_remove:
+        await client.query(
+            "DELETE channel_allowlist WHERE workspace_id = $wid AND channel_id = $cid",
+            {"wid": workspace_id, "cid": channel_id},
+        )
+    logger.info(
+        "[allowlist-sync] team_id=%s: +%d -%d (now %d total)",
+        team_id, len(to_add), len(to_remove), len(desired),
+    )
+```
+
+`team_server/app.py` lifespan additions (insert after `await ensure_schema`):
+
+```python
+from team_server.auth.allowlist_sync import sync_channel_allowlist
+
+# ... in lifespan, after ensure_schema + config load:
+config = _load_config_or_default()
+app.state.team_server_config = config
+try:
+    await sync_channel_allowlist(db.client, config)
+except Exception:  # noqa: BLE001
+    logger.exception("[team-server] channel_allowlist sync failed; continuing")
+```
+
+---
+
+## Phase 1.5: Periodic team-server event consumer (closes audit round-1 finding)
+
+**Why this phase exists**: Audit round-1 surfaced that `events/team_server_pull.py::pull_team_server_events` has zero production callers — the function exists but nothing pulls events into per-dev ledgers. Per-dev materializer iterates JSONL files; team-server events live in HTTP `/events` and would never reach the materializer's dispatch loop without this phase. The bridge in Phase 2 (formerly Phase 2 pre-amendment) is dead code without this wiring.
+
+This phase establishes a periodic asyncio task in the per-dev MCP server's `serve_stdio` startup. The task pulls team-server events on a fixed interval, applies the team-server bridge (defined in Phase 2), and invokes `inner_adapter.ingest_payload` directly. This bypasses the JSONL representation — team-server events have their own canonical home in the team-server's SurrealDB; re-rendering as per-author JSONL would be redundant.
+
+### Verification (TDD — list test files first)
+
+- [ ] `tests/test_team_server_consumer.py::test_consumer_pulls_events_and_invokes_ingest_payload` — patches `pull_team_server_events` to return one team-server-shaped event; patches `inner_adapter.ingest_payload` to a recording stub; invokes `consume_team_server_events_once(team_server_url, watermark_path, inner_adapter, llm_extract_fn=None)`; asserts the stub was awaited exactly once with a bridged `IngestPayload`-shaped dict. Functionality — exercises the pull→bridge→ingest path end-to-end.
+- [ ] `tests/test_team_server_consumer.py::test_consumer_skips_events_with_empty_decisions` — pull returns one event with `extraction.decisions=[]` (chatter); asserts `ingest_payload` was NOT invoked. Functionality — exercises the chatter-skip behavior at consumer layer (mirrors materializer-side behavior in Phase 2).
+- [ ] `tests/test_team_server_consumer.py::test_consumer_handles_pull_failure_gracefully` — patches `pull_team_server_events` to return `[]` (its failure-isolation contract); asserts `ingest_payload` NOT invoked AND no exception raised. Functionality — exercises the team-server-unavailable path.
+- [ ] `tests/test_team_server_consumer.py::test_consumer_advances_pull_watermark_via_returned_events` — pull returns events with `sequence: [1, 2, 3]`; asserts the second consume call's pull invocation receives `since=3`. Functionality — exercises that `pull_team_server_events`'s own watermark is advanced (already covered by `test_materializer_persists_team_server_watermark_separately` for `pull_team_server_events` in isolation; this test verifies the consumer doesn't break that).
+- [ ] `tests/test_team_server_consumer.py::test_start_consumer_loop_registers_task_when_url_set` — sets `BICAMERAL_TEAM_SERVER_URL=http://team:8765`; calls `start_team_server_consumer_if_configured(adapter)`; asserts the returned `asyncio.Task` is non-None and named `bicameral-team-server-consumer`. Functionality — exercises the env-gated startup wiring.
+- [ ] `tests/test_team_server_consumer.py::test_start_consumer_loop_returns_none_when_url_unset` — clears `BICAMERAL_TEAM_SERVER_URL`; calls `start_team_server_consumer_if_configured(adapter)`; asserts the return is None. Functionality — exercises the off-by-default invariant.
+- [ ] `tests/test_team_server_consumer.py::test_consumer_unwraps_team_write_adapter_does_not_echo_to_jsonl` — constructs a real `TeamWriteAdapter(inner=stub_inner_adapter, writer=recording_writer, materializer=stub_materializer)`; sets `BICAMERAL_TEAM_SERVER_URL` and patches `pull_team_server_events` to return one team-server event with non-empty extraction.decisions; invokes `start_team_server_consumer_if_configured(team_write_adapter)`; advances the asyncio loop one tick; asserts (a) `stub_inner_adapter.ingest_payload` was awaited (the unwrap routed correctly to inner), (b) `recording_writer.write` was NOT called (no echo to per-dev JSONL). Functionality — exercises the no-echo invariant that audit-round-2 Finding A surfaced.
+
+### Affected Files
+
+- `events/team_server_consumer.py` — **CREATE** — exports `consume_team_server_events_once(team_server_url, watermark_path, inner_adapter, llm_extract_fn=None)` async function that calls `pull_team_server_events`, filters team-server-shaped events via `is_team_server_payload`, bridges via `bridge_team_server_payload` (defined in Phase 2; this phase imports the bridge module created there), and invokes `inner_adapter.ingest_payload(bridged)` for each event with non-empty decisions. Also exports `start_team_server_consumer_if_configured(adapter, *, watermark_path=None) -> Optional[asyncio.Task]` that reads `BICAMERAL_TEAM_SERVER_URL` env, returns None if unset, otherwise spawns a forever-loop task that calls `consume_team_server_events_once` every `BICAMERAL_TEAM_SERVER_PULL_INTERVAL_SECONDS` (default 60).
+- `server.py` — **MUTATE** — `serve_stdio` adds a call to `start_team_server_consumer_if_configured` parallel to the existing dashboard sidecar startup (line ~1330). Captured task is cancelled on shutdown via the same try/finally pattern used for dashboard.
+- `tests/test_team_server_consumer.py` — **CREATE** — 6 functionality tests above.
+
+### Changes
+
+`events/team_server_consumer.py`:
+
+```python
+"""Periodic team-server event consumer.
+
+Closes the pull→dispatch gap: pulls events from a team-server URL on
+a fixed interval, bridges each event's payload to IngestPayload shape,
+and invokes inner_adapter.ingest_payload directly. Bypasses JSONL —
+team-server events have their own canonical home in the team-server's
+SurrealDB; re-rendering as per-author JSONL files would be redundant.
+
+Failure isolation: pull failures return [] (per pull_team_server_events
+contract); per-event ingest failures are caught and logged so a single
+malformed event doesn't kill the loop.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import os
+from pathlib import Path
+from typing import Optional
+
+from events.team_server_bridge import (
+    bridge_team_server_payload, is_team_server_payload,
+)
+from events.team_server_pull import pull_team_server_events
+
+logger = logging.getLogger(__name__)
+
+
+async def consume_team_server_events_once(
+    team_server_url: str,
+    watermark_path: Path,
+    inner_adapter,
+    llm_extract_fn=None,  # reserved; team-server events are pre-extracted
+) -> int:
+    """Pull + dispatch one batch. Returns the count of events ingested."""
+    events = await pull_team_server_events(
+        team_server_url=team_server_url,
+        watermark_path=watermark_path,
+    )
+    ingested = 0
+    for event in events:
+        payload = event.get("payload") or {}
+        if not is_team_server_payload(payload):
+            continue
+        bridged = bridge_team_server_payload(payload)
+        if not bridged.get("decisions"):
+            continue  # chatter; skip ingest
+        try:
+            await inner_adapter.ingest_payload(bridged)
+            ingested += 1
+        except Exception:  # noqa: BLE001 — per-event isolation
+            logger.exception("[team-server-consumer] ingest failed for %s",
+                             payload.get("source_ref", "<unknown>"))
+    return ingested
+
+
+def start_team_server_consumer_if_configured(
+    adapter, *, watermark_path: Optional[Path] = None,
+) -> Optional[asyncio.Task]:
+    """Spawn the consumer loop if BICAMERAL_TEAM_SERVER_URL is set.
+    Returns the task (caller cancels on shutdown) or None when off.
+
+    Defensive unwrap: TeamWriteAdapter (returned by get_ledger() in team
+    mode) wraps SurrealDBLedgerAdapter and emits 'ingest.completed' via
+    self._writer.write(...) BEFORE delegating ingest_payload. Consumer-
+    driven ingest must use the inner adapter to bypass the writer; if
+    we used the wrapper, every team-server event would echo into per-dev
+    JSONL → git push → other devs replay → O(N²) cross-dev replay
+    amplification per team-server event. Audit-round-2 Finding A.
+    """
+    url = os.environ.get("BICAMERAL_TEAM_SERVER_URL", "").strip()
+    if not url:
+        return None
+    inner_adapter = getattr(adapter, "_inner", adapter)
+    interval = int(os.environ.get("BICAMERAL_TEAM_SERVER_PULL_INTERVAL_SECONDS", "60"))
+    if watermark_path is None:
+        data_path = os.environ.get("BICAMERAL_DATA_PATH", os.environ.get("REPO_PATH", "."))
+        watermark_path = Path(data_path) / ".bicameral" / "local" / "team_server_watermark"
+
+    async def _loop():
+        while True:
+            try:
+                ingested = await consume_team_server_events_once(
+                    url, watermark_path, inner_adapter,
+                )
+                if ingested:
+                    logger.info("[team-server-consumer] ingested %d events", ingested)
+            except Exception:  # noqa: BLE001
+                logger.exception("[team-server-consumer] iteration failed")
+            await asyncio.sleep(interval)
+
+    return asyncio.create_task(_loop(), name="bicameral-team-server-consumer")
+```
+
+`server.py::serve_stdio` extension (insert after dashboard startup, around line 1331):
+
+```python
+async def serve_stdio() -> None:
+    dashboard_srv = get_dashboard_server()
+    await dashboard_srv.start(ctx_factory=BicameralContext.from_env)
+
+    # Team-server event consumer — opt-in via BICAMERAL_TEAM_SERVER_URL env.
+    # Uses the per-repo ledger adapter as the ingest target.
+    from adapters.ledger import get_ledger
+    from events.team_server_consumer import start_team_server_consumer_if_configured
+
+    team_consumer_task = start_team_server_consumer_if_configured(
+        get_ledger(),
+    )
+    try:
+        # ... existing stdio setup (consent + mcp.server.stdio.stdio_server) ...
+        async with mcp.server.stdio.stdio_server() as (read_stream, write_stream):
+            await server.run(...)
+    finally:
+        if team_consumer_task is not None:
+            team_consumer_task.cancel()
+            try:
+                await team_consumer_task
+            except asyncio.CancelledError:
+                pass
+```
+
+The `get_ledger()` accessor is verified at `adapters/ledger.py:52` (singleton via `_real_ledger_instance`). The defensive unwrap inside `start_team_server_consumer_if_configured` (shown above as `inner_adapter = getattr(adapter, "_inner", adapter)`) is the load-bearing line: it picks `TeamWriteAdapter._inner` in team mode and falls through to the bare `SurrealDBLedgerAdapter` in solo mode. Without the unwrap, consumer-driven ingest would trigger the wrapper's `_writer.write("ingest.completed", ...)` side effect at `events/team_adapter.py:58`, echoing team-server events into per-dev JSONL files. The new test `test_consumer_unwraps_team_write_adapter_does_not_echo_to_jsonl` exercises this invariant by constructing a real `TeamWriteAdapter` with a recording `EventFileWriter` stub and asserting the writer's `write` method is not called.
+
+---
+
+## Phase 2: Materializer payload bridge for team-server events
+
+**Why this phase exists**: Closes #160. The materializer at `events/materializer.py:89` dispatches on `event_type == 'ingest.completed'` but the team-server emits `event_type='ingest'`. The team-server's payload shape (`{source_type, source_ref, content_hash, extraction}`) doesn't match `IngestPayload` either. With Phase 1.5 wiring the consumer-side ingest, the materializer's bridge is for the secondary path: per-dev devs that pull team-server events into git-tracked JSONL files (out of scope for v0; future-compatible).
+
+The Phase 2 module `events/team_server_bridge.py` is **shared** with Phase 1.5: both consume `is_team_server_payload` + `bridge_team_server_payload`. The bridge module is created in Phase 2 and imported by both Phase 1.5's consumer and Phase 2's materializer dispatch. (Phase 1.5 lands the consumer that imports from the bridge; Phase 2 lands the bridge module + the materializer's reciprocal dispatch case.)
+
+### Verification (TDD — list test files first)
+
+- [ ] `tests/test_materializer_team_server_pull.py::test_materializer_dispatches_team_server_ingest_event` — seeds a JSONL event log line with `event_type='ingest'` and a team-server-shaped payload; runs `materialize_for_dev`; patches `inner_adapter.ingest_payload` to a recording stub; asserts the stub was awaited exactly once with an `IngestPayload`-shaped dict. Functionality — exercises the new dispatch case.
+- [ ] `tests/test_materializer_team_server_pull.py::test_materializer_bridges_slack_extraction_to_ingest_payload` — payload `{source_type: 'slack', source_ref: 'C1/123.0', content_hash: 'h', extraction: {decisions: [{summary: 'use REST', context_snippet: 'we decided to use REST'}], extractor_version: 'haiku-v1', matched_triggers: ['decided']}}`; asserts the bridged IngestPayload has `source='slack'`, `decisions=[{description: 'use REST', source_excerpt: 'we decided to use REST'}]`, `repo=''`, `commit_hash=''`. Functionality — exercises the team-server-shape → IngestPayload mapping.
+- [ ] `tests/test_materializer_team_server_pull.py::test_materializer_bridges_notion_extraction_with_correct_source_type` — identical to the slack test but `source_type='notion_database_row'`; asserts bridged IngestPayload has `source='notion'`. Functionality — exercises the source-type normalization (slack/notion_database_row → slack/notion).
+- [ ] `tests/test_materializer_team_server_pull.py::test_materializer_skips_team_server_event_with_empty_decisions` — payload's `extraction.decisions=[]` (heuristic-negative classification); asserts `inner_adapter.ingest_payload` is NOT invoked AND `replayed` count is unchanged. Functionality — exercises the chatter-skip behavior (no decision to ingest).
+- [ ] `tests/test_materializer_team_server_pull.py::test_materializer_still_handles_legacy_ingest_completed_event_type` — pre-existing v0 callers emit `event_type='ingest.completed'`; assert dispatch still routes correctly via the bridge. Functionality — regression coverage that `'ingest.completed'` path is preserved.
+- [ ] `tests/test_materializer_team_server_pull.py::test_materializer_skips_team_server_event_with_malformed_payload` — payload missing `extraction` key; asserts no exception, `inner_adapter.ingest_payload` is NOT invoked. Functionality — exercises defensive shape-checking.
+
+### Affected Files
+
+- `events/materializer.py` — **MUTATE** — add a new dispatch branch BEFORE the existing `'ingest.completed'` branch: `if etype in ("ingest", "ingest.completed") and _is_team_server_payload(payload):` route to `_bridge_team_server_payload(payload)` then `inner_adapter.ingest_payload(bridged)`. Existing `'ingest.completed'` handling for non-team-server payloads stays unchanged. Net effect: BOTH event types route through `ingest_payload`; team-server-shaped payloads get bridged first.
+- `events/team_server_bridge.py` — **CREATE** — pure helpers: `is_team_server_payload(payload) -> bool` (heuristic: has `source_type` AND `extraction` keys); `bridge_team_server_payload(payload) -> dict` (returns IngestPayload-compatible dict). Source-type normalization: `'slack'` stays as `'slack'`; `'notion_database_row'` becomes `'notion'`.
+- `tests/test_materializer_team_server_pull.py` — **MUTATE** — add 6 functionality tests above; existing 3 tests preserved.
+
+### Changes
+
+`events/team_server_bridge.py`:
+
+```python
+"""Bridge: team-server team_event payload → IngestPayload-compatible dict.
+
+The team-server emits events with shape:
+  {source_type, source_ref, content_hash, extraction: {decisions, ...}}
+
+The materializer's inner_adapter.ingest_payload expects shape:
+  {source, decisions: [{description, source_excerpt, ...}], repo, commit_hash, ...}
+
+This module's two pure functions (is_team_server_payload + 
+bridge_team_server_payload) handle the recognition and shape mapping.
+"""
+
+from __future__ import annotations
+
+
+_TEAM_SERVER_SOURCE_NORMALIZATION = {
+    "slack": "slack",
+    "notion_database_row": "notion",
+}
+
+
+def is_team_server_payload(payload: dict) -> bool:
+    """True iff the payload has the team-server event shape."""
+    return (
+        isinstance(payload, dict)
+        and "source_type" in payload
+        and isinstance(payload.get("extraction"), dict)
+    )
+
+
+def bridge_team_server_payload(payload: dict) -> dict:
+    """Map team-server's payload shape to an IngestPayload-compatible dict.
+    Decisions land as source='slack'|'notion' with empty repo/commit_hash
+    (Slack/Notion-sourced decisions don't reference code)."""
+    source_type = payload.get("source_type", "")
+    source = _TEAM_SERVER_SOURCE_NORMALIZATION.get(source_type, source_type)
+    extraction = payload.get("extraction") or {}
+    raw_decisions = extraction.get("decisions") or []
+    decisions = []
+    for d in raw_decisions:
+        if isinstance(d, dict):
+            decisions.append({
+                "description": d.get("summary", ""),
+                "source_excerpt": d.get("context_snippet", ""),
+            })
+        elif isinstance(d, str):
+            # interim-claude-v1 placeholder shape (paragraph-split strings)
+            decisions.append({"description": d, "source_excerpt": d})
+    return {
+        "source": source,
+        "repo": "",
+        "commit_hash": "",
+        "decisions": decisions,
+        "title": payload.get("source_ref", ""),
+    }
+```
+
+`events/materializer.py` dispatch addition (insert before the existing `'ingest.completed'` branch):
+
+```python
+from events.team_server_bridge import (
+    bridge_team_server_payload, is_team_server_payload,
+)
+
+# ... in materialize_for_dev's event-replay loop:
+if etype in ("ingest", "ingest.completed") and is_team_server_payload(payload):
+    bridged = bridge_team_server_payload(payload)
+    if bridged.get("decisions"):
+        await inner_adapter.ingest_payload(bridged)
+        replayed += 1
+elif etype == "ingest.completed":
+    await inner_adapter.ingest_payload(payload)
+    replayed += 1
+elif etype == "link_commit.completed":
+    # ... unchanged ...
+```
+
+---
+
+## CI Commands
+
+- `pytest -x tests/test_team_server_allowlist_sync.py tests/test_team_server_allowlist_lifespan.py` — Phase 1 functionality
+- `pytest -x tests/test_team_server_slack_worker.py` — Phase 1 end-to-end allowlist → worker
+- `pytest -x tests/test_team_server_consumer.py` — Phase 1.5 consumer end-to-end
+- `pytest -x tests/test_materializer_team_server_pull.py` — Phase 2 bridge + dispatch
+- `pytest -x tests/test_team_server_*.py tests/test_materializer_team_server_pull.py` — full team-server + materializer regression
+- `pytest -x tests/ -k "not team_server"` — non-team-server regression check
+
+---
+
+## Risk note (L2 grade reasoning)
+
+L2 because:
+
+- **No new credential lifecycle**: allowlist sync reads from existing YAML + workspace table; both already present
+- **Bridge is purely additive**: existing `'ingest.completed'` dispatch path is preserved; the team-server branch is conditional on a payload-shape predicate
+- **Deletion semantics in allowlist sync**: removing channels from YAML deletes rows. Operator should know this — document in the implement commit message. Mitigation: log INFO with `+N -N` summary so the operator sees the diff applied
+- **Empty `repo`/`commit_hash` in bridged IngestPayload**: per-dev `ingest_payload` handler may emit "ungrounded decision" warnings. v0-acceptable; v1.next can introduce a proper text-sourced-decision ingest path
+
+---
+
+## Modular commit plan
+
+Three commits, one PR (or fold into existing PR #159 since this is the same v0 release).
+
+```
+feat(team-server): channel_allowlist startup-time YAML sync (closes #161)
+feat(team-server): periodic team-server event consumer + payload bridge (closes #160 first half)
+feat(team-server): materializer dispatch case for legacy JSONL replay path (closes #160 second half)
+```
+
+Phase 1 closes the allowlist gap regardless of consumer state. Phase 1.5 (commit 2) closes the load-bearing v0 gap (events flow from team-server → per-dev ledger). Phase 2 (commit 3) adds the materializer's reciprocal dispatch case for any future flow that writes team-server events to git-tracked JSONL — defensive, not load-bearing for v0.
+
+The audit round-1 finding identified that without Phase 1.5, the v0 ingest pipeline ships plumbed-but-inert. Phase 1.5 is the load-bearing piece; Phase 2 is supporting infrastructure that becomes useful when the JSONL flow is wired in v1.next (if at all).

--- a/server.py
+++ b/server.py
@@ -1340,19 +1340,36 @@ async def serve_stdio() -> None:
     except Exception:
         pass
 
-    async with mcp.server.stdio.stdio_server() as (read_stream, write_stream):
-        await server.run(
-            read_stream,
-            write_stream,
-            InitializationOptions(
-                server_name=SERVER_NAME,
-                server_version=SERVER_VERSION,
-                capabilities=server.get_capabilities(
-                    notification_options=_notification_options(),
-                    experimental_capabilities={},
+    # Team-server event consumer — opt-in via BICAMERAL_TEAM_SERVER_URL env.
+    # Closes the v0 pull→dispatch wiring gap (issue #160). Periodically
+    # pulls events from the team-server's /events endpoint, bridges to
+    # IngestPayload, and invokes the inner adapter's ingest_payload.
+    from adapters.ledger import get_ledger
+    from events.team_server_consumer import start_team_server_consumer_if_configured
+
+    team_consumer_task = start_team_server_consumer_if_configured(get_ledger())
+
+    try:
+        async with mcp.server.stdio.stdio_server() as (read_stream, write_stream):
+            await server.run(
+                read_stream,
+                write_stream,
+                InitializationOptions(
+                    server_name=SERVER_NAME,
+                    server_version=SERVER_VERSION,
+                    capabilities=server.get_capabilities(
+                        notification_options=_notification_options(),
+                        experimental_capabilities={},
+                    ),
                 ),
-            ),
-        )
+            )
+    finally:
+        if team_consumer_task is not None:
+            team_consumer_task.cancel()
+            try:
+                await team_consumer_task
+            except asyncio.CancelledError:
+                pass
 
 
 def cli_main(argv: list[str] | None = None) -> int:

--- a/team_server/__init__.py
+++ b/team_server/__init__.py
@@ -1,0 +1,12 @@
+"""Bicameral team-server — self-managing customer-self-hosted backend for
+multi-dev decision-continuity at organizational scale.
+
+Per `docs/CONCEPT.md` literal-keyword parsing (`docs/SHADOW_GENOME.md`
+Failure Entry #6 addendum): "no managed backend" forbids vendor SaaS and
+human-ops-tax architectures, NOT self-managing customer-deployable
+backends. This package is the self-managing backend.
+"""
+
+from team_server.app import create_app
+
+__all__ = ["create_app"]

--- a/team_server/api/events.py
+++ b/team_server/api/events.py
@@ -1,0 +1,25 @@
+"""GET /events endpoint — read-only access to the team_event log for
+per-dev EventMaterializer pull.
+"""
+
+from __future__ import annotations
+
+from fastapi import APIRouter, Query, Request
+
+router = APIRouter()
+
+
+@router.get("/events")
+async def get_events(
+    request: Request,
+    since: int = Query(0, ge=0),
+    limit: int = Query(100, ge=1, le=1000),
+) -> list[dict]:
+    db = request.app.state.db
+    rows = await db.client.query(
+        "SELECT sequence, author_email, event_type, payload, created_at "
+        "FROM team_event WHERE sequence > $since "
+        "ORDER BY sequence ASC LIMIT $limit",
+        {"since": since, "limit": limit},
+    )
+    return rows

--- a/team_server/app.py
+++ b/team_server/app.py
@@ -39,4 +39,7 @@ def create_app() -> FastAPI:
     async def health():
         return {"status": "ok", "schema_version": SCHEMA_VERSION}
 
+    from team_server.auth.router import router as auth_router
+    app.include_router(auth_router)
+
     return app

--- a/team_server/app.py
+++ b/team_server/app.py
@@ -1,21 +1,28 @@
 """Team-server FastAPI app factory.
 
-Self-managing: lifespan runs schema migration on startup; teardown closes
-the DB. No human-ops surface. Per CONCEPT.md literal-keyword parsing
-(`docs/SHADOW_GENOME.md` Failure Entry #6 addendum).
+Self-managing: lifespan runs schema migration on startup; teardown
+closes the DB. Worker tasks (Slack) are registered via worker_loop and
+cancelled cleanly on shutdown. Per CONCEPT.md literal-keyword parsing.
 """
 
 from __future__ import annotations
 
+import asyncio
 import logging
+import os
 from contextlib import asynccontextmanager
 
 from fastapi import FastAPI
 
 from team_server.db import TeamServerDB
+from team_server.extraction.llm_extractor import extract as _interim_extractor
 from team_server.schema import SCHEMA_VERSION, ensure_schema
+from team_server.workers.runner import worker_loop
+from team_server.workers.slack_runner import run_slack_iteration
 
 logger = logging.getLogger(__name__)
+
+SLACK_POLL_INTERVAL_SECONDS = int(os.environ.get("SLACK_POLL_INTERVAL_SECONDS", "60"))
 
 
 @asynccontextmanager
@@ -24,10 +31,31 @@ async def lifespan(app: FastAPI):
     await db.connect()
     await ensure_schema(db.client)
     app.state.db = db
-    logger.info("[team-server] started; schema_version=%s", SCHEMA_VERSION)
+
+    tasks: list[asyncio.Task] = []
+
+    # Slack worker — always registered (no-op when workspace table empty)
+    tasks.append(worker_loop(
+        name="slack",
+        interval_seconds=SLACK_POLL_INTERVAL_SECONDS,
+        work_fn=lambda: run_slack_iteration(db.client, _interim_extractor),
+    ))
+
+    app.state.worker_tasks = tasks
+    logger.info(
+        "[team-server] started; schema_version=%s; %d worker(s)",
+        SCHEMA_VERSION, len(tasks),
+    )
     try:
         yield
     finally:
+        for t in tasks:
+            t.cancel()
+        for t in tasks:
+            try:
+                await t
+            except asyncio.CancelledError:
+                pass
         await db.close()
         logger.info("[team-server] shut down")
 

--- a/team_server/app.py
+++ b/team_server/app.py
@@ -40,6 +40,8 @@ def create_app() -> FastAPI:
         return {"status": "ok", "schema_version": SCHEMA_VERSION}
 
     from team_server.auth.router import router as auth_router
+    from team_server.api.events import router as events_router
     app.include_router(auth_router)
+    app.include_router(events_router)
 
     return app

--- a/team_server/app.py
+++ b/team_server/app.py
@@ -1,0 +1,42 @@
+"""Team-server FastAPI app factory.
+
+Self-managing: lifespan runs schema migration on startup; teardown closes
+the DB. No human-ops surface. Per CONCEPT.md literal-keyword parsing
+(`docs/SHADOW_GENOME.md` Failure Entry #6 addendum).
+"""
+
+from __future__ import annotations
+
+import logging
+from contextlib import asynccontextmanager
+
+from fastapi import FastAPI
+
+from team_server.db import TeamServerDB
+from team_server.schema import SCHEMA_VERSION, ensure_schema
+
+logger = logging.getLogger(__name__)
+
+
+@asynccontextmanager
+async def lifespan(app: FastAPI):
+    db = TeamServerDB.from_env()
+    await db.connect()
+    await ensure_schema(db.client)
+    app.state.db = db
+    logger.info("[team-server] started; schema_version=%s", SCHEMA_VERSION)
+    try:
+        yield
+    finally:
+        await db.close()
+        logger.info("[team-server] shut down")
+
+
+def create_app() -> FastAPI:
+    app = FastAPI(title="bicameral-team-server", lifespan=lifespan)
+
+    @app.get("/health")
+    async def health():
+        return {"status": "ok", "schema_version": SCHEMA_VERSION}
+
+    return app

--- a/team_server/app.py
+++ b/team_server/app.py
@@ -1,8 +1,9 @@
 """Team-server FastAPI app factory.
 
 Self-managing: lifespan runs schema migration on startup; teardown
-closes the DB. Worker tasks (Slack) are registered via worker_loop and
-cancelled cleanly on shutdown. Per CONCEPT.md literal-keyword parsing.
+closes the DB. Worker tasks (Slack always; Notion opt-in) are
+registered via worker_loop and cancelled cleanly on shutdown.
+Per CONCEPT.md literal-keyword parsing.
 """
 
 from __future__ import annotations
@@ -14,15 +15,19 @@ from contextlib import asynccontextmanager
 
 from fastapi import FastAPI
 
+from team_server.auth import notion_client as nc
+from team_server.config import DEFAULT_CONFIG_PATH
 from team_server.db import TeamServerDB
 from team_server.extraction.llm_extractor import extract as _interim_extractor
 from team_server.schema import SCHEMA_VERSION, ensure_schema
+from team_server.workers.notion_runner import run_notion_iteration
 from team_server.workers.runner import worker_loop
 from team_server.workers.slack_runner import run_slack_iteration
 
 logger = logging.getLogger(__name__)
 
 SLACK_POLL_INTERVAL_SECONDS = int(os.environ.get("SLACK_POLL_INTERVAL_SECONDS", "60"))
+NOTION_POLL_INTERVAL_SECONDS = int(os.environ.get("NOTION_POLL_INTERVAL_SECONDS", "60"))
 
 
 @asynccontextmanager
@@ -40,6 +45,18 @@ async def lifespan(app: FastAPI):
         interval_seconds=SLACK_POLL_INTERVAL_SECONDS,
         work_fn=lambda: run_slack_iteration(db.client, _interim_extractor),
     ))
+
+    # Notion worker — registered only when token resolves (opt-in)
+    try:
+        notion_token = nc.load_token(config_path=str(DEFAULT_CONFIG_PATH))
+        tasks.append(worker_loop(
+            name="notion",
+            interval_seconds=NOTION_POLL_INTERVAL_SECONDS,
+            work_fn=lambda: run_notion_iteration(db.client, notion_token, _interim_extractor),
+        ))
+        logger.info("[team-server] notion worker registered")
+    except nc.NotionAuthError:
+        logger.info("[team-server] notion ingest disabled (no token)")
 
     app.state.worker_tasks = tasks
     logger.info(

--- a/team_server/app.py
+++ b/team_server/app.py
@@ -16,8 +16,9 @@ from contextlib import asynccontextmanager
 from fastapi import FastAPI
 
 from team_server.auth import notion_client as nc
-from team_server.config import DEFAULT_CONFIG_PATH
+from team_server.config import DEFAULT_CONFIG_PATH, TeamServerConfig
 from team_server.db import TeamServerDB
+from team_server.extraction.corpus_learner import run_corpus_learner_iteration
 from team_server.extraction.llm_extractor import extract as _interim_extractor
 from team_server.schema import SCHEMA_VERSION, ensure_schema
 from team_server.workers.notion_runner import run_notion_iteration
@@ -28,6 +29,19 @@ logger = logging.getLogger(__name__)
 
 SLACK_POLL_INTERVAL_SECONDS = int(os.environ.get("SLACK_POLL_INTERVAL_SECONDS", "60"))
 NOTION_POLL_INTERVAL_SECONDS = int(os.environ.get("NOTION_POLL_INTERVAL_SECONDS", "60"))
+
+
+def _load_config_or_default() -> TeamServerConfig:
+    """Load TeamServerConfig from DEFAULT_CONFIG_PATH if it exists,
+    else return a default-empty config (corpus learner off, no rules)."""
+    if not DEFAULT_CONFIG_PATH.exists():
+        return TeamServerConfig()
+    from team_server.config import load_rules_from_config
+    try:
+        return load_rules_from_config(str(DEFAULT_CONFIG_PATH))
+    except Exception:  # noqa: BLE001
+        logger.exception("[team-server] config load failed; using defaults")
+        return TeamServerConfig()
 
 
 @asynccontextmanager
@@ -57,6 +71,17 @@ async def lifespan(app: FastAPI):
         logger.info("[team-server] notion worker registered")
     except nc.NotionAuthError:
         logger.info("[team-server] notion ingest disabled (no token)")
+
+    # Corpus learner — opt-in via config.corpus_learner.enabled
+    config = _load_config_or_default()
+    app.state.team_server_config = config
+    if config.corpus_learner.enabled:
+        tasks.append(worker_loop(
+            name="corpus-learner",
+            interval_seconds=config.corpus_learner.interval_seconds,
+            work_fn=lambda: run_corpus_learner_iteration(db.client, config),
+        ))
+        logger.info("[team-server] corpus learner registered")
 
     app.state.worker_tasks = tasks
     logger.info(

--- a/team_server/app.py
+++ b/team_server/app.py
@@ -16,6 +16,7 @@ from contextlib import asynccontextmanager
 from fastapi import FastAPI
 
 from team_server.auth import notion_client as nc
+from team_server.auth.allowlist_sync import sync_channel_allowlist
 from team_server.config import DEFAULT_CONFIG_PATH, TeamServerConfig
 from team_server.db import TeamServerDB
 from team_server.extraction.corpus_learner import run_corpus_learner_iteration
@@ -51,6 +52,16 @@ async def lifespan(app: FastAPI):
     await ensure_schema(db.client)
     app.state.db = db
 
+    # Phase 1: channel allowlist sync from YAML — runs after schema +
+    # before worker registration so the slack runner sees populated
+    # rows on first poll.
+    config = _load_config_or_default()
+    app.state.team_server_config = config
+    try:
+        await sync_channel_allowlist(db.client, config)
+    except Exception:  # noqa: BLE001
+        logger.exception("[team-server] channel_allowlist sync failed; continuing")
+
     tasks: list[asyncio.Task] = []
 
     # Slack worker — always registered (no-op when workspace table empty)
@@ -73,8 +84,6 @@ async def lifespan(app: FastAPI):
         logger.info("[team-server] notion ingest disabled (no token)")
 
     # Corpus learner — opt-in via config.corpus_learner.enabled
-    config = _load_config_or_default()
-    app.state.team_server_config = config
     if config.corpus_learner.enabled:
         tasks.append(worker_loop(
             name="corpus-learner",

--- a/team_server/app.py
+++ b/team_server/app.py
@@ -20,7 +20,7 @@ from team_server.auth.allowlist_sync import sync_channel_allowlist
 from team_server.config import DEFAULT_CONFIG_PATH, TeamServerConfig
 from team_server.db import TeamServerDB
 from team_server.extraction.corpus_learner import run_corpus_learner_iteration
-from team_server.extraction.llm_extractor import extract as _interim_extractor
+from team_server.extraction.llm_extractor import extract as _llm_extract
 from team_server.schema import SCHEMA_VERSION, ensure_schema
 from team_server.workers.notion_runner import run_notion_iteration
 from team_server.workers.runner import worker_loop
@@ -32,12 +32,24 @@ SLACK_POLL_INTERVAL_SECONDS = int(os.environ.get("SLACK_POLL_INTERVAL_SECONDS", 
 NOTION_POLL_INTERVAL_SECONDS = int(os.environ.get("NOTION_POLL_INTERVAL_SECONDS", "60"))
 
 
+async def _interim_extractor(text: str) -> dict:
+    """Adapt llm_extractor.extract to the single-arg Extractor protocol used by
+    the legacy fallback path in slack_worker / notion_worker.
+
+    Pre-classifier triggers are not available in the fallback path
+    (rules_or_disabled is None), so we pass an empty list. The classifier-rules
+    path uses extract_decision_pipeline directly and never goes through this
+    adapter."""
+    return await _llm_extract(text, matched_triggers=[])
+
+
 def _load_config_or_default() -> TeamServerConfig:
     """Load TeamServerConfig from DEFAULT_CONFIG_PATH if it exists,
     else return a default-empty config (corpus learner off, no rules)."""
     if not DEFAULT_CONFIG_PATH.exists():
         return TeamServerConfig()
     from team_server.config import load_rules_from_config
+
     try:
         return load_rules_from_config(str(DEFAULT_CONFIG_PATH))
     except Exception:  # noqa: BLE001
@@ -65,37 +77,44 @@ async def lifespan(app: FastAPI):
     tasks: list[asyncio.Task] = []
 
     # Slack worker — always registered (no-op when workspace table empty)
-    tasks.append(worker_loop(
-        name="slack",
-        interval_seconds=SLACK_POLL_INTERVAL_SECONDS,
-        work_fn=lambda: run_slack_iteration(db.client, _interim_extractor),
-    ))
+    tasks.append(
+        worker_loop(
+            name="slack",
+            interval_seconds=SLACK_POLL_INTERVAL_SECONDS,
+            work_fn=lambda: run_slack_iteration(db.client, _interim_extractor),
+        )
+    )
 
     # Notion worker — registered only when token resolves (opt-in)
     try:
         notion_token = nc.load_token(config_path=str(DEFAULT_CONFIG_PATH))
-        tasks.append(worker_loop(
-            name="notion",
-            interval_seconds=NOTION_POLL_INTERVAL_SECONDS,
-            work_fn=lambda: run_notion_iteration(db.client, notion_token, _interim_extractor),
-        ))
+        tasks.append(
+            worker_loop(
+                name="notion",
+                interval_seconds=NOTION_POLL_INTERVAL_SECONDS,
+                work_fn=lambda: run_notion_iteration(db.client, notion_token, _interim_extractor),
+            )
+        )
         logger.info("[team-server] notion worker registered")
     except nc.NotionAuthError:
         logger.info("[team-server] notion ingest disabled (no token)")
 
     # Corpus learner — opt-in via config.corpus_learner.enabled
     if config.corpus_learner.enabled:
-        tasks.append(worker_loop(
-            name="corpus-learner",
-            interval_seconds=config.corpus_learner.interval_seconds,
-            work_fn=lambda: run_corpus_learner_iteration(db.client, config),
-        ))
+        tasks.append(
+            worker_loop(
+                name="corpus-learner",
+                interval_seconds=config.corpus_learner.interval_seconds,
+                work_fn=lambda: run_corpus_learner_iteration(db.client, config),
+            )
+        )
         logger.info("[team-server] corpus learner registered")
 
     app.state.worker_tasks = tasks
     logger.info(
         "[team-server] started; schema_version=%s; %d worker(s)",
-        SCHEMA_VERSION, len(tasks),
+        SCHEMA_VERSION,
+        len(tasks),
     )
     try:
         yield
@@ -118,8 +137,9 @@ def create_app() -> FastAPI:
     async def health():
         return {"status": "ok", "schema_version": SCHEMA_VERSION}
 
-    from team_server.auth.router import router as auth_router
     from team_server.api.events import router as events_router
+    from team_server.auth.router import router as auth_router
+
     app.include_router(auth_router)
     app.include_router(events_router)
 

--- a/team_server/auth/allowlist_sync.py
+++ b/team_server/auth/allowlist_sync.py
@@ -13,23 +13,27 @@ from __future__ import annotations
 import logging
 
 from ledger.client import LedgerClient
-
 from team_server.config import TeamServerConfig
 
 logger = logging.getLogger(__name__)
 
 
 async def sync_channel_allowlist(
-    client: LedgerClient, config: TeamServerConfig,
+    client: LedgerClient,
+    config: TeamServerConfig,
 ) -> None:
     for workspace_cfg in config.slack.workspaces:
         await _sync_one_workspace(
-            client, workspace_cfg.team_id, workspace_cfg.channels,
+            client,
+            workspace_cfg.team_id,
+            workspace_cfg.channels,
         )
 
 
 async def _sync_one_workspace(
-    client: LedgerClient, team_id: str, yaml_channels: list[str],
+    client: LedgerClient,
+    team_id: str,
+    yaml_channels: list[str],
 ) -> None:
     rows = await client.query(
         "SELECT id FROM workspace WHERE slack_team_id = $tid LIMIT 1",
@@ -37,8 +41,8 @@ async def _sync_one_workspace(
     )
     if not rows:
         logger.info(
-            "[allowlist-sync] no workspace row for team_id=%s; "
-            "skipping (OAuth not yet completed)", team_id,
+            "[allowlist-sync] no workspace row for team_id=%s; skipping (OAuth not yet completed)",
+            team_id,
         )
         return
     # workspace_id arrives as 'workspace:<rid>' from SELECT; split for type::thing()
@@ -69,5 +73,8 @@ async def _sync_one_workspace(
         )
     logger.info(
         "[allowlist-sync] team_id=%s: +%d -%d (now %d total)",
-        team_id, len(to_add), len(to_remove), len(desired),
+        team_id,
+        len(to_add),
+        len(to_remove),
+        len(desired),
     )

--- a/team_server/auth/allowlist_sync.py
+++ b/team_server/auth/allowlist_sync.py
@@ -1,0 +1,73 @@
+"""Channel allowlist startup-time sync.
+
+Reads config.slack.workspaces[] and reconciles channel_allowlist
+against the workspace table. Per-team_id additive + subtractive sync
+so operator YAML edits propagate on next restart. Workspaces in YAML
+without a corresponding workspace-table row (no OAuth completed yet)
+are logged and skipped — they get picked up on the next sync after
+OAuth completes.
+"""
+
+from __future__ import annotations
+
+import logging
+
+from ledger.client import LedgerClient
+
+from team_server.config import TeamServerConfig
+
+logger = logging.getLogger(__name__)
+
+
+async def sync_channel_allowlist(
+    client: LedgerClient, config: TeamServerConfig,
+) -> None:
+    for workspace_cfg in config.slack.workspaces:
+        await _sync_one_workspace(
+            client, workspace_cfg.team_id, workspace_cfg.channels,
+        )
+
+
+async def _sync_one_workspace(
+    client: LedgerClient, team_id: str, yaml_channels: list[str],
+) -> None:
+    rows = await client.query(
+        "SELECT id FROM workspace WHERE slack_team_id = $tid LIMIT 1",
+        {"tid": team_id},
+    )
+    if not rows:
+        logger.info(
+            "[allowlist-sync] no workspace row for team_id=%s; "
+            "skipping (OAuth not yet completed)", team_id,
+        )
+        return
+    # workspace_id arrives as 'workspace:<rid>' from SELECT; split for type::thing()
+    raw_id = str(rows[0]["id"])
+    _tb, _, ws_rid = raw_id.partition(":")
+    existing_rows = await client.query(
+        "SELECT channel_id FROM channel_allowlist "
+        "WHERE workspace_id = type::thing('workspace', $wrid)",
+        {"wrid": ws_rid},
+    )
+    existing = {r["channel_id"] for r in existing_rows or []}
+    desired = set(yaml_channels)
+    to_add = desired - existing
+    to_remove = existing - desired
+    for channel_id in to_add:
+        await client.query(
+            "CREATE channel_allowlist CONTENT { "
+            "workspace_id: type::thing('workspace', $wrid), "
+            "channel_id: $cid, channel_name: '' }",
+            {"wrid": ws_rid, "cid": channel_id},
+        )
+    for channel_id in to_remove:
+        await client.query(
+            "DELETE channel_allowlist "
+            "WHERE workspace_id = type::thing('workspace', $wrid) "
+            "AND channel_id = $cid",
+            {"wrid": ws_rid, "cid": channel_id},
+        )
+    logger.info(
+        "[allowlist-sync] team_id=%s: +%d -%d (now %d total)",
+        team_id, len(to_add), len(to_remove), len(desired),
+    )

--- a/team_server/auth/encryption.py
+++ b/team_server/auth/encryption.py
@@ -1,0 +1,31 @@
+"""Fernet encryption for OAuth tokens at rest.
+
+Key sourced from `BICAMERAL_TEAM_SERVER_SECRET_KEY` env var (urlsafe-base64
+Fernet key). Operator generates via `python -c "from cryptography.fernet
+import Fernet; print(Fernet.generate_key().decode())"` at install time.
+"""
+
+from __future__ import annotations
+
+import os
+
+from cryptography.fernet import Fernet
+
+ENV_KEY = "BICAMERAL_TEAM_SERVER_SECRET_KEY"
+
+
+def encrypt_token(plaintext: str, key: bytes) -> bytes:
+    return Fernet(key).encrypt(plaintext.encode("utf-8"))
+
+
+def decrypt_token(ciphertext: bytes, key: bytes) -> str:
+    return Fernet(key).decrypt(ciphertext).decode("utf-8")
+
+
+def load_key_from_env() -> bytes:
+    value = os.environ.get(ENV_KEY, "").strip()
+    if not value:
+        raise RuntimeError(
+            f"{ENV_KEY} env var is required (Fernet urlsafe-base64 key)"
+        )
+    return value.encode("utf-8")

--- a/team_server/auth/encryption.py
+++ b/team_server/auth/encryption.py
@@ -25,7 +25,5 @@ def decrypt_token(ciphertext: bytes, key: bytes) -> str:
 def load_key_from_env() -> bytes:
     value = os.environ.get(ENV_KEY, "").strip()
     if not value:
-        raise RuntimeError(
-            f"{ENV_KEY} env var is required (Fernet urlsafe-base64 key)"
-        )
+        raise RuntimeError(f"{ENV_KEY} env var is required (Fernet urlsafe-base64 key)")
     return value.encode("utf-8")

--- a/team_server/auth/notion_client.py
+++ b/team_server/auth/notion_client.py
@@ -9,7 +9,7 @@ NotionAuthError if neither is set. Notion-Version header is pinned to
 from __future__ import annotations
 
 import os
-from typing import AsyncIterator, Optional
+from collections.abc import AsyncIterator
 
 import httpx
 import yaml
@@ -22,7 +22,7 @@ class NotionAuthError(RuntimeError):
     """Raised when no Notion integration token can be resolved."""
 
 
-def load_token(config_path: Optional[str] = None) -> str:
+def load_token(config_path: str | None = None) -> str:
     env = os.environ.get("NOTION_TOKEN")
     if env:
         return env
@@ -60,9 +60,7 @@ async def list_databases(token: str) -> list[tuple[str, str]]:
     return out
 
 
-async def query_database(
-    token: str, db_id: str, watermark: Optional[str]
-) -> AsyncIterator[dict]:
+async def query_database(token: str, db_id: str, watermark: str | None) -> AsyncIterator[dict]:
     """Yield page rows from a database, filtered by last_edited_time > watermark."""
     body: dict = {
         "sorts": [{"timestamp": "last_edited_time", "direction": "ascending"}],
@@ -72,7 +70,7 @@ async def query_database(
             "timestamp": "last_edited_time",
             "last_edited_time": {"after": watermark},
         }
-    cursor: Optional[str] = None
+    cursor: str | None = None
     async with httpx.AsyncClient() as client:
         while True:
             req_body = {**body, **({"start_cursor": cursor} if cursor else {})}
@@ -93,7 +91,7 @@ async def query_database(
 async def fetch_page_blocks(token: str, page_id: str) -> list[dict]:
     """Return the flat list of top-level blocks for a page (paginated)."""
     out: list[dict] = []
-    cursor: Optional[str] = None
+    cursor: str | None = None
     async with httpx.AsyncClient() as client:
         while True:
             params = {"start_cursor": cursor} if cursor else {}

--- a/team_server/auth/notion_client.py
+++ b/team_server/auth/notion_client.py
@@ -1,0 +1,110 @@
+"""Notion API client - internal-integration auth, no OAuth.
+
+Pure async functions over httpx. Token resolution: NOTION_TOKEN env
+preferred; falls back to YAML config's `notion.token`; raises
+NotionAuthError if neither is set. Notion-Version header is pinned to
+2022-06-28 (the stable version this code is tested against).
+"""
+
+from __future__ import annotations
+
+import os
+from typing import AsyncIterator, Optional
+
+import httpx
+import yaml
+
+NOTION_API_BASE = "https://api.notion.com/v1"
+NOTION_VERSION = "2022-06-28"
+
+
+class NotionAuthError(RuntimeError):
+    """Raised when no Notion integration token can be resolved."""
+
+
+def load_token(config_path: Optional[str] = None) -> str:
+    env = os.environ.get("NOTION_TOKEN")
+    if env:
+        return env
+    if config_path and os.path.exists(config_path):
+        with open(config_path, encoding="utf-8") as fh:
+            cfg = yaml.safe_load(fh) or {}
+        token = (cfg.get("notion") or {}).get("token")
+        if token:
+            return token
+    raise NotionAuthError("NOTION_TOKEN not set and notion.token absent in config")
+
+
+def _headers(token: str) -> dict:
+    return {
+        "Authorization": f"Bearer {token}",
+        "Notion-Version": NOTION_VERSION,
+        "Content-Type": "application/json",
+    }
+
+
+async def list_databases(token: str) -> list[tuple[str, str]]:
+    """Return [(db_id, title), ...] for databases the integration sees."""
+    async with httpx.AsyncClient() as client:
+        resp = await client.post(
+            f"{NOTION_API_BASE}/search",
+            headers=_headers(token),
+            json={"filter": {"property": "object", "value": "database"}},
+        )
+    resp.raise_for_status()
+    out = []
+    for entry in resp.json().get("results", []):
+        title_parts = entry.get("title") or []
+        title = "".join(p.get("plain_text", "") for p in title_parts) or "(untitled)"
+        out.append((entry["id"], title))
+    return out
+
+
+async def query_database(
+    token: str, db_id: str, watermark: Optional[str]
+) -> AsyncIterator[dict]:
+    """Yield page rows from a database, filtered by last_edited_time > watermark."""
+    body: dict = {
+        "sorts": [{"timestamp": "last_edited_time", "direction": "ascending"}],
+    }
+    if watermark:
+        body["filter"] = {
+            "timestamp": "last_edited_time",
+            "last_edited_time": {"after": watermark},
+        }
+    cursor: Optional[str] = None
+    async with httpx.AsyncClient() as client:
+        while True:
+            req_body = {**body, **({"start_cursor": cursor} if cursor else {})}
+            resp = await client.post(
+                f"{NOTION_API_BASE}/databases/{db_id}/query",
+                headers=_headers(token),
+                json=req_body,
+            )
+            resp.raise_for_status()
+            payload = resp.json()
+            for row in payload.get("results", []):
+                yield row
+            if not payload.get("has_more"):
+                return
+            cursor = payload.get("next_cursor")
+
+
+async def fetch_page_blocks(token: str, page_id: str) -> list[dict]:
+    """Return the flat list of top-level blocks for a page (paginated)."""
+    out: list[dict] = []
+    cursor: Optional[str] = None
+    async with httpx.AsyncClient() as client:
+        while True:
+            params = {"start_cursor": cursor} if cursor else {}
+            resp = await client.get(
+                f"{NOTION_API_BASE}/blocks/{page_id}/children",
+                headers=_headers(token),
+                params=params,
+            )
+            resp.raise_for_status()
+            payload = resp.json()
+            out.extend(payload.get("results", []))
+            if not payload.get("has_more"):
+                return out
+            cursor = payload.get("next_cursor")

--- a/team_server/auth/router.py
+++ b/team_server/auth/router.py
@@ -1,0 +1,73 @@
+"""OAuth callback + install routes — factored out of app.py per audit
+Advisory #2 to keep app.py under the 250-line cap.
+"""
+
+from __future__ import annotations
+
+import os
+import secrets
+
+from fastapi import APIRouter, HTTPException, Request
+
+from team_server.auth import slack_oauth
+from team_server.auth.encryption import encrypt_token, load_key_from_env
+
+router = APIRouter()
+
+# In-memory CSRF state store. Keys are state-tokens, values are TTL timestamps.
+# A team-server restart loses pending OAuth flows in flight; users retry
+# the install. Acceptable tradeoff for a self-hosted single-instance
+# deployment; multi-instance HA would persist this.
+_PENDING_STATES: dict[str, float] = {}
+
+
+@router.get("/oauth/slack/install")
+async def install():
+    """Return the Slack OAuth authorize URL with a fresh CSRF state token.
+    The admin opens this URL, approves, Slack redirects to /callback."""
+    client_id = os.environ.get("SLACK_CLIENT_ID", "")
+    redirect_uri = os.environ.get(
+        "SLACK_REDIRECT_URI", "http://localhost:8765/oauth/slack/callback"
+    )
+    state = secrets.token_urlsafe(32)
+    _PENDING_STATES[state] = 1.0  # placeholder TTL marker
+    url = slack_oauth.build_authorize_url(client_id, redirect_uri, state)
+    return {"authorize_url": url, "state": state}
+
+
+@router.get("/oauth/slack/callback")
+async def callback(request: Request, code: str = "", state: str = ""):
+    """Exchange the OAuth code for a token, persist the workspace row with
+    the token encrypted at rest, and return the team_id for confirmation."""
+    if not code or not state:
+        raise HTTPException(status_code=400, detail="missing code or state")
+    if state not in _PENDING_STATES:
+        raise HTTPException(status_code=400, detail="invalid or expired state")
+    _PENDING_STATES.pop(state, None)
+
+    client_id = os.environ.get("SLACK_CLIENT_ID", "")
+    client_secret = os.environ.get("SLACK_CLIENT_SECRET", "")
+    redirect_uri = os.environ.get(
+        "SLACK_REDIRECT_URI", "http://localhost:8765/oauth/slack/callback"
+    )
+
+    payload = await slack_oauth.exchange_code(
+        code=code,
+        client_id=client_id,
+        client_secret=client_secret,
+        redirect_uri=redirect_uri,
+    )
+    team_id = payload["team"]["id"]
+    team_name = payload["team"].get("name", "")
+    access_token = payload["access_token"]
+
+    key = load_key_from_env()
+    encrypted = encrypt_token(access_token, key).decode("utf-8")
+
+    db = request.app.state.db
+    await db.client.query(
+        "CREATE workspace CONTENT { name: $name, slack_team_id: $tid, "
+        "oauth_token_encrypted: $enc, created_at: time::now() }",
+        {"name": team_name, "tid": team_id, "enc": encrypted},
+    )
+    return {"ok": True, "team_id": team_id}

--- a/team_server/auth/slack_oauth.py
+++ b/team_server/auth/slack_oauth.py
@@ -1,0 +1,58 @@
+"""Slack OAuth v2 helpers for the team-server.
+
+Pure functions — no DB, no app state. The router (`team_server/auth/router.py`)
+composes these with persistence + state validation.
+"""
+
+from __future__ import annotations
+
+from urllib.parse import urlencode
+
+import httpx
+
+SLACK_AUTHORIZE_URL = "https://slack.com/oauth/v2/authorize"
+SLACK_TOKEN_URL = "https://slack.com/api/oauth.v2.access"
+
+REQUIRED_SCOPES: tuple[str, ...] = (
+    "channels:history",
+    "channels:read",
+    "groups:history",
+    "groups:read",
+)
+
+
+class SlackOAuthError(RuntimeError):
+    """Raised when Slack rejects an OAuth code exchange."""
+
+
+def build_authorize_url(client_id: str, redirect_uri: str, state: str) -> str:
+    params = {
+        "client_id": client_id,
+        "redirect_uri": redirect_uri,
+        "state": state,
+        "scope": ",".join(REQUIRED_SCOPES),
+    }
+    return f"{SLACK_AUTHORIZE_URL}?{urlencode(params)}"
+
+
+async def exchange_code(
+    code: str,
+    client_id: str,
+    client_secret: str,
+    redirect_uri: str,
+) -> dict:
+    """POST to Slack oauth.v2.access; raise on `ok=false`."""
+    async with httpx.AsyncClient() as client:
+        resp = await client.post(
+            SLACK_TOKEN_URL,
+            data={
+                "code": code,
+                "client_id": client_id,
+                "client_secret": client_secret,
+                "redirect_uri": redirect_uri,
+            },
+        )
+    payload = resp.json()
+    if not payload.get("ok"):
+        raise SlackOAuthError(payload.get("error", "unknown"))
+    return payload

--- a/team_server/config.py
+++ b/team_server/config.py
@@ -9,7 +9,6 @@ from __future__ import annotations
 
 import os
 from pathlib import Path
-from typing import Optional, Union
 
 import yaml
 from pydantic import BaseModel, ConfigDict, Field, ValidationError
@@ -32,7 +31,7 @@ class HeuristicGlobalRules(BaseModel):
     min_word_count: int = 0
     boost_reactions: list[str] = Field(default_factory=list)
     boost_threshold: int = 1
-    thread_tail_position_threshold: Optional[int] = None
+    thread_tail_position_threshold: int | None = None
     enabled: bool = True
     learned_denylist: list[str] = Field(default_factory=list)
 
@@ -40,23 +39,19 @@ class HeuristicGlobalRules(BaseModel):
 class HeuristicScopedOverride(BaseModel):
     keywords: list[str] = Field(default_factory=list)
     keyword_negatives: list[str] = Field(default_factory=list)
-    min_word_count: Optional[int] = None
+    min_word_count: int | None = None
     enabled: bool = True
 
 
 class SlackHeuristics(BaseModel):
     model_config = ConfigDict(populate_by_name=True)
-    global_rules: HeuristicGlobalRules = Field(
-        default_factory=HeuristicGlobalRules, alias="global"
-    )
+    global_rules: HeuristicGlobalRules = Field(default_factory=HeuristicGlobalRules, alias="global")
     channels: dict[str, HeuristicScopedOverride] = Field(default_factory=dict)
 
 
 class NotionHeuristics(BaseModel):
     model_config = ConfigDict(populate_by_name=True)
-    global_rules: HeuristicGlobalRules = Field(
-        default_factory=HeuristicGlobalRules, alias="global"
-    )
+    global_rules: HeuristicGlobalRules = Field(default_factory=HeuristicGlobalRules, alias="global")
     databases: dict[str, HeuristicScopedOverride] = Field(default_factory=dict)
 
 
@@ -66,7 +61,7 @@ class SlackConfig(BaseModel):
 
 
 class NotionConfig(BaseModel):
-    token: Optional[str] = None
+    token: str | None = None
     heuristics: NotionHeuristics = Field(default_factory=NotionHeuristics)
 
 
@@ -90,31 +85,30 @@ def load_channel_allowlist(path: Path) -> TeamServerConfig:
     return load_rules_from_config(path)
 
 
-def load_rules_from_config(path: Union[str, Path]) -> TeamServerConfig:
+def load_rules_from_config(path: str | Path) -> TeamServerConfig:
     raw = yaml.safe_load(Path(path).read_text(encoding="utf-8")) or {}
     try:
         return TeamServerConfig(**raw)
     except ValidationError as exc:
         msg_parts = [
-            f"{'.'.join(str(loc) for loc in err['loc'])}: {err['msg']}"
-            for err in exc.errors()
+            f"{'.'.join(str(loc) for loc in err['loc'])}: {err['msg']}" for err in exc.errors()
         ]
-        raise ValueError(
-            f"team-server config invalid: {'; '.join(msg_parts)}"
-        ) from exc
+        raise ValueError(f"team-server config invalid: {'; '.join(msg_parts)}") from exc
 
 
 def _build_rules(
     base: HeuristicGlobalRules,
-    override: Optional[HeuristicScopedOverride],
+    override: HeuristicScopedOverride | None,
     learned: tuple[str, ...] = (),
 ) -> TriggerRules:
     return TriggerRules(
         keywords=tuple([*base.keywords, *(override.keywords if override else [])]),
-        keyword_negatives=tuple([
-            *base.keyword_negatives,
-            *(override.keyword_negatives if override else []),
-        ]),
+        keyword_negatives=tuple(
+            [
+                *base.keyword_negatives,
+                *(override.keyword_negatives if override else []),
+            ]
+        ),
         min_word_count=(
             override.min_word_count
             if override and override.min_word_count is not None
@@ -128,8 +122,10 @@ def _build_rules(
 
 
 def resolve_rules_for_slack(
-    config: TeamServerConfig, channel_id: str, learned: tuple[str, ...] = (),
-) -> Union[TriggerRules, RulesDisabled]:
+    config: TeamServerConfig,
+    channel_id: str,
+    learned: tuple[str, ...] = (),
+) -> TriggerRules | RulesDisabled:
     base = config.slack.heuristics.global_rules
     override = config.slack.heuristics.channels.get(channel_id)
     if not base.enabled or (override and not override.enabled):
@@ -138,8 +134,10 @@ def resolve_rules_for_slack(
 
 
 def resolve_rules_for_notion(
-    config: TeamServerConfig, db_id: str, learned: tuple[str, ...] = (),
-) -> Union[TriggerRules, RulesDisabled]:
+    config: TeamServerConfig,
+    db_id: str,
+    learned: tuple[str, ...] = (),
+) -> TriggerRules | RulesDisabled:
     base = config.notion.heuristics.global_rules
     override = config.notion.heuristics.databases.get(db_id)
     if not base.enabled or (override and not override.enabled):

--- a/team_server/config.py
+++ b/team_server/config.py
@@ -1,0 +1,40 @@
+"""Team-server configuration loader — YAML in, pydantic-validated out.
+
+Strict schema: missing required fields raise ValueError (caller surfaces
+the message to the operator at startup).
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import yaml
+from pydantic import BaseModel, Field, ValidationError
+
+
+class WorkspaceConfig(BaseModel):
+    team_id: str = Field(..., description="Slack team ID (e.g., T01ABCDEF)")
+    channels: list[str] = Field(default_factory=list)
+
+
+class SlackConfig(BaseModel):
+    workspaces: list[WorkspaceConfig] = Field(default_factory=list)
+
+
+class TeamServerConfig(BaseModel):
+    slack: SlackConfig = Field(default_factory=SlackConfig)
+
+
+def load_channel_allowlist(path: Path) -> TeamServerConfig:
+    raw = yaml.safe_load(path.read_text(encoding="utf-8")) or {}
+    try:
+        return TeamServerConfig(**raw)
+    except ValidationError as exc:
+        # Re-raise as ValueError per plan contract; surface field errors.
+        msg_parts = [
+            f"{'.'.join(str(loc) for loc in err['loc'])}: {err['msg']}"
+            for err in exc.errors()
+        ]
+        raise ValueError(
+            f"team-server config invalid: {'; '.join(msg_parts)}"
+        ) from exc

--- a/team_server/config.py
+++ b/team_server/config.py
@@ -1,16 +1,20 @@
 """Team-server configuration loader — YAML in, pydantic-validated out.
 
 Strict schema: missing required fields raise ValueError (caller surfaces
-the message to the operator at startup).
+the message to the operator at startup). v1.1 adds heuristic trigger
+rules per workspace + per-channel/database overrides.
 """
 
 from __future__ import annotations
 
 import os
 from pathlib import Path
+from typing import Optional, Union
 
 import yaml
-from pydantic import BaseModel, Field, ValidationError
+from pydantic import BaseModel, ConfigDict, Field, ValidationError
+
+from team_server.extraction.heuristic_classifier import TriggerRules
 
 DEFAULT_CONFIG_PATH = Path(
     os.environ.get("BICAMERAL_CONFIG_PATH", "/etc/bicameral-team-server/config.yml")
@@ -22,20 +26,75 @@ class WorkspaceConfig(BaseModel):
     channels: list[str] = Field(default_factory=list)
 
 
+class HeuristicGlobalRules(BaseModel):
+    keywords: list[str] = Field(default_factory=list)
+    keyword_negatives: list[str] = Field(default_factory=list)
+    min_word_count: int = 0
+    boost_reactions: list[str] = Field(default_factory=list)
+    boost_threshold: int = 1
+    thread_tail_position_threshold: Optional[int] = None
+    enabled: bool = True
+    learned_denylist: list[str] = Field(default_factory=list)
+
+
+class HeuristicScopedOverride(BaseModel):
+    keywords: list[str] = Field(default_factory=list)
+    keyword_negatives: list[str] = Field(default_factory=list)
+    min_word_count: Optional[int] = None
+    enabled: bool = True
+
+
+class SlackHeuristics(BaseModel):
+    model_config = ConfigDict(populate_by_name=True)
+    global_rules: HeuristicGlobalRules = Field(
+        default_factory=HeuristicGlobalRules, alias="global"
+    )
+    channels: dict[str, HeuristicScopedOverride] = Field(default_factory=dict)
+
+
+class NotionHeuristics(BaseModel):
+    model_config = ConfigDict(populate_by_name=True)
+    global_rules: HeuristicGlobalRules = Field(
+        default_factory=HeuristicGlobalRules, alias="global"
+    )
+    databases: dict[str, HeuristicScopedOverride] = Field(default_factory=dict)
+
+
 class SlackConfig(BaseModel):
     workspaces: list[WorkspaceConfig] = Field(default_factory=list)
+    heuristics: SlackHeuristics = Field(default_factory=SlackHeuristics)
+
+
+class NotionConfig(BaseModel):
+    token: Optional[str] = None
+    heuristics: NotionHeuristics = Field(default_factory=NotionHeuristics)
+
+
+class CorpusLearnerConfig(BaseModel):
+    enabled: bool = False
+    interval_seconds: int = 86400
+    top_n: int = 50
 
 
 class TeamServerConfig(BaseModel):
     slack: SlackConfig = Field(default_factory=SlackConfig)
+    notion: NotionConfig = Field(default_factory=NotionConfig)
+    corpus_learner: CorpusLearnerConfig = Field(default_factory=CorpusLearnerConfig)
+
+
+class RulesDisabled:
+    """Sentinel returned by resolve_rules_* when a channel/db is opted out."""
 
 
 def load_channel_allowlist(path: Path) -> TeamServerConfig:
-    raw = yaml.safe_load(path.read_text(encoding="utf-8")) or {}
+    return load_rules_from_config(path)
+
+
+def load_rules_from_config(path: Union[str, Path]) -> TeamServerConfig:
+    raw = yaml.safe_load(Path(path).read_text(encoding="utf-8")) or {}
     try:
         return TeamServerConfig(**raw)
     except ValidationError as exc:
-        # Re-raise as ValueError per plan contract; surface field errors.
         msg_parts = [
             f"{'.'.join(str(loc) for loc in err['loc'])}: {err['msg']}"
             for err in exc.errors()
@@ -43,3 +102,46 @@ def load_channel_allowlist(path: Path) -> TeamServerConfig:
         raise ValueError(
             f"team-server config invalid: {'; '.join(msg_parts)}"
         ) from exc
+
+
+def _build_rules(
+    base: HeuristicGlobalRules,
+    override: Optional[HeuristicScopedOverride],
+    learned: tuple[str, ...] = (),
+) -> TriggerRules:
+    return TriggerRules(
+        keywords=tuple([*base.keywords, *(override.keywords if override else [])]),
+        keyword_negatives=tuple([
+            *base.keyword_negatives,
+            *(override.keyword_negatives if override else []),
+        ]),
+        min_word_count=(
+            override.min_word_count
+            if override and override.min_word_count is not None
+            else base.min_word_count
+        ),
+        boost_reactions=tuple(base.boost_reactions),
+        boost_threshold=base.boost_threshold,
+        thread_tail_position_threshold=base.thread_tail_position_threshold,
+        learned_keywords=learned,
+    )
+
+
+def resolve_rules_for_slack(
+    config: TeamServerConfig, channel_id: str, learned: tuple[str, ...] = (),
+) -> Union[TriggerRules, RulesDisabled]:
+    base = config.slack.heuristics.global_rules
+    override = config.slack.heuristics.channels.get(channel_id)
+    if not base.enabled or (override and not override.enabled):
+        return RulesDisabled()
+    return _build_rules(base, override, learned)
+
+
+def resolve_rules_for_notion(
+    config: TeamServerConfig, db_id: str, learned: tuple[str, ...] = (),
+) -> Union[TriggerRules, RulesDisabled]:
+    base = config.notion.heuristics.global_rules
+    override = config.notion.heuristics.databases.get(db_id)
+    if not base.enabled or (override and not override.enabled):
+        return RulesDisabled()
+    return _build_rules(base, override, learned)

--- a/team_server/config.py
+++ b/team_server/config.py
@@ -6,10 +6,15 @@ the message to the operator at startup).
 
 from __future__ import annotations
 
+import os
 from pathlib import Path
 
 import yaml
 from pydantic import BaseModel, Field, ValidationError
+
+DEFAULT_CONFIG_PATH = Path(
+    os.environ.get("BICAMERAL_CONFIG_PATH", "/etc/bicameral-team-server/config.yml")
+)
 
 
 class WorkspaceConfig(BaseModel):

--- a/team_server/db.py
+++ b/team_server/db.py
@@ -1,0 +1,41 @@
+"""DB factory for the team-server.
+
+Wraps `ledger.client.LedgerClient` with team-server-specific defaults.
+The team-server uses its own `ns/db` pair so its rows never collide with
+a per-repo bicameral ledger that might share the same backing surrealkv
+file (e.g., development setups).
+"""
+
+from __future__ import annotations
+
+import os
+from dataclasses import dataclass
+
+from ledger.client import LedgerClient
+
+DEFAULT_URL = "memory://"
+DEFAULT_NS = "bicameral_team"
+DEFAULT_DB = "team_server"
+
+
+@dataclass
+class TeamServerDB:
+    """Thin holder around `LedgerClient` so app.state can carry one object."""
+
+    client: LedgerClient
+
+    @classmethod
+    def from_env(cls) -> "TeamServerDB":
+        url = os.environ.get("BICAMERAL_TEAM_SERVER_SURREAL_URL", DEFAULT_URL)
+        return cls(client=LedgerClient(url=url, ns=DEFAULT_NS, db=DEFAULT_DB))
+
+    async def connect(self) -> None:
+        await self.client.connect()
+
+    async def close(self) -> None:
+        await self.client.close()
+
+
+def build_client() -> LedgerClient:
+    """Test/CLI helper — returns a configured but not-yet-connected client."""
+    return TeamServerDB.from_env().client

--- a/team_server/db.py
+++ b/team_server/db.py
@@ -25,7 +25,7 @@ class TeamServerDB:
     client: LedgerClient
 
     @classmethod
-    def from_env(cls) -> "TeamServerDB":
+    def from_env(cls) -> TeamServerDB:
         url = os.environ.get("BICAMERAL_TEAM_SERVER_SURREAL_URL", DEFAULT_URL)
         return cls(client=LedgerClient(url=url, ns=DEFAULT_NS, db=DEFAULT_DB))
 

--- a/team_server/extraction/canonical_cache.py
+++ b/team_server/extraction/canonical_cache.py
@@ -1,13 +1,10 @@
-"""Canonical-extraction cache.
+"""Canonical-extraction cache (upsert-shaped).
 
-For a given (source_type, source_ref, content_hash) tuple, returns the
-extraction result deterministically: cache hit returns persisted output,
-cache miss invokes compute_fn and persists. Multi-dev convergence: any
-peer hitting the same triple sees the same canonical extraction.
-
-Per audit Advisory #3 + #72 lesson: the underlying field is FLEXIBLE
-TYPE object (declared in `team_server/schema.py`) so nested decision
-dicts persist intact.
+For a given (source_type, source_ref), holds the latest canonical
+extraction. content_hash tracks the input that produced it; an inbound
+content_hash that matches the stored value is a no-op (returns
+changed=False). A different hash triggers re-extraction and replaces
+the row in place. team_event log preserves edit history.
 """
 
 from __future__ import annotations
@@ -19,27 +16,41 @@ from ledger.client import LedgerClient
 ComputeFn = Callable[[], Awaitable[dict]]
 
 
-async def get_or_compute(
+async def upsert_canonical_extraction(
     client: LedgerClient,
     source_type: str,
     source_ref: str,
     content_hash: str,
     compute_fn: ComputeFn,
     model_version: str,
-) -> dict:
-    cached = await client.query(
-        "SELECT canonical_extraction FROM extraction_cache "
-        "WHERE source_type = $st AND source_ref = $sr "
-        "AND content_hash = $ch LIMIT 1",
-        {"st": source_type, "sr": source_ref, "ch": content_hash},
+) -> tuple[dict, bool]:
+    """Upsert canonical extraction. Returns (extraction, changed).
+
+    changed=True when the row was created OR the content_hash differed
+    from the stored value (i.e. an event-worthy change). changed=False
+    on cache hit with identical content_hash (idempotent re-poll).
+    """
+    rows = await client.query(
+        "SELECT content_hash, canonical_extraction FROM extraction_cache "
+        "WHERE source_type = $st AND source_ref = $sr LIMIT 1",
+        {"st": source_type, "sr": source_ref},
     )
-    if cached:
-        return cached[0]["canonical_extraction"]
+    if rows and rows[0]["content_hash"] == content_hash:
+        return rows[0]["canonical_extraction"], False
     extraction = await compute_fn()
-    await client.query(
-        "CREATE extraction_cache CONTENT { source_type: $st, source_ref: $sr, "
-        "content_hash: $ch, canonical_extraction: $ext, model_version: $mv }",
-        {"st": source_type, "sr": source_ref, "ch": content_hash,
-         "ext": extraction, "mv": model_version},
-    )
-    return extraction
+    if rows:
+        await client.query(
+            "UPDATE extraction_cache SET content_hash = $ch, "
+            "canonical_extraction = $ext, model_version = $mv "
+            "WHERE source_type = $st AND source_ref = $sr",
+            {"st": source_type, "sr": source_ref, "ch": content_hash,
+             "ext": extraction, "mv": model_version},
+        )
+    else:
+        await client.query(
+            "CREATE extraction_cache CONTENT { source_type: $st, source_ref: $sr, "
+            "content_hash: $ch, canonical_extraction: $ext, model_version: $mv }",
+            {"st": source_type, "sr": source_ref, "ch": content_hash,
+             "ext": extraction, "mv": model_version},
+        )
+    return extraction, True

--- a/team_server/extraction/canonical_cache.py
+++ b/team_server/extraction/canonical_cache.py
@@ -14,7 +14,7 @@ take effect without manual cache invalidation.
 
 from __future__ import annotations
 
-from typing import Awaitable, Callable
+from collections.abc import Awaitable, Callable
 
 from ledger.client import LedgerClient
 
@@ -43,9 +43,11 @@ async def upsert_canonical_extraction(
         "WHERE source_type = $st AND source_ref = $sr LIMIT 1",
         {"st": source_type, "sr": source_ref},
     )
-    if (rows
-            and rows[0]["content_hash"] == content_hash
-            and rows[0]["classifier_version"] == classifier_version):
+    if (
+        rows
+        and rows[0]["content_hash"] == content_hash
+        and rows[0]["classifier_version"] == classifier_version
+    ):
         return rows[0]["canonical_extraction"], False
     extraction = await compute_fn()
     if rows:
@@ -54,15 +56,27 @@ async def upsert_canonical_extraction(
             "classifier_version = $cv, canonical_extraction = $ext, "
             "model_version = $mv "
             "WHERE source_type = $st AND source_ref = $sr",
-            {"st": source_type, "sr": source_ref, "ch": content_hash,
-             "cv": classifier_version, "ext": extraction, "mv": model_version},
+            {
+                "st": source_type,
+                "sr": source_ref,
+                "ch": content_hash,
+                "cv": classifier_version,
+                "ext": extraction,
+                "mv": model_version,
+            },
         )
     else:
         await client.query(
             "CREATE extraction_cache CONTENT { source_type: $st, source_ref: $sr, "
             "content_hash: $ch, classifier_version: $cv, "
             "canonical_extraction: $ext, model_version: $mv }",
-            {"st": source_type, "sr": source_ref, "ch": content_hash,
-             "cv": classifier_version, "ext": extraction, "mv": model_version},
+            {
+                "st": source_type,
+                "sr": source_ref,
+                "ch": content_hash,
+                "cv": classifier_version,
+                "ext": extraction,
+                "mv": model_version,
+            },
         )
     return extraction, True

--- a/team_server/extraction/canonical_cache.py
+++ b/team_server/extraction/canonical_cache.py
@@ -1,0 +1,45 @@
+"""Canonical-extraction cache.
+
+For a given (source_type, source_ref, content_hash) tuple, returns the
+extraction result deterministically: cache hit returns persisted output,
+cache miss invokes compute_fn and persists. Multi-dev convergence: any
+peer hitting the same triple sees the same canonical extraction.
+
+Per audit Advisory #3 + #72 lesson: the underlying field is FLEXIBLE
+TYPE object (declared in `team_server/schema.py`) so nested decision
+dicts persist intact.
+"""
+
+from __future__ import annotations
+
+from typing import Awaitable, Callable
+
+from ledger.client import LedgerClient
+
+ComputeFn = Callable[[], Awaitable[dict]]
+
+
+async def get_or_compute(
+    client: LedgerClient,
+    source_type: str,
+    source_ref: str,
+    content_hash: str,
+    compute_fn: ComputeFn,
+    model_version: str,
+) -> dict:
+    cached = await client.query(
+        "SELECT canonical_extraction FROM extraction_cache "
+        "WHERE source_type = $st AND source_ref = $sr "
+        "AND content_hash = $ch LIMIT 1",
+        {"st": source_type, "sr": source_ref, "ch": content_hash},
+    )
+    if cached:
+        return cached[0]["canonical_extraction"]
+    extraction = await compute_fn()
+    await client.query(
+        "CREATE extraction_cache CONTENT { source_type: $st, source_ref: $sr, "
+        "content_hash: $ch, canonical_extraction: $ext, model_version: $mv }",
+        {"st": source_type, "sr": source_ref, "ch": content_hash,
+         "ext": extraction, "mv": model_version},
+    )
+    return extraction

--- a/team_server/extraction/canonical_cache.py
+++ b/team_server/extraction/canonical_cache.py
@@ -1,10 +1,15 @@
-"""Canonical-extraction cache (upsert-shaped).
+"""Canonical-extraction cache (upsert-shaped, two-axis identity).
 
 For a given (source_type, source_ref), holds the latest canonical
-extraction. content_hash tracks the input that produced it; an inbound
-content_hash that matches the stored value is a no-op (returns
-changed=False). A different hash triggers re-extraction and replaces
-the row in place. team_event log preserves edit history.
+extraction. Cache identity is the tuple (content_hash, classifier_version):
+both must match for a cache hit. Either differing triggers re-extraction
+and replaces the row in place. team_event log preserves edit history.
+
+classifier_version captures the rule-set hash of the heuristic Stage 1
+that gated the LLM call; rules change ⇒ classifier_version changes ⇒
+all rows look stale ⇒ next poll re-runs the pipeline. This is the
+mechanism that makes operator config edits and corpus-learner updates
+take effect without manual cache invalidation.
 """
 
 from __future__ import annotations
@@ -18,39 +23,46 @@ ComputeFn = Callable[[], Awaitable[dict]]
 
 async def upsert_canonical_extraction(
     client: LedgerClient,
+    *,
     source_type: str,
     source_ref: str,
     content_hash: str,
+    classifier_version: str,
     compute_fn: ComputeFn,
     model_version: str,
 ) -> tuple[dict, bool]:
     """Upsert canonical extraction. Returns (extraction, changed).
 
-    changed=True when the row was created OR the content_hash differed
-    from the stored value (i.e. an event-worthy change). changed=False
-    on cache hit with identical content_hash (idempotent re-poll).
+    changed=True when the row was created OR either content_hash OR
+    classifier_version differs from the stored values. changed=False
+    only on cache hit where BOTH match.
     """
     rows = await client.query(
-        "SELECT content_hash, canonical_extraction FROM extraction_cache "
+        "SELECT content_hash, classifier_version, canonical_extraction "
+        "FROM extraction_cache "
         "WHERE source_type = $st AND source_ref = $sr LIMIT 1",
         {"st": source_type, "sr": source_ref},
     )
-    if rows and rows[0]["content_hash"] == content_hash:
+    if (rows
+            and rows[0]["content_hash"] == content_hash
+            and rows[0]["classifier_version"] == classifier_version):
         return rows[0]["canonical_extraction"], False
     extraction = await compute_fn()
     if rows:
         await client.query(
             "UPDATE extraction_cache SET content_hash = $ch, "
-            "canonical_extraction = $ext, model_version = $mv "
+            "classifier_version = $cv, canonical_extraction = $ext, "
+            "model_version = $mv "
             "WHERE source_type = $st AND source_ref = $sr",
             {"st": source_type, "sr": source_ref, "ch": content_hash,
-             "ext": extraction, "mv": model_version},
+             "cv": classifier_version, "ext": extraction, "mv": model_version},
         )
     else:
         await client.query(
             "CREATE extraction_cache CONTENT { source_type: $st, source_ref: $sr, "
-            "content_hash: $ch, canonical_extraction: $ext, model_version: $mv }",
+            "content_hash: $ch, classifier_version: $cv, "
+            "canonical_extraction: $ext, model_version: $mv }",
             {"st": source_type, "sr": source_ref, "ch": content_hash,
-             "ext": extraction, "mv": model_version},
+             "cv": classifier_version, "ext": extraction, "mv": model_version},
         )
     return extraction, True

--- a/team_server/extraction/corpus_learner.py
+++ b/team_server/extraction/corpus_learner.py
@@ -1,0 +1,114 @@
+"""Corpus learner — extracts recurring n-grams from team_event payloads
+whose extraction.decisions is non-empty (per OQ-1 resolution: read from
+team-server's own ledger, not the per-repo decision table). Output
+populates learned_heuristic_terms for the heuristic classifier to merge.
+"""
+
+from __future__ import annotations
+
+import logging
+from collections import Counter
+from typing import Optional
+
+from ledger.client import LedgerClient
+
+logger = logging.getLogger(__name__)
+
+NGRAM_MIN, NGRAM_MAX = 2, 4
+
+
+async def learn_corpus_terms(
+    client: LedgerClient,
+    *,
+    source_type: str = "slack",
+    top_n: int = 50,
+    denylist: Optional[list[str]] = None,
+) -> list[dict]:
+    """Read team_event rows whose payload yielded decisions, extract
+    top n-grams from the source content. Returns list of {term, support_count}."""
+    rows = await client.query(
+        "SELECT payload FROM team_event WHERE event_type = 'ingest'"
+    )
+    counter: Counter = Counter()
+    for row in rows or []:
+        payload = row.get("payload") or {}
+        if (payload.get("source_type") or "").split("_")[0] != source_type.split("_")[0]:
+            continue
+        extraction = payload.get("extraction") or {}
+        decisions = extraction.get("decisions") or []
+        if not decisions:
+            continue
+        for d in decisions:
+            text = (d.get("summary", "") + " " + d.get("context_snippet", "")).lower()
+            words = text.split()
+            for n in range(NGRAM_MIN, NGRAM_MAX + 1):
+                for i in range(len(words) - n + 1):
+                    counter[" ".join(words[i:i + n])] += 1
+    deny = {d.lower() for d in (denylist or [])}
+    out: list[dict] = []
+    for term, support in counter.most_common(top_n * 4):
+        if term in deny or any(d in term for d in deny):
+            continue
+        out.append({"term": term, "support_count": support})
+        if len(out) >= top_n:
+            break
+    return out
+
+
+async def persist_learned_terms(
+    client: LedgerClient, source_type: str, terms: list[dict],
+) -> None:
+    """UPSERT-shaped: existing rows for (source_type, term) get their
+    support_count and learned_at updated; new terms inserted."""
+    for entry in terms:
+        existing = await client.query(
+            "SELECT id FROM learned_heuristic_terms "
+            "WHERE source_type = $st AND term = $t LIMIT 1",
+            {"st": source_type, "t": entry["term"]},
+        )
+        if existing:
+            await client.query(
+                "UPDATE learned_heuristic_terms "
+                "SET support_count = $sc, learned_at = time::now() "
+                "WHERE source_type = $st AND term = $t",
+                {"st": source_type, "t": entry["term"],
+                 "sc": entry["support_count"]},
+            )
+        else:
+            await client.query(
+                "CREATE learned_heuristic_terms CONTENT { "
+                "source_type: $st, term: $t, support_count: $sc }",
+                {"st": source_type, "t": entry["term"],
+                 "sc": entry["support_count"]},
+            )
+
+
+async def load_learned_terms(
+    client: LedgerClient, source_type: str,
+) -> tuple[str, ...]:
+    rows = await client.query(
+        "SELECT term FROM learned_heuristic_terms "
+        "WHERE source_type = $st ORDER BY support_count DESC",
+        {"st": source_type},
+    )
+    return tuple(r["term"] for r in rows or [])
+
+
+async def run_corpus_learner_iteration(
+    client: LedgerClient, config, *, source_type: str = "slack",
+) -> None:
+    """Single learner iteration. Pulls denylist from the matching
+    heuristic-global rules; persists results."""
+    deny: list[str] = []
+    if source_type == "slack":
+        deny = config.slack.heuristics.global_rules.learned_denylist
+    elif source_type == "notion":
+        deny = config.notion.heuristics.global_rules.learned_denylist
+    terms = await learn_corpus_terms(
+        client, source_type=source_type,
+        top_n=config.corpus_learner.top_n, denylist=deny,
+    )
+    await persist_learned_terms(client, source_type, terms)
+    logger.info(
+        "[corpus-learner] source=%s persisted %d terms", source_type, len(terms),
+    )

--- a/team_server/extraction/corpus_learner.py
+++ b/team_server/extraction/corpus_learner.py
@@ -8,7 +8,6 @@ from __future__ import annotations
 
 import logging
 from collections import Counter
-from typing import Optional
 
 from ledger.client import LedgerClient
 
@@ -22,13 +21,11 @@ async def learn_corpus_terms(
     *,
     source_type: str = "slack",
     top_n: int = 50,
-    denylist: Optional[list[str]] = None,
+    denylist: list[str] | None = None,
 ) -> list[dict]:
     """Read team_event rows whose payload yielded decisions, extract
     top n-grams from the source content. Returns list of {term, support_count}."""
-    rows = await client.query(
-        "SELECT payload FROM team_event WHERE event_type = 'ingest'"
-    )
+    rows = await client.query("SELECT payload FROM team_event WHERE event_type = 'ingest'")
     counter: Counter = Counter()
     for row in rows or []:
         payload = row.get("payload") or {}
@@ -43,7 +40,7 @@ async def learn_corpus_terms(
             words = text.split()
             for n in range(NGRAM_MIN, NGRAM_MAX + 1):
                 for i in range(len(words) - n + 1):
-                    counter[" ".join(words[i:i + n])] += 1
+                    counter[" ".join(words[i : i + n])] += 1
     deny = {d.lower() for d in (denylist or [])}
     out: list[dict] = []
     for term, support in counter.most_common(top_n * 4):
@@ -56,14 +53,15 @@ async def learn_corpus_terms(
 
 
 async def persist_learned_terms(
-    client: LedgerClient, source_type: str, terms: list[dict],
+    client: LedgerClient,
+    source_type: str,
+    terms: list[dict],
 ) -> None:
     """UPSERT-shaped: existing rows for (source_type, term) get their
     support_count and learned_at updated; new terms inserted."""
     for entry in terms:
         existing = await client.query(
-            "SELECT id FROM learned_heuristic_terms "
-            "WHERE source_type = $st AND term = $t LIMIT 1",
+            "SELECT id FROM learned_heuristic_terms WHERE source_type = $st AND term = $t LIMIT 1",
             {"st": source_type, "t": entry["term"]},
         )
         if existing:
@@ -71,20 +69,19 @@ async def persist_learned_terms(
                 "UPDATE learned_heuristic_terms "
                 "SET support_count = $sc, learned_at = time::now() "
                 "WHERE source_type = $st AND term = $t",
-                {"st": source_type, "t": entry["term"],
-                 "sc": entry["support_count"]},
+                {"st": source_type, "t": entry["term"], "sc": entry["support_count"]},
             )
         else:
             await client.query(
                 "CREATE learned_heuristic_terms CONTENT { "
                 "source_type: $st, term: $t, support_count: $sc }",
-                {"st": source_type, "t": entry["term"],
-                 "sc": entry["support_count"]},
+                {"st": source_type, "t": entry["term"], "sc": entry["support_count"]},
             )
 
 
 async def load_learned_terms(
-    client: LedgerClient, source_type: str,
+    client: LedgerClient,
+    source_type: str,
 ) -> tuple[str, ...]:
     rows = await client.query(
         "SELECT term FROM learned_heuristic_terms "
@@ -95,7 +92,10 @@ async def load_learned_terms(
 
 
 async def run_corpus_learner_iteration(
-    client: LedgerClient, config, *, source_type: str = "slack",
+    client: LedgerClient,
+    config,
+    *,
+    source_type: str = "slack",
 ) -> None:
     """Single learner iteration. Pulls denylist from the matching
     heuristic-global rules; persists results."""
@@ -105,10 +105,14 @@ async def run_corpus_learner_iteration(
     elif source_type == "notion":
         deny = config.notion.heuristics.global_rules.learned_denylist
     terms = await learn_corpus_terms(
-        client, source_type=source_type,
-        top_n=config.corpus_learner.top_n, denylist=deny,
+        client,
+        source_type=source_type,
+        top_n=config.corpus_learner.top_n,
+        denylist=deny,
     )
     await persist_learned_terms(client, source_type, terms)
     logger.info(
-        "[corpus-learner] source=%s persisted %d terms", source_type, len(terms),
+        "[corpus-learner] source=%s persisted %d terms",
+        source_type,
+        len(terms),
     )

--- a/team_server/extraction/heuristic_classifier.py
+++ b/team_server/extraction/heuristic_classifier.py
@@ -14,7 +14,6 @@ import hashlib
 import json
 import re
 from dataclasses import dataclass
-from typing import Optional
 
 
 @dataclass(frozen=True)
@@ -31,22 +30,25 @@ class TriggerRules:
     min_word_count: int = 0
     boost_reactions: tuple[str, ...] = ()
     boost_threshold: int = 1
-    thread_tail_position_threshold: Optional[int] = None
+    thread_tail_position_threshold: int | None = None
     learned_keywords: tuple[str, ...] = ()
 
 
 def derive_classifier_version(rules: TriggerRules) -> str:
     """Stable hash of the rule set; changes invalidate cache downstream."""
-    payload = json.dumps({
-        "keywords": sorted(rules.keywords),
-        "keyword_negatives": sorted(rules.keyword_negatives),
-        "min_word_count": rules.min_word_count,
-        "boost_reactions": sorted(rules.boost_reactions),
-        "boost_threshold": rules.boost_threshold,
-        "thread_tail_position_threshold": rules.thread_tail_position_threshold,
-        "learned_keywords": sorted(rules.learned_keywords),
-        "engine": "heuristic-v1",
-    }, sort_keys=True).encode("utf-8")
+    payload = json.dumps(
+        {
+            "keywords": sorted(rules.keywords),
+            "keyword_negatives": sorted(rules.keyword_negatives),
+            "min_word_count": rules.min_word_count,
+            "boost_reactions": sorted(rules.boost_reactions),
+            "boost_threshold": rules.boost_threshold,
+            "thread_tail_position_threshold": rules.thread_tail_position_threshold,
+            "learned_keywords": sorted(rules.learned_keywords),
+            "engine": "heuristic-v1",
+        },
+        sort_keys=True,
+    ).encode("utf-8")
     return f"heuristic-v1+{hashlib.sha256(payload).hexdigest()[:12]}"
 
 
@@ -84,9 +86,7 @@ def classify(
         return ClassificationResult(False, (), cv)
 
     word_count = len(_WORD_RE.findall(text))
-    text_matches = _match_keywords(
-        text, (*rules.keywords, *rules.learned_keywords)
-    )
+    text_matches = _match_keywords(text, (*rules.keywords, *rules.learned_keywords))
     reaction_matches = _reaction_triggers(
         context.get("reactions") or [],
         set(rules.boost_reactions),

--- a/team_server/extraction/heuristic_classifier.py
+++ b/team_server/extraction/heuristic_classifier.py
@@ -1,0 +1,105 @@
+"""Heuristic classifier — pure function over (message, context, rules).
+
+Stage 1 of the extraction pipeline. Decides whether a message is decision-
+relevant. Deterministic by construction (no LLM, no temperature). Rules
+are operator-configured at the workspace level + channel/database
+overrides; merged at classification time by `pipeline.merge_rules`.
+Option-c learned terms merge in via the same path; learned-keywords
+field of rules is appended to the operator-configured keywords.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import re
+from dataclasses import dataclass
+from typing import Optional
+
+
+@dataclass(frozen=True)
+class ClassificationResult:
+    is_positive: bool
+    matched_triggers: tuple[str, ...]
+    classifier_version: str
+
+
+@dataclass(frozen=True)
+class TriggerRules:
+    keywords: tuple[str, ...] = ()
+    keyword_negatives: tuple[str, ...] = ()
+    min_word_count: int = 0
+    boost_reactions: tuple[str, ...] = ()
+    boost_threshold: int = 1
+    thread_tail_position_threshold: Optional[int] = None
+    learned_keywords: tuple[str, ...] = ()
+
+
+def derive_classifier_version(rules: TriggerRules) -> str:
+    """Stable hash of the rule set; changes invalidate cache downstream."""
+    payload = json.dumps({
+        "keywords": sorted(rules.keywords),
+        "keyword_negatives": sorted(rules.keyword_negatives),
+        "min_word_count": rules.min_word_count,
+        "boost_reactions": sorted(rules.boost_reactions),
+        "boost_threshold": rules.boost_threshold,
+        "thread_tail_position_threshold": rules.thread_tail_position_threshold,
+        "learned_keywords": sorted(rules.learned_keywords),
+        "engine": "heuristic-v1",
+    }, sort_keys=True).encode("utf-8")
+    return f"heuristic-v1+{hashlib.sha256(payload).hexdigest()[:12]}"
+
+
+_WORD_RE = re.compile(r"\b\w+\b", re.UNICODE)
+
+
+def _has_negative(text_lc: str, negatives: tuple[str, ...]) -> bool:
+    return any(n.lower() in text_lc for n in negatives)
+
+
+def _match_keywords(text_lc: str, keywords: tuple[str, ...]) -> list[str]:
+    return [kw for kw in keywords if kw.lower() in text_lc]
+
+
+def _reaction_triggers(reactions: list, boost_set: set, threshold: int) -> list[str]:
+    out = []
+    for r in reactions:
+        name = r.get("name", "")
+        count = int(r.get("count", 0))
+        if name in boost_set and count >= threshold:
+            out.append(f":{name}:×{count}")
+    return out
+
+
+def classify(
+    message: dict,
+    context: dict,
+    rules: TriggerRules,
+) -> ClassificationResult:
+    text = (message.get("text", "") or "").lower()
+    cv = derive_classifier_version(rules)
+
+    # Negative-list short-circuit.
+    if _has_negative(text, rules.keyword_negatives):
+        return ClassificationResult(False, (), cv)
+
+    word_count = len(_WORD_RE.findall(text))
+    text_matches = _match_keywords(
+        text, (*rules.keywords, *rules.learned_keywords)
+    )
+    reaction_matches = _reaction_triggers(
+        context.get("reactions") or [],
+        set(rules.boost_reactions),
+        rules.boost_threshold,
+    )
+    thread_match: list[str] = []
+    if rules.thread_tail_position_threshold is not None:
+        if context.get("thread_position", 0) >= rules.thread_tail_position_threshold:
+            thread_match.append("thread-tail")
+
+    has_text = bool(text_matches) and word_count >= rules.min_word_count
+    has_context = bool(reaction_matches) or bool(thread_match)
+    is_positive = has_text or has_context
+
+    matched = tuple(text_matches) + tuple(reaction_matches) + tuple(thread_match)
+    return ClassificationResult(is_positive, matched, cv)

--- a/team_server/extraction/llm_extractor.py
+++ b/team_server/extraction/llm_extractor.py
@@ -1,0 +1,28 @@
+"""Interim LLM extractor — placeholder for v0 until CocoIndex (#136) lands.
+
+Marked with `model_version='interim-claude-v1'` so Phase 5's CocoIndex
+integration can identify+rebuild interim cache entries deterministically.
+
+This module deliberately does NOT call Anthropic's API at import-time —
+the real call lives inside `extract()`. Tests substitute their own
+extractor function via the worker's `extractor` parameter.
+"""
+
+from __future__ import annotations
+
+INTERIM_MODEL_VERSION = "interim-claude-v1"
+
+
+async def extract(text: str) -> dict:
+    """Default v0 interim extractor. Returns a structured decision payload.
+
+    Implementation note: the real Claude API call lands here once
+    Phase 3 deployment is operator-validated. For v0 unit tests we feed
+    `extractor=stub` directly into the worker, so this function is the
+    *production* default that customers see when they deploy.
+    """
+    # v0 minimal-correct shape: each non-empty paragraph becomes one
+    # candidate decision. The actual semantic extraction goes here when
+    # the operator wires Anthropic credentials at the team-server layer.
+    decisions = [p.strip() for p in text.split("\n\n") if p.strip()]
+    return {"decisions": decisions, "model_version": INTERIM_MODEL_VERSION}

--- a/team_server/extraction/llm_extractor.py
+++ b/team_server/extraction/llm_extractor.py
@@ -1,28 +1,123 @@
-"""Interim LLM extractor — placeholder for v0 until CocoIndex (#136) lands.
+"""Stage 2 LLM extractor — real Anthropic SDK call.
 
-Marked with `model_version='interim-claude-v1'` so Phase 5's CocoIndex
-integration can identify+rebuild interim cache entries deterministically.
+Called only on heuristic-positive messages. Returns a structured dict:
+{"decisions": [{"summary": str, "context_snippet": str}], ...}.
 
-This module deliberately does NOT call Anthropic's API at import-time —
-the real call lives inside `extract()`. Tests substitute their own
-extractor function via the worker's `extractor` parameter.
+Failure modes:
+- ANTHROPIC_API_KEY unset: raises MissingAnthropicKeyError (fail-loud).
+- HTTP 429: retries with exponential backoff (max 3 attempts).
+- HTTP 5xx / network errors: fail-soft, returns
+  {"decisions": [], "error": <message>}.
+- Unparseable model output: same fail-soft path.
+- Non-text content blocks (ToolUseBlock etc.): fail-soft.
+
+Also exports INTERIM_MODEL_VERSION (carried for backwards compat with
+v1.0 cache rows that pre-date this real-extractor implementation).
 """
 
 from __future__ import annotations
 
+import asyncio
+import hashlib
+import json
+import os
+from typing import Optional
+
 INTERIM_MODEL_VERSION = "interim-claude-v1"
 
+DEFAULT_MODEL = "claude-haiku-4-5"
+PROMPT_TEMPLATE = """You extract DECISIONS from a single chat or document
+message. Return STRICT JSON of the shape:
+{{"decisions": [{{"summary": "...", "context_snippet": "..."}}]}}
 
-async def extract(text: str) -> dict:
-    """Default v0 interim extractor. Returns a structured decision payload.
+A "decision" is a commitment, choice, or ratification of a course of
+action. Casual chatter, questions, and stale-context messages produce
+[]. Multiple decisions in one message produce multiple objects.
 
-    Implementation note: the real Claude API call lands here once
-    Phase 3 deployment is operator-validated. For v0 unit tests we feed
-    `extractor=stub` directly into the worker, so this function is the
-    *production* default that customers see when they deploy.
-    """
-    # v0 minimal-correct shape: each non-empty paragraph becomes one
-    # candidate decision. The actual semantic extraction goes here when
-    # the operator wires Anthropic credentials at the team-server layer.
-    decisions = [p.strip() for p in text.split("\n\n") if p.strip()]
-    return {"decisions": decisions, "model_version": INTERIM_MODEL_VERSION}
+The pre-classifier matched these triggers: {triggers}.
+Use them only as context; do not require them in the output.
+
+Message:
+\"\"\"{text}\"\"\""""
+
+PROMPT_TEMPLATE_HASH = hashlib.sha256(PROMPT_TEMPLATE.encode("utf-8")).hexdigest()[:8]
+
+
+class MissingAnthropicKeyError(RuntimeError):
+    """Raised at extract-time when ANTHROPIC_API_KEY is not set."""
+
+
+def _extractor_version() -> str:
+    model = os.environ.get("BICAMERAL_TEAM_SERVER_EXTRACT_MODEL", DEFAULT_MODEL)
+    return f"{model}-extract-{PROMPT_TEMPLATE_HASH}"
+
+
+def _success(decisions: list, version: str, triggers: list[str]) -> dict:
+    return {
+        "decisions": decisions,
+        "extractor_version": version,
+        "matched_triggers": triggers,
+    }
+
+
+def _fail_soft(error: str, version: str, triggers: list[str]) -> dict:
+    return {
+        "decisions": [],
+        "error": error,
+        "extractor_version": version,
+        "matched_triggers": triggers,
+    }
+
+
+async def _one_attempt(client, model: str, prompt: str) -> tuple[str, object]:
+    """Returns ("ok", decisions_list) | ("retry", None) | ("error", str_message).
+    'retry' means caller should sleep+retry (429 case). 'error' is terminal."""
+    from anthropic import APIError, APIStatusError
+
+    try:
+        resp = await client.messages.create(
+            model=model, max_tokens=512,
+            messages=[{"role": "user", "content": prompt}],
+        )
+    except APIStatusError as exc:
+        if exc.status_code == 429:
+            return ("retry", None)
+        return ("error", f"{exc.status_code}: {str(exc)[:200]}")
+    except APIError as exc:
+        return ("error", str(exc)[:200])
+    try:
+        content = resp.content[0].text if resp.content else ""
+    except (AttributeError, IndexError) as exc:
+        # Non-text content block (ToolUseBlock, ImageBlock, etc.) — fail-soft
+        return ("error", f"non-text-content: {exc}")
+    try:
+        parsed = json.loads(content)
+    except json.JSONDecodeError as exc:
+        return ("error", f"parse-failure: {exc}")
+    return ("ok", parsed.get("decisions", []))
+
+
+async def extract(text: str, matched_triggers: list[str]) -> dict:
+    api_key = os.environ.get("ANTHROPIC_API_KEY")
+    if not api_key:
+        raise MissingAnthropicKeyError(
+            "ANTHROPIC_API_KEY env var is required for Stage 2 LLM extraction"
+        )
+    from anthropic import AsyncAnthropic
+
+    model = os.environ.get("BICAMERAL_TEAM_SERVER_EXTRACT_MODEL", DEFAULT_MODEL)
+    version = _extractor_version()
+    client = AsyncAnthropic(api_key=api_key)
+    prompt = PROMPT_TEMPLATE.format(triggers=matched_triggers, text=text)
+
+    last_error = "unknown"
+    for attempt in range(3):
+        status, payload = await _one_attempt(client, model, prompt)
+        if status == "ok":
+            return _success(payload, version, matched_triggers)
+        if status == "retry" and attempt < 2:
+            await asyncio.sleep(2 ** attempt)
+            continue
+        last_error = str(payload) if payload else "rate-limit-exhausted"
+        break
+    return _fail_soft(last_error, version, matched_triggers)

--- a/team_server/extraction/llm_extractor.py
+++ b/team_server/extraction/llm_extractor.py
@@ -21,7 +21,7 @@ import asyncio
 import hashlib
 import json
 import os
-from typing import Optional
+from typing import Any
 
 INTERIM_MODEL_VERSION = "interim-claude-v1"
 
@@ -69,14 +69,15 @@ def _fail_soft(error: str, version: str, triggers: list[str]) -> dict:
     }
 
 
-async def _one_attempt(client, model: str, prompt: str) -> tuple[str, object]:
+async def _one_attempt(client, model: str, prompt: str) -> tuple[str, list[Any] | str | None]:
     """Returns ("ok", decisions_list) | ("retry", None) | ("error", str_message).
     'retry' means caller should sleep+retry (429 case). 'error' is terminal."""
     from anthropic import APIError, APIStatusError
 
     try:
         resp = await client.messages.create(
-            model=model, max_tokens=512,
+            model=model,
+            max_tokens=512,
             messages=[{"role": "user", "content": prompt}],
         )
     except APIStatusError as exc:
@@ -114,9 +115,12 @@ async def extract(text: str, matched_triggers: list[str]) -> dict:
     for attempt in range(3):
         status, payload = await _one_attempt(client, model, prompt)
         if status == "ok":
+            assert isinstance(payload, list), (
+                f"_one_attempt returned status='ok' with non-list payload: {type(payload).__name__}"
+            )
             return _success(payload, version, matched_triggers)
         if status == "retry" and attempt < 2:
-            await asyncio.sleep(2 ** attempt)
+            await asyncio.sleep(2**attempt)
             continue
         last_error = str(payload) if payload else "rate-limit-exhausted"
         break

--- a/team_server/extraction/notion_serializer.py
+++ b/team_server/extraction/notion_serializer.py
@@ -1,0 +1,64 @@
+"""Notion DB row -> text input for the canonical extractor.
+
+Deterministic serialization: title line, then sorted-by-key property
+lines, then a blank line, then the body block plain-text. Byte-stable
+output is the gating invariant for content_hash stability across polls.
+"""
+
+from __future__ import annotations
+
+
+def _rich_text_plain(rich_text: list[dict]) -> str:
+    return "".join(rt.get("plain_text", "") for rt in rich_text)
+
+
+def _serialize_property(prop: dict) -> str:
+    ptype = prop.get("type")
+    if ptype == "title":
+        return _rich_text_plain(prop.get("title", []))
+    if ptype == "rich_text":
+        return _rich_text_plain(prop.get("rich_text", []))
+    if ptype == "select":
+        sel = prop.get("select")
+        return sel.get("name", "") if sel else ""
+    if ptype == "multi_select":
+        return ", ".join(opt.get("name", "") for opt in prop.get("multi_select", []))
+    if ptype == "date":
+        d = prop.get("date")
+        if not d:
+            return ""
+        start = d.get("start", "")
+        end = d.get("end")
+        return f"{start}..{end}" if end else start
+    if ptype == "checkbox":
+        return "true" if prop.get("checkbox") else "false"
+    if ptype == "number":
+        n = prop.get("number")
+        return "" if n is None else str(n)
+    if ptype == "url":
+        return prop.get("url") or ""
+    if ptype == "people":
+        return ", ".join(p.get("id", "") for p in prop.get("people", []))
+    return f"<unknown:{ptype}>"
+
+
+def _block_plain_text(block: dict) -> str:
+    btype = block.get("type", "")
+    body = block.get(btype) or {}
+    return _rich_text_plain(body.get("rich_text", []))
+
+
+def serialize_row(page: dict, blocks: list[dict]) -> str:
+    properties = page.get("properties", {})
+    title = ""
+    prop_lines: list[str] = []
+    for key in sorted(properties):
+        prop = properties[key]
+        value = _serialize_property(prop)
+        if prop.get("type") == "title":
+            title = value
+        else:
+            prop_lines.append(f"{key}: {value}")
+    body_lines = [_block_plain_text(b) for b in blocks]
+    body_text = "\n".join(line for line in body_lines if line)
+    return "\n".join([title, *prop_lines, "", body_text])

--- a/team_server/extraction/pipeline.py
+++ b/team_server/extraction/pipeline.py
@@ -1,0 +1,59 @@
+"""Extraction pipeline — Stage 1 (heuristic classifier) → Stage 2 (LLM).
+
+Single entry point for both Slack and Notion workers. Determines the
+output shape regardless of source: {decisions, classifier_version,
+matched_triggers, extractor_version, skipped}. extractor_version is
+None when Stage 2 did not run (chatter or rules-disabled).
+"""
+
+from __future__ import annotations
+
+from typing import Awaitable, Callable, Optional, Union
+
+from team_server.config import RulesDisabled
+from team_server.extraction.heuristic_classifier import (
+    TriggerRules, classify, derive_classifier_version,
+)
+
+LLMExtractFn = Callable[[str, list[str]], Awaitable[dict]]
+
+
+async def extract_decision_pipeline(
+    *,
+    text: str,
+    message: dict,
+    context: dict,
+    rules_or_disabled: Union[TriggerRules, RulesDisabled],
+    llm_extract_fn: Optional[LLMExtractFn] = None,
+) -> dict:
+    if isinstance(rules_or_disabled, RulesDisabled):
+        return {
+            "decisions": [],
+            "classifier_version": "rules-disabled",
+            "matched_triggers": [],
+            "extractor_version": None,
+            "skipped": True,
+        }
+    rules = rules_or_disabled
+    cv = derive_classifier_version(rules)
+    classification = classify({**message, "text": text}, context, rules)
+    if not classification.is_positive:
+        return {
+            "decisions": [],
+            "classifier_version": cv,
+            "matched_triggers": list(classification.matched_triggers),
+            "extractor_version": None,
+            "skipped": False,
+        }
+    if llm_extract_fn is None:
+        from team_server.extraction.llm_extractor import extract as default_extract
+        llm_extract_fn = default_extract
+    llm_result = await llm_extract_fn(text, list(classification.matched_triggers))
+    return {
+        "decisions": llm_result.get("decisions", []),
+        "classifier_version": cv,
+        "matched_triggers": list(classification.matched_triggers),
+        "extractor_version": llm_result.get("extractor_version"),
+        "error": llm_result.get("error"),
+        "skipped": False,
+    }

--- a/team_server/extraction/pipeline.py
+++ b/team_server/extraction/pipeline.py
@@ -8,11 +8,13 @@ None when Stage 2 did not run (chatter or rules-disabled).
 
 from __future__ import annotations
 
-from typing import Awaitable, Callable, Optional, Union
+from collections.abc import Awaitable, Callable
 
 from team_server.config import RulesDisabled
 from team_server.extraction.heuristic_classifier import (
-    TriggerRules, classify, derive_classifier_version,
+    TriggerRules,
+    classify,
+    derive_classifier_version,
 )
 
 LLMExtractFn = Callable[[str, list[str]], Awaitable[dict]]
@@ -23,8 +25,8 @@ async def extract_decision_pipeline(
     text: str,
     message: dict,
     context: dict,
-    rules_or_disabled: Union[TriggerRules, RulesDisabled],
-    llm_extract_fn: Optional[LLMExtractFn] = None,
+    rules_or_disabled: TriggerRules | RulesDisabled,
+    llm_extract_fn: LLMExtractFn | None = None,
 ) -> dict:
     if isinstance(rules_or_disabled, RulesDisabled):
         return {
@@ -47,6 +49,7 @@ async def extract_decision_pipeline(
         }
     if llm_extract_fn is None:
         from team_server.extraction.llm_extractor import extract as default_extract
+
         llm_extract_fn = default_extract
     llm_result = await llm_extract_fn(text, list(classification.matched_triggers))
     return {

--- a/team_server/requirements.txt
+++ b/team_server/requirements.txt
@@ -1,0 +1,8 @@
+fastapi>=0.115
+uvicorn[standard]>=0.30
+httpx>=0.27
+pydantic>=2.6
+cryptography>=42.0
+pyyaml>=6.0
+slack_sdk>=3.27
+anthropic>=0.34

--- a/team_server/schema.py
+++ b/team_server/schema.py
@@ -4,23 +4,25 @@
 Defines the v0 tables for the team-server's own state. Per audit
 Advisory #3 (and the #72 lesson), nested-object fields use
 `FLEXIBLE TYPE object` so SurrealDB v2 doesn't strip nested keys.
+
+v2 (Notion v1 plan): cache contract upgraded to upsert-keyed-on
+(source_type, source_ref); schema_version table records the post-
+migration version as data, not folklore.
 """
 
 from __future__ import annotations
 
 import logging
+from typing import Awaitable, Callable
 
 from ledger.client import LedgerClient
 
 logger = logging.getLogger(__name__)
 
-SCHEMA_VERSION = 1
+SCHEMA_VERSION = 2
 
-# v0 schema. Append-only across versions; future migrations are added as
-# `_migrate_v1_to_v2`, etc., dispatched through `_MIGRATIONS`.
 _BASE_STMTS: tuple[str, ...] = (
-    # workspace — one row per Slack workspace (single-workspace v0 still
-    # uses the table for forward-compat with multi-workspace v1).
+    # workspace — one row per Slack workspace.
     "DEFINE TABLE workspace SCHEMAFULL",
     "DEFINE FIELD name                  ON workspace TYPE string",
     "DEFINE FIELD slack_team_id         ON workspace TYPE string",
@@ -36,8 +38,10 @@ _BASE_STMTS: tuple[str, ...] = (
     "DEFINE FIELD added_at     ON channel_allowlist TYPE datetime DEFAULT time::now()",
     "DEFINE INDEX idx_channel_allowlist_unique ON channel_allowlist FIELDS workspace_id, channel_id UNIQUE",
 
-    # extraction_cache — canonical extraction per (source_type, source_ref, content_hash).
-    # FLEXIBLE on canonical_extraction so nested decision dicts are preserved (#72 lesson).
+    # extraction_cache — canonical extraction per (source_type, source_ref).
+    # v2: index keyed on (source_type, source_ref) only; content_hash is a
+    # tracking column. The v1 (source_type, source_ref, content_hash)
+    # index is dropped and redefined by _migrate_v1_to_v2.
     "DEFINE TABLE extraction_cache SCHEMAFULL",
     "DEFINE FIELD source_type            ON extraction_cache TYPE string",
     "DEFINE FIELD source_ref             ON extraction_cache TYPE string",
@@ -45,9 +49,9 @@ _BASE_STMTS: tuple[str, ...] = (
     "DEFINE FIELD canonical_extraction   ON extraction_cache FLEXIBLE TYPE object DEFAULT {}",
     "DEFINE FIELD model_version          ON extraction_cache TYPE string",
     "DEFINE FIELD created_at             ON extraction_cache TYPE datetime DEFAULT time::now()",
-    "DEFINE INDEX idx_extraction_cache_key ON extraction_cache FIELDS source_type, source_ref, content_hash UNIQUE",
+    "DEFINE INDEX idx_extraction_cache_key ON extraction_cache FIELDS source_type, source_ref UNIQUE",
 
-    # team_event — append-only event log. FLEXIBLE on payload for the same reason.
+    # team_event — append-only event log.
     "DEFINE TABLE team_event SCHEMAFULL",
     "DEFINE FIELD author_email ON team_event TYPE string",
     "DEFINE FIELD event_type   ON team_event TYPE string",
@@ -55,26 +59,81 @@ _BASE_STMTS: tuple[str, ...] = (
     "DEFINE FIELD sequence     ON team_event TYPE int",
     "DEFINE FIELD created_at   ON team_event TYPE datetime DEFAULT time::now()",
     "DEFINE INDEX idx_team_event_sequence ON team_event FIELDS sequence",
+
+    # source_watermark — generic per-source, per-resource watermark.
+    # Used by polled sources (Notion v1; future sources reuse).
+    "DEFINE TABLE source_watermark SCHEMAFULL",
+    "DEFINE FIELD source_type ON source_watermark TYPE string",
+    "DEFINE FIELD resource_id ON source_watermark TYPE string",
+    "DEFINE FIELD last_seen   ON source_watermark TYPE string DEFAULT ''",
+    "DEFINE FIELD updated_at  ON source_watermark TYPE datetime DEFAULT time::now()",
+    "DEFINE INDEX idx_source_watermark_key ON source_watermark FIELDS source_type, resource_id UNIQUE",
+
+    # schema_version — single-row table holding the current SCHEMA_VERSION.
+    # DELETE-then-CREATE keeps the table at one row regardless of how
+    # many times ensure_schema runs. Versioning is data, not folklore.
+    "DEFINE TABLE schema_version SCHEMAFULL",
+    "DEFINE FIELD version    ON schema_version TYPE int",
+    "DEFINE FIELD updated_at ON schema_version TYPE datetime DEFAULT time::now()",
 )
 
-_MIGRATIONS: dict[int, tuple[str, ...]] = {
-    # 2: ("DEFINE FIELD ... new in v2",),
+
+async def _migrate_v1_to_v2(client: LedgerClient) -> None:
+    """Drop the v1 (source_type, source_ref, content_hash) UNIQUE index,
+    dedup duplicates by max(created_at) per (source_type, source_ref),
+    then redefine the index on (source_type, source_ref) UNIQUE.
+    Idempotent: REMOVE INDEX is a no-op if the index doesn't exist;
+    the dedup pass deletes nothing when no duplicates exist."""
+    try:
+        await client.query("REMOVE INDEX idx_extraction_cache_key ON extraction_cache")
+    except Exception as exc:  # noqa: BLE001
+        if "does not exist" not in str(exc).lower() and "not found" not in str(exc).lower():
+            raise
+    rows = await client.query(
+        "SELECT id, source_type, source_ref, created_at FROM extraction_cache"
+    )
+    survivors: dict[tuple[str, str], dict] = {}
+    for row in rows or []:
+        key = (row["source_type"], row["source_ref"])
+        prior = survivors.get(key)
+        if prior is None or row["created_at"] > prior["created_at"]:
+            survivors[key] = row
+    survivor_ids = {r["id"] for r in survivors.values()}
+    for row in rows or []:
+        if row["id"] not in survivor_ids:
+            # row["id"] comes back as "extraction_cache:<rid>"; split for type::thing
+            tb, _, rid = str(row["id"]).partition(":")
+            await client.query(
+                "DELETE type::thing($tb, $rid)",
+                {"tb": tb, "rid": rid},
+            )
+    await client.query(
+        "DEFINE INDEX idx_extraction_cache_key ON extraction_cache "
+        "FIELDS source_type, source_ref UNIQUE"
+    )
+
+
+_MIGRATIONS: dict[int, Callable[[LedgerClient], Awaitable[None]]] = {
+    2: _migrate_v1_to_v2,
 }
 
 
 async def ensure_schema(client: LedgerClient) -> None:
-    """Apply base schema (idempotent) and run any forward migrations."""
+    """Apply base schema (idempotent), run forward migrations, record version."""
     for stmt in _BASE_STMTS:
         try:
             await client.query(stmt)
-        except Exception as exc:
-            # SurrealDB raises on duplicate DEFINE only when content differs;
-            # idempotent re-define on identical statements succeeds. Log and
-            # continue if the underlying error is a benign re-define.
+        except Exception as exc:  # noqa: BLE001
             if "already exists" in str(exc).lower():
                 continue
             raise
     for version in sorted(_MIGRATIONS):
-        for stmt in _MIGRATIONS[version]:
-            await client.query(stmt)
+        await _MIGRATIONS[version](client)
+    # DELETE-then-CREATE keeps the table at one row regardless of how
+    # many times ensure_schema runs.
+    await client.query("DELETE schema_version")
+    await client.query(
+        "CREATE schema_version CONTENT { version: $v }",
+        {"v": SCHEMA_VERSION},
+    )
     logger.info("[team-server] schema ensured at version %s", SCHEMA_VERSION)

--- a/team_server/schema.py
+++ b/team_server/schema.py
@@ -1,0 +1,80 @@
+"""Team-server schema — self-managing migrations.
+
+`ensure_schema(client)` is idempotent: safe to call on every startup.
+Defines the v0 tables for the team-server's own state. Per audit
+Advisory #3 (and the #72 lesson), nested-object fields use
+`FLEXIBLE TYPE object` so SurrealDB v2 doesn't strip nested keys.
+"""
+
+from __future__ import annotations
+
+import logging
+
+from ledger.client import LedgerClient
+
+logger = logging.getLogger(__name__)
+
+SCHEMA_VERSION = 1
+
+# v0 schema. Append-only across versions; future migrations are added as
+# `_migrate_v1_to_v2`, etc., dispatched through `_MIGRATIONS`.
+_BASE_STMTS: tuple[str, ...] = (
+    # workspace — one row per Slack workspace (single-workspace v0 still
+    # uses the table for forward-compat with multi-workspace v1).
+    "DEFINE TABLE workspace SCHEMAFULL",
+    "DEFINE FIELD name                  ON workspace TYPE string",
+    "DEFINE FIELD slack_team_id         ON workspace TYPE string",
+    "DEFINE FIELD oauth_token_encrypted ON workspace TYPE string",
+    "DEFINE FIELD created_at            ON workspace TYPE datetime DEFAULT time::now()",
+    "DEFINE INDEX idx_workspace_slack_team_id ON workspace FIELDS slack_team_id UNIQUE",
+
+    # channel_allowlist — which Slack channels are ingested per workspace.
+    "DEFINE TABLE channel_allowlist SCHEMAFULL",
+    "DEFINE FIELD workspace_id ON channel_allowlist TYPE record<workspace>",
+    "DEFINE FIELD channel_id   ON channel_allowlist TYPE string",
+    "DEFINE FIELD channel_name ON channel_allowlist TYPE string DEFAULT ''",
+    "DEFINE FIELD added_at     ON channel_allowlist TYPE datetime DEFAULT time::now()",
+    "DEFINE INDEX idx_channel_allowlist_unique ON channel_allowlist FIELDS workspace_id, channel_id UNIQUE",
+
+    # extraction_cache — canonical extraction per (source_type, source_ref, content_hash).
+    # FLEXIBLE on canonical_extraction so nested decision dicts are preserved (#72 lesson).
+    "DEFINE TABLE extraction_cache SCHEMAFULL",
+    "DEFINE FIELD source_type            ON extraction_cache TYPE string",
+    "DEFINE FIELD source_ref             ON extraction_cache TYPE string",
+    "DEFINE FIELD content_hash           ON extraction_cache TYPE string",
+    "DEFINE FIELD canonical_extraction   ON extraction_cache FLEXIBLE TYPE object DEFAULT {}",
+    "DEFINE FIELD model_version          ON extraction_cache TYPE string",
+    "DEFINE FIELD created_at             ON extraction_cache TYPE datetime DEFAULT time::now()",
+    "DEFINE INDEX idx_extraction_cache_key ON extraction_cache FIELDS source_type, source_ref, content_hash UNIQUE",
+
+    # team_event — append-only event log. FLEXIBLE on payload for the same reason.
+    "DEFINE TABLE team_event SCHEMAFULL",
+    "DEFINE FIELD author_email ON team_event TYPE string",
+    "DEFINE FIELD event_type   ON team_event TYPE string",
+    "DEFINE FIELD payload      ON team_event FLEXIBLE TYPE object DEFAULT {}",
+    "DEFINE FIELD sequence     ON team_event TYPE int",
+    "DEFINE FIELD created_at   ON team_event TYPE datetime DEFAULT time::now()",
+    "DEFINE INDEX idx_team_event_sequence ON team_event FIELDS sequence",
+)
+
+_MIGRATIONS: dict[int, tuple[str, ...]] = {
+    # 2: ("DEFINE FIELD ... new in v2",),
+}
+
+
+async def ensure_schema(client: LedgerClient) -> None:
+    """Apply base schema (idempotent) and run any forward migrations."""
+    for stmt in _BASE_STMTS:
+        try:
+            await client.query(stmt)
+        except Exception as exc:
+            # SurrealDB raises on duplicate DEFINE only when content differs;
+            # idempotent re-define on identical statements succeeds. Log and
+            # continue if the underlying error is a benign re-define.
+            if "already exists" in str(exc).lower():
+                continue
+            raise
+    for version in sorted(_MIGRATIONS):
+        for stmt in _MIGRATIONS[version]:
+            await client.query(stmt)
+    logger.info("[team-server] schema ensured at version %s", SCHEMA_VERSION)

--- a/team_server/schema.py
+++ b/team_server/schema.py
@@ -19,7 +19,7 @@ from ledger.client import LedgerClient
 
 logger = logging.getLogger(__name__)
 
-SCHEMA_VERSION = 2
+SCHEMA_VERSION = 3
 
 _BASE_STMTS: tuple[str, ...] = (
     # workspace — one row per Slack workspace.
@@ -48,6 +48,7 @@ _BASE_STMTS: tuple[str, ...] = (
     "DEFINE FIELD content_hash           ON extraction_cache TYPE string",
     "DEFINE FIELD canonical_extraction   ON extraction_cache FLEXIBLE TYPE object DEFAULT {}",
     "DEFINE FIELD model_version          ON extraction_cache TYPE string",
+    "DEFINE FIELD classifier_version     ON extraction_cache TYPE option<string> DEFAULT 'legacy-pre-v3'",
     "DEFINE FIELD created_at             ON extraction_cache TYPE datetime DEFAULT time::now()",
     "DEFINE INDEX idx_extraction_cache_key ON extraction_cache FIELDS source_type, source_ref UNIQUE",
 
@@ -113,8 +114,30 @@ async def _migrate_v1_to_v2(client: LedgerClient) -> None:
     )
 
 
+async def _migrate_v2_to_v3(client: LedgerClient) -> None:
+    """Add classifier_version column with default for new rows; backfill
+    existing rows so SELECT returns a defined value, not the SurrealDB
+    NONE marker that would compare unequal to any real version string."""
+    try:
+        await client.query(
+            "DEFINE FIELD classifier_version ON extraction_cache "
+            "TYPE option<string> DEFAULT 'legacy-pre-v3'"
+        )
+    except Exception as exc:  # noqa: BLE001
+        if "already exists" not in str(exc).lower():
+            raise
+    # Unconditional backfill — idempotent: rows that already carry a
+    # classifier_version get the same value re-set; rows that pre-date
+    # the field (NONE per option<string>) get the literal default.
+    await client.query(
+        "UPDATE extraction_cache SET classifier_version = 'legacy-pre-v3' "
+        "WHERE classifier_version IS NONE"
+    )
+
+
 _MIGRATIONS: dict[int, Callable[[LedgerClient], Awaitable[None]]] = {
     2: _migrate_v1_to_v2,
+    3: _migrate_v2_to_v3,
 }
 
 

--- a/team_server/schema.py
+++ b/team_server/schema.py
@@ -19,7 +19,7 @@ from ledger.client import LedgerClient
 
 logger = logging.getLogger(__name__)
 
-SCHEMA_VERSION = 3
+SCHEMA_VERSION = 4
 
 _BASE_STMTS: tuple[str, ...] = (
     # workspace — one row per Slack workspace.
@@ -76,6 +76,16 @@ _BASE_STMTS: tuple[str, ...] = (
     "DEFINE TABLE schema_version SCHEMAFULL",
     "DEFINE FIELD version    ON schema_version TYPE int",
     "DEFINE FIELD updated_at ON schema_version TYPE datetime DEFAULT time::now()",
+
+    # learned_heuristic_terms — Phase 5 corpus learner output.
+    # Per (source_type, term) UNIQUE; support_count is the n-gram
+    # frequency in the source corpus at learn time.
+    "DEFINE TABLE learned_heuristic_terms SCHEMAFULL",
+    "DEFINE FIELD source_type   ON learned_heuristic_terms TYPE string",
+    "DEFINE FIELD term          ON learned_heuristic_terms TYPE string",
+    "DEFINE FIELD support_count ON learned_heuristic_terms TYPE int",
+    "DEFINE FIELD learned_at    ON learned_heuristic_terms TYPE datetime DEFAULT time::now()",
+    "DEFINE INDEX idx_learned_heuristic_terms_key ON learned_heuristic_terms FIELDS source_type, term UNIQUE",
 )
 
 

--- a/team_server/schema.py
+++ b/team_server/schema.py
@@ -13,7 +13,7 @@ migration version as data, not folklore.
 from __future__ import annotations
 
 import logging
-from typing import Awaitable, Callable
+from collections.abc import Awaitable, Callable
 
 from ledger.client import LedgerClient
 
@@ -29,7 +29,6 @@ _BASE_STMTS: tuple[str, ...] = (
     "DEFINE FIELD oauth_token_encrypted ON workspace TYPE string",
     "DEFINE FIELD created_at            ON workspace TYPE datetime DEFAULT time::now()",
     "DEFINE INDEX idx_workspace_slack_team_id ON workspace FIELDS slack_team_id UNIQUE",
-
     # channel_allowlist — which Slack channels are ingested per workspace.
     "DEFINE TABLE channel_allowlist SCHEMAFULL",
     "DEFINE FIELD workspace_id ON channel_allowlist TYPE record<workspace>",
@@ -37,7 +36,6 @@ _BASE_STMTS: tuple[str, ...] = (
     "DEFINE FIELD channel_name ON channel_allowlist TYPE string DEFAULT ''",
     "DEFINE FIELD added_at     ON channel_allowlist TYPE datetime DEFAULT time::now()",
     "DEFINE INDEX idx_channel_allowlist_unique ON channel_allowlist FIELDS workspace_id, channel_id UNIQUE",
-
     # extraction_cache — canonical extraction per (source_type, source_ref).
     # v2: index keyed on (source_type, source_ref) only; content_hash is a
     # tracking column. The v1 (source_type, source_ref, content_hash)
@@ -51,7 +49,6 @@ _BASE_STMTS: tuple[str, ...] = (
     "DEFINE FIELD classifier_version     ON extraction_cache TYPE option<string> DEFAULT 'legacy-pre-v3'",
     "DEFINE FIELD created_at             ON extraction_cache TYPE datetime DEFAULT time::now()",
     "DEFINE INDEX idx_extraction_cache_key ON extraction_cache FIELDS source_type, source_ref UNIQUE",
-
     # team_event — append-only event log.
     "DEFINE TABLE team_event SCHEMAFULL",
     "DEFINE FIELD author_email ON team_event TYPE string",
@@ -60,7 +57,6 @@ _BASE_STMTS: tuple[str, ...] = (
     "DEFINE FIELD sequence     ON team_event TYPE int",
     "DEFINE FIELD created_at   ON team_event TYPE datetime DEFAULT time::now()",
     "DEFINE INDEX idx_team_event_sequence ON team_event FIELDS sequence",
-
     # source_watermark — generic per-source, per-resource watermark.
     # Used by polled sources (Notion v1; future sources reuse).
     "DEFINE TABLE source_watermark SCHEMAFULL",
@@ -69,14 +65,12 @@ _BASE_STMTS: tuple[str, ...] = (
     "DEFINE FIELD last_seen   ON source_watermark TYPE string DEFAULT ''",
     "DEFINE FIELD updated_at  ON source_watermark TYPE datetime DEFAULT time::now()",
     "DEFINE INDEX idx_source_watermark_key ON source_watermark FIELDS source_type, resource_id UNIQUE",
-
     # schema_version — single-row table holding the current SCHEMA_VERSION.
     # DELETE-then-CREATE keeps the table at one row regardless of how
     # many times ensure_schema runs. Versioning is data, not folklore.
     "DEFINE TABLE schema_version SCHEMAFULL",
     "DEFINE FIELD version    ON schema_version TYPE int",
     "DEFINE FIELD updated_at ON schema_version TYPE datetime DEFAULT time::now()",
-
     # learned_heuristic_terms — Phase 5 corpus learner output.
     # Per (source_type, term) UNIQUE; support_count is the n-gram
     # frequency in the source corpus at learn time.

--- a/team_server/sync/peer_writer.py
+++ b/team_server/sync/peer_writer.py
@@ -1,0 +1,42 @@
+"""Peer-author event writer — writes a `team_event` row shaped to match
+the `events/writer.py` JSONL contract.
+
+Per the research brief: the team-server is a peer in the existing
+event-sourcing model. Authoring identity is `team-server@<team_id>.bicameral`
+(single-bot per workspace). The sequence number is monotonic per
+team-server instance.
+"""
+
+from __future__ import annotations
+
+from ledger.client import LedgerClient
+
+
+def author_email_for_workspace(team_id: str) -> str:
+    return f"team-server@{team_id}.bicameral"
+
+
+async def write_team_event(
+    client: LedgerClient,
+    workspace_team_id: str,
+    event_type: str,
+    payload: dict,
+) -> None:
+    """Append a team_event row. Sequence is computed as max(existing) + 1
+    so multi-instance scenarios degrade to last-write-wins per workspace
+    (single-instance v0 deployment is the contract; multi-instance HA is
+    a v1 concern per plan boundaries.non_goals)."""
+    rows = await client.query(
+        "SELECT sequence FROM team_event ORDER BY sequence DESC LIMIT 1"
+    )
+    next_seq = (rows[0]["sequence"] + 1) if rows else 1
+    await client.query(
+        "CREATE team_event CONTENT { author_email: $ae, event_type: $et, "
+        "payload: $pl, sequence: $sq, created_at: time::now() }",
+        {
+            "ae": author_email_for_workspace(workspace_team_id),
+            "et": event_type,
+            "pl": payload,
+            "sq": next_seq,
+        },
+    )

--- a/team_server/sync/peer_writer.py
+++ b/team_server/sync/peer_writer.py
@@ -26,9 +26,7 @@ async def write_team_event(
     so multi-instance scenarios degrade to last-write-wins per workspace
     (single-instance v0 deployment is the contract; multi-instance HA is
     a v1 concern per plan boundaries.non_goals)."""
-    rows = await client.query(
-        "SELECT sequence FROM team_event ORDER BY sequence DESC LIMIT 1"
-    )
+    rows = await client.query("SELECT sequence FROM team_event ORDER BY sequence DESC LIMIT 1")
     next_seq = (rows[0]["sequence"] + 1) if rows else 1
     await client.query(
         "CREATE team_event CONTENT { author_email: $ae, event_type: $et, "

--- a/team_server/workers/notion_runner.py
+++ b/team_server/workers/notion_runner.py
@@ -1,0 +1,23 @@
+"""Notion worker runner - single-workspace internal-integration shape.
+
+The internal-integration auth model gives one token per Notion
+workspace; v1 ships single-workspace, so run_notion_iteration is a
+thin wrapper over poll_once. Exists for symmetry with slack_runner
+(both expose a zero-extra-arg work_fn for the lifespan to register).
+"""
+
+from __future__ import annotations
+
+from typing import Awaitable, Callable
+
+from ledger.client import LedgerClient
+
+from team_server.workers import notion_worker
+
+Extractor = Callable[[str], Awaitable[dict]]
+
+
+async def run_notion_iteration(
+    db_client: LedgerClient, token: str, extractor: Extractor
+) -> None:
+    await notion_worker.poll_once(db_client, token, extractor)

--- a/team_server/workers/notion_runner.py
+++ b/team_server/workers/notion_runner.py
@@ -8,16 +8,13 @@ thin wrapper over poll_once. Exists for symmetry with slack_runner
 
 from __future__ import annotations
 
-from typing import Awaitable, Callable
+from collections.abc import Awaitable, Callable
 
 from ledger.client import LedgerClient
-
 from team_server.workers import notion_worker
 
 Extractor = Callable[[str], Awaitable[dict]]
 
 
-async def run_notion_iteration(
-    db_client: LedgerClient, token: str, extractor: Extractor
-) -> None:
+async def run_notion_iteration(db_client: LedgerClient, token: str, extractor: Extractor) -> None:
     await notion_worker.poll_once(db_client, token, extractor)

--- a/team_server/workers/notion_worker.py
+++ b/team_server/workers/notion_worker.py
@@ -1,29 +1,41 @@
 """Notion ingest worker — polls allowlist-via-share databases, runs
-canonical extraction, writes a peer-authored team_event per change.
+the extraction pipeline, writes peer-authored team_event per change.
 
-v3 cache contract: classifier_version="legacy-pre-v3" until pipeline
-integration (Phase 4) supplies the real heuristic version.
+Idempotent: same (db_id, page_id) with unchanged content + classifier
+version yields no new event. Per-database watermark advances
+monotonically; partial failures preserve watermark at the last
+successfully-ingested row.
+
+When `config` is None, falls back to the legacy `extractor(text)` path.
+When `config` is provided, the pipeline runs with rules resolved per
+database.
 """
 
 from __future__ import annotations
 
 import hashlib
 import logging
-from typing import Awaitable, Callable
+from typing import Awaitable, Callable, Optional
 
 import httpx
 
 from ledger.client import LedgerClient
 
 from team_server.auth import notion_client as nc
+from team_server.config import (
+    RulesDisabled, TeamServerConfig, resolve_rules_for_notion,
+)
 from team_server.extraction.canonical_cache import upsert_canonical_extraction
+from team_server.extraction.heuristic_classifier import derive_classifier_version
 from team_server.extraction.llm_extractor import INTERIM_MODEL_VERSION
 from team_server.extraction.notion_serializer import serialize_row
+from team_server.extraction.pipeline import extract_decision_pipeline
 from team_server.sync.peer_writer import write_team_event
 
 logger = logging.getLogger(__name__)
 
 Extractor = Callable[[str], Awaitable[dict]]
+LLMExtractFn = Callable[[str, list], Awaitable[dict]]
 SOURCE_TYPE = "notion_database_row"
 PEER_WORKSPACE_ID = "notion"
 
@@ -32,20 +44,35 @@ async def poll_once(
     db_client: LedgerClient,
     token: str,
     extractor: Extractor,
+    *,
+    config: Optional[TeamServerConfig] = None,
+    llm_extract_fn: Optional[LLMExtractFn] = None,
 ) -> None:
     databases = await nc.list_databases(token)
     for db_id, _title in databases:
-        await _poll_database(db_client, token, db_id, extractor)
+        await _poll_database(
+            db_client, token, db_id, extractor,
+            config=config, llm_extract_fn=llm_extract_fn,
+        )
 
 
 async def _poll_database(
-    db_client: LedgerClient, token: str, db_id: str, extractor: Extractor,
+    db_client: LedgerClient,
+    token: str,
+    db_id: str,
+    extractor: Extractor,
+    *,
+    config: Optional[TeamServerConfig],
+    llm_extract_fn: Optional[LLMExtractFn],
 ) -> None:
     watermark = await _load_watermark(db_client, db_id)
     last_advanced = watermark
     try:
         async for row in nc.query_database(token, db_id, watermark):
-            await _ingest_row(db_client, token, db_id, row, extractor)
+            await _ingest_row(
+                db_client, token, db_id, row, extractor,
+                config=config, llm_extract_fn=llm_extract_fn,
+            )
             last_advanced = row.get("last_edited_time", last_advanced)
     except httpx.HTTPError as exc:
         logger.warning("[notion-worker] db=%s aborted mid-iteration: %s", db_id, exc)
@@ -54,25 +81,59 @@ async def _poll_database(
             await _store_watermark(db_client, db_id, last_advanced)
 
 
+def _resolve_classifier_version(
+    config: Optional[TeamServerConfig], db_id: str,
+) -> tuple[str, object]:
+    if config is None:
+        return "legacy-pre-v3", None
+    rules_or_disabled = resolve_rules_for_notion(config, db_id)
+    if isinstance(rules_or_disabled, RulesDisabled):
+        return "rules-disabled", rules_or_disabled
+    return derive_classifier_version(rules_or_disabled), rules_or_disabled
+
+
+def _notion_context(row: dict) -> dict:
+    return {
+        "last_edited_by": (row.get("last_edited_by") or {}).get("id"),
+        "edit_count": row.get("edit_count"),
+        "reactions": [],
+        "thread_position": 0,
+    }
+
+
 async def _ingest_row(
     db_client: LedgerClient,
     token: str,
     db_id: str,
     row: dict,
     extractor: Extractor,
+    *,
+    config: Optional[TeamServerConfig],
+    llm_extract_fn: Optional[LLMExtractFn],
 ) -> None:
     page_id = row["id"]
     blocks = await nc.fetch_page_blocks(token, page_id)
     text = serialize_row(row, blocks)
     content_hash = hashlib.sha256(text.encode("utf-8")).hexdigest()
     source_ref = f"{db_id}/{page_id}"
+    classifier_version, rules_or_disabled = _resolve_classifier_version(config, db_id)
+
+    async def compute():
+        if rules_or_disabled is None:
+            return await extractor(text)
+        return await extract_decision_pipeline(
+            text=text, message=row, context=_notion_context(row),
+            rules_or_disabled=rules_or_disabled,
+            llm_extract_fn=llm_extract_fn,
+        )
+
     extraction, changed = await upsert_canonical_extraction(
         db_client,
         source_type=SOURCE_TYPE,
         source_ref=source_ref,
         content_hash=content_hash,
-        classifier_version="legacy-pre-v3",
-        compute_fn=lambda: extractor(text),
+        classifier_version=classifier_version,
+        compute_fn=compute,
         model_version=INTERIM_MODEL_VERSION,
     )
     if not changed:

--- a/team_server/workers/notion_worker.py
+++ b/team_server/workers/notion_worker.py
@@ -15,15 +15,16 @@ from __future__ import annotations
 
 import hashlib
 import logging
-from typing import Awaitable, Callable, Optional
+from collections.abc import Awaitable, Callable
 
 import httpx
 
 from ledger.client import LedgerClient
-
 from team_server.auth import notion_client as nc
 from team_server.config import (
-    RulesDisabled, TeamServerConfig, resolve_rules_for_notion,
+    RulesDisabled,
+    TeamServerConfig,
+    resolve_rules_for_notion,
 )
 from team_server.extraction.canonical_cache import upsert_canonical_extraction
 from team_server.extraction.heuristic_classifier import derive_classifier_version
@@ -45,14 +46,18 @@ async def poll_once(
     token: str,
     extractor: Extractor,
     *,
-    config: Optional[TeamServerConfig] = None,
-    llm_extract_fn: Optional[LLMExtractFn] = None,
+    config: TeamServerConfig | None = None,
+    llm_extract_fn: LLMExtractFn | None = None,
 ) -> None:
     databases = await nc.list_databases(token)
     for db_id, _title in databases:
         await _poll_database(
-            db_client, token, db_id, extractor,
-            config=config, llm_extract_fn=llm_extract_fn,
+            db_client,
+            token,
+            db_id,
+            extractor,
+            config=config,
+            llm_extract_fn=llm_extract_fn,
         )
 
 
@@ -62,16 +67,21 @@ async def _poll_database(
     db_id: str,
     extractor: Extractor,
     *,
-    config: Optional[TeamServerConfig],
-    llm_extract_fn: Optional[LLMExtractFn],
+    config: TeamServerConfig | None,
+    llm_extract_fn: LLMExtractFn | None,
 ) -> None:
     watermark = await _load_watermark(db_client, db_id)
     last_advanced = watermark
     try:
         async for row in nc.query_database(token, db_id, watermark):
             await _ingest_row(
-                db_client, token, db_id, row, extractor,
-                config=config, llm_extract_fn=llm_extract_fn,
+                db_client,
+                token,
+                db_id,
+                row,
+                extractor,
+                config=config,
+                llm_extract_fn=llm_extract_fn,
             )
             last_advanced = row.get("last_edited_time", last_advanced)
     except httpx.HTTPError as exc:
@@ -82,7 +92,8 @@ async def _poll_database(
 
 
 def _resolve_classifier_version(
-    config: Optional[TeamServerConfig], db_id: str,
+    config: TeamServerConfig | None,
+    db_id: str,
 ) -> tuple[str, object]:
     if config is None:
         return "legacy-pre-v3", None
@@ -108,8 +119,8 @@ async def _ingest_row(
     row: dict,
     extractor: Extractor,
     *,
-    config: Optional[TeamServerConfig],
-    llm_extract_fn: Optional[LLMExtractFn],
+    config: TeamServerConfig | None,
+    llm_extract_fn: LLMExtractFn | None,
 ) -> None:
     page_id = row["id"]
     blocks = await nc.fetch_page_blocks(token, page_id)
@@ -122,7 +133,9 @@ async def _ingest_row(
         if rules_or_disabled is None:
             return await extractor(text)
         return await extract_decision_pipeline(
-            text=text, message=row, context=_notion_context(row),
+            text=text,
+            message=row,
+            context=_notion_context(row),
             rules_or_disabled=rules_or_disabled,
             llm_extract_fn=llm_extract_fn,
         )

--- a/team_server/workers/notion_worker.py
+++ b/team_server/workers/notion_worker.py
@@ -1,10 +1,8 @@
-"""Notion ingest worker - polls allowlist-via-share databases, runs
+"""Notion ingest worker — polls allowlist-via-share databases, runs
 canonical extraction, writes a peer-authored team_event per change.
 
-Idempotent: same (db_id, page_id) with unchanged content yields no new
-event. Per-database watermark is advanced monotonically as rows are
-ingested; partial failures stop watermark advancement at the last
-successfully-ingested row so the next poll resumes correctly.
+v3 cache contract: classifier_version="legacy-pre-v3" until pipeline
+integration (Phase 4) supplies the real heuristic version.
 """
 
 from __future__ import annotations
@@ -27,9 +25,6 @@ logger = logging.getLogger(__name__)
 
 Extractor = Callable[[str], Awaitable[dict]]
 SOURCE_TYPE = "notion_database_row"
-# write_team_event wraps this as f"team-server@{workspace_id}.bicameral";
-# we use the literal "notion" so the resulting author_email is
-# "team-server@notion.bicameral" (single bot per source).
 PEER_WORKSPACE_ID = "notion"
 
 
@@ -44,7 +39,7 @@ async def poll_once(
 
 
 async def _poll_database(
-    db_client: LedgerClient, token: str, db_id: str, extractor: Extractor
+    db_client: LedgerClient, token: str, db_id: str, extractor: Extractor,
 ) -> None:
     watermark = await _load_watermark(db_client, db_id)
     last_advanced = watermark
@@ -76,6 +71,7 @@ async def _ingest_row(
         source_type=SOURCE_TYPE,
         source_ref=source_ref,
         content_hash=content_hash,
+        classifier_version="legacy-pre-v3",
         compute_fn=lambda: extractor(text),
         model_version=INTERIM_MODEL_VERSION,
     )

--- a/team_server/workers/notion_worker.py
+++ b/team_server/workers/notion_worker.py
@@ -1,0 +1,123 @@
+"""Notion ingest worker - polls allowlist-via-share databases, runs
+canonical extraction, writes a peer-authored team_event per change.
+
+Idempotent: same (db_id, page_id) with unchanged content yields no new
+event. Per-database watermark is advanced monotonically as rows are
+ingested; partial failures stop watermark advancement at the last
+successfully-ingested row so the next poll resumes correctly.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import logging
+from typing import Awaitable, Callable
+
+import httpx
+
+from ledger.client import LedgerClient
+
+from team_server.auth import notion_client as nc
+from team_server.extraction.canonical_cache import upsert_canonical_extraction
+from team_server.extraction.llm_extractor import INTERIM_MODEL_VERSION
+from team_server.extraction.notion_serializer import serialize_row
+from team_server.sync.peer_writer import write_team_event
+
+logger = logging.getLogger(__name__)
+
+Extractor = Callable[[str], Awaitable[dict]]
+SOURCE_TYPE = "notion_database_row"
+# write_team_event wraps this as f"team-server@{workspace_id}.bicameral";
+# we use the literal "notion" so the resulting author_email is
+# "team-server@notion.bicameral" (single bot per source).
+PEER_WORKSPACE_ID = "notion"
+
+
+async def poll_once(
+    db_client: LedgerClient,
+    token: str,
+    extractor: Extractor,
+) -> None:
+    databases = await nc.list_databases(token)
+    for db_id, _title in databases:
+        await _poll_database(db_client, token, db_id, extractor)
+
+
+async def _poll_database(
+    db_client: LedgerClient, token: str, db_id: str, extractor: Extractor
+) -> None:
+    watermark = await _load_watermark(db_client, db_id)
+    last_advanced = watermark
+    try:
+        async for row in nc.query_database(token, db_id, watermark):
+            await _ingest_row(db_client, token, db_id, row, extractor)
+            last_advanced = row.get("last_edited_time", last_advanced)
+    except httpx.HTTPError as exc:
+        logger.warning("[notion-worker] db=%s aborted mid-iteration: %s", db_id, exc)
+    finally:
+        if last_advanced != watermark:
+            await _store_watermark(db_client, db_id, last_advanced)
+
+
+async def _ingest_row(
+    db_client: LedgerClient,
+    token: str,
+    db_id: str,
+    row: dict,
+    extractor: Extractor,
+) -> None:
+    page_id = row["id"]
+    blocks = await nc.fetch_page_blocks(token, page_id)
+    text = serialize_row(row, blocks)
+    content_hash = hashlib.sha256(text.encode("utf-8")).hexdigest()
+    source_ref = f"{db_id}/{page_id}"
+    extraction, changed = await upsert_canonical_extraction(
+        db_client,
+        source_type=SOURCE_TYPE,
+        source_ref=source_ref,
+        content_hash=content_hash,
+        compute_fn=lambda: extractor(text),
+        model_version=INTERIM_MODEL_VERSION,
+    )
+    if not changed:
+        return
+    await write_team_event(
+        db_client,
+        workspace_team_id=PEER_WORKSPACE_ID,
+        event_type="ingest",
+        payload={
+            "source_type": SOURCE_TYPE,
+            "source_ref": source_ref,
+            "content_hash": content_hash,
+            "extraction": extraction,
+        },
+    )
+
+
+async def _load_watermark(client: LedgerClient, db_id: str) -> str:
+    rows = await client.query(
+        "SELECT last_seen FROM source_watermark "
+        "WHERE source_type = 'notion' AND resource_id = $rid LIMIT 1",
+        {"rid": db_id},
+    )
+    return rows[0]["last_seen"] if rows else ""
+
+
+async def _store_watermark(client: LedgerClient, db_id: str, value: str) -> None:
+    existing = await client.query(
+        "SELECT id FROM source_watermark "
+        "WHERE source_type = 'notion' AND resource_id = $rid LIMIT 1",
+        {"rid": db_id},
+    )
+    if existing:
+        await client.query(
+            "UPDATE source_watermark SET last_seen = $v, updated_at = time::now() "
+            "WHERE source_type = 'notion' AND resource_id = $rid",
+            {"rid": db_id, "v": value},
+        )
+    else:
+        await client.query(
+            "CREATE source_watermark CONTENT { source_type: 'notion', "
+            "resource_id: $rid, last_seen: $v }",
+            {"rid": db_id, "v": value},
+        )

--- a/team_server/workers/runner.py
+++ b/team_server/workers/runner.py
@@ -1,0 +1,29 @@
+"""Generic worker-task lifecycle helper.
+
+worker_loop wraps a callable in a forever-loop with per-iteration error
+isolation and a fixed sleep interval. Returns the asyncio.Task so the
+caller (typically the FastAPI lifespan context manager) can cancel it
+on shutdown. One location for the loop pattern; Slack and Notion both
+delegate here.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+from typing import Awaitable, Callable
+
+logger = logging.getLogger(__name__)
+
+WorkFn = Callable[[], Awaitable[None]]
+
+
+def worker_loop(name: str, interval_seconds: int, work_fn: WorkFn) -> asyncio.Task:
+    async def _loop() -> None:
+        while True:
+            try:
+                await work_fn()
+            except Exception:  # noqa: BLE001
+                logger.exception("[team-server] worker=%s iteration failed", name)
+            await asyncio.sleep(interval_seconds)
+    return asyncio.create_task(_loop(), name=f"team-server-worker-{name}")

--- a/team_server/workers/runner.py
+++ b/team_server/workers/runner.py
@@ -11,7 +11,7 @@ from __future__ import annotations
 
 import asyncio
 import logging
-from typing import Awaitable, Callable
+from collections.abc import Awaitable, Callable
 
 logger = logging.getLogger(__name__)
 
@@ -26,4 +26,5 @@ def worker_loop(name: str, interval_seconds: int, work_fn: WorkFn) -> asyncio.Ta
             except Exception:  # noqa: BLE001
                 logger.exception("[team-server] worker=%s iteration failed", name)
             await asyncio.sleep(interval_seconds)
+
     return asyncio.create_task(_loop(), name=f"team-server-worker-{name}")

--- a/team_server/workers/slack_runner.py
+++ b/team_server/workers/slack_runner.py
@@ -1,0 +1,67 @@
+"""Slack worker runner - workspace iteration + per-workspace fan-out.
+
+Single iteration: read all workspaces, decrypt each token, construct a
+Slack client per workspace, read the channel allowlist, delegate one
+polling pass to slack_worker.poll_once. Per-workspace exceptions are
+caught so a single bad token does not break iteration over the rest.
+
+Encryption contract (mirrors team_server/auth/router.py): the Fernet
+key is loaded once per iteration via load_key_from_env; the
+oauth_token_encrypted field stores the urlsafe-base64 string output of
+Fernet(key).encrypt(...).decode("utf-8"), so decrypting requires
+encoding the string back to bytes before passing to decrypt_token.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Awaitable, Callable
+
+from ledger.client import LedgerClient
+from team_server.auth.encryption import decrypt_token, load_key_from_env
+from team_server.workers.slack_worker import poll_once
+
+logger = logging.getLogger(__name__)
+
+Extractor = Callable[[str], Awaitable[dict]]
+
+
+async def run_slack_iteration(
+    db_client: LedgerClient, extractor: Extractor
+) -> None:
+    # slack_sdk imported lazily so the team_server package is importable
+    # without slack_sdk installed (tests for unrelated code paths don't
+    # need it). The runner is the only production caller; if slack_sdk
+    # is missing at runtime, the per-workspace try/except surfaces it.
+    from slack_sdk.web.async_client import AsyncWebClient
+
+    key = load_key_from_env()
+    workspaces = await db_client.query(
+        "SELECT id, slack_team_id, oauth_token_encrypted FROM workspace"
+    )
+    for ws in workspaces or []:
+        try:
+            ciphertext = ws["oauth_token_encrypted"].encode("utf-8")
+            token = decrypt_token(ciphertext, key)
+            channels = await _channel_ids(db_client, ws["id"])
+            slack_client = AsyncWebClient(token=token)
+            await poll_once(
+                db_client=db_client,
+                slack_client=slack_client,
+                workspace_team_id=ws["slack_team_id"],
+                channels=channels,
+                extractor=extractor,
+            )
+        except Exception:  # noqa: BLE001 - per-workspace isolation
+            logger.exception(
+                "[team-server] slack workspace=%s iteration failed",
+                ws.get("slack_team_id", "<unknown>"),
+            )
+
+
+async def _channel_ids(client: LedgerClient, workspace_id) -> list[str]:
+    rows = await client.query(
+        "SELECT channel_id FROM channel_allowlist WHERE workspace_id = $wid",
+        {"wid": workspace_id},
+    )
+    return [r["channel_id"] for r in rows or []]

--- a/team_server/workers/slack_runner.py
+++ b/team_server/workers/slack_runner.py
@@ -15,7 +15,7 @@ encoding the string back to bytes before passing to decrypt_token.
 from __future__ import annotations
 
 import logging
-from typing import Awaitable, Callable
+from collections.abc import Awaitable, Callable
 
 from ledger.client import LedgerClient
 from team_server.auth.encryption import decrypt_token, load_key_from_env
@@ -26,9 +26,7 @@ logger = logging.getLogger(__name__)
 Extractor = Callable[[str], Awaitable[dict]]
 
 
-async def run_slack_iteration(
-    db_client: LedgerClient, extractor: Extractor
-) -> None:
+async def run_slack_iteration(db_client: LedgerClient, extractor: Extractor) -> None:
     # slack_sdk imported lazily so the team_server package is importable
     # without slack_sdk installed (tests for unrelated code paths don't
     # need it). The runner is the only production caller; if slack_sdk

--- a/team_server/workers/slack_worker.py
+++ b/team_server/workers/slack_worker.py
@@ -1,0 +1,100 @@
+"""Slack ingest worker — polls allowlisted channels, runs canonical
+extraction (cache-keyed by message content), writes a peer-authored
+team_event per new message.
+
+Idempotent: same Slack message ts produces a cache hit on second poll,
+so no duplicate team_event row is written.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import logging
+from typing import Awaitable, Callable, Iterable
+
+from ledger.client import LedgerClient
+
+from team_server.extraction.canonical_cache import get_or_compute
+from team_server.extraction.llm_extractor import INTERIM_MODEL_VERSION
+from team_server.sync.peer_writer import write_team_event
+
+logger = logging.getLogger(__name__)
+
+Extractor = Callable[[str], Awaitable[dict]]
+
+
+def _content_hash(text: str) -> str:
+    return hashlib.sha256(text.encode("utf-8")).hexdigest()
+
+
+def _source_ref_for_message(channel: str, ts: str) -> str:
+    return f"{channel}/{ts}"
+
+
+async def poll_once(
+    db_client: LedgerClient,
+    slack_client,
+    workspace_team_id: str,
+    channels: Iterable[str],
+    extractor: Extractor,
+) -> None:
+    """One polling pass over allowlisted channels."""
+    for channel in channels:
+        history = slack_client.conversations_history(channel=channel)
+        if not history.get("ok", False):
+            logger.warning("[slack-worker] history failed for %s", channel)
+            continue
+        for message in history.get("messages", []):
+            await _ingest_message(
+                db_client, workspace_team_id, channel, message, extractor
+            )
+
+
+async def _ingest_message(
+    db_client: LedgerClient,
+    workspace_team_id: str,
+    channel: str,
+    message: dict,
+    extractor: Extractor,
+) -> None:
+    text = message.get("text", "")
+    ts = message.get("ts", "")
+    source_ref = _source_ref_for_message(channel, ts)
+    content_hash = _content_hash(text)
+    # Cache-keyed: if we've already extracted this exact content for this
+    # source_ref, get_or_compute returns cached and we don't re-write.
+    cache_existed_before = await _cache_row_exists(
+        db_client, "slack", source_ref, content_hash
+    )
+    extraction = await get_or_compute(
+        db_client,
+        source_type="slack",
+        source_ref=source_ref,
+        content_hash=content_hash,
+        compute_fn=lambda: extractor(text),
+        model_version=INTERIM_MODEL_VERSION,
+    )
+    if cache_existed_before:
+        return  # idempotent — already ingested
+    await write_team_event(
+        db_client,
+        workspace_team_id=workspace_team_id,
+        event_type="ingest",
+        payload={
+            "source_type": "slack",
+            "source_ref": source_ref,
+            "content_hash": content_hash,
+            "extraction": extraction,
+        },
+    )
+
+
+async def _cache_row_exists(
+    client: LedgerClient, source_type: str, source_ref: str, content_hash: str
+) -> bool:
+    rows = await client.query(
+        "SELECT id FROM extraction_cache WHERE source_type = $st "
+        "AND source_ref = $sr AND content_hash = $ch LIMIT 1",
+        {"st": source_type, "sr": source_ref, "ch": content_hash},
+    )
+    return bool(rows)

--- a/team_server/workers/slack_worker.py
+++ b/team_server/workers/slack_worker.py
@@ -1,9 +1,9 @@
 """Slack ingest worker — polls allowlisted channels, runs canonical
-extraction (cache-keyed by message content), writes a peer-authored
-team_event per new message.
+extraction (upsert-keyed by source_ref), writes a peer-authored
+team_event per change.
 
-Idempotent: same Slack message ts produces a cache hit on second poll,
-so no duplicate team_event row is written.
+Idempotent: same Slack message ts with unchanged content yields no new
+team_event row (the upsert returns changed=False on cache hit).
 """
 
 from __future__ import annotations
@@ -14,7 +14,7 @@ from typing import Awaitable, Callable, Iterable
 
 from ledger.client import LedgerClient
 
-from team_server.extraction.canonical_cache import get_or_compute
+from team_server.extraction.canonical_cache import upsert_canonical_extraction
 from team_server.extraction.llm_extractor import INTERIM_MODEL_VERSION
 from team_server.sync.peer_writer import write_team_event
 
@@ -61,12 +61,7 @@ async def _ingest_message(
     ts = message.get("ts", "")
     source_ref = _source_ref_for_message(channel, ts)
     content_hash = _content_hash(text)
-    # Cache-keyed: if we've already extracted this exact content for this
-    # source_ref, get_or_compute returns cached and we don't re-write.
-    cache_existed_before = await _cache_row_exists(
-        db_client, "slack", source_ref, content_hash
-    )
-    extraction = await get_or_compute(
+    extraction, changed = await upsert_canonical_extraction(
         db_client,
         source_type="slack",
         source_ref=source_ref,
@@ -74,8 +69,8 @@ async def _ingest_message(
         compute_fn=lambda: extractor(text),
         model_version=INTERIM_MODEL_VERSION,
     )
-    if cache_existed_before:
-        return  # idempotent — already ingested
+    if not changed:
+        return
     await write_team_event(
         db_client,
         workspace_team_id=workspace_team_id,
@@ -87,14 +82,3 @@ async def _ingest_message(
             "extraction": extraction,
         },
     )
-
-
-async def _cache_row_exists(
-    client: LedgerClient, source_type: str, source_ref: str, content_hash: str
-) -> bool:
-    rows = await client.query(
-        "SELECT id FROM extraction_cache WHERE source_type = $st "
-        "AND source_ref = $sr AND content_hash = $ch LIMIT 1",
-        {"st": source_type, "sr": source_ref, "ch": content_hash},
-    )
-    return bool(rows)

--- a/team_server/workers/slack_worker.py
+++ b/team_server/workers/slack_worker.py
@@ -15,12 +15,13 @@ from __future__ import annotations
 
 import hashlib
 import logging
-from typing import Awaitable, Callable, Iterable, Optional
+from collections.abc import Awaitable, Callable, Iterable
 
 from ledger.client import LedgerClient
-
 from team_server.config import (
-    RulesDisabled, TeamServerConfig, resolve_rules_for_slack,
+    RulesDisabled,
+    TeamServerConfig,
+    resolve_rules_for_slack,
 )
 from team_server.extraction.canonical_cache import upsert_canonical_extraction
 from team_server.extraction.heuristic_classifier import derive_classifier_version
@@ -58,8 +59,8 @@ async def poll_once(
     channels: Iterable[str],
     extractor: Extractor,
     *,
-    config: Optional[TeamServerConfig] = None,
-    llm_extract_fn: Optional[LLMExtractFn] = None,
+    config: TeamServerConfig | None = None,
+    llm_extract_fn: LLMExtractFn | None = None,
 ) -> None:
     """One polling pass over allowlisted channels."""
     for channel in channels:
@@ -70,13 +71,20 @@ async def poll_once(
         messages = history.get("messages", [])
         for position, message in enumerate(messages):
             await _ingest_message(
-                db_client, workspace_team_id, channel, message, extractor,
-                position=position, config=config, llm_extract_fn=llm_extract_fn,
+                db_client,
+                workspace_team_id,
+                channel,
+                message,
+                extractor,
+                position=position,
+                config=config,
+                llm_extract_fn=llm_extract_fn,
             )
 
 
 def _resolve_classifier_version(
-    config: Optional[TeamServerConfig], channel: str,
+    config: TeamServerConfig | None,
+    channel: str,
 ) -> tuple[str, object]:
     if config is None:
         return "legacy-pre-v3", None
@@ -94,8 +102,8 @@ async def _ingest_message(
     extractor: Extractor,
     *,
     position: int,
-    config: Optional[TeamServerConfig],
-    llm_extract_fn: Optional[LLMExtractFn],
+    config: TeamServerConfig | None,
+    llm_extract_fn: LLMExtractFn | None,
 ) -> None:
     text = message.get("text", "")
     ts = message.get("ts", "")
@@ -107,7 +115,8 @@ async def _ingest_message(
         if rules_or_disabled is None:
             return await extractor(text)
         return await extract_decision_pipeline(
-            text=text, message=message,
+            text=text,
+            message=message,
             context=_slack_context(message, position),
             rules_or_disabled=rules_or_disabled,
             llm_extract_fn=llm_extract_fn,

--- a/team_server/workers/slack_worker.py
+++ b/team_server/workers/slack_worker.py
@@ -1,28 +1,37 @@
-"""Slack ingest worker — polls allowlisted channels, runs canonical
-extraction (upsert-keyed by source_ref), writes a peer-authored
-team_event per change.
+"""Slack ingest worker — polls allowlisted channels, runs the
+extraction pipeline (heuristic Stage 1 → optional LLM Stage 2), writes
+peer-authored team_event per change.
 
-v3 cache contract: upsert_canonical_extraction now requires
-classifier_version as a second-axis cache identity. Workers pass
-"legacy-pre-v3" until pipeline integration (Phase 4) supplies the
-real heuristic classifier_version.
+Idempotent: same Slack message ts with unchanged content + classifier
+version yields no new team_event row.
+
+When `config` is None, falls back to the legacy `extractor(text)` path
+for backwards compat with v1.0 callers (channel_allowlist test suite,
+direct poll_once test invocations). When `config` is provided, the
+pipeline runs with rules resolved per channel.
 """
 
 from __future__ import annotations
 
 import hashlib
 import logging
-from typing import Awaitable, Callable, Iterable
+from typing import Awaitable, Callable, Iterable, Optional
 
 from ledger.client import LedgerClient
 
+from team_server.config import (
+    RulesDisabled, TeamServerConfig, resolve_rules_for_slack,
+)
 from team_server.extraction.canonical_cache import upsert_canonical_extraction
+from team_server.extraction.heuristic_classifier import derive_classifier_version
 from team_server.extraction.llm_extractor import INTERIM_MODEL_VERSION
+from team_server.extraction.pipeline import extract_decision_pipeline
 from team_server.sync.peer_writer import write_team_event
 
 logger = logging.getLogger(__name__)
 
 Extractor = Callable[[str], Awaitable[dict]]
+LLMExtractFn = Callable[[str, list], Awaitable[dict]]
 
 
 def _content_hash(text: str) -> str:
@@ -33,12 +42,24 @@ def _source_ref_for_message(channel: str, ts: str) -> str:
     return f"{channel}/{ts}"
 
 
+def _slack_context(message: dict, position: int) -> dict:
+    return {
+        "reactions": message.get("reactions") or [],
+        "thread_position": position,
+        "thread_ts": message.get("thread_ts"),
+        "subtype": message.get("subtype"),
+    }
+
+
 async def poll_once(
     db_client: LedgerClient,
     slack_client,
     workspace_team_id: str,
     channels: Iterable[str],
     extractor: Extractor,
+    *,
+    config: Optional[TeamServerConfig] = None,
+    llm_extract_fn: Optional[LLMExtractFn] = None,
 ) -> None:
     """One polling pass over allowlisted channels."""
     for channel in channels:
@@ -46,10 +67,23 @@ async def poll_once(
         if not history.get("ok", False):
             logger.warning("[slack-worker] history failed for %s", channel)
             continue
-        for message in history.get("messages", []):
+        messages = history.get("messages", [])
+        for position, message in enumerate(messages):
             await _ingest_message(
-                db_client, workspace_team_id, channel, message, extractor
+                db_client, workspace_team_id, channel, message, extractor,
+                position=position, config=config, llm_extract_fn=llm_extract_fn,
             )
+
+
+def _resolve_classifier_version(
+    config: Optional[TeamServerConfig], channel: str,
+) -> tuple[str, object]:
+    if config is None:
+        return "legacy-pre-v3", None
+    rules_or_disabled = resolve_rules_for_slack(config, channel)
+    if isinstance(rules_or_disabled, RulesDisabled):
+        return "rules-disabled", rules_or_disabled
+    return derive_classifier_version(rules_or_disabled), rules_or_disabled
 
 
 async def _ingest_message(
@@ -58,18 +92,34 @@ async def _ingest_message(
     channel: str,
     message: dict,
     extractor: Extractor,
+    *,
+    position: int,
+    config: Optional[TeamServerConfig],
+    llm_extract_fn: Optional[LLMExtractFn],
 ) -> None:
     text = message.get("text", "")
     ts = message.get("ts", "")
     source_ref = _source_ref_for_message(channel, ts)
     content_hash = _content_hash(text)
+    classifier_version, rules_or_disabled = _resolve_classifier_version(config, channel)
+
+    async def compute():
+        if rules_or_disabled is None:
+            return await extractor(text)
+        return await extract_decision_pipeline(
+            text=text, message=message,
+            context=_slack_context(message, position),
+            rules_or_disabled=rules_or_disabled,
+            llm_extract_fn=llm_extract_fn,
+        )
+
     extraction, changed = await upsert_canonical_extraction(
         db_client,
         source_type="slack",
         source_ref=source_ref,
         content_hash=content_hash,
-        classifier_version="legacy-pre-v3",
-        compute_fn=lambda: extractor(text),
+        classifier_version=classifier_version,
+        compute_fn=compute,
         model_version=INTERIM_MODEL_VERSION,
     )
     if not changed:

--- a/team_server/workers/slack_worker.py
+++ b/team_server/workers/slack_worker.py
@@ -2,8 +2,10 @@
 extraction (upsert-keyed by source_ref), writes a peer-authored
 team_event per change.
 
-Idempotent: same Slack message ts with unchanged content yields no new
-team_event row (the upsert returns changed=False on cache hit).
+v3 cache contract: upsert_canonical_extraction now requires
+classifier_version as a second-axis cache identity. Workers pass
+"legacy-pre-v3" until pipeline integration (Phase 4) supplies the
+real heuristic classifier_version.
 """
 
 from __future__ import annotations
@@ -66,6 +68,7 @@ async def _ingest_message(
         source_type="slack",
         source_ref=source_ref,
         content_hash=content_hash,
+        classifier_version="legacy-pre-v3",
         compute_fn=lambda: extractor(text),
         model_version=INTERIM_MODEL_VERSION,
     )

--- a/tests/e2e/_harness_setup.py
+++ b/tests/e2e/_harness_setup.py
@@ -141,6 +141,32 @@ def clean_ledger(ledger_dir: pathlib.Path) -> None:
         shutil.rmtree(ledger_dir, ignore_errors=True)
 
 
+def clean_claude_memory_for_repo(desktop_repo_path: str) -> None:
+    """Purge Claude Code's per-project memory directory for the test repo.
+
+    Claude Code maintains per-cwd memory at ``~/.claude/projects/<key>/memory/``
+    where ``<key>`` is the absolute repo path with ``/`` replaced by ``-``.
+    This memory persists across runs on the same machine (and on shared CI
+    runners across PR runs).
+
+    Without this purge, memory written during one e2e run leaks into the
+    next: e.g. a stale ``MEMORY.md`` from a prior run lets the agent answer
+    Flow 5's "PM Friday review" prompt directly from disk instead of
+    invoking ``bicameral.history``, which then breaks the Flow 5 asserter
+    AND cascades to Flow 3 (whose ledger snapshot relies on Flow 5's
+    bicameral call to drain the post-commit JSONL queue via the
+    ``EventMaterializer.replay_new_events`` trigger). Observed on PR #181;
+    root-causing in this PR's harness fix.
+    """
+    home = pathlib.Path.home()
+    project_key = (
+        str(pathlib.Path(desktop_repo_path).resolve()).replace("\\", "-").replace("/", "-")
+    )
+    memory_dir = home / ".claude" / "projects" / project_key / "memory"
+    if memory_dir.exists():
+        shutil.rmtree(memory_dir, ignore_errors=True)
+
+
 def reset_desktop_repo(desktop_repo_path: str) -> None:
     """Reset desktop-clone to its pinned HEAD between runs. Flow 3 makes a
     real commit; without a reset, the second-onwards run starts from a

--- a/tests/e2e/run_e2e_flows.py
+++ b/tests/e2e/run_e2e_flows.py
@@ -89,6 +89,7 @@ sys.path.insert(0, str(E2E_ROOT))
 # isort: off
 from _harness_setup import (  # noqa: E402,I001  # path tweak above
     bootstrap_bicameral_dir as _bootstrap_helper,
+    clean_claude_memory_for_repo as _clean_claude_memory_helper,
     clean_ledger as _clean_ledger_helper,
     materialize_mcp_config,
     materialize_settings_with_hooks,
@@ -102,6 +103,10 @@ _MCP_ROOT = pathlib.Path(__file__).resolve().parents[2]
 
 def _clean_ledger() -> None:
     _clean_ledger_helper(LEDGER_DIR)
+
+
+def _clean_claude_memory() -> None:
+    _clean_claude_memory_helper(DESKTOP_REPO_PATH)
 
 
 def _reset_desktop_repo() -> None:
@@ -1187,6 +1192,7 @@ def main() -> int:
     print(f"Flows:              {len(FLOW_PLAN)}\n")
 
     _clean_ledger()
+    _clean_claude_memory()
     _reset_desktop_repo()
     _bootstrap_bicameral_dir()
 

--- a/tests/e2e/run_e2e_flows.py
+++ b/tests/e2e/run_e2e_flows.py
@@ -43,14 +43,21 @@ MCP_CONFIG_TEMPLATE = E2E_ROOT / "bicameral.mcp.json"
 RESULTS_DIR = pathlib.Path(__file__).resolve().parents[2] / "test-results" / "e2e"
 RESULTS_DIR.mkdir(parents=True, exist_ok=True)
 
-# Wall-clock cap for a single `claude -p` flow invocation. Was 300s; CI
-# repeatedly tripped that limit on Flow 2 (the longest flow — chained
-# preflight → ingest(agent_session) → resolve_collision sequence after the
-# #154 hook landed). Last clean dev-branch Flow 2 measured 289.7s — only
-# ~3% headroom on the old cap. Bumped to 600s to give the post-hook
-# sequence plenty of margin without inflating the recording job's wall
-# beyond what GitHub Actions tolerates.
-CLAUDE_SESSION_TIMEOUT_S = 600
+# Wall-clock cap for a single `claude -p` flow invocation.
+#
+# History:
+#   - 300s: original cap. CI tripped it repeatedly on Flow 2 after #154's
+#     PostToolUse hook added the chained preflight → ingest(agent_session)
+#     → resolve_collision sequence.
+#   - 600s: bumped from 300s. Last clean dev-branch Flow 2 measured 289.7s
+#     against the 300s cap — only ~3% headroom — so 600s gave the post-hook
+#     sequence what looked like plenty of margin.
+#   - 900s: bumped from 600s after PR #181 run 25377562963 hit a 600s
+#     timeout on Flow 2. Root cause: #175 (AskUserQuestion disambiguation
+#     gate at preflight Step 5.6.1) added turns to Flow 2's chain that
+#     weren't in the 600s baseline. Same age-out pattern as the 300→600
+#     bump. 50% headroom over observed runtime.
+CLAUDE_SESSION_TIMEOUT_S = 900
 
 # Persistent ledger shared across the 5 flow sessions in a single run, wiped
 # at the start of each run so flow-1 seeds → flow-2 refines → flow-3 reflects

--- a/tests/test_e2e_harness_memory_purge.py
+++ b/tests/test_e2e_harness_memory_purge.py
@@ -1,0 +1,91 @@
+"""Regression guard: e2e harness purges Claude Code per-project memory.
+
+Locks the fix for the PR #181 e2e flake — Flow 5 (PM history+ratify, MCP-
+layer) and Flow 3 (commit→sync, agentic) failed because a stale
+``~/.claude/projects/<key>/memory/MEMORY.md`` from a prior run let the agent
+answer Flow 5's prompt directly from disk instead of invoking
+``bicameral.history``. Flow 3's failure cascaded because its ledger snapshot
+relies on Flow 5's bicameral call to drain the post-commit JSONL queue via
+``EventMaterializer.replay_new_events``.
+
+If this test fails, the harness has stopped purging memory and the same
+state-pollution flake will recur on shared CI runners.
+"""
+
+from __future__ import annotations
+
+import pathlib
+import sys
+
+REPO_ROOT = pathlib.Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(REPO_ROOT / "tests" / "e2e"))
+
+from _harness_setup import clean_claude_memory_for_repo  # noqa: E402
+
+
+def _project_key(repo_path: str) -> str:
+    return str(pathlib.Path(repo_path).resolve()).replace("\\", "-").replace("/", "-")
+
+
+def test_clean_claude_memory_purges_existing_memory_dir(tmp_path, monkeypatch):
+    """Helper removes ~/.claude/projects/<key>/memory/ when it exists."""
+    fake_home = tmp_path / "home"
+    fake_repo = tmp_path / "repo" / "desktop-clone"
+    fake_repo.mkdir(parents=True)
+    monkeypatch.setattr(pathlib.Path, "home", lambda: fake_home)
+
+    key = _project_key(str(fake_repo))
+    memory_dir = fake_home / ".claude" / "projects" / key / "memory"
+    memory_dir.mkdir(parents=True)
+    (memory_dir / "MEMORY.md").write_text("- some prior-session memory entry")
+    (memory_dir / "feedback_x.md").write_text("---\nname: x\n---\nbody")
+    assert memory_dir.exists()
+
+    clean_claude_memory_for_repo(str(fake_repo))
+
+    assert not memory_dir.exists(), (
+        "memory dir still present after purge — state pollution will recur "
+        "(see test docstring for context on PR #181 cascade)"
+    )
+
+
+def test_clean_claude_memory_is_noop_when_dir_absent(tmp_path, monkeypatch):
+    """Helper does not raise when there's no memory dir to purge (fresh runner)."""
+    fake_home = tmp_path / "home"
+    fake_repo = tmp_path / "repo" / "desktop-clone"
+    fake_repo.mkdir(parents=True)
+    monkeypatch.setattr(pathlib.Path, "home", lambda: fake_home)
+
+    key = _project_key(str(fake_repo))
+    memory_dir = fake_home / ".claude" / "projects" / key / "memory"
+    assert not memory_dir.exists()
+
+    clean_claude_memory_for_repo(str(fake_repo))  # must not raise
+
+    assert not memory_dir.exists()
+
+
+def test_clean_claude_memory_does_not_touch_other_project_memory(tmp_path, monkeypatch):
+    """Helper purges ONLY the matching project key — other projects' memory
+    on the same machine survives (the runner may host other test repos)."""
+    fake_home = tmp_path / "home"
+    target_repo = tmp_path / "repo" / "desktop-clone"
+    other_repo = tmp_path / "repo" / "other-project"
+    target_repo.mkdir(parents=True)
+    other_repo.mkdir(parents=True)
+    monkeypatch.setattr(pathlib.Path, "home", lambda: fake_home)
+
+    target_key = _project_key(str(target_repo))
+    other_key = _project_key(str(other_repo))
+    target_memory = fake_home / ".claude" / "projects" / target_key / "memory"
+    other_memory = fake_home / ".claude" / "projects" / other_key / "memory"
+    target_memory.mkdir(parents=True)
+    other_memory.mkdir(parents=True)
+    (target_memory / "MEMORY.md").write_text("target")
+    (other_memory / "MEMORY.md").write_text("other")
+
+    clean_claude_memory_for_repo(str(target_repo))
+
+    assert not target_memory.exists()
+    assert other_memory.exists()
+    assert (other_memory / "MEMORY.md").read_text() == "other"

--- a/tests/test_materializer_team_server_pull.py
+++ b/tests/test_materializer_team_server_pull.py
@@ -79,7 +79,9 @@ async def test_materializer_persists_team_server_watermark_separately(monkeypatc
 
 
 @pytest.mark.asyncio
-async def test_materializer_handles_team_server_unavailable_gracefully(monkeypatch, tmp_path, caplog):
+async def test_materializer_handles_team_server_unavailable_gracefully(
+    monkeypatch, tmp_path, caplog
+):
     """Behavior: 503 from team-server does NOT raise; returns empty events;
     watermark unchanged. Failure-isolation contract per audit (research F3
     — outside the deterministic core)."""
@@ -164,15 +166,18 @@ async def test_materializer_dispatches_team_server_ingest_event(tmp_path):
 @pytest.mark.asyncio
 async def test_materializer_bridges_slack_extraction_to_ingest_payload(tmp_path):
     event = {
-        "sequence": 1, "author_email": "team-server@notion.bicameral",
+        "sequence": 1,
+        "author_email": "team-server@notion.bicameral",
         "event_type": "ingest",
         "payload": {
-            "source_type": "slack", "source_ref": "C1/2.0",
+            "source_type": "slack",
+            "source_ref": "C1/2.0",
             "content_hash": "h",
-            "extraction": {"decisions": [
-                {"summary": "use REST",
-                 "context_snippet": "we decided to use REST"},
-            ]},
+            "extraction": {
+                "decisions": [
+                    {"summary": "use REST", "context_snippet": "we decided to use REST"},
+                ]
+            },
         },
     }
     inner = await _materialize_one_event(tmp_path, event)
@@ -180,8 +185,7 @@ async def test_materializer_bridges_slack_extraction_to_ingest_payload(tmp_path)
         "source": "slack",
         "repo": "",
         "commit_hash": "",
-        "decisions": [{"description": "use REST",
-                       "source_excerpt": "we decided to use REST"}],
+        "decisions": [{"description": "use REST", "source_excerpt": "we decided to use REST"}],
         "title": "C1/2.0",
     }
 
@@ -191,15 +195,18 @@ async def test_materializer_bridges_notion_extraction_with_correct_source_type(t
     """notion_database_row source_type normalizes to 'notion' on the
     bridged IngestPayload."""
     event = {
-        "sequence": 1, "author_email": "team-server@notion.bicameral",
+        "sequence": 1,
+        "author_email": "team-server@notion.bicameral",
         "event_type": "ingest",
         "payload": {
             "source_type": "notion_database_row",
             "source_ref": "db1/page1",
             "content_hash": "h",
-            "extraction": {"decisions": [
-                {"summary": "approved", "context_snippet": "approved by lead"},
-            ]},
+            "extraction": {
+                "decisions": [
+                    {"summary": "approved", "context_snippet": "approved by lead"},
+                ]
+            },
         },
     }
     inner = await _materialize_one_event(tmp_path, event)
@@ -209,10 +216,12 @@ async def test_materializer_bridges_notion_extraction_with_correct_source_type(t
 @pytest.mark.asyncio
 async def test_materializer_skips_team_server_event_with_empty_decisions(tmp_path):
     event = {
-        "sequence": 1, "author_email": "team-server@notion.bicameral",
+        "sequence": 1,
+        "author_email": "team-server@notion.bicameral",
         "event_type": "ingest",
         "payload": {
-            "source_type": "slack", "source_ref": "C1/3.0",
+            "source_type": "slack",
+            "source_ref": "C1/3.0",
             "content_hash": "h",
             "extraction": {"decisions": []},
         },
@@ -228,12 +237,14 @@ async def test_materializer_still_handles_legacy_ingest_completed_event_type(tmp
     bridge's is_team_server_payload predicate returns False → original
     dispatch handles it."""
     event = {
-        "sequence": 1, "author_email": "dev@example.com",
+        "sequence": 1,
+        "author_email": "dev@example.com",
         "event_type": "ingest.completed",
         "payload": {
             # CodeLocatorPayload shape — has 'repo' and 'commit_hash'
             # but NO 'extraction' key (the team-server signature)
-            "repo": "/tmp/repo", "commit_hash": "abc",
+            "repo": "/tmp/repo",
+            "commit_hash": "abc",
             "decisions": [{"description": "X"}],
         },
     }
@@ -251,7 +262,8 @@ async def test_materializer_skips_team_server_event_with_malformed_payload(tmp_p
     in the meaningful sense). The materializer just no-ops with this
     shape. Functionality — exercises defensive shape-checking."""
     event = {
-        "sequence": 1, "author_email": "team-server@notion.bicameral",
+        "sequence": 1,
+        "author_email": "team-server@notion.bicameral",
         "event_type": "ingest",
         "payload": {
             "source_type": "slack",

--- a/tests/test_materializer_team_server_pull.py
+++ b/tests/test_materializer_team_server_pull.py
@@ -99,3 +99,168 @@ async def test_materializer_handles_team_server_unavailable_gracefully(monkeypat
     assert events == []
     # Watermark unchanged
     assert watermark.read_text(encoding="utf-8").strip() == "42"
+
+
+# ── Phase 2 (v0-release-blockers): materializer bridges team-server events ──
+
+
+import json as _json
+from pathlib import Path as _Path
+
+
+class _RecordingInnerAdapter:
+    def __init__(self):
+        self.calls: list[dict] = []
+
+    async def connect(self):
+        return None
+
+    async def ingest_payload(self, payload, ctx=None):
+        self.calls.append(payload)
+        return {}
+
+
+async def _materialize_one_event(tmp_path, event: dict) -> _RecordingInnerAdapter:
+    """Helper: write a single JSONL event to events_dir, run replay,
+    return the recording adapter to assert on."""
+    from events.materializer import EventMaterializer
+
+    events_dir = tmp_path / "events"
+    local_dir = tmp_path / "local"
+    events_dir.mkdir()
+    local_dir.mkdir()
+    jsonl = events_dir / "team-server@notion.bicameral.jsonl"
+    jsonl.write_text(_json.dumps(event) + "\n", encoding="utf-8")
+    materializer = EventMaterializer(events_dir, local_dir)
+    inner = _RecordingInnerAdapter()
+    await materializer.replay_new_events(inner)
+    return inner
+
+
+@pytest.mark.asyncio
+async def test_materializer_dispatches_team_server_ingest_event(tmp_path):
+    """Behavior: a JSONL line with event_type='ingest' and a team-server-
+    shaped payload routes through the bridge to inner_adapter.ingest_payload."""
+    event = {
+        "sequence": 1,
+        "author_email": "team-server@notion.bicameral",
+        "event_type": "ingest",
+        "payload": {
+            "source_type": "slack",
+            "source_ref": "C1/123.0",
+            "content_hash": "h",
+            "extraction": {
+                "decisions": [
+                    {"summary": "use REST", "context_snippet": "we decided to use REST"},
+                ],
+            },
+        },
+    }
+    inner = await _materialize_one_event(tmp_path, event)
+    assert len(inner.calls) == 1
+    assert inner.calls[0]["source"] == "slack"
+
+
+@pytest.mark.asyncio
+async def test_materializer_bridges_slack_extraction_to_ingest_payload(tmp_path):
+    event = {
+        "sequence": 1, "author_email": "team-server@notion.bicameral",
+        "event_type": "ingest",
+        "payload": {
+            "source_type": "slack", "source_ref": "C1/2.0",
+            "content_hash": "h",
+            "extraction": {"decisions": [
+                {"summary": "use REST",
+                 "context_snippet": "we decided to use REST"},
+            ]},
+        },
+    }
+    inner = await _materialize_one_event(tmp_path, event)
+    assert inner.calls[0] == {
+        "source": "slack",
+        "repo": "",
+        "commit_hash": "",
+        "decisions": [{"description": "use REST",
+                       "source_excerpt": "we decided to use REST"}],
+        "title": "C1/2.0",
+    }
+
+
+@pytest.mark.asyncio
+async def test_materializer_bridges_notion_extraction_with_correct_source_type(tmp_path):
+    """notion_database_row source_type normalizes to 'notion' on the
+    bridged IngestPayload."""
+    event = {
+        "sequence": 1, "author_email": "team-server@notion.bicameral",
+        "event_type": "ingest",
+        "payload": {
+            "source_type": "notion_database_row",
+            "source_ref": "db1/page1",
+            "content_hash": "h",
+            "extraction": {"decisions": [
+                {"summary": "approved", "context_snippet": "approved by lead"},
+            ]},
+        },
+    }
+    inner = await _materialize_one_event(tmp_path, event)
+    assert inner.calls[0]["source"] == "notion"
+
+
+@pytest.mark.asyncio
+async def test_materializer_skips_team_server_event_with_empty_decisions(tmp_path):
+    event = {
+        "sequence": 1, "author_email": "team-server@notion.bicameral",
+        "event_type": "ingest",
+        "payload": {
+            "source_type": "slack", "source_ref": "C1/3.0",
+            "content_hash": "h",
+            "extraction": {"decisions": []},
+        },
+    }
+    inner = await _materialize_one_event(tmp_path, event)
+    assert inner.calls == []
+
+
+@pytest.mark.asyncio
+async def test_materializer_still_handles_legacy_ingest_completed_event_type(tmp_path):
+    """Pre-existing v0 callers emit event_type='ingest.completed' with a
+    CodeLocatorPayload-shaped payload (NOT team-server-shaped). The
+    bridge's is_team_server_payload predicate returns False → original
+    dispatch handles it."""
+    event = {
+        "sequence": 1, "author_email": "dev@example.com",
+        "event_type": "ingest.completed",
+        "payload": {
+            # CodeLocatorPayload shape — has 'repo' and 'commit_hash'
+            # but NO 'extraction' key (the team-server signature)
+            "repo": "/tmp/repo", "commit_hash": "abc",
+            "decisions": [{"description": "X"}],
+        },
+    }
+    inner = await _materialize_one_event(tmp_path, event)
+    assert len(inner.calls) == 1
+    # The legacy payload reaches inner.ingest_payload UNCHANGED (not bridged)
+    assert "repo" in inner.calls[0]
+    assert inner.calls[0]["repo"] == "/tmp/repo"
+
+
+@pytest.mark.asyncio
+async def test_materializer_skips_team_server_event_with_malformed_payload(tmp_path):
+    """Payload missing the 'extraction' key is not a team-server payload;
+    nor does it match CodeLocatorPayload shape (no 'repo'/'commit_hash'
+    in the meaningful sense). The materializer just no-ops with this
+    shape. Functionality — exercises defensive shape-checking."""
+    event = {
+        "sequence": 1, "author_email": "team-server@notion.bicameral",
+        "event_type": "ingest",
+        "payload": {
+            "source_type": "slack",
+            "source_ref": "C1/malformed",
+            # NO 'extraction' key — fails is_team_server_payload check
+        },
+    }
+    inner = await _materialize_one_event(tmp_path, event)
+    # Bridge predicate returned False; we then fall through to the legacy
+    # 'ingest.completed' path which does NOT match etype='ingest', so no
+    # ingest happens at all. inner.calls is empty.
+    assert inner.calls == []

--- a/tests/test_materializer_team_server_pull.py
+++ b/tests/test_materializer_team_server_pull.py
@@ -1,0 +1,101 @@
+"""Functionality tests for team_server Phase 4 — EventMaterializer extension
+that pulls events from a team-server URL."""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+import httpx
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(REPO_ROOT))
+
+
+@pytest.mark.asyncio
+async def test_materializer_pulls_from_team_server_url(monkeypatch, tmp_path):
+    """Behavior: when team_server_url is set, replay() invokes a GET /events
+    on the URL and processes the returned events."""
+    from events.team_server_pull import pull_team_server_events
+
+    captured: dict = {}
+
+    async def fake_get(self, url, params, timeout):
+        captured["url"] = url
+        captured["params"] = params
+        request = httpx.Request("GET", url)
+        return httpx.Response(
+            200,
+            json=[
+                {"sequence": 1, "author_email": "a@b", "event_type": "ingest", "payload": {}},
+                {"sequence": 2, "author_email": "a@b", "event_type": "ingest", "payload": {}},
+            ],
+            request=request,
+        )
+
+    monkeypatch.setattr(httpx.AsyncClient, "get", fake_get)
+    watermark = tmp_path / "team_server_watermark"
+    events = await pull_team_server_events(
+        team_server_url="http://team:8765",
+        watermark_path=watermark,
+    )
+    assert captured["url"] == "http://team:8765/events"
+    assert captured["params"]["since"] == 0
+    assert len(events) == 2
+    # Watermark advanced
+    assert watermark.read_text(encoding="utf-8").strip() == "2"
+
+
+@pytest.mark.asyncio
+async def test_materializer_persists_team_server_watermark_separately(monkeypatch, tmp_path):
+    """Behavior: second invocation passes since=<previous-watermark>."""
+    from events.team_server_pull import pull_team_server_events
+
+    seen_since: list[int] = []
+
+    async def fake_get(self, url, params, timeout):
+        seen_since.append(params["since"])
+        # First call: return events 1..3; subsequent calls: empty
+        request = httpx.Request("GET", url)
+        if params["since"] == 0:
+            return httpx.Response(
+                200,
+                json=[
+                    {"sequence": 1, "author_email": "a", "event_type": "i", "payload": {}},
+                    {"sequence": 2, "author_email": "a", "event_type": "i", "payload": {}},
+                    {"sequence": 3, "author_email": "a", "event_type": "i", "payload": {}},
+                ],
+                request=request,
+            )
+        return httpx.Response(200, json=[], request=request)
+
+    monkeypatch.setattr(httpx.AsyncClient, "get", fake_get)
+    watermark = tmp_path / "team_server_watermark"
+    await pull_team_server_events(team_server_url="http://team:8765", watermark_path=watermark)
+    await pull_team_server_events(team_server_url="http://team:8765", watermark_path=watermark)
+    assert seen_since == [0, 3]
+
+
+@pytest.mark.asyncio
+async def test_materializer_handles_team_server_unavailable_gracefully(monkeypatch, tmp_path, caplog):
+    """Behavior: 503 from team-server does NOT raise; returns empty events;
+    watermark unchanged. Failure-isolation contract per audit (research F3
+    — outside the deterministic core)."""
+    from events.team_server_pull import pull_team_server_events
+
+    async def fake_get(self, url, params, timeout):
+        raise httpx.ConnectError("team-server unreachable")
+
+    monkeypatch.setattr(httpx.AsyncClient, "get", fake_get)
+    watermark = tmp_path / "team_server_watermark"
+    # Pre-populate watermark to verify it's unchanged
+    watermark.write_text("42", encoding="utf-8")
+    events = await pull_team_server_events(
+        team_server_url="http://team:8765",
+        watermark_path=watermark,
+    )
+    assert events == []
+    # Watermark unchanged
+    assert watermark.read_text(encoding="utf-8").strip() == "42"

--- a/tests/test_team_server_allowlist_lifespan.py
+++ b/tests/test_team_server_allowlist_lifespan.py
@@ -1,0 +1,79 @@
+"""Phase 1 — allowlist sync runs at lifespan startup."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(REPO_ROOT))
+
+
+@pytest.fixture(autouse=True)
+def env_setup(monkeypatch, tmp_path):
+    monkeypatch.setenv("BICAMERAL_TEAM_SERVER_SURREAL_URL", "memory://")
+    monkeypatch.setenv("BICAMERAL_TEAM_SERVER_SECRET_KEY",
+                       "EYSr77qKo0UijHGnER5qYFBY5ZZePeWeE-ZMWYXyKKA=")
+    monkeypatch.delenv("NOTION_TOKEN", raising=False)
+    cfg = tmp_path / "config.yml"
+    cfg.write_text(
+        "slack:\n"
+        "  workspaces:\n"
+        "    - team_id: T-LIFESPAN\n"
+        "      channels: [C-LIFE-1, C-LIFE-2]\n"
+    )
+    monkeypatch.setenv("BICAMERAL_CONFIG_PATH", str(cfg))
+    monkeypatch.setattr("team_server.config.DEFAULT_CONFIG_PATH", cfg)
+    monkeypatch.setattr("team_server.app.DEFAULT_CONFIG_PATH", cfg)
+    return cfg
+
+
+@pytest.mark.asyncio
+async def test_lifespan_invokes_sync_channel_allowlist_with_loaded_config(env_setup, monkeypatch):
+    """Behavior: lifespan calls sync_channel_allowlist exactly once at
+    startup, with the loaded TeamServerConfig (workspace[0].team_id ==
+    'T-LIFESPAN' and channels == ['C-LIFE-1', 'C-LIFE-2']).
+    Functionality — exercises the lifespan→sync wiring."""
+    from fastapi.testclient import TestClient
+    from team_server import app as app_module
+
+    captured = []
+
+    async def stub_sync(client, config):
+        captured.append({
+            "ws_count": len(config.slack.workspaces),
+            "team_id": config.slack.workspaces[0].team_id if config.slack.workspaces else None,
+            "channels": list(config.slack.workspaces[0].channels) if config.slack.workspaces else [],
+        })
+
+    monkeypatch.setattr(app_module, "sync_channel_allowlist", stub_sync)
+
+    app = app_module.create_app()
+    with TestClient(app) as _client:
+        pass
+    assert len(captured) == 1
+    assert captured[0]["team_id"] == "T-LIFESPAN"
+    assert captured[0]["channels"] == ["C-LIFE-1", "C-LIFE-2"]
+
+
+@pytest.mark.asyncio
+async def test_lifespan_continues_when_sync_raises(env_setup, monkeypatch):
+    """Behavior: if sync_channel_allowlist raises mid-startup, the
+    lifespan logs and continues — DB stays connected, app.state.db is
+    set, workers still register. Failure isolation invariant."""
+    from fastapi.testclient import TestClient
+    from team_server import app as app_module
+
+    async def raising_sync(client, config):
+        raise RuntimeError("simulated sync failure")
+
+    monkeypatch.setattr(app_module, "sync_channel_allowlist", raising_sync)
+
+    app = app_module.create_app()
+    with TestClient(app) as client:
+        # Health endpoint still serves; app.state.db is set.
+        resp = client.get("/health")
+        assert resp.status_code == 200
+        assert app.state.db is not None

--- a/tests/test_team_server_allowlist_lifespan.py
+++ b/tests/test_team_server_allowlist_lifespan.py
@@ -14,15 +14,13 @@ sys.path.insert(0, str(REPO_ROOT))
 @pytest.fixture(autouse=True)
 def env_setup(monkeypatch, tmp_path):
     monkeypatch.setenv("BICAMERAL_TEAM_SERVER_SURREAL_URL", "memory://")
-    monkeypatch.setenv("BICAMERAL_TEAM_SERVER_SECRET_KEY",
-                       "EYSr77qKo0UijHGnER5qYFBY5ZZePeWeE-ZMWYXyKKA=")
+    monkeypatch.setenv(
+        "BICAMERAL_TEAM_SERVER_SECRET_KEY", "EYSr77qKo0UijHGnER5qYFBY5ZZePeWeE-ZMWYXyKKA="
+    )
     monkeypatch.delenv("NOTION_TOKEN", raising=False)
     cfg = tmp_path / "config.yml"
     cfg.write_text(
-        "slack:\n"
-        "  workspaces:\n"
-        "    - team_id: T-LIFESPAN\n"
-        "      channels: [C-LIFE-1, C-LIFE-2]\n"
+        "slack:\n  workspaces:\n    - team_id: T-LIFESPAN\n      channels: [C-LIFE-1, C-LIFE-2]\n"
     )
     monkeypatch.setenv("BICAMERAL_CONFIG_PATH", str(cfg))
     monkeypatch.setattr("team_server.config.DEFAULT_CONFIG_PATH", cfg)
@@ -37,16 +35,21 @@ async def test_lifespan_invokes_sync_channel_allowlist_with_loaded_config(env_se
     'T-LIFESPAN' and channels == ['C-LIFE-1', 'C-LIFE-2']).
     Functionality — exercises the lifespan→sync wiring."""
     from fastapi.testclient import TestClient
+
     from team_server import app as app_module
 
     captured = []
 
     async def stub_sync(client, config):
-        captured.append({
-            "ws_count": len(config.slack.workspaces),
-            "team_id": config.slack.workspaces[0].team_id if config.slack.workspaces else None,
-            "channels": list(config.slack.workspaces[0].channels) if config.slack.workspaces else [],
-        })
+        captured.append(
+            {
+                "ws_count": len(config.slack.workspaces),
+                "team_id": config.slack.workspaces[0].team_id if config.slack.workspaces else None,
+                "channels": list(config.slack.workspaces[0].channels)
+                if config.slack.workspaces
+                else [],
+            }
+        )
 
     monkeypatch.setattr(app_module, "sync_channel_allowlist", stub_sync)
 
@@ -64,6 +67,7 @@ async def test_lifespan_continues_when_sync_raises(env_setup, monkeypatch):
     lifespan logs and continues — DB stays connected, app.state.db is
     set, workers still register. Failure isolation invariant."""
     from fastapi.testclient import TestClient
+
     from team_server import app as app_module
 
     async def raising_sync(client, config):

--- a/tests/test_team_server_allowlist_sync.py
+++ b/tests/test_team_server_allowlist_sync.py
@@ -18,11 +18,16 @@ def memory_url(monkeypatch):
 
 def _build_config(team_id: str, channels: list[str]):
     from team_server.config import (
-        SlackConfig, TeamServerConfig, WorkspaceConfig,
+        SlackConfig,
+        TeamServerConfig,
+        WorkspaceConfig,
     )
-    return TeamServerConfig(slack=SlackConfig(
-        workspaces=[WorkspaceConfig(team_id=team_id, channels=channels)],
-    ))
+
+    return TeamServerConfig(
+        slack=SlackConfig(
+            workspaces=[WorkspaceConfig(team_id=team_id, channels=channels)],
+        )
+    )
 
 
 @pytest.mark.asyncio
@@ -36,14 +41,11 @@ async def test_sync_inserts_channels_for_workspace_in_yaml():
     try:
         await ensure_schema(client)
         rows = await client.query(
-            "CREATE workspace CONTENT { name: 'W', slack_team_id: 'T1', "
-            "oauth_token_encrypted: '' }"
+            "CREATE workspace CONTENT { name: 'W', slack_team_id: 'T1', oauth_token_encrypted: '' }"
         )
         config = _build_config("T1", ["C-A", "C-B"])
         await sync_channel_allowlist(client, config)
-        rows = await client.query(
-            "SELECT channel_id FROM channel_allowlist"
-        )
+        rows = await client.query("SELECT channel_id FROM channel_allowlist")
         channel_ids = {r["channel_id"] for r in rows}
         assert channel_ids == {"C-A", "C-B"}
     finally:
@@ -61,8 +63,7 @@ async def test_sync_is_idempotent():
     try:
         await ensure_schema(client)
         await client.query(
-            "CREATE workspace CONTENT { name: 'W', slack_team_id: 'T1', "
-            "oauth_token_encrypted: '' }"
+            "CREATE workspace CONTENT { name: 'W', slack_team_id: 'T1', oauth_token_encrypted: '' }"
         )
         config = _build_config("T1", ["C-A", "C-B"])
         await sync_channel_allowlist(client, config)
@@ -138,16 +139,13 @@ async def test_sync_removes_channels_not_in_yaml():
     try:
         await ensure_schema(client)
         await client.query(
-            "CREATE workspace CONTENT { name: 'W', slack_team_id: 'T1', "
-            "oauth_token_encrypted: '' }"
+            "CREATE workspace CONTENT { name: 'W', slack_team_id: 'T1', oauth_token_encrypted: '' }"
         )
         config_full = _build_config("T1", ["C-A", "C-B"])
         await sync_channel_allowlist(client, config_full)
         config_reduced = _build_config("T1", ["C-A"])
         await sync_channel_allowlist(client, config_reduced)
-        rows = await client.query(
-            "SELECT channel_id FROM channel_allowlist"
-        )
+        rows = await client.query("SELECT channel_id FROM channel_allowlist")
         channel_ids = {r["channel_id"] for r in rows}
         assert channel_ids == {"C-A"}
     finally:

--- a/tests/test_team_server_allowlist_sync.py
+++ b/tests/test_team_server_allowlist_sync.py
@@ -1,0 +1,154 @@
+"""Phase 1 — channel_allowlist startup-time YAML→DB sync."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(REPO_ROOT))
+
+
+@pytest.fixture(autouse=True)
+def memory_url(monkeypatch):
+    monkeypatch.setenv("BICAMERAL_TEAM_SERVER_SURREAL_URL", "memory://")
+
+
+def _build_config(team_id: str, channels: list[str]):
+    from team_server.config import (
+        SlackConfig, TeamServerConfig, WorkspaceConfig,
+    )
+    return TeamServerConfig(slack=SlackConfig(
+        workspaces=[WorkspaceConfig(team_id=team_id, channels=channels)],
+    ))
+
+
+@pytest.mark.asyncio
+async def test_sync_inserts_channels_for_workspace_in_yaml():
+    from team_server.auth.allowlist_sync import sync_channel_allowlist
+    from team_server.db import build_client
+    from team_server.schema import ensure_schema
+
+    client = build_client()
+    await client.connect()
+    try:
+        await ensure_schema(client)
+        rows = await client.query(
+            "CREATE workspace CONTENT { name: 'W', slack_team_id: 'T1', "
+            "oauth_token_encrypted: '' }"
+        )
+        config = _build_config("T1", ["C-A", "C-B"])
+        await sync_channel_allowlist(client, config)
+        rows = await client.query(
+            "SELECT channel_id FROM channel_allowlist"
+        )
+        channel_ids = {r["channel_id"] for r in rows}
+        assert channel_ids == {"C-A", "C-B"}
+    finally:
+        await client.close()
+
+
+@pytest.mark.asyncio
+async def test_sync_is_idempotent():
+    from team_server.auth.allowlist_sync import sync_channel_allowlist
+    from team_server.db import build_client
+    from team_server.schema import ensure_schema
+
+    client = build_client()
+    await client.connect()
+    try:
+        await ensure_schema(client)
+        await client.query(
+            "CREATE workspace CONTENT { name: 'W', slack_team_id: 'T1', "
+            "oauth_token_encrypted: '' }"
+        )
+        config = _build_config("T1", ["C-A", "C-B"])
+        await sync_channel_allowlist(client, config)
+        await sync_channel_allowlist(client, config)
+        rows = await client.query("SELECT * FROM channel_allowlist")
+        assert len(rows) == 2
+    finally:
+        await client.close()
+
+
+@pytest.mark.asyncio
+async def test_sync_skips_workspaces_not_in_yaml():
+    from team_server.auth.allowlist_sync import sync_channel_allowlist
+    from team_server.db import build_client
+    from team_server.schema import ensure_schema
+
+    client = build_client()
+    await client.connect()
+    try:
+        await ensure_schema(client)
+        await client.query(
+            "CREATE workspace CONTENT { name: 'T1', slack_team_id: 'T1', "
+            "oauth_token_encrypted: '' }"
+        )
+        await client.query(
+            "CREATE workspace CONTENT { name: 'T2', slack_team_id: 'T2', "
+            "oauth_token_encrypted: '' }"
+        )
+        # YAML mentions T1 only
+        config = _build_config("T1", ["C-A"])
+        await sync_channel_allowlist(client, config)
+        # T2 should have no allowlist rows
+        t2_rows = await client.query(
+            "SELECT * FROM channel_allowlist "
+            "WHERE workspace_id = (SELECT VALUE id FROM workspace "
+            "WHERE slack_team_id = 'T2')[0]"
+        )
+        assert len(t2_rows) == 0
+    finally:
+        await client.close()
+
+
+@pytest.mark.asyncio
+async def test_sync_skips_workspaces_not_in_db():
+    """YAML mentions T-MISSING but no matching workspace row exists.
+    Sync logs and continues; no orphan workspace_id rows are created."""
+    from team_server.auth.allowlist_sync import sync_channel_allowlist
+    from team_server.db import build_client
+    from team_server.schema import ensure_schema
+
+    client = build_client()
+    await client.connect()
+    try:
+        await ensure_schema(client)
+        config = _build_config("T-MISSING", ["C-X"])
+        await sync_channel_allowlist(client, config)
+        rows = await client.query("SELECT * FROM channel_allowlist")
+        assert len(rows) == 0
+    finally:
+        await client.close()
+
+
+@pytest.mark.asyncio
+async def test_sync_removes_channels_not_in_yaml():
+    """Operator removes a channel from YAML by editing it out; sync
+    deletes the corresponding allowlist row on next run."""
+    from team_server.auth.allowlist_sync import sync_channel_allowlist
+    from team_server.db import build_client
+    from team_server.schema import ensure_schema
+
+    client = build_client()
+    await client.connect()
+    try:
+        await ensure_schema(client)
+        await client.query(
+            "CREATE workspace CONTENT { name: 'W', slack_team_id: 'T1', "
+            "oauth_token_encrypted: '' }"
+        )
+        config_full = _build_config("T1", ["C-A", "C-B"])
+        await sync_channel_allowlist(client, config_full)
+        config_reduced = _build_config("T1", ["C-A"])
+        await sync_channel_allowlist(client, config_reduced)
+        rows = await client.query(
+            "SELECT channel_id FROM channel_allowlist"
+        )
+        channel_ids = {r["channel_id"] for r in rows}
+        assert channel_ids == {"C-A"}
+    finally:
+        await client.close()

--- a/tests/test_team_server_app.py
+++ b/tests/test_team_server_app.py
@@ -1,0 +1,119 @@
+"""Functionality tests for team_server Phase 1 — scaffold + self-managing schema."""
+
+from __future__ import annotations
+
+import os
+import sys
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(REPO_ROOT))
+
+
+@pytest.fixture
+def memory_url(monkeypatch):
+    monkeypatch.setenv("BICAMERAL_TEAM_SERVER_SURREAL_URL", "memory://")
+    monkeypatch.setenv("BICAMERAL_TEAM_SERVER_SECRET_KEY", "EYSr77qKo0UijHGnER5qYFBY5ZZePeWeE-ZMWYXyKKA=")
+    yield
+
+
+@pytest.mark.asyncio
+async def test_app_starts_and_serves_health(memory_url):
+    """Behavior: create_app() builds a FastAPI app whose lifespan migrates
+    schema and exposes a /health endpoint that returns the schema version."""
+    from httpx import ASGITransport, AsyncClient
+
+    from team_server.app import create_app
+
+    app = create_app()
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+        # Manually trigger lifespan via context
+        async with app.router.lifespan_context(app):
+            resp = await client.get("/health")
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["status"] == "ok"
+    assert isinstance(body["schema_version"], int)
+    assert body["schema_version"] >= 1
+
+
+@pytest.mark.asyncio
+async def test_schema_migrates_from_empty_ledger(memory_url):
+    """Behavior: ensure_schema() against a fresh memory:// SurrealDB defines
+    all v0 team-server tables (workspace, channel_allowlist, extraction_cache,
+    team_event)."""
+    from team_server.db import build_client
+    from team_server.schema import ensure_schema
+
+    client = build_client()
+    await client.connect()
+    try:
+        await ensure_schema(client)
+        # Insert + query each table to prove it exists with the expected fields
+        await client.query(
+            "CREATE workspace CONTENT { name: 'acme', slack_team_id: 'T1', "
+            "oauth_token_encrypted: 'enc', created_at: time::now() }"
+        )
+        rows = await client.query("SELECT * FROM workspace")
+        assert len(rows) == 1
+        assert rows[0]["slack_team_id"] == "T1"
+    finally:
+        await client.close()
+
+
+@pytest.mark.asyncio
+async def test_schema_migration_is_idempotent(memory_url):
+    """Behavior: running ensure_schema() twice on the same client succeeds
+    (no exception) and table definitions remain valid afterward."""
+    from team_server.db import build_client
+    from team_server.schema import ensure_schema
+
+    client = build_client()
+    await client.connect()
+    try:
+        await ensure_schema(client)
+        await ensure_schema(client)  # second call must be no-op
+        # Sanity: tables still functional after double-migrate
+        await client.query(
+            "CREATE workspace CONTENT { name: 'a', slack_team_id: 'T2', "
+            "oauth_token_encrypted: 'enc', created_at: time::now() }"
+        )
+        rows = await client.query("SELECT * FROM workspace WHERE slack_team_id = 'T2'")
+        assert len(rows) == 1
+    finally:
+        await client.close()
+
+
+@pytest.mark.asyncio
+async def test_app_shutdown_releases_db(memory_url):
+    """Behavior: lifespan context teardown closes the DB client; subsequent
+    queries on the closed client raise rather than silently no-op."""
+    from team_server.app import create_app
+
+    app = create_app()
+    async with app.router.lifespan_context(app):
+        db = app.state.db
+        # Active during the context
+        await db.client.query("RETURN 1")
+    # After context exit, the underlying client is closed
+    with pytest.raises((RuntimeError, AttributeError, Exception)):
+        await db.client.query("RETURN 1")
+
+
+def test_health_endpoint_returns_well_formed_json(memory_url):
+    """Behavior: /health returns JSON with required fields (synchronous test
+    via TestClient — proves the route handler works without asyncio fixture
+    contention)."""
+    from fastapi.testclient import TestClient
+
+    from team_server.app import create_app
+
+    app = create_app()
+    with TestClient(app) as client:
+        resp = client.get("/health")
+    assert resp.status_code == 200
+    body = resp.json()
+    assert set(body.keys()) >= {"status", "schema_version"}
+    assert body["status"] == "ok"

--- a/tests/test_team_server_app.py
+++ b/tests/test_team_server_app.py
@@ -15,7 +15,9 @@ sys.path.insert(0, str(REPO_ROOT))
 @pytest.fixture
 def memory_url(monkeypatch):
     monkeypatch.setenv("BICAMERAL_TEAM_SERVER_SURREAL_URL", "memory://")
-    monkeypatch.setenv("BICAMERAL_TEAM_SERVER_SECRET_KEY", "EYSr77qKo0UijHGnER5qYFBY5ZZePeWeE-ZMWYXyKKA=")
+    monkeypatch.setenv(
+        "BICAMERAL_TEAM_SERVER_SECRET_KEY", "EYSr77qKo0UijHGnER5qYFBY5ZZePeWeE-ZMWYXyKKA="
+    )
     yield
 
 

--- a/tests/test_team_server_cache_upsert.py
+++ b/tests/test_team_server_cache_upsert.py
@@ -62,14 +62,22 @@ async def test_upsert_returns_changed_false_on_same_hash():
             return {"decisions": ["v1"]}
 
         await upsert_canonical_extraction(
-            client, source_type="slack", source_ref="C1/2.0",
-            content_hash="h2", classifier_version="legacy-pre-v3",
-            compute_fn=stub, model_version="interim-claude-v1",
+            client,
+            source_type="slack",
+            source_ref="C1/2.0",
+            content_hash="h2",
+            classifier_version="legacy-pre-v3",
+            compute_fn=stub,
+            model_version="interim-claude-v1",
         )
         extraction, changed = await upsert_canonical_extraction(
-            client, source_type="slack", source_ref="C1/2.0",
-            content_hash="h2", classifier_version="legacy-pre-v3",
-            compute_fn=stub, model_version="interim-claude-v1",
+            client,
+            source_type="slack",
+            source_ref="C1/2.0",
+            content_hash="h2",
+            classifier_version="legacy-pre-v3",
+            compute_fn=stub,
+            model_version="interim-claude-v1",
         )
         assert changed is False
         assert extraction == {"decisions": ["v1"]}
@@ -96,14 +104,22 @@ async def test_upsert_replaces_extraction_on_hash_change():
             return {"decisions": ["v2"]}
 
         await upsert_canonical_extraction(
-            client, source_type="slack", source_ref="C1/3.0",
-            content_hash="ha", classifier_version="legacy-pre-v3",
-            compute_fn=stub_v1, model_version="interim-claude-v1",
+            client,
+            source_type="slack",
+            source_ref="C1/3.0",
+            content_hash="ha",
+            classifier_version="legacy-pre-v3",
+            compute_fn=stub_v1,
+            model_version="interim-claude-v1",
         )
         extraction, changed = await upsert_canonical_extraction(
-            client, source_type="slack", source_ref="C1/3.0",
-            content_hash="hb", classifier_version="legacy-pre-v3",
-            compute_fn=stub_v2, model_version="interim-claude-v1",
+            client,
+            source_type="slack",
+            source_ref="C1/3.0",
+            content_hash="hb",
+            classifier_version="legacy-pre-v3",
+            compute_fn=stub_v2,
+            model_version="interim-claude-v1",
         )
         assert changed is True
         assert extraction == {"decisions": ["v2"]}
@@ -125,8 +141,8 @@ async def test_upsert_replaces_extraction_on_hash_change():
 async def test_upsert_unique_index_is_source_type_and_ref_only():
     """Functionality: after migration, the unique index rejects a duplicate
     (source_type, source_ref) regardless of content_hash differences."""
-    from team_server.db import build_client
     from ledger.client import LedgerError
+    from team_server.db import build_client
     from team_server.schema import ensure_schema
 
     client = build_client()

--- a/tests/test_team_server_cache_upsert.py
+++ b/tests/test_team_server_cache_upsert.py
@@ -35,6 +35,7 @@ async def test_upsert_returns_extraction_and_changed_true_on_first_write():
             source_type="slack",
             source_ref="C1/1.0",
             content_hash="h1",
+            classifier_version="legacy-pre-v3",
             compute_fn=stub,
             model_version="interim-claude-v1",
         )
@@ -61,10 +62,14 @@ async def test_upsert_returns_changed_false_on_same_hash():
             return {"decisions": ["v1"]}
 
         await upsert_canonical_extraction(
-            client, "slack", "C1/2.0", "h2", stub, "interim-claude-v1"
+            client, source_type="slack", source_ref="C1/2.0",
+            content_hash="h2", classifier_version="legacy-pre-v3",
+            compute_fn=stub, model_version="interim-claude-v1",
         )
         extraction, changed = await upsert_canonical_extraction(
-            client, "slack", "C1/2.0", "h2", stub, "interim-claude-v1"
+            client, source_type="slack", source_ref="C1/2.0",
+            content_hash="h2", classifier_version="legacy-pre-v3",
+            compute_fn=stub, model_version="interim-claude-v1",
         )
         assert changed is False
         assert extraction == {"decisions": ["v1"]}
@@ -91,10 +96,14 @@ async def test_upsert_replaces_extraction_on_hash_change():
             return {"decisions": ["v2"]}
 
         await upsert_canonical_extraction(
-            client, "slack", "C1/3.0", "ha", stub_v1, "interim-claude-v1"
+            client, source_type="slack", source_ref="C1/3.0",
+            content_hash="ha", classifier_version="legacy-pre-v3",
+            compute_fn=stub_v1, model_version="interim-claude-v1",
         )
         extraction, changed = await upsert_canonical_extraction(
-            client, "slack", "C1/3.0", "hb", stub_v2, "interim-claude-v1"
+            client, source_type="slack", source_ref="C1/3.0",
+            content_hash="hb", classifier_version="legacy-pre-v3",
+            compute_fn=stub_v2, model_version="interim-claude-v1",
         )
         assert changed is True
         assert extraction == {"decisions": ["v2"]}

--- a/tests/test_team_server_cache_upsert.py
+++ b/tests/test_team_server_cache_upsert.py
@@ -1,0 +1,137 @@
+"""Functionality tests for team_server Phase 0 — upsert-shaped canonical cache."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(REPO_ROOT))
+
+
+@pytest.fixture(autouse=True)
+def memory_url(monkeypatch):
+    monkeypatch.setenv("BICAMERAL_TEAM_SERVER_SURREAL_URL", "memory://")
+
+
+@pytest.mark.asyncio
+async def test_upsert_returns_extraction_and_changed_true_on_first_write():
+    from team_server.db import build_client
+    from team_server.extraction.canonical_cache import upsert_canonical_extraction
+    from team_server.schema import ensure_schema
+
+    client = build_client()
+    await client.connect()
+    try:
+        await ensure_schema(client)
+
+        async def stub():
+            return {"decisions": ["x"]}
+
+        extraction, changed = await upsert_canonical_extraction(
+            client,
+            source_type="slack",
+            source_ref="C1/1.0",
+            content_hash="h1",
+            compute_fn=stub,
+            model_version="interim-claude-v1",
+        )
+        assert extraction == {"decisions": ["x"]}
+        assert changed is True
+    finally:
+        await client.close()
+
+
+@pytest.mark.asyncio
+async def test_upsert_returns_changed_false_on_same_hash():
+    from team_server.db import build_client
+    from team_server.extraction.canonical_cache import upsert_canonical_extraction
+    from team_server.schema import ensure_schema
+
+    client = build_client()
+    await client.connect()
+    try:
+        await ensure_schema(client)
+        call_count = {"n": 0}
+
+        async def stub():
+            call_count["n"] += 1
+            return {"decisions": ["v1"]}
+
+        await upsert_canonical_extraction(
+            client, "slack", "C1/2.0", "h2", stub, "interim-claude-v1"
+        )
+        extraction, changed = await upsert_canonical_extraction(
+            client, "slack", "C1/2.0", "h2", stub, "interim-claude-v1"
+        )
+        assert changed is False
+        assert extraction == {"decisions": ["v1"]}
+        assert call_count["n"] == 1
+    finally:
+        await client.close()
+
+
+@pytest.mark.asyncio
+async def test_upsert_replaces_extraction_on_hash_change():
+    from team_server.db import build_client
+    from team_server.extraction.canonical_cache import upsert_canonical_extraction
+    from team_server.schema import ensure_schema
+
+    client = build_client()
+    await client.connect()
+    try:
+        await ensure_schema(client)
+
+        async def stub_v1():
+            return {"decisions": ["v1"]}
+
+        async def stub_v2():
+            return {"decisions": ["v2"]}
+
+        await upsert_canonical_extraction(
+            client, "slack", "C1/3.0", "ha", stub_v1, "interim-claude-v1"
+        )
+        extraction, changed = await upsert_canonical_extraction(
+            client, "slack", "C1/3.0", "hb", stub_v2, "interim-claude-v1"
+        )
+        assert changed is True
+        assert extraction == {"decisions": ["v2"]}
+        rows = await client.query(
+            "SELECT count() AS n FROM extraction_cache "
+            "WHERE source_type = 'slack' AND source_ref = 'C1/3.0' GROUP ALL"
+        )
+        assert rows[0]["n"] == 1
+        rows = await client.query(
+            "SELECT canonical_extraction FROM extraction_cache "
+            "WHERE source_type = 'slack' AND source_ref = 'C1/3.0'"
+        )
+        assert rows[0]["canonical_extraction"] == {"decisions": ["v2"]}
+    finally:
+        await client.close()
+
+
+@pytest.mark.asyncio
+async def test_upsert_unique_index_is_source_type_and_ref_only():
+    """Functionality: after migration, the unique index rejects a duplicate
+    (source_type, source_ref) regardless of content_hash differences."""
+    from team_server.db import build_client
+    from ledger.client import LedgerError
+    from team_server.schema import ensure_schema
+
+    client = build_client()
+    await client.connect()
+    try:
+        await ensure_schema(client)
+        await client.query(
+            "CREATE extraction_cache CONTENT { source_type: 'slack', source_ref: 'C1/4.0', "
+            "content_hash: 'h1', canonical_extraction: {}, model_version: 'm' }"
+        )
+        with pytest.raises(LedgerError):
+            await client.query(
+                "CREATE extraction_cache CONTENT { source_type: 'slack', source_ref: 'C1/4.0', "
+                "content_hash: 'h2', canonical_extraction: {}, model_version: 'm' }"
+            )
+    finally:
+        await client.close()

--- a/tests/test_team_server_canonical_cache.py
+++ b/tests/test_team_server_canonical_cache.py
@@ -1,4 +1,4 @@
-"""Functionality tests for team_server Phase 3 — canonical-extraction cache."""
+"""Functionality tests for team_server canonical-extraction cache (v2 upsert contract)."""
 
 from __future__ import annotations
 
@@ -18,19 +18,17 @@ def memory_url(monkeypatch):
 
 
 @pytest.mark.asyncio
-async def test_cache_hit_returns_existing_extraction():
-    """Behavior: get_or_compute returns the persisted extraction without
-    invoking compute_fn when the (source_type, source_ref, content_hash)
-    tuple already exists in extraction_cache."""
+async def test_cache_hit_returns_existing_extraction_without_invoking_compute():
+    """v2 behavior: matching (source_type, source_ref, content_hash)
+    triple returns (extraction, changed=False) without invoking compute_fn."""
     from team_server.db import build_client
-    from team_server.extraction.canonical_cache import get_or_compute
+    from team_server.extraction.canonical_cache import upsert_canonical_extraction
     from team_server.schema import ensure_schema
 
     client = build_client()
     await client.connect()
     try:
         await ensure_schema(client)
-        # Seed a cache row
         await client.query(
             "CREATE extraction_cache CONTENT { source_type: 'slack', "
             "source_ref: 'C123/T456', content_hash: 'abc', "
@@ -44,7 +42,7 @@ async def test_cache_hit_returns_existing_extraction():
             compute_calls.append(1)
             return {"decisions": ["new"]}
 
-        result = await get_or_compute(
+        result, changed = await upsert_canonical_extraction(
             client,
             source_type="slack",
             source_ref="C123/T456",
@@ -52,19 +50,20 @@ async def test_cache_hit_returns_existing_extraction():
             compute_fn=compute_fn,
             model_version="interim-claude-v1",
         )
-        assert compute_calls == []  # NOT invoked
+        assert compute_calls == []
+        assert changed is False
         assert result == {"decisions": ["existing"]}
     finally:
         await client.close()
 
 
 @pytest.mark.asyncio
-async def test_cache_miss_invokes_compute_and_persists():
-    """Behavior: cache miss invokes compute_fn, persists the result, AND a
-    subsequent call with same key returns the cached value (no second
-    compute_fn invocation)."""
+async def test_cache_miss_invokes_compute_persists_and_returns_changed_true():
+    """v2 behavior: cache miss invokes compute_fn, persists, returns
+    (extraction, changed=True). A subsequent call with the same key+hash
+    returns changed=False without re-invoking compute_fn."""
     from team_server.db import build_client
-    from team_server.extraction.canonical_cache import get_or_compute
+    from team_server.extraction.canonical_cache import upsert_canonical_extraction
     from team_server.schema import ensure_schema
 
     client = build_client()
@@ -77,37 +76,31 @@ async def test_cache_miss_invokes_compute_and_persists():
             compute_calls.append(1)
             return {"decisions": ["d1", "d2"]}
 
-        first = await get_or_compute(
-            client,
-            source_type="slack",
-            source_ref="C/T",
-            content_hash="h1",
-            compute_fn=compute_fn,
-            model_version="interim-claude-v1",
+        first, first_changed = await upsert_canonical_extraction(
+            client, "slack", "C/T", "h1", compute_fn, "interim-claude-v1",
         )
         assert compute_calls == [1]
+        assert first_changed is True
         assert first == {"decisions": ["d1", "d2"]}
 
-        second = await get_or_compute(
-            client,
-            source_type="slack",
-            source_ref="C/T",
-            content_hash="h1",
-            compute_fn=compute_fn,
-            model_version="interim-claude-v1",
+        second, second_changed = await upsert_canonical_extraction(
+            client, "slack", "C/T", "h1", compute_fn, "interim-claude-v1",
         )
-        assert compute_calls == [1]  # NOT invoked again
+        assert compute_calls == [1]
+        assert second_changed is False
         assert second == first
     finally:
         await client.close()
 
 
 @pytest.mark.asyncio
-async def test_cache_keys_on_content_hash_changes():
-    """Behavior: different content_hash with same (source_type, source_ref)
-    produces a new cache row (Slack message edit -> re-extract)."""
+async def test_content_hash_change_replaces_in_place_not_new_row():
+    """v2 behavior: under the upsert contract, a different content_hash
+    with same (source_type, source_ref) REPLACES the row in place — total
+    row count remains 1 for that key. (v1 behavior produced a new row;
+    that's been intentionally changed in the cache contract migration.)"""
     from team_server.db import build_client
-    from team_server.extraction.canonical_cache import get_or_compute
+    from team_server.extraction.canonical_cache import upsert_canonical_extraction
     from team_server.schema import ensure_schema
 
     client = build_client()
@@ -120,14 +113,18 @@ async def test_cache_keys_on_content_hash_changes():
             n[0] += 1
             return {"decisions": [f"d{n[0]}"]}
 
-        await get_or_compute(client, "slack", "C/T", "hash-A", compute_fn, "v1")
-        await get_or_compute(client, "slack", "C/T", "hash-B", compute_fn, "v1")
+        await upsert_canonical_extraction(
+            client, "slack", "C/T", "hash-A", compute_fn, "v1",
+        )
+        await upsert_canonical_extraction(
+            client, "slack", "C/T", "hash-B", compute_fn, "v1",
+        )
 
         rows = await client.query(
             "SELECT * FROM extraction_cache WHERE source_ref = 'C/T'"
         )
-        assert len(rows) == 2
-        hashes = {r["content_hash"] for r in rows}
-        assert hashes == {"hash-A", "hash-B"}
+        assert len(rows) == 1
+        assert rows[0]["content_hash"] == "hash-B"
+        assert rows[0]["canonical_extraction"] == {"decisions": ["d2"]}
     finally:
         await client.close()

--- a/tests/test_team_server_canonical_cache.py
+++ b/tests/test_team_server_canonical_cache.py
@@ -47,6 +47,7 @@ async def test_cache_hit_returns_existing_extraction_without_invoking_compute():
             source_type="slack",
             source_ref="C123/T456",
             content_hash="abc",
+            classifier_version="legacy-pre-v3",
             compute_fn=compute_fn,
             model_version="interim-claude-v1",
         )
@@ -77,14 +78,18 @@ async def test_cache_miss_invokes_compute_persists_and_returns_changed_true():
             return {"decisions": ["d1", "d2"]}
 
         first, first_changed = await upsert_canonical_extraction(
-            client, "slack", "C/T", "h1", compute_fn, "interim-claude-v1",
+            client, source_type="slack", source_ref="C/T",
+            content_hash="h1", classifier_version="legacy-pre-v3",
+            compute_fn=compute_fn, model_version="interim-claude-v1",
         )
         assert compute_calls == [1]
         assert first_changed is True
         assert first == {"decisions": ["d1", "d2"]}
 
         second, second_changed = await upsert_canonical_extraction(
-            client, "slack", "C/T", "h1", compute_fn, "interim-claude-v1",
+            client, source_type="slack", source_ref="C/T",
+            content_hash="h1", classifier_version="legacy-pre-v3",
+            compute_fn=compute_fn, model_version="interim-claude-v1",
         )
         assert compute_calls == [1]
         assert second_changed is False
@@ -114,10 +119,14 @@ async def test_content_hash_change_replaces_in_place_not_new_row():
             return {"decisions": [f"d{n[0]}"]}
 
         await upsert_canonical_extraction(
-            client, "slack", "C/T", "hash-A", compute_fn, "v1",
+            client, source_type="slack", source_ref="C/T",
+            content_hash="hash-A", classifier_version="legacy-pre-v3",
+            compute_fn=compute_fn, model_version="v1",
         )
         await upsert_canonical_extraction(
-            client, "slack", "C/T", "hash-B", compute_fn, "v1",
+            client, source_type="slack", source_ref="C/T",
+            content_hash="hash-B", classifier_version="legacy-pre-v3",
+            compute_fn=compute_fn, model_version="v1",
         )
 
         rows = await client.query(

--- a/tests/test_team_server_canonical_cache.py
+++ b/tests/test_team_server_canonical_cache.py
@@ -1,0 +1,133 @@
+"""Functionality tests for team_server Phase 3 — canonical-extraction cache."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(REPO_ROOT))
+
+
+@pytest.fixture(autouse=True)
+def memory_url(monkeypatch):
+    monkeypatch.setenv("BICAMERAL_TEAM_SERVER_SURREAL_URL", "memory://")
+    monkeypatch.setenv("BICAMERAL_TEAM_SERVER_SECRET_KEY", "EYSr77qKo0UijHGnER5qYFBY5ZZePeWeE-ZMWYXyKKA=")
+
+
+@pytest.mark.asyncio
+async def test_cache_hit_returns_existing_extraction():
+    """Behavior: get_or_compute returns the persisted extraction without
+    invoking compute_fn when the (source_type, source_ref, content_hash)
+    tuple already exists in extraction_cache."""
+    from team_server.db import build_client
+    from team_server.extraction.canonical_cache import get_or_compute
+    from team_server.schema import ensure_schema
+
+    client = build_client()
+    await client.connect()
+    try:
+        await ensure_schema(client)
+        # Seed a cache row
+        await client.query(
+            "CREATE extraction_cache CONTENT { source_type: 'slack', "
+            "source_ref: 'C123/T456', content_hash: 'abc', "
+            "canonical_extraction: { decisions: ['existing'] }, "
+            "model_version: 'interim-claude-v1' }"
+        )
+
+        compute_calls = []
+
+        async def compute_fn():
+            compute_calls.append(1)
+            return {"decisions": ["new"]}
+
+        result = await get_or_compute(
+            client,
+            source_type="slack",
+            source_ref="C123/T456",
+            content_hash="abc",
+            compute_fn=compute_fn,
+            model_version="interim-claude-v1",
+        )
+        assert compute_calls == []  # NOT invoked
+        assert result == {"decisions": ["existing"]}
+    finally:
+        await client.close()
+
+
+@pytest.mark.asyncio
+async def test_cache_miss_invokes_compute_and_persists():
+    """Behavior: cache miss invokes compute_fn, persists the result, AND a
+    subsequent call with same key returns the cached value (no second
+    compute_fn invocation)."""
+    from team_server.db import build_client
+    from team_server.extraction.canonical_cache import get_or_compute
+    from team_server.schema import ensure_schema
+
+    client = build_client()
+    await client.connect()
+    try:
+        await ensure_schema(client)
+        compute_calls = []
+
+        async def compute_fn():
+            compute_calls.append(1)
+            return {"decisions": ["d1", "d2"]}
+
+        first = await get_or_compute(
+            client,
+            source_type="slack",
+            source_ref="C/T",
+            content_hash="h1",
+            compute_fn=compute_fn,
+            model_version="interim-claude-v1",
+        )
+        assert compute_calls == [1]
+        assert first == {"decisions": ["d1", "d2"]}
+
+        second = await get_or_compute(
+            client,
+            source_type="slack",
+            source_ref="C/T",
+            content_hash="h1",
+            compute_fn=compute_fn,
+            model_version="interim-claude-v1",
+        )
+        assert compute_calls == [1]  # NOT invoked again
+        assert second == first
+    finally:
+        await client.close()
+
+
+@pytest.mark.asyncio
+async def test_cache_keys_on_content_hash_changes():
+    """Behavior: different content_hash with same (source_type, source_ref)
+    produces a new cache row (Slack message edit -> re-extract)."""
+    from team_server.db import build_client
+    from team_server.extraction.canonical_cache import get_or_compute
+    from team_server.schema import ensure_schema
+
+    client = build_client()
+    await client.connect()
+    try:
+        await ensure_schema(client)
+        n = [0]
+
+        async def compute_fn():
+            n[0] += 1
+            return {"decisions": [f"d{n[0]}"]}
+
+        await get_or_compute(client, "slack", "C/T", "hash-A", compute_fn, "v1")
+        await get_or_compute(client, "slack", "C/T", "hash-B", compute_fn, "v1")
+
+        rows = await client.query(
+            "SELECT * FROM extraction_cache WHERE source_ref = 'C/T'"
+        )
+        assert len(rows) == 2
+        hashes = {r["content_hash"] for r in rows}
+        assert hashes == {"hash-A", "hash-B"}
+    finally:
+        await client.close()

--- a/tests/test_team_server_canonical_cache.py
+++ b/tests/test_team_server_canonical_cache.py
@@ -14,7 +14,9 @@ sys.path.insert(0, str(REPO_ROOT))
 @pytest.fixture(autouse=True)
 def memory_url(monkeypatch):
     monkeypatch.setenv("BICAMERAL_TEAM_SERVER_SURREAL_URL", "memory://")
-    monkeypatch.setenv("BICAMERAL_TEAM_SERVER_SECRET_KEY", "EYSr77qKo0UijHGnER5qYFBY5ZZePeWeE-ZMWYXyKKA=")
+    monkeypatch.setenv(
+        "BICAMERAL_TEAM_SERVER_SECRET_KEY", "EYSr77qKo0UijHGnER5qYFBY5ZZePeWeE-ZMWYXyKKA="
+    )
 
 
 @pytest.mark.asyncio
@@ -78,18 +80,26 @@ async def test_cache_miss_invokes_compute_persists_and_returns_changed_true():
             return {"decisions": ["d1", "d2"]}
 
         first, first_changed = await upsert_canonical_extraction(
-            client, source_type="slack", source_ref="C/T",
-            content_hash="h1", classifier_version="legacy-pre-v3",
-            compute_fn=compute_fn, model_version="interim-claude-v1",
+            client,
+            source_type="slack",
+            source_ref="C/T",
+            content_hash="h1",
+            classifier_version="legacy-pre-v3",
+            compute_fn=compute_fn,
+            model_version="interim-claude-v1",
         )
         assert compute_calls == [1]
         assert first_changed is True
         assert first == {"decisions": ["d1", "d2"]}
 
         second, second_changed = await upsert_canonical_extraction(
-            client, source_type="slack", source_ref="C/T",
-            content_hash="h1", classifier_version="legacy-pre-v3",
-            compute_fn=compute_fn, model_version="interim-claude-v1",
+            client,
+            source_type="slack",
+            source_ref="C/T",
+            content_hash="h1",
+            classifier_version="legacy-pre-v3",
+            compute_fn=compute_fn,
+            model_version="interim-claude-v1",
         )
         assert compute_calls == [1]
         assert second_changed is False
@@ -119,19 +129,25 @@ async def test_content_hash_change_replaces_in_place_not_new_row():
             return {"decisions": [f"d{n[0]}"]}
 
         await upsert_canonical_extraction(
-            client, source_type="slack", source_ref="C/T",
-            content_hash="hash-A", classifier_version="legacy-pre-v3",
-            compute_fn=compute_fn, model_version="v1",
+            client,
+            source_type="slack",
+            source_ref="C/T",
+            content_hash="hash-A",
+            classifier_version="legacy-pre-v3",
+            compute_fn=compute_fn,
+            model_version="v1",
         )
         await upsert_canonical_extraction(
-            client, source_type="slack", source_ref="C/T",
-            content_hash="hash-B", classifier_version="legacy-pre-v3",
-            compute_fn=compute_fn, model_version="v1",
+            client,
+            source_type="slack",
+            source_ref="C/T",
+            content_hash="hash-B",
+            classifier_version="legacy-pre-v3",
+            compute_fn=compute_fn,
+            model_version="v1",
         )
 
-        rows = await client.query(
-            "SELECT * FROM extraction_cache WHERE source_ref = 'C/T'"
-        )
+        rows = await client.query("SELECT * FROM extraction_cache WHERE source_ref = 'C/T'")
         assert len(rows) == 1
         assert rows[0]["content_hash"] == "hash-B"
         assert rows[0]["canonical_extraction"] == {"decisions": ["d2"]}

--- a/tests/test_team_server_channel_allowlist.py
+++ b/tests/test_team_server_channel_allowlist.py
@@ -1,0 +1,51 @@
+"""Functionality tests for team_server Phase 2 — channel allow-list config."""
+
+from __future__ import annotations
+
+import sys
+import textwrap
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(REPO_ROOT))
+
+
+def test_config_yaml_loads_channel_allowlist(tmp_path):
+    """Behavior: load_channel_allowlist parses a valid YAML and returns a
+    structured object whose Slack workspaces + channel lists match input."""
+    from team_server.config import load_channel_allowlist
+
+    cfg_path = tmp_path / "team-server-config.yml"
+    cfg_path.write_text(textwrap.dedent("""\
+        slack:
+          workspaces:
+            - team_id: T123
+              channels:
+                - C001
+                - C002
+            - team_id: T999
+              channels:
+                - CABC
+    """))
+    config = load_channel_allowlist(cfg_path)
+    workspaces = {w.team_id: w.channels for w in config.slack.workspaces}
+    assert workspaces == {"T123": ["C001", "C002"], "T999": ["CABC"]}
+
+
+def test_config_yaml_rejects_missing_workspace_id(tmp_path):
+    """Behavior: load_channel_allowlist raises ValueError when a workspace
+    entry omits team_id (required field)."""
+    from team_server.config import load_channel_allowlist
+
+    cfg_path = tmp_path / "team-server-config.yml"
+    cfg_path.write_text(textwrap.dedent("""\
+        slack:
+          workspaces:
+            - channels:
+                - C001
+    """))
+    with pytest.raises(ValueError) as excinfo:
+        load_channel_allowlist(cfg_path)
+    assert "team_id" in str(excinfo.value).lower()

--- a/tests/test_team_server_channel_allowlist.py
+++ b/tests/test_team_server_channel_allowlist.py
@@ -18,7 +18,8 @@ def test_config_yaml_loads_channel_allowlist(tmp_path):
     from team_server.config import load_channel_allowlist
 
     cfg_path = tmp_path / "team-server-config.yml"
-    cfg_path.write_text(textwrap.dedent("""\
+    cfg_path.write_text(
+        textwrap.dedent("""\
         slack:
           workspaces:
             - team_id: T123
@@ -28,7 +29,8 @@ def test_config_yaml_loads_channel_allowlist(tmp_path):
             - team_id: T999
               channels:
                 - CABC
-    """))
+    """)
+    )
     config = load_channel_allowlist(cfg_path)
     workspaces = {w.team_id: w.channels for w in config.slack.workspaces}
     assert workspaces == {"T123": ["C001", "C002"], "T999": ["CABC"]}
@@ -40,12 +42,14 @@ def test_config_yaml_rejects_missing_workspace_id(tmp_path):
     from team_server.config import load_channel_allowlist
 
     cfg_path = tmp_path / "team-server-config.yml"
-    cfg_path.write_text(textwrap.dedent("""\
+    cfg_path.write_text(
+        textwrap.dedent("""\
         slack:
           workspaces:
             - channels:
                 - C001
-    """))
+    """)
+    )
     with pytest.raises(ValueError) as excinfo:
         load_channel_allowlist(cfg_path)
     assert "team_id" in str(excinfo.value).lower()

--- a/tests/test_team_server_classifier_version.py
+++ b/tests/test_team_server_classifier_version.py
@@ -1,0 +1,209 @@
+"""Functionality tests for Phase 0 — classifier_version axis on extraction_cache."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(REPO_ROOT))
+
+
+@pytest.fixture(autouse=True)
+def memory_url(monkeypatch):
+    monkeypatch.setenv("BICAMERAL_TEAM_SERVER_SURREAL_URL", "memory://")
+
+
+@pytest.mark.asyncio
+async def test_upsert_returns_changed_true_when_classifier_version_differs():
+    from team_server.db import build_client
+    from team_server.extraction.canonical_cache import upsert_canonical_extraction
+    from team_server.schema import ensure_schema
+
+    client = build_client()
+    await client.connect()
+    try:
+        await ensure_schema(client)
+
+        async def stub_v1():
+            return {"decisions": ["v1"]}
+
+        async def stub_v2():
+            return {"decisions": ["v2"]}
+
+        await upsert_canonical_extraction(
+            client, source_type="slack", source_ref="A/1",
+            content_hash="h", classifier_version="cv-1",
+            compute_fn=stub_v1, model_version="m",
+        )
+        extraction, changed = await upsert_canonical_extraction(
+            client, source_type="slack", source_ref="A/1",
+            content_hash="h", classifier_version="cv-2",
+            compute_fn=stub_v2, model_version="m",
+        )
+        assert changed is True
+        assert extraction == {"decisions": ["v2"]}
+        rows = await client.query(
+            "SELECT classifier_version FROM extraction_cache "
+            "WHERE source_type = 'slack' AND source_ref = 'A/1'"
+        )
+        assert rows[0]["classifier_version"] == "cv-2"
+    finally:
+        await client.close()
+
+
+@pytest.mark.asyncio
+async def test_upsert_returns_changed_false_when_both_hash_and_version_match():
+    from team_server.db import build_client
+    from team_server.extraction.canonical_cache import upsert_canonical_extraction
+    from team_server.schema import ensure_schema
+
+    client = build_client()
+    await client.connect()
+    try:
+        await ensure_schema(client)
+        compute_count = {"n": 0}
+
+        async def stub():
+            compute_count["n"] += 1
+            return {"decisions": ["x"]}
+
+        await upsert_canonical_extraction(
+            client, source_type="slack", source_ref="B/1",
+            content_hash="h", classifier_version="cv-1",
+            compute_fn=stub, model_version="m",
+        )
+        extraction, changed = await upsert_canonical_extraction(
+            client, source_type="slack", source_ref="B/1",
+            content_hash="h", classifier_version="cv-1",
+            compute_fn=stub, model_version="m",
+        )
+        assert changed is False
+        assert extraction == {"decisions": ["x"]}
+        assert compute_count["n"] == 1
+    finally:
+        await client.close()
+
+
+@pytest.mark.asyncio
+async def test_upsert_returns_changed_true_when_content_hash_differs_classifier_same():
+    from team_server.db import build_client
+    from team_server.extraction.canonical_cache import upsert_canonical_extraction
+    from team_server.schema import ensure_schema
+
+    client = build_client()
+    await client.connect()
+    try:
+        await ensure_schema(client)
+
+        async def stub_a():
+            return {"decisions": ["a"]}
+
+        async def stub_b():
+            return {"decisions": ["b"]}
+
+        await upsert_canonical_extraction(
+            client, source_type="slack", source_ref="C/1",
+            content_hash="h-a", classifier_version="cv-1",
+            compute_fn=stub_a, model_version="m",
+        )
+        extraction, changed = await upsert_canonical_extraction(
+            client, source_type="slack", source_ref="C/1",
+            content_hash="h-b", classifier_version="cv-1",
+            compute_fn=stub_b, model_version="m",
+        )
+        assert changed is True
+        assert extraction == {"decisions": ["b"]}
+    finally:
+        await client.close()
+
+
+@pytest.mark.asyncio
+async def test_v2_to_v3_migration_adds_classifier_version_column():
+    """Behavior: after migration, INSERT with classifier_version succeeds
+    AND pre-existing rows are backfilled with 'legacy-pre-v3'."""
+    from team_server.db import build_client
+    from team_server.schema import ensure_schema
+
+    client = build_client()
+    await client.connect()
+    try:
+        await ensure_schema(client)
+        await client.query(
+            "CREATE extraction_cache CONTENT { source_type: 'slack', "
+            "source_ref: 'X/1', content_hash: 'h', "
+            "canonical_extraction: {}, model_version: 'm', "
+            "classifier_version: 'cv-real' }"
+        )
+        rows = await client.query(
+            "SELECT classifier_version FROM extraction_cache "
+            "WHERE source_type = 'slack' AND source_ref = 'X/1'"
+        )
+        assert rows[0]["classifier_version"] == "cv-real"
+    finally:
+        await client.close()
+
+
+@pytest.mark.asyncio
+async def test_v2_to_v3_migration_backfills_legacy_rows_with_default_classifier_version():
+    """Behavior: rows that pre-date the classifier_version column read
+    back as 'legacy-pre-v3' after the migration applies the field's
+    DEFAULT clause. Closes the SurrealDB v2 embedded IS NONE quirk
+    coverage gap (Fixer L4-B)."""
+    from team_server.db import build_client
+    from team_server.schema import ensure_schema
+
+    client = build_client()
+    await client.connect()
+    try:
+        # Bootstrap minimal schema (without the v3 field) by manually defining
+        # the v1-shape extraction_cache, then run ensure_schema to migrate.
+        await client.query("DEFINE TABLE extraction_cache SCHEMAFULL")
+        await client.query("DEFINE FIELD source_type ON extraction_cache TYPE string")
+        await client.query("DEFINE FIELD source_ref ON extraction_cache TYPE string")
+        await client.query("DEFINE FIELD content_hash ON extraction_cache TYPE string")
+        await client.query(
+            "DEFINE FIELD canonical_extraction ON extraction_cache "
+            "FLEXIBLE TYPE object DEFAULT {}"
+        )
+        await client.query(
+            "DEFINE FIELD model_version ON extraction_cache TYPE string"
+        )
+        await client.query(
+            "DEFINE FIELD created_at ON extraction_cache "
+            "TYPE datetime DEFAULT time::now()"
+        )
+        await client.query(
+            "CREATE extraction_cache CONTENT { source_type: 'slack', "
+            "source_ref: 'legacy/1', content_hash: 'h', "
+            "canonical_extraction: {}, model_version: 'm', "
+            "created_at: time::now() }"
+        )
+        await ensure_schema(client)
+        rows = await client.query(
+            "SELECT classifier_version FROM extraction_cache "
+            "WHERE source_type = 'slack' AND source_ref = 'legacy/1'"
+        )
+        assert len(rows) == 1
+        assert rows[0]["classifier_version"] == "legacy-pre-v3"
+    finally:
+        await client.close()
+
+
+@pytest.mark.asyncio
+async def test_v2_to_v3_migration_is_idempotent():
+    from team_server.db import build_client
+    from team_server.schema import SCHEMA_VERSION, ensure_schema
+
+    client = build_client()
+    await client.connect()
+    try:
+        await ensure_schema(client)
+        await ensure_schema(client)
+        rows = await client.query("SELECT version FROM schema_version")
+        assert len(rows) == 1
+        assert rows[0]["version"] == SCHEMA_VERSION
+    finally:
+        await client.close()

--- a/tests/test_team_server_classifier_version.py
+++ b/tests/test_team_server_classifier_version.py
@@ -34,14 +34,22 @@ async def test_upsert_returns_changed_true_when_classifier_version_differs():
             return {"decisions": ["v2"]}
 
         await upsert_canonical_extraction(
-            client, source_type="slack", source_ref="A/1",
-            content_hash="h", classifier_version="cv-1",
-            compute_fn=stub_v1, model_version="m",
+            client,
+            source_type="slack",
+            source_ref="A/1",
+            content_hash="h",
+            classifier_version="cv-1",
+            compute_fn=stub_v1,
+            model_version="m",
         )
         extraction, changed = await upsert_canonical_extraction(
-            client, source_type="slack", source_ref="A/1",
-            content_hash="h", classifier_version="cv-2",
-            compute_fn=stub_v2, model_version="m",
+            client,
+            source_type="slack",
+            source_ref="A/1",
+            content_hash="h",
+            classifier_version="cv-2",
+            compute_fn=stub_v2,
+            model_version="m",
         )
         assert changed is True
         assert extraction == {"decisions": ["v2"]}
@@ -71,14 +79,22 @@ async def test_upsert_returns_changed_false_when_both_hash_and_version_match():
             return {"decisions": ["x"]}
 
         await upsert_canonical_extraction(
-            client, source_type="slack", source_ref="B/1",
-            content_hash="h", classifier_version="cv-1",
-            compute_fn=stub, model_version="m",
+            client,
+            source_type="slack",
+            source_ref="B/1",
+            content_hash="h",
+            classifier_version="cv-1",
+            compute_fn=stub,
+            model_version="m",
         )
         extraction, changed = await upsert_canonical_extraction(
-            client, source_type="slack", source_ref="B/1",
-            content_hash="h", classifier_version="cv-1",
-            compute_fn=stub, model_version="m",
+            client,
+            source_type="slack",
+            source_ref="B/1",
+            content_hash="h",
+            classifier_version="cv-1",
+            compute_fn=stub,
+            model_version="m",
         )
         assert changed is False
         assert extraction == {"decisions": ["x"]}
@@ -105,14 +121,22 @@ async def test_upsert_returns_changed_true_when_content_hash_differs_classifier_
             return {"decisions": ["b"]}
 
         await upsert_canonical_extraction(
-            client, source_type="slack", source_ref="C/1",
-            content_hash="h-a", classifier_version="cv-1",
-            compute_fn=stub_a, model_version="m",
+            client,
+            source_type="slack",
+            source_ref="C/1",
+            content_hash="h-a",
+            classifier_version="cv-1",
+            compute_fn=stub_a,
+            model_version="m",
         )
         extraction, changed = await upsert_canonical_extraction(
-            client, source_type="slack", source_ref="C/1",
-            content_hash="h-b", classifier_version="cv-1",
-            compute_fn=stub_b, model_version="m",
+            client,
+            source_type="slack",
+            source_ref="C/1",
+            content_hash="h-b",
+            classifier_version="cv-1",
+            compute_fn=stub_b,
+            model_version="m",
         )
         assert changed is True
         assert extraction == {"decisions": ["b"]}
@@ -165,15 +189,11 @@ async def test_v2_to_v3_migration_backfills_legacy_rows_with_default_classifier_
         await client.query("DEFINE FIELD source_ref ON extraction_cache TYPE string")
         await client.query("DEFINE FIELD content_hash ON extraction_cache TYPE string")
         await client.query(
-            "DEFINE FIELD canonical_extraction ON extraction_cache "
-            "FLEXIBLE TYPE object DEFAULT {}"
+            "DEFINE FIELD canonical_extraction ON extraction_cache FLEXIBLE TYPE object DEFAULT {}"
         )
+        await client.query("DEFINE FIELD model_version ON extraction_cache TYPE string")
         await client.query(
-            "DEFINE FIELD model_version ON extraction_cache TYPE string"
-        )
-        await client.query(
-            "DEFINE FIELD created_at ON extraction_cache "
-            "TYPE datetime DEFAULT time::now()"
+            "DEFINE FIELD created_at ON extraction_cache TYPE datetime DEFAULT time::now()"
         )
         await client.query(
             "CREATE extraction_cache CONTENT { source_type: 'slack', "

--- a/tests/test_team_server_consumer.py
+++ b/tests/test_team_server_consumer.py
@@ -1,0 +1,227 @@
+"""Phase 1.5 — periodic team-server event consumer."""
+
+from __future__ import annotations
+
+import asyncio
+import sys
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(REPO_ROOT))
+
+
+def _team_server_event(seq: int, source_ref: str, decisions=None) -> dict:
+    return {
+        "sequence": seq,
+        "author_email": "team-server@notion.bicameral",
+        "event_type": "ingest",
+        "payload": {
+            "source_type": "slack",
+            "source_ref": source_ref,
+            "content_hash": "h",
+            "extraction": {
+                "decisions": decisions if decisions is not None else [
+                    {"summary": "use REST", "context_snippet": "we decided to use REST"},
+                ],
+            },
+        },
+    }
+
+
+class _RecordingAdapter:
+    def __init__(self):
+        self.calls: list[dict] = []
+
+    async def ingest_payload(self, payload, ctx=None):
+        self.calls.append(payload)
+        return {}
+
+
+@pytest.mark.asyncio
+async def test_consumer_pulls_events_and_invokes_ingest_payload(monkeypatch, tmp_path):
+    from events import team_server_consumer
+
+    async def fake_pull(team_server_url, watermark_path, *, timeout=10.0):
+        return [_team_server_event(1, "C1/1.0")]
+
+    monkeypatch.setattr(team_server_consumer, "pull_team_server_events", fake_pull)
+    adapter = _RecordingAdapter()
+    n = await team_server_consumer.consume_team_server_events_once(
+        team_server_url="http://team:8765",
+        watermark_path=tmp_path / "wm",
+        inner_adapter=adapter,
+    )
+    assert n == 1
+    assert len(adapter.calls) == 1
+    assert adapter.calls[0]["source"] == "slack"
+    assert adapter.calls[0]["decisions"][0]["description"] == "use REST"
+
+
+@pytest.mark.asyncio
+async def test_consumer_skips_events_with_empty_decisions(monkeypatch, tmp_path):
+    from events import team_server_consumer
+
+    async def fake_pull(team_server_url, watermark_path, *, timeout=10.0):
+        return [_team_server_event(1, "C1/1.0", decisions=[])]
+
+    monkeypatch.setattr(team_server_consumer, "pull_team_server_events", fake_pull)
+    adapter = _RecordingAdapter()
+    n = await team_server_consumer.consume_team_server_events_once(
+        team_server_url="http://team:8765",
+        watermark_path=tmp_path / "wm",
+        inner_adapter=adapter,
+    )
+    assert n == 0
+    assert adapter.calls == []
+
+
+@pytest.mark.asyncio
+async def test_consumer_handles_pull_failure_gracefully(monkeypatch, tmp_path):
+    from events import team_server_consumer
+
+    async def fake_pull(team_server_url, watermark_path, *, timeout=10.0):
+        return []  # pull failure semantics
+
+    monkeypatch.setattr(team_server_consumer, "pull_team_server_events", fake_pull)
+    adapter = _RecordingAdapter()
+    n = await team_server_consumer.consume_team_server_events_once(
+        team_server_url="http://team:8765",
+        watermark_path=tmp_path / "wm",
+        inner_adapter=adapter,
+    )
+    assert n == 0
+    assert adapter.calls == []
+
+
+@pytest.mark.asyncio
+async def test_consumer_advances_pull_watermark_via_returned_events(monkeypatch, tmp_path):
+    """The pull_team_server_events function manages its own watermark
+    file; the consumer doesn't break that. After one consume call, the
+    next pull's `since` parameter equals the max sequence seen."""
+    from events import team_server_consumer
+
+    seen_since: list[int] = []
+
+    async def fake_pull(team_server_url, watermark_path, *, timeout=10.0):
+        # Mimic real pull_team_server_events behavior: advance watermark
+        # based on max sequence in returned events.
+        prior = 0
+        if Path(watermark_path).exists():
+            try:
+                prior = int(Path(watermark_path).read_text(encoding="utf-8").strip())
+            except (ValueError, OSError):
+                prior = 0
+        seen_since.append(prior)
+        if prior == 0:
+            events = [_team_server_event(1, "C/1"),
+                      _team_server_event(2, "C/2"),
+                      _team_server_event(3, "C/3")]
+            Path(watermark_path).parent.mkdir(parents=True, exist_ok=True)
+            Path(watermark_path).write_text("3", encoding="utf-8")
+            return events
+        return []
+
+    monkeypatch.setattr(team_server_consumer, "pull_team_server_events", fake_pull)
+    adapter = _RecordingAdapter()
+    wm = tmp_path / "wm"
+    await team_server_consumer.consume_team_server_events_once(
+        "http://team:8765", wm, adapter,
+    )
+    await team_server_consumer.consume_team_server_events_once(
+        "http://team:8765", wm, adapter,
+    )
+    assert seen_since == [0, 3]
+
+
+@pytest.mark.asyncio
+async def test_start_consumer_loop_registers_task_when_url_set(monkeypatch, tmp_path):
+    from events import team_server_consumer
+
+    monkeypatch.setenv("BICAMERAL_TEAM_SERVER_URL", "http://team:8765")
+    monkeypatch.setenv("BICAMERAL_TEAM_SERVER_PULL_INTERVAL_SECONDS", "60")
+    monkeypatch.setenv("BICAMERAL_DATA_PATH", str(tmp_path))
+    adapter = _RecordingAdapter()
+    task = team_server_consumer.start_team_server_consumer_if_configured(adapter)
+    try:
+        assert task is not None
+        assert task.get_name() == "bicameral-team-server-consumer"
+    finally:
+        task.cancel()
+        try:
+            await task
+        except asyncio.CancelledError:
+            pass
+
+
+@pytest.mark.asyncio
+async def test_start_consumer_loop_returns_none_when_url_unset(monkeypatch):
+    from events import team_server_consumer
+
+    monkeypatch.delenv("BICAMERAL_TEAM_SERVER_URL", raising=False)
+    adapter = _RecordingAdapter()
+    task = team_server_consumer.start_team_server_consumer_if_configured(adapter)
+    assert task is None
+
+
+@pytest.mark.asyncio
+async def test_consumer_unwraps_team_write_adapter_does_not_echo_to_jsonl(monkeypatch, tmp_path):
+    """The load-bearing test from audit-round-2 Finding A: when
+    start_team_server_consumer_if_configured is passed a real
+    TeamWriteAdapter, the consumer must call _inner.ingest_payload
+    (NOT the wrapper) so no synthetic 'ingest.completed' echo is
+    written to per-dev JSONL files."""
+    from events import team_server_consumer
+
+    monkeypatch.setenv("BICAMERAL_TEAM_SERVER_URL", "http://team:8765")
+    # Use 0-second interval so the loop fires immediately on schedule
+    monkeypatch.setenv("BICAMERAL_TEAM_SERVER_PULL_INTERVAL_SECONDS", "0")
+    monkeypatch.setenv("BICAMERAL_DATA_PATH", str(tmp_path))
+
+    inner = _RecordingAdapter()
+
+    class _RecordingWriter:
+        def __init__(self):
+            self.calls: list[tuple] = []
+
+        def write(self, event_type: str, payload: dict) -> None:
+            self.calls.append((event_type, payload))
+
+    class _StubMaterializer:
+        async def replay_new_events(self, _inner_adapter):
+            return 0
+
+    writer = _RecordingWriter()
+
+    # Stub the pull to return one team-server event so consume has work
+    async def fake_pull(team_server_url, watermark_path, *, timeout=10.0):
+        return [_team_server_event(1, "C/T")]
+
+    monkeypatch.setattr(team_server_consumer, "pull_team_server_events", fake_pull)
+
+    # Construct a real TeamWriteAdapter with the recording writer
+    from events.team_adapter import TeamWriteAdapter
+    team_adapter = TeamWriteAdapter(
+        inner=inner, writer=writer, materializer=_StubMaterializer(),
+    )
+
+    task = team_server_consumer.start_team_server_consumer_if_configured(team_adapter)
+    try:
+        # Yield to let _loop fire once
+        for _ in range(20):
+            await asyncio.sleep(0.05)
+            if inner.calls:
+                break
+    finally:
+        task.cancel()
+        try:
+            await task
+        except asyncio.CancelledError:
+            pass
+
+    # (a) Inner adapter received the ingest call
+    assert len(inner.calls) >= 1
+    assert inner.calls[0]["source"] == "slack"
+    # (b) Writer was NEVER invoked — the unwrap bypassed the wrapper's side effect
+    assert writer.calls == []

--- a/tests/test_team_server_consumer.py
+++ b/tests/test_team_server_consumer.py
@@ -22,7 +22,9 @@ def _team_server_event(seq: int, source_ref: str, decisions=None) -> dict:
             "source_ref": source_ref,
             "content_hash": "h",
             "extraction": {
-                "decisions": decisions if decisions is not None else [
+                "decisions": decisions
+                if decisions is not None
+                else [
                     {"summary": "use REST", "context_snippet": "we decided to use REST"},
                 ],
             },
@@ -115,9 +117,11 @@ async def test_consumer_advances_pull_watermark_via_returned_events(monkeypatch,
                 prior = 0
         seen_since.append(prior)
         if prior == 0:
-            events = [_team_server_event(1, "C/1"),
-                      _team_server_event(2, "C/2"),
-                      _team_server_event(3, "C/3")]
+            events = [
+                _team_server_event(1, "C/1"),
+                _team_server_event(2, "C/2"),
+                _team_server_event(3, "C/3"),
+            ]
             Path(watermark_path).parent.mkdir(parents=True, exist_ok=True)
             Path(watermark_path).write_text("3", encoding="utf-8")
             return events
@@ -127,10 +131,14 @@ async def test_consumer_advances_pull_watermark_via_returned_events(monkeypatch,
     adapter = _RecordingAdapter()
     wm = tmp_path / "wm"
     await team_server_consumer.consume_team_server_events_once(
-        "http://team:8765", wm, adapter,
+        "http://team:8765",
+        wm,
+        adapter,
     )
     await team_server_consumer.consume_team_server_events_once(
-        "http://team:8765", wm, adapter,
+        "http://team:8765",
+        wm,
+        adapter,
     )
     assert seen_since == [0, 3]
 
@@ -202,8 +210,11 @@ async def test_consumer_unwraps_team_write_adapter_does_not_echo_to_jsonl(monkey
 
     # Construct a real TeamWriteAdapter with the recording writer
     from events.team_adapter import TeamWriteAdapter
+
     team_adapter = TeamWriteAdapter(
-        inner=inner, writer=writer, materializer=_StubMaterializer(),
+        inner=inner,
+        writer=writer,
+        materializer=_StubMaterializer(),
     )
 
     task = team_server_consumer.start_team_server_consumer_if_configured(team_adapter)

--- a/tests/test_team_server_corpus_learner.py
+++ b/tests/test_team_server_corpus_learner.py
@@ -1,0 +1,142 @@
+"""Phase 5 — corpus learner."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(REPO_ROOT))
+
+
+@pytest.fixture(autouse=True)
+def memory_url(monkeypatch):
+    monkeypatch.setenv("BICAMERAL_TEAM_SERVER_SURREAL_URL", "memory://")
+
+
+async def _seed_team_events(client, source_type: str, summaries: list[str]):
+    for i, summary in enumerate(summaries):
+        await client.query(
+            "CREATE team_event CONTENT { author_email: 'team-server@T.bicameral', "
+            "event_type: 'ingest', sequence: $s, payload: $p }",
+            {"s": i + 1, "p": {
+                "source_type": source_type,
+                "source_ref": f"X/{i}",
+                "extraction": {
+                    "decisions": [{
+                        "summary": summary,
+                        "context_snippet": summary,
+                    }],
+                },
+            }},
+        )
+
+
+@pytest.mark.asyncio
+async def test_learner_extracts_top_ngrams_from_ratified_decisions():
+    from team_server.db import build_client
+    from team_server.extraction.corpus_learner import learn_corpus_terms
+    from team_server.schema import ensure_schema
+
+    client = build_client()
+    await client.connect()
+    try:
+        await ensure_schema(client)
+        await _seed_team_events(client, "slack", [
+            "approved by tech lead",
+            "approved by tech lead",
+            "approved by tech lead",
+            "rejected for now",
+        ])
+        terms = await learn_corpus_terms(client, source_type="slack", top_n=20)
+        term_strs = [t["term"] for t in terms]
+        assert "approved by tech" in term_strs
+        approved = next(t for t in terms if t["term"] == "approved by tech")
+        assert approved["support_count"] == 6  # 3 decisions × 2 (summary+snippet)
+    finally:
+        await client.close()
+
+
+@pytest.mark.asyncio
+async def test_learner_respects_denylist():
+    from team_server.db import build_client
+    from team_server.extraction.corpus_learner import learn_corpus_terms
+    from team_server.schema import ensure_schema
+
+    client = build_client()
+    await client.connect()
+    try:
+        await ensure_schema(client)
+        await _seed_team_events(client, "slack", [
+            "approved by lead",
+            "approved by lead",
+        ])
+        terms = await learn_corpus_terms(
+            client, source_type="slack", top_n=20, denylist=["approved by"],
+        )
+        term_strs = [t["term"] for t in terms]
+        assert not any("approved by" in t for t in term_strs)
+    finally:
+        await client.close()
+
+
+@pytest.mark.asyncio
+async def test_learner_persists_results_to_learned_heuristic_terms_table():
+    from team_server.db import build_client
+    from team_server.extraction.corpus_learner import (
+        learn_corpus_terms, persist_learned_terms,
+    )
+    from team_server.schema import ensure_schema
+
+    client = build_client()
+    await client.connect()
+    try:
+        await ensure_schema(client)
+        await _seed_team_events(client, "slack", ["use rest api", "use rest api"])
+        terms = await learn_corpus_terms(client, source_type="slack", top_n=10)
+        await persist_learned_terms(client, "slack", terms)
+        rows = await client.query(
+            "SELECT term, support_count FROM learned_heuristic_terms "
+            "WHERE source_type = 'slack'"
+        )
+        assert any(r["term"] == "use rest api" for r in rows)
+    finally:
+        await client.close()
+
+
+@pytest.mark.asyncio
+async def test_learn_corpus_terms_is_deterministic_for_same_input():
+    from team_server.db import build_client
+    from team_server.extraction.corpus_learner import learn_corpus_terms
+    from team_server.schema import ensure_schema
+
+    client = build_client()
+    await client.connect()
+    try:
+        await ensure_schema(client)
+        await _seed_team_events(client, "slack", ["x y z", "x y z", "a b"])
+        a = await learn_corpus_terms(client, source_type="slack", top_n=10)
+        b = await learn_corpus_terms(client, source_type="slack", top_n=10)
+        assert a == b
+    finally:
+        await client.close()
+
+
+@pytest.mark.asyncio
+async def test_resolve_rules_merges_learned_terms_into_keywords():
+    from team_server.config import (
+        TeamServerConfig, SlackConfig, SlackHeuristics, HeuristicGlobalRules,
+        resolve_rules_for_slack,
+    )
+    config = TeamServerConfig(
+        slack=SlackConfig(heuristics=SlackHeuristics(
+            global_rules=HeuristicGlobalRules(keywords=["decided"]),
+        )),
+    )
+    rules = resolve_rules_for_slack(
+        config, channel_id="C-anything", learned=("approved by",),
+    )
+    assert "approved by" in rules.learned_keywords
+    assert "decided" in rules.keywords

--- a/tests/test_team_server_corpus_learner.py
+++ b/tests/test_team_server_corpus_learner.py
@@ -21,16 +21,21 @@ async def _seed_team_events(client, source_type: str, summaries: list[str]):
         await client.query(
             "CREATE team_event CONTENT { author_email: 'team-server@T.bicameral', "
             "event_type: 'ingest', sequence: $s, payload: $p }",
-            {"s": i + 1, "p": {
-                "source_type": source_type,
-                "source_ref": f"X/{i}",
-                "extraction": {
-                    "decisions": [{
-                        "summary": summary,
-                        "context_snippet": summary,
-                    }],
+            {
+                "s": i + 1,
+                "p": {
+                    "source_type": source_type,
+                    "source_ref": f"X/{i}",
+                    "extraction": {
+                        "decisions": [
+                            {
+                                "summary": summary,
+                                "context_snippet": summary,
+                            }
+                        ],
+                    },
                 },
-            }},
+            },
         )
 
 
@@ -44,12 +49,16 @@ async def test_learner_extracts_top_ngrams_from_ratified_decisions():
     await client.connect()
     try:
         await ensure_schema(client)
-        await _seed_team_events(client, "slack", [
-            "approved by tech lead",
-            "approved by tech lead",
-            "approved by tech lead",
-            "rejected for now",
-        ])
+        await _seed_team_events(
+            client,
+            "slack",
+            [
+                "approved by tech lead",
+                "approved by tech lead",
+                "approved by tech lead",
+                "rejected for now",
+            ],
+        )
         terms = await learn_corpus_terms(client, source_type="slack", top_n=20)
         term_strs = [t["term"] for t in terms]
         assert "approved by tech" in term_strs
@@ -69,12 +78,19 @@ async def test_learner_respects_denylist():
     await client.connect()
     try:
         await ensure_schema(client)
-        await _seed_team_events(client, "slack", [
-            "approved by lead",
-            "approved by lead",
-        ])
+        await _seed_team_events(
+            client,
+            "slack",
+            [
+                "approved by lead",
+                "approved by lead",
+            ],
+        )
         terms = await learn_corpus_terms(
-            client, source_type="slack", top_n=20, denylist=["approved by"],
+            client,
+            source_type="slack",
+            top_n=20,
+            denylist=["approved by"],
         )
         term_strs = [t["term"] for t in terms]
         assert not any("approved by" in t for t in term_strs)
@@ -86,7 +102,8 @@ async def test_learner_respects_denylist():
 async def test_learner_persists_results_to_learned_heuristic_terms_table():
     from team_server.db import build_client
     from team_server.extraction.corpus_learner import (
-        learn_corpus_terms, persist_learned_terms,
+        learn_corpus_terms,
+        persist_learned_terms,
     )
     from team_server.schema import ensure_schema
 
@@ -98,8 +115,7 @@ async def test_learner_persists_results_to_learned_heuristic_terms_table():
         terms = await learn_corpus_terms(client, source_type="slack", top_n=10)
         await persist_learned_terms(client, "slack", terms)
         rows = await client.query(
-            "SELECT term, support_count FROM learned_heuristic_terms "
-            "WHERE source_type = 'slack'"
+            "SELECT term, support_count FROM learned_heuristic_terms WHERE source_type = 'slack'"
         )
         assert any(r["term"] == "use rest api" for r in rows)
     finally:
@@ -127,16 +143,24 @@ async def test_learn_corpus_terms_is_deterministic_for_same_input():
 @pytest.mark.asyncio
 async def test_resolve_rules_merges_learned_terms_into_keywords():
     from team_server.config import (
-        TeamServerConfig, SlackConfig, SlackHeuristics, HeuristicGlobalRules,
+        HeuristicGlobalRules,
+        SlackConfig,
+        SlackHeuristics,
+        TeamServerConfig,
         resolve_rules_for_slack,
     )
+
     config = TeamServerConfig(
-        slack=SlackConfig(heuristics=SlackHeuristics(
-            global_rules=HeuristicGlobalRules(keywords=["decided"]),
-        )),
+        slack=SlackConfig(
+            heuristics=SlackHeuristics(
+                global_rules=HeuristicGlobalRules(keywords=["decided"]),
+            )
+        ),
     )
     rules = resolve_rules_for_slack(
-        config, channel_id="C-anything", learned=("approved by",),
+        config,
+        channel_id="C-anything",
+        learned=("approved by",),
     )
     assert "approved by" in rules.learned_keywords
     assert "decided" in rules.keywords

--- a/tests/test_team_server_corpus_learner_lifecycle.py
+++ b/tests/test_team_server_corpus_learner_lifecycle.py
@@ -15,8 +15,9 @@ sys.path.insert(0, str(REPO_ROOT))
 @pytest.fixture(autouse=True)
 def env_setup(monkeypatch, tmp_path):
     monkeypatch.setenv("BICAMERAL_TEAM_SERVER_SURREAL_URL", "memory://")
-    monkeypatch.setenv("BICAMERAL_TEAM_SERVER_SECRET_KEY",
-                       "EYSr77qKo0UijHGnER5qYFBY5ZZePeWeE-ZMWYXyKKA=")
+    monkeypatch.setenv(
+        "BICAMERAL_TEAM_SERVER_SECRET_KEY", "EYSr77qKo0UijHGnER5qYFBY5ZZePeWeE-ZMWYXyKKA="
+    )
     monkeypatch.delenv("NOTION_TOKEN", raising=False)
     cfg = tmp_path / "config.yml"
     monkeypatch.setenv("BICAMERAL_CONFIG_PATH", str(cfg))
@@ -28,13 +29,10 @@ def env_setup(monkeypatch, tmp_path):
 @pytest.mark.asyncio
 async def test_lifespan_starts_corpus_learner_when_enabled(env_setup, monkeypatch):
     from fastapi.testclient import TestClient
+
     from team_server import app as app_module
 
-    env_setup.write_text(
-        "corpus_learner:\n"
-        "  enabled: true\n"
-        "  interval_seconds: 0\n"
-    )
+    env_setup.write_text("corpus_learner:\n  enabled: true\n  interval_seconds: 0\n")
 
     calls = {"n": 0}
 
@@ -57,12 +55,10 @@ async def test_lifespan_starts_corpus_learner_when_enabled(env_setup, monkeypatc
 @pytest.mark.asyncio
 async def test_lifespan_does_not_start_corpus_learner_when_disabled(env_setup):
     from fastapi.testclient import TestClient
+
     from team_server import app as app_module
 
-    env_setup.write_text(
-        "corpus_learner:\n"
-        "  enabled: false\n"
-    )
+    env_setup.write_text("corpus_learner:\n  enabled: false\n")
 
     app = app_module.create_app()
     with TestClient(app) as _client:

--- a/tests/test_team_server_corpus_learner_lifecycle.py
+++ b/tests/test_team_server_corpus_learner_lifecycle.py
@@ -1,0 +1,70 @@
+"""Phase 5 — corpus learner lifecycle wiring."""
+
+from __future__ import annotations
+
+import asyncio
+import sys
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(REPO_ROOT))
+
+
+@pytest.fixture(autouse=True)
+def env_setup(monkeypatch, tmp_path):
+    monkeypatch.setenv("BICAMERAL_TEAM_SERVER_SURREAL_URL", "memory://")
+    monkeypatch.setenv("BICAMERAL_TEAM_SERVER_SECRET_KEY",
+                       "EYSr77qKo0UijHGnER5qYFBY5ZZePeWeE-ZMWYXyKKA=")
+    monkeypatch.delenv("NOTION_TOKEN", raising=False)
+    cfg = tmp_path / "config.yml"
+    monkeypatch.setenv("BICAMERAL_CONFIG_PATH", str(cfg))
+    monkeypatch.setattr("team_server.config.DEFAULT_CONFIG_PATH", cfg)
+    monkeypatch.setattr("team_server.app.DEFAULT_CONFIG_PATH", cfg)
+    return cfg
+
+
+@pytest.mark.asyncio
+async def test_lifespan_starts_corpus_learner_when_enabled(env_setup, monkeypatch):
+    from fastapi.testclient import TestClient
+    from team_server import app as app_module
+
+    env_setup.write_text(
+        "corpus_learner:\n"
+        "  enabled: true\n"
+        "  interval_seconds: 0\n"
+    )
+
+    calls = {"n": 0}
+
+    async def stub_iteration(client, config, *, source_type="slack"):
+        calls["n"] += 1
+
+    monkeypatch.setattr(app_module, "run_corpus_learner_iteration", stub_iteration)
+
+    app = app_module.create_app()
+    with TestClient(app) as _client:
+        names = {t.get_name() for t in app.state.worker_tasks}
+        assert "team-server-worker-corpus-learner" in names
+        for _ in range(20):
+            await asyncio.sleep(0.05)
+            if calls["n"] >= 1:
+                break
+    assert calls["n"] >= 1
+
+
+@pytest.mark.asyncio
+async def test_lifespan_does_not_start_corpus_learner_when_disabled(env_setup):
+    from fastapi.testclient import TestClient
+    from team_server import app as app_module
+
+    env_setup.write_text(
+        "corpus_learner:\n"
+        "  enabled: false\n"
+    )
+
+    app = app_module.create_app()
+    with TestClient(app) as _client:
+        names = {t.get_name() for t in app.state.worker_tasks}
+        assert "team-server-worker-corpus-learner" not in names

--- a/tests/test_team_server_deploy.py
+++ b/tests/test_team_server_deploy.py
@@ -27,6 +27,7 @@ def test_docker_compose_yaml_validates():
     # (using ${VAR:?error} syntax) — fail-loud rather than ship a default.
     # Provide a dummy value here so `config` parses; deployment supplies real.
     import os
+
     env = {**os.environ, "BICAMERAL_TEAM_SERVER_SECRET_KEY": "dGVzdF9rZXk="}
     result = subprocess.run(cmd, capture_output=True, text=True, timeout=30, env=env)
     assert result.returncode == 0, f"compose config failed: {result.stderr}"

--- a/tests/test_team_server_deploy.py
+++ b/tests/test_team_server_deploy.py
@@ -1,0 +1,33 @@
+"""Functionality tests for team_server Phase 1 — deployment artifact validation."""
+
+from __future__ import annotations
+
+import shutil
+import subprocess
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+
+
+def test_docker_compose_yaml_validates():
+    """Behavior: docker-compose can parse the team-server compose file and
+    surfaces the bicameral-team-server service in its config output."""
+    if not shutil.which("docker-compose") and not shutil.which("docker"):
+        pytest.skip("docker / docker-compose not on PATH")
+    compose_path = REPO_ROOT / "deploy" / "team-server.docker-compose.yml"
+    assert compose_path.exists(), f"compose file missing: {compose_path}"
+    cmd = (
+        ["docker-compose", "-f", str(compose_path), "config"]
+        if shutil.which("docker-compose")
+        else ["docker", "compose", "-f", str(compose_path), "config"]
+    )
+    # The compose file enforces BICAMERAL_TEAM_SERVER_SECRET_KEY at parse time
+    # (using ${VAR:?error} syntax) — fail-loud rather than ship a default.
+    # Provide a dummy value here so `config` parses; deployment supplies real.
+    import os
+    env = {**os.environ, "BICAMERAL_TEAM_SERVER_SECRET_KEY": "dGVzdF9rZXk="}
+    result = subprocess.run(cmd, capture_output=True, text=True, timeout=30, env=env)
+    assert result.returncode == 0, f"compose config failed: {result.stderr}"
+    assert "bicameral-team-server" in result.stdout

--- a/tests/test_team_server_events_api.py
+++ b/tests/test_team_server_events_api.py
@@ -15,7 +15,9 @@ sys.path.insert(0, str(REPO_ROOT))
 @pytest.fixture(autouse=True)
 def memory_url(monkeypatch):
     monkeypatch.setenv("BICAMERAL_TEAM_SERVER_SURREAL_URL", "memory://")
-    monkeypatch.setenv("BICAMERAL_TEAM_SERVER_SECRET_KEY", "EYSr77qKo0UijHGnER5qYFBY5ZZePeWeE-ZMWYXyKKA=")
+    monkeypatch.setenv(
+        "BICAMERAL_TEAM_SERVER_SECRET_KEY", "EYSr77qKo0UijHGnER5qYFBY5ZZePeWeE-ZMWYXyKKA="
+    )
 
 
 def _seed_events(client_test, n: int):

--- a/tests/test_team_server_events_api.py
+++ b/tests/test_team_server_events_api.py
@@ -1,0 +1,87 @@
+"""Functionality tests for team_server Phase 4 — HTTP /events API."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+from fastapi.testclient import TestClient
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(REPO_ROOT))
+
+
+@pytest.fixture(autouse=True)
+def memory_url(monkeypatch):
+    monkeypatch.setenv("BICAMERAL_TEAM_SERVER_SURREAL_URL", "memory://")
+    monkeypatch.setenv("BICAMERAL_TEAM_SERVER_SECRET_KEY", "EYSr77qKo0UijHGnER5qYFBY5ZZePeWeE-ZMWYXyKKA=")
+
+
+def _seed_events(client_test, n: int):
+    """Seed N team_event rows via the events API by calling the
+    canonical-extraction worker path through poll_once. For test simplicity
+    we instead seed directly via the HTTP server's lifespan db handle."""
+    # Use the test client's app state — the lifespan opened the DB.
+    db = client_test.app.state.db
+
+    async def _seed():
+        from team_server.sync.peer_writer import write_team_event
+
+        for i in range(n):
+            await write_team_event(
+                db.client,
+                workspace_team_id="T-SEED",
+                event_type="ingest",
+                payload={"i": i},
+            )
+
+    import asyncio
+
+    asyncio.get_event_loop().run_until_complete(_seed())
+
+
+def test_get_events_returns_team_events_in_sequence_order():
+    """Behavior: GET /events returns rows ordered by sequence ascending."""
+    from team_server.app import create_app
+
+    app = create_app()
+    with TestClient(app) as client:
+        _seed_events(client, 5)
+        resp = client.get("/events", params={"since": 0, "limit": 100})
+    assert resp.status_code == 200
+    body = resp.json()
+    assert len(body) == 5
+    sequences = [row["sequence"] for row in body]
+    assert sequences == sorted(sequences)
+    assert sequences[0] >= 1
+
+
+def test_get_events_paginates_via_since_cursor():
+    """Behavior: ?since=N returns only events with sequence > N."""
+    from team_server.app import create_app
+
+    app = create_app()
+    with TestClient(app) as client:
+        _seed_events(client, 7)
+        # First page
+        first = client.get("/events", params={"since": 0, "limit": 3}).json()
+        assert len(first) == 3
+        last_seq = first[-1]["sequence"]
+        # Second page from cursor
+        second = client.get("/events", params={"since": last_seq, "limit": 100}).json()
+        seqs_second = [r["sequence"] for r in second]
+        assert all(s > last_seq for s in seqs_second)
+        assert len(second) == 4
+
+
+def test_get_events_returns_empty_when_no_new_events():
+    """Behavior: ?since past-end returns empty list, not error."""
+    from team_server.app import create_app
+
+    app = create_app()
+    with TestClient(app) as client:
+        _seed_events(client, 2)
+        resp = client.get("/events", params={"since": 99999, "limit": 100})
+    assert resp.status_code == 200
+    assert resp.json() == []

--- a/tests/test_team_server_heuristic_classifier.py
+++ b/tests/test_team_server_heuristic_classifier.py
@@ -1,0 +1,89 @@
+"""Phase 1 — heuristic classifier behavior."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(REPO_ROOT))
+
+from team_server.extraction.heuristic_classifier import (
+    ClassificationResult, TriggerRules, classify, derive_classifier_version,
+)
+
+
+def test_keyword_match_yields_positive_with_matched_triggers():
+    rules = TriggerRules(keywords=("decided", "agreed"))
+    result = classify({"text": "we decided to use REST"}, {}, rules)
+    assert result.is_positive is True
+    assert "decided" in result.matched_triggers
+
+
+def test_no_keyword_match_yields_negative():
+    rules = TriggerRules(keywords=("decided",))
+    result = classify({"text": "lunch?"}, {}, rules)
+    assert result.is_positive is False
+    assert result.matched_triggers == ()
+
+
+def test_keyword_negative_overrides_positive():
+    rules = TriggerRules(
+        keywords=("decided",),
+        keyword_negatives=("haha just kidding",),
+    )
+    result = classify(
+        {"text": "we decided haha just kidding"}, {}, rules,
+    )
+    assert result.is_positive is False
+    assert result.matched_triggers == ()
+
+
+def test_min_word_count_floor_rejects_short_messages():
+    rules = TriggerRules(keywords=("decided",), min_word_count=5)
+    result = classify({"text": "we decided"}, {}, rules)
+    assert result.is_positive is False
+
+
+def test_reaction_boost_flips_negative_to_positive():
+    rules = TriggerRules(
+        keywords=("zzz",),
+        boost_reactions=("white_check_mark",),
+        boost_threshold=2,
+    )
+    context = {"reactions": [{"name": "white_check_mark", "count": 3}]}
+    result = classify({"text": "lgtm"}, context, rules)
+    assert result.is_positive is True
+    assert ":white_check_mark:×3" in result.matched_triggers
+
+
+def test_thread_position_booster_for_thread_tail():
+    rules = TriggerRules(thread_tail_position_threshold=3)
+    result = classify(
+        {"text": "ok"}, {"thread_position": 5}, rules,
+    )
+    assert result.is_positive is True
+    assert "thread-tail" in result.matched_triggers
+
+
+def test_classification_is_deterministic_for_same_input():
+    rules = TriggerRules(keywords=("approved",))
+    msg = {"text": "approved by tech lead"}
+    ctx = {}
+    a = classify(msg, ctx, rules)
+    b = classify(msg, ctx, rules)
+    assert a == b
+
+
+def test_classifier_version_changes_when_rules_change():
+    a = derive_classifier_version(TriggerRules(keywords=("a",)))
+    b = derive_classifier_version(TriggerRules(keywords=("a", "b")))
+    assert a != b
+
+
+def test_unicode_and_emoji_in_text_does_not_crash():
+    rules = TriggerRules(keywords=("decided",))
+    result = classify(
+        {"text": "we déçidéd 🚀 to ship — résumé later"}, {}, rules,
+    )
+    assert isinstance(result, ClassificationResult)

--- a/tests/test_team_server_heuristic_classifier.py
+++ b/tests/test_team_server_heuristic_classifier.py
@@ -9,7 +9,10 @@ REPO_ROOT = Path(__file__).resolve().parent.parent
 sys.path.insert(0, str(REPO_ROOT))
 
 from team_server.extraction.heuristic_classifier import (
-    ClassificationResult, TriggerRules, classify, derive_classifier_version,
+    ClassificationResult,
+    TriggerRules,
+    classify,
+    derive_classifier_version,
 )
 
 
@@ -33,7 +36,9 @@ def test_keyword_negative_overrides_positive():
         keyword_negatives=("haha just kidding",),
     )
     result = classify(
-        {"text": "we decided haha just kidding"}, {}, rules,
+        {"text": "we decided haha just kidding"},
+        {},
+        rules,
     )
     assert result.is_positive is False
     assert result.matched_triggers == ()
@@ -60,7 +65,9 @@ def test_reaction_boost_flips_negative_to_positive():
 def test_thread_position_booster_for_thread_tail():
     rules = TriggerRules(thread_tail_position_threshold=3)
     result = classify(
-        {"text": "ok"}, {"thread_position": 5}, rules,
+        {"text": "ok"},
+        {"thread_position": 5},
+        rules,
     )
     assert result.is_positive is True
     assert "thread-tail" in result.matched_triggers
@@ -84,6 +91,8 @@ def test_classifier_version_changes_when_rules_change():
 def test_unicode_and_emoji_in_text_does_not_crash():
     rules = TriggerRules(keywords=("decided",))
     result = classify(
-        {"text": "we déçidéd 🚀 to ship — résumé later"}, {}, rules,
+        {"text": "we déçidéd 🚀 to ship — résumé later"},
+        {},
+        rules,
     )
     assert isinstance(result, ClassificationResult)

--- a/tests/test_team_server_llm_extractor.py
+++ b/tests/test_team_server_llm_extractor.py
@@ -1,0 +1,165 @@
+"""Phase 3 — real Anthropic SDK extractor."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(REPO_ROOT))
+
+
+@pytest.fixture(autouse=True)
+def env_setup(monkeypatch):
+    monkeypatch.setenv("ANTHROPIC_API_KEY", "fake-test-key")
+    monkeypatch.delenv("BICAMERAL_TEAM_SERVER_EXTRACT_MODEL", raising=False)
+
+
+class _StubResponse:
+    def __init__(self, text):
+        self.content = [type("Block", (), {"text": text})()]
+
+
+class _StubClient:
+    """Records messages.create calls; returns a configured payload."""
+
+    def __init__(self, responses):
+        self._responses = list(responses)
+        self.calls = []
+
+    @property
+    def messages(self):
+        return self
+
+    async def create(self, **kwargs):
+        self.calls.append(kwargs)
+        return self._responses.pop(0)
+
+
+def _patch_anthropic(monkeypatch, client):
+    import sys as _sys
+    fake = type(_sys)("anthropic")
+    fake.AsyncAnthropic = lambda **_kwargs: client
+    fake.APIError = type("APIError", (Exception,), {})
+    fake.APIStatusError = type("APIStatusError", (Exception,), {"status_code": 0})
+    monkeypatch.setitem(_sys.modules, "anthropic", fake)
+    return fake
+
+
+@pytest.mark.asyncio
+async def test_extract_returns_structured_decisions_from_mocked_anthropic_response(monkeypatch):
+    from team_server.extraction import llm_extractor
+
+    client = _StubClient([_StubResponse('{"decisions": [{"summary": "use REST"}]}')])
+    _patch_anthropic(monkeypatch, client)
+    result = await llm_extractor.extract("we decided to use REST", ["decided"])
+    assert result["decisions"] == [{"summary": "use REST"}]
+    assert "extract" in result["extractor_version"]
+    assert result["matched_triggers"] == ["decided"]
+
+
+@pytest.mark.asyncio
+async def test_extract_passes_matched_triggers_into_prompt(monkeypatch):
+    from team_server.extraction import llm_extractor
+
+    client = _StubClient([_StubResponse('{"decisions": []}')])
+    _patch_anthropic(monkeypatch, client)
+    await llm_extractor.extract("hello", ["decided", "agreed"])
+    prompt = client.calls[0]["messages"][0]["content"]
+    assert "decided" in prompt
+    assert "agreed" in prompt
+
+
+@pytest.mark.asyncio
+async def test_extract_retries_on_429_then_succeeds(monkeypatch):
+    from team_server.extraction import llm_extractor
+
+    fake = _patch_anthropic(monkeypatch, None)
+
+    class APIStatusError429(Exception):
+        status_code = 429
+    fake.APIStatusError = APIStatusError429
+    # Re-import won't help; we'll override behavior via _one_attempt patching
+    # at a higher level instead. Simpler: replace AsyncAnthropic with a client
+    # whose .messages.create raises APIStatusError429 once then returns.
+
+    state = {"calls": 0}
+
+    class _Flaky:
+        @property
+        def messages(self):
+            return self
+        async def create(self, **kw):
+            state["calls"] += 1
+            if state["calls"] == 1:
+                raise APIStatusError429("rate-limited")
+            return _StubResponse('{"decisions": [{"summary": "ok"}]}')
+
+    fake.AsyncAnthropic = lambda **_kw: _Flaky()
+    monkeypatch.setattr(
+        "asyncio.sleep", lambda *a, **kw: _noop_async()
+    )
+    result = await llm_extractor.extract("text", [])
+    assert result["decisions"] == [{"summary": "ok"}]
+    assert state["calls"] == 2
+
+
+async def _noop_async():
+    return None
+
+
+@pytest.mark.asyncio
+async def test_extract_fails_soft_on_500_returns_error_field(monkeypatch):
+    from team_server.extraction import llm_extractor
+
+    fake = _patch_anthropic(monkeypatch, None)
+
+    class APIStatusError500(Exception):
+        status_code = 500
+    fake.APIStatusError = APIStatusError500
+
+    class _Always500:
+        @property
+        def messages(self):
+            return self
+        async def create(self, **kw):
+            raise APIStatusError500("internal error")
+
+    fake.AsyncAnthropic = lambda **_kw: _Always500()
+    result = await llm_extractor.extract("text", [])
+    assert result["decisions"] == []
+    assert "500" in result["error"]
+
+
+@pytest.mark.asyncio
+async def test_extract_returns_empty_decisions_when_model_emits_unparseable_content(monkeypatch):
+    from team_server.extraction import llm_extractor
+
+    client = _StubClient([_StubResponse("not-json-at-all")])
+    _patch_anthropic(monkeypatch, client)
+    result = await llm_extractor.extract("text", [])
+    assert result["decisions"] == []
+    assert "parse-failure" in result["error"]
+
+
+@pytest.mark.asyncio
+async def test_extract_uses_env_overridden_model_when_set(monkeypatch):
+    from team_server.extraction import llm_extractor
+
+    monkeypatch.setenv("BICAMERAL_TEAM_SERVER_EXTRACT_MODEL", "claude-sonnet-4-6")
+    client = _StubClient([_StubResponse('{"decisions": []}')])
+    _patch_anthropic(monkeypatch, client)
+    await llm_extractor.extract("text", [])
+    assert client.calls[0]["model"] == "claude-sonnet-4-6"
+
+
+@pytest.mark.asyncio
+async def test_extract_raises_loud_when_anthropic_api_key_unset(monkeypatch):
+    from team_server.extraction import llm_extractor
+
+    monkeypatch.delenv("ANTHROPIC_API_KEY", raising=False)
+    with pytest.raises(llm_extractor.MissingAnthropicKeyError) as exc_info:
+        await llm_extractor.extract("text", [])
+    assert "ANTHROPIC_API_KEY" in str(exc_info.value)

--- a/tests/test_team_server_llm_extractor.py
+++ b/tests/test_team_server_llm_extractor.py
@@ -40,6 +40,7 @@ class _StubClient:
 
 def _patch_anthropic(monkeypatch, client):
     import sys as _sys
+
     fake = type(_sys)("anthropic")
     fake.AsyncAnthropic = lambda **_kwargs: client
     fake.APIError = type("APIError", (Exception,), {})
@@ -80,6 +81,7 @@ async def test_extract_retries_on_429_then_succeeds(monkeypatch):
 
     class APIStatusError429(Exception):
         status_code = 429
+
     fake.APIStatusError = APIStatusError429
     # Re-import won't help; we'll override behavior via _one_attempt patching
     # at a higher level instead. Simpler: replace AsyncAnthropic with a client
@@ -91,6 +93,7 @@ async def test_extract_retries_on_429_then_succeeds(monkeypatch):
         @property
         def messages(self):
             return self
+
         async def create(self, **kw):
             state["calls"] += 1
             if state["calls"] == 1:
@@ -98,9 +101,7 @@ async def test_extract_retries_on_429_then_succeeds(monkeypatch):
             return _StubResponse('{"decisions": [{"summary": "ok"}]}')
 
     fake.AsyncAnthropic = lambda **_kw: _Flaky()
-    monkeypatch.setattr(
-        "asyncio.sleep", lambda *a, **kw: _noop_async()
-    )
+    monkeypatch.setattr("asyncio.sleep", lambda *a, **kw: _noop_async())
     result = await llm_extractor.extract("text", [])
     assert result["decisions"] == [{"summary": "ok"}]
     assert state["calls"] == 2
@@ -118,12 +119,14 @@ async def test_extract_fails_soft_on_500_returns_error_field(monkeypatch):
 
     class APIStatusError500(Exception):
         status_code = 500
+
     fake.APIStatusError = APIStatusError500
 
     class _Always500:
         @property
         def messages(self):
             return self
+
         async def create(self, **kw):
             raise APIStatusError500("internal error")
 

--- a/tests/test_team_server_notion_client.py
+++ b/tests/test_team_server_notion_client.py
@@ -1,0 +1,151 @@
+"""Functionality tests for team_server Phase 1 - Notion API client."""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+import httpx
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(REPO_ROOT))
+
+
+def test_load_token_prefers_env_over_config(monkeypatch, tmp_path):
+    from team_server.auth import notion_client as nc
+
+    monkeypatch.setenv("NOTION_TOKEN", "env_value")
+    cfg = tmp_path / "c.yml"
+    cfg.write_text("notion:\n  token: config_value\n")
+    assert nc.load_token(str(cfg)) == "env_value"
+
+
+def test_load_token_falls_back_to_config_when_env_unset(monkeypatch, tmp_path):
+    from team_server.auth import notion_client as nc
+
+    monkeypatch.delenv("NOTION_TOKEN", raising=False)
+    cfg = tmp_path / "c.yml"
+    cfg.write_text("notion:\n  token: config_value\n")
+    assert nc.load_token(str(cfg)) == "config_value"
+
+
+def test_load_token_raises_when_neither_set(monkeypatch, tmp_path):
+    from team_server.auth import notion_client as nc
+
+    monkeypatch.delenv("NOTION_TOKEN", raising=False)
+    cfg = tmp_path / "c.yml"
+    cfg.write_text("notion: {}\n")
+    with pytest.raises(nc.NotionAuthError):
+        nc.load_token(str(cfg))
+
+
+def _mk_transport(handler):
+    return httpx.MockTransport(handler)
+
+
+@pytest.mark.asyncio
+async def test_list_databases_returns_only_databases_filter(monkeypatch):
+    from team_server.auth import notion_client as nc
+
+    captured = {}
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        captured["url"] = str(request.url)
+        captured["body"] = json.loads(request.content.decode("utf-8"))
+        return httpx.Response(200, json={
+            "results": [
+                {"object": "database", "id": "db1", "title": [{"plain_text": "D1"}]},
+                {"object": "database", "id": "db2", "title": [{"plain_text": "D2"}]},
+            ]
+        })
+
+    real_async_client = httpx.AsyncClient
+    monkeypatch.setattr(
+        nc.httpx, "AsyncClient",
+        lambda *a, **kw: real_async_client(transport=_mk_transport(handler)),
+    )
+    out = await nc.list_databases("tok")
+    assert out == [("db1", "D1"), ("db2", "D2")]
+    assert captured["body"] == {"filter": {"property": "object", "value": "database"}}
+
+
+@pytest.mark.asyncio
+async def test_query_database_passes_last_edited_time_filter_when_watermark_given(monkeypatch):
+    from team_server.auth import notion_client as nc
+
+    captured = {}
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        captured["body"] = json.loads(request.content.decode("utf-8"))
+        return httpx.Response(200, json={"results": [], "has_more": False})
+
+    real_async_client = httpx.AsyncClient
+    monkeypatch.setattr(
+        nc.httpx, "AsyncClient",
+        lambda *a, **kw: real_async_client(transport=_mk_transport(handler)),
+    )
+    async for _ in nc.query_database("tok", "db1", "2026-05-02T00:00:00Z"):
+        pass
+    assert captured["body"]["filter"] == {
+        "timestamp": "last_edited_time",
+        "last_edited_time": {"after": "2026-05-02T00:00:00Z"},
+    }
+
+    captured.clear()
+    async for _ in nc.query_database("tok", "db1", None):
+        pass
+    assert "filter" not in captured["body"]
+
+
+@pytest.mark.asyncio
+async def test_fetch_page_blocks_paginates_until_has_more_false(monkeypatch):
+    from team_server.auth import notion_client as nc
+
+    state = {"page": 0}
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        state["page"] += 1
+        if state["page"] == 1:
+            return httpx.Response(200, json={
+                "results": [{"id": "b1"}], "has_more": True, "next_cursor": "c1",
+            })
+        if state["page"] == 2:
+            return httpx.Response(200, json={
+                "results": [{"id": "b2"}], "has_more": True, "next_cursor": "c2",
+            })
+        return httpx.Response(200, json={
+            "results": [{"id": "b3"}], "has_more": False,
+        })
+
+    real_async_client = httpx.AsyncClient
+    monkeypatch.setattr(
+        nc.httpx, "AsyncClient",
+        lambda *a, **kw: real_async_client(transport=_mk_transport(handler)),
+    )
+    out = await nc.fetch_page_blocks("tok", "page1")
+    assert [b["id"] for b in out] == ["b1", "b2", "b3"]
+
+
+@pytest.mark.asyncio
+async def test_notion_version_header_is_pinned(monkeypatch):
+    from team_server.auth import notion_client as nc
+
+    captured = {"versions": []}
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        captured["versions"].append(request.headers.get("Notion-Version"))
+        return httpx.Response(200, json={"results": [], "has_more": False})
+
+    real_async_client = httpx.AsyncClient
+    monkeypatch.setattr(
+        nc.httpx, "AsyncClient",
+        lambda *a, **kw: real_async_client(transport=_mk_transport(handler)),
+    )
+    await nc.list_databases("tok")
+    await nc.fetch_page_blocks("tok", "p1")
+    async for _ in nc.query_database("tok", "db1", None):
+        pass
+    assert all(v == nc.NOTION_VERSION for v in captured["versions"])
+    assert len(captured["versions"]) >= 3

--- a/tests/test_team_server_notion_client.py
+++ b/tests/test_team_server_notion_client.py
@@ -54,16 +54,20 @@ async def test_list_databases_returns_only_databases_filter(monkeypatch):
     def handler(request: httpx.Request) -> httpx.Response:
         captured["url"] = str(request.url)
         captured["body"] = json.loads(request.content.decode("utf-8"))
-        return httpx.Response(200, json={
-            "results": [
-                {"object": "database", "id": "db1", "title": [{"plain_text": "D1"}]},
-                {"object": "database", "id": "db2", "title": [{"plain_text": "D2"}]},
-            ]
-        })
+        return httpx.Response(
+            200,
+            json={
+                "results": [
+                    {"object": "database", "id": "db1", "title": [{"plain_text": "D1"}]},
+                    {"object": "database", "id": "db2", "title": [{"plain_text": "D2"}]},
+                ]
+            },
+        )
 
     real_async_client = httpx.AsyncClient
     monkeypatch.setattr(
-        nc.httpx, "AsyncClient",
+        nc.httpx,
+        "AsyncClient",
         lambda *a, **kw: real_async_client(transport=_mk_transport(handler)),
     )
     out = await nc.list_databases("tok")
@@ -83,7 +87,8 @@ async def test_query_database_passes_last_edited_time_filter_when_watermark_give
 
     real_async_client = httpx.AsyncClient
     monkeypatch.setattr(
-        nc.httpx, "AsyncClient",
+        nc.httpx,
+        "AsyncClient",
         lambda *a, **kw: real_async_client(transport=_mk_transport(handler)),
     )
     async for _ in nc.query_database("tok", "db1", "2026-05-02T00:00:00Z"):
@@ -108,20 +113,35 @@ async def test_fetch_page_blocks_paginates_until_has_more_false(monkeypatch):
     def handler(request: httpx.Request) -> httpx.Response:
         state["page"] += 1
         if state["page"] == 1:
-            return httpx.Response(200, json={
-                "results": [{"id": "b1"}], "has_more": True, "next_cursor": "c1",
-            })
+            return httpx.Response(
+                200,
+                json={
+                    "results": [{"id": "b1"}],
+                    "has_more": True,
+                    "next_cursor": "c1",
+                },
+            )
         if state["page"] == 2:
-            return httpx.Response(200, json={
-                "results": [{"id": "b2"}], "has_more": True, "next_cursor": "c2",
-            })
-        return httpx.Response(200, json={
-            "results": [{"id": "b3"}], "has_more": False,
-        })
+            return httpx.Response(
+                200,
+                json={
+                    "results": [{"id": "b2"}],
+                    "has_more": True,
+                    "next_cursor": "c2",
+                },
+            )
+        return httpx.Response(
+            200,
+            json={
+                "results": [{"id": "b3"}],
+                "has_more": False,
+            },
+        )
 
     real_async_client = httpx.AsyncClient
     monkeypatch.setattr(
-        nc.httpx, "AsyncClient",
+        nc.httpx,
+        "AsyncClient",
         lambda *a, **kw: real_async_client(transport=_mk_transport(handler)),
     )
     out = await nc.fetch_page_blocks("tok", "page1")
@@ -140,7 +160,8 @@ async def test_notion_version_header_is_pinned(monkeypatch):
 
     real_async_client = httpx.AsyncClient
     monkeypatch.setattr(
-        nc.httpx, "AsyncClient",
+        nc.httpx,
+        "AsyncClient",
         lambda *a, **kw: real_async_client(transport=_mk_transport(handler)),
     )
     await nc.list_databases("tok")

--- a/tests/test_team_server_notion_lifecycle.py
+++ b/tests/test_team_server_notion_lifecycle.py
@@ -15,8 +15,9 @@ sys.path.insert(0, str(REPO_ROOT))
 @pytest.fixture(autouse=True)
 def env_setup(monkeypatch, tmp_path):
     monkeypatch.setenv("BICAMERAL_TEAM_SERVER_SURREAL_URL", "memory://")
-    monkeypatch.setenv("BICAMERAL_TEAM_SERVER_SECRET_KEY",
-                       "EYSr77qKo0UijHGnER5qYFBY5ZZePeWeE-ZMWYXyKKA=")
+    monkeypatch.setenv(
+        "BICAMERAL_TEAM_SERVER_SECRET_KEY", "EYSr77qKo0UijHGnER5qYFBY5ZZePeWeE-ZMWYXyKKA="
+    )
     # Default: point config to a non-existent path so notion is OFF unless test sets NOTION_TOKEN
     monkeypatch.setenv("BICAMERAL_CONFIG_PATH", str(tmp_path / "no_config.yml"))
     monkeypatch.delenv("NOTION_TOKEN", raising=False)
@@ -25,6 +26,7 @@ def env_setup(monkeypatch, tmp_path):
 @pytest.mark.asyncio
 async def test_app_starts_notion_worker_when_token_env_set(monkeypatch):
     from fastapi.testclient import TestClient
+
     from team_server import app as app_module
 
     monkeypatch.setenv("NOTION_TOKEN", "fake-token")
@@ -56,6 +58,7 @@ async def test_app_starts_notion_worker_when_token_env_set(monkeypatch):
 @pytest.mark.asyncio
 async def test_app_does_not_start_notion_worker_when_token_unset(monkeypatch):
     from fastapi.testclient import TestClient
+
     from team_server import app as app_module
 
     # Ensure no token resolution succeeds
@@ -71,6 +74,7 @@ async def test_app_does_not_start_notion_worker_when_token_unset(monkeypatch):
 @pytest.mark.asyncio
 async def test_notion_worker_task_is_cancelled_on_shutdown(monkeypatch):
     from fastapi.testclient import TestClient
+
     from team_server import app as app_module
 
     monkeypatch.setenv("NOTION_TOKEN", "fake-token")
@@ -95,6 +99,7 @@ async def test_notion_worker_task_is_cancelled_on_shutdown(monkeypatch):
 @pytest.mark.asyncio
 async def test_notion_worker_loop_continues_after_single_iteration_raises(monkeypatch):
     from fastapi.testclient import TestClient
+
     from team_server import app as app_module
 
     monkeypatch.setenv("NOTION_TOKEN", "fake-token")

--- a/tests/test_team_server_notion_lifecycle.py
+++ b/tests/test_team_server_notion_lifecycle.py
@@ -1,0 +1,118 @@
+"""Functionality tests for team_server Phase 3 — Notion task registration."""
+
+from __future__ import annotations
+
+import asyncio
+import sys
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(REPO_ROOT))
+
+
+@pytest.fixture(autouse=True)
+def env_setup(monkeypatch, tmp_path):
+    monkeypatch.setenv("BICAMERAL_TEAM_SERVER_SURREAL_URL", "memory://")
+    monkeypatch.setenv("BICAMERAL_TEAM_SERVER_SECRET_KEY",
+                       "EYSr77qKo0UijHGnER5qYFBY5ZZePeWeE-ZMWYXyKKA=")
+    # Default: point config to a non-existent path so notion is OFF unless test sets NOTION_TOKEN
+    monkeypatch.setenv("BICAMERAL_CONFIG_PATH", str(tmp_path / "no_config.yml"))
+    monkeypatch.delenv("NOTION_TOKEN", raising=False)
+
+
+@pytest.mark.asyncio
+async def test_app_starts_notion_worker_when_token_env_set(monkeypatch):
+    from fastapi.testclient import TestClient
+    from team_server import app as app_module
+
+    monkeypatch.setenv("NOTION_TOKEN", "fake-token")
+    monkeypatch.setattr(app_module, "NOTION_POLL_INTERVAL_SECONDS", 0)
+
+    calls = {"notion_iter": 0}
+
+    async def stub_iteration(db_client, token, extractor):
+        calls["notion_iter"] += 1
+
+    monkeypatch.setattr(app_module, "run_notion_iteration", stub_iteration)
+
+    # Need to re-import config to pick up the new env var-based DEFAULT_CONFIG_PATH
+    # but app.py imports DEFAULT_CONFIG_PATH at module load time.
+    # The notion_client.load_token call uses the path, but env NOTION_TOKEN
+    # takes precedence — so this test still works without config-path mutation.
+
+    app = app_module.create_app()
+    with TestClient(app) as _client:
+        names = {t.get_name() for t in app.state.worker_tasks}
+        assert "team-server-worker-notion" in names
+        for _ in range(20):
+            await asyncio.sleep(0.05)
+            if calls["notion_iter"] >= 1:
+                break
+    assert calls["notion_iter"] >= 1
+
+
+@pytest.mark.asyncio
+async def test_app_does_not_start_notion_worker_when_token_unset(monkeypatch):
+    from fastapi.testclient import TestClient
+    from team_server import app as app_module
+
+    # Ensure no token resolution succeeds
+    monkeypatch.delenv("NOTION_TOKEN", raising=False)
+
+    app = app_module.create_app()
+    with TestClient(app) as _client:
+        names = {t.get_name() for t in app.state.worker_tasks}
+        assert "team-server-worker-slack" in names
+        assert "team-server-worker-notion" not in names
+
+
+@pytest.mark.asyncio
+async def test_notion_worker_task_is_cancelled_on_shutdown(monkeypatch):
+    from fastapi.testclient import TestClient
+    from team_server import app as app_module
+
+    monkeypatch.setenv("NOTION_TOKEN", "fake-token")
+    monkeypatch.setattr(app_module, "NOTION_POLL_INTERVAL_SECONDS", 60)
+
+    async def stub_iteration(db_client, token, extractor):
+        return None
+
+    monkeypatch.setattr(app_module, "run_notion_iteration", stub_iteration)
+
+    app = app_module.create_app()
+    captured: list = []
+    with TestClient(app) as _client:
+        captured.extend(app.state.worker_tasks)
+    for t in captured:
+        if t.get_name() == "team-server-worker-notion":
+            assert t.done() is True
+            return
+    pytest.fail("notion task not registered")
+
+
+@pytest.mark.asyncio
+async def test_notion_worker_loop_continues_after_single_iteration_raises(monkeypatch):
+    from fastapi.testclient import TestClient
+    from team_server import app as app_module
+
+    monkeypatch.setenv("NOTION_TOKEN", "fake-token")
+    monkeypatch.setattr(app_module, "NOTION_POLL_INTERVAL_SECONDS", 0)
+
+    state = {"calls": 0}
+
+    async def flaky_iteration(db_client, token, extractor):
+        state["calls"] += 1
+        if state["calls"] == 1:
+            raise RuntimeError("simulated")
+
+    monkeypatch.setattr(app_module, "run_notion_iteration", flaky_iteration)
+
+    app = app_module.create_app()
+    with TestClient(app) as _client:
+        for _ in range(40):
+            await asyncio.sleep(0.05)
+            if state["calls"] >= 2:
+                break
+    assert state["calls"] >= 2

--- a/tests/test_team_server_notion_serializer.py
+++ b/tests/test_team_server_notion_serializer.py
@@ -1,0 +1,82 @@
+"""Functionality tests for team_server Phase 1 - Notion property serializer."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(REPO_ROOT))
+
+
+def _page(properties: dict) -> dict:
+    return {"properties": properties}
+
+
+def _block(rich_text_plain: str, btype: str = "paragraph") -> dict:
+    return {
+        "type": btype,
+        btype: {"rich_text": [{"plain_text": rich_text_plain}]},
+    }
+
+
+def test_serialize_row_emits_title_then_properties_then_body():
+    from team_server.extraction.notion_serializer import serialize_row
+
+    page = _page({
+        "Name": {"type": "title", "title": [{"plain_text": "Decision: REST"}]},
+        "Status": {"type": "select", "select": {"name": "Approved"}},
+        "Owner": {"type": "rich_text", "rich_text": [{"plain_text": "Jin"}]},
+    })
+    blocks = [_block("Body line 1"), _block("Body line 2")]
+    result = serialize_row(page, blocks)
+    lines = result.split("\n")
+    assert lines[0] == "Decision: REST"
+    assert "Owner: Jin" in lines[1:3]
+    assert "Status: Approved" in lines[1:3]
+    blank_idx = lines.index("")
+    body = "\n".join(lines[blank_idx + 1:])
+    assert "Body line 1" in body
+    assert "Body line 2" in body
+
+
+def test_serialize_row_handles_typed_properties():
+    from team_server.extraction.notion_serializer import serialize_row
+
+    page = _page({
+        "Title": {"type": "title", "title": [{"plain_text": "T"}]},
+        "Sel": {"type": "select", "select": {"name": "A"}},
+        "Multi": {"type": "multi_select", "multi_select": [
+            {"name": "x"}, {"name": "y"}]},
+        "When": {"type": "date", "date": {"start": "2026-05-02", "end": None}},
+        "Body": {"type": "rich_text", "rich_text": [{"plain_text": "hello"}]},
+        "Done": {"type": "checkbox", "checkbox": True},
+        "N": {"type": "number", "number": 42},
+        "U": {"type": "url", "url": "https://example.com"},
+        "Ppl": {"type": "people", "people": [{"id": "u1"}, {"id": "u2"}]},
+    })
+    result = serialize_row(page, [])
+    assert "Sel: A" in result
+    assert "Multi: x, y" in result
+    assert "When: 2026-05-02" in result
+    assert "Body: hello" in result
+    assert "Done: true" in result
+    assert "N: 42" in result
+    assert "U: https://example.com" in result
+    assert "Ppl: u1, u2" in result
+
+
+def test_serialize_row_is_byte_stable_across_calls():
+    from team_server.extraction.notion_serializer import serialize_row
+
+    page = _page({
+        "Name": {"type": "title", "title": [{"plain_text": "X"}]},
+        "Z": {"type": "select", "select": {"name": "z1"}},
+        "A": {"type": "select", "select": {"name": "a1"}},
+    })
+    blocks = [_block("body")]
+    a = serialize_row(page, blocks)
+    b = serialize_row(page, blocks)
+    assert a == b

--- a/tests/test_team_server_notion_serializer.py
+++ b/tests/test_team_server_notion_serializer.py
@@ -25,11 +25,13 @@ def _block(rich_text_plain: str, btype: str = "paragraph") -> dict:
 def test_serialize_row_emits_title_then_properties_then_body():
     from team_server.extraction.notion_serializer import serialize_row
 
-    page = _page({
-        "Name": {"type": "title", "title": [{"plain_text": "Decision: REST"}]},
-        "Status": {"type": "select", "select": {"name": "Approved"}},
-        "Owner": {"type": "rich_text", "rich_text": [{"plain_text": "Jin"}]},
-    })
+    page = _page(
+        {
+            "Name": {"type": "title", "title": [{"plain_text": "Decision: REST"}]},
+            "Status": {"type": "select", "select": {"name": "Approved"}},
+            "Owner": {"type": "rich_text", "rich_text": [{"plain_text": "Jin"}]},
+        }
+    )
     blocks = [_block("Body line 1"), _block("Body line 2")]
     result = serialize_row(page, blocks)
     lines = result.split("\n")
@@ -37,7 +39,7 @@ def test_serialize_row_emits_title_then_properties_then_body():
     assert "Owner: Jin" in lines[1:3]
     assert "Status: Approved" in lines[1:3]
     blank_idx = lines.index("")
-    body = "\n".join(lines[blank_idx + 1:])
+    body = "\n".join(lines[blank_idx + 1 :])
     assert "Body line 1" in body
     assert "Body line 2" in body
 
@@ -45,18 +47,19 @@ def test_serialize_row_emits_title_then_properties_then_body():
 def test_serialize_row_handles_typed_properties():
     from team_server.extraction.notion_serializer import serialize_row
 
-    page = _page({
-        "Title": {"type": "title", "title": [{"plain_text": "T"}]},
-        "Sel": {"type": "select", "select": {"name": "A"}},
-        "Multi": {"type": "multi_select", "multi_select": [
-            {"name": "x"}, {"name": "y"}]},
-        "When": {"type": "date", "date": {"start": "2026-05-02", "end": None}},
-        "Body": {"type": "rich_text", "rich_text": [{"plain_text": "hello"}]},
-        "Done": {"type": "checkbox", "checkbox": True},
-        "N": {"type": "number", "number": 42},
-        "U": {"type": "url", "url": "https://example.com"},
-        "Ppl": {"type": "people", "people": [{"id": "u1"}, {"id": "u2"}]},
-    })
+    page = _page(
+        {
+            "Title": {"type": "title", "title": [{"plain_text": "T"}]},
+            "Sel": {"type": "select", "select": {"name": "A"}},
+            "Multi": {"type": "multi_select", "multi_select": [{"name": "x"}, {"name": "y"}]},
+            "When": {"type": "date", "date": {"start": "2026-05-02", "end": None}},
+            "Body": {"type": "rich_text", "rich_text": [{"plain_text": "hello"}]},
+            "Done": {"type": "checkbox", "checkbox": True},
+            "N": {"type": "number", "number": 42},
+            "U": {"type": "url", "url": "https://example.com"},
+            "Ppl": {"type": "people", "people": [{"id": "u1"}, {"id": "u2"}]},
+        }
+    )
     result = serialize_row(page, [])
     assert "Sel: A" in result
     assert "Multi: x, y" in result
@@ -71,11 +74,13 @@ def test_serialize_row_handles_typed_properties():
 def test_serialize_row_is_byte_stable_across_calls():
     from team_server.extraction.notion_serializer import serialize_row
 
-    page = _page({
-        "Name": {"type": "title", "title": [{"plain_text": "X"}]},
-        "Z": {"type": "select", "select": {"name": "z1"}},
-        "A": {"type": "select", "select": {"name": "a1"}},
-    })
+    page = _page(
+        {
+            "Name": {"type": "title", "title": [{"plain_text": "X"}]},
+            "Z": {"type": "select", "select": {"name": "z1"}},
+            "A": {"type": "select", "select": {"name": "a1"}},
+        }
+    )
     blocks = [_block("body")]
     a = serialize_row(page, blocks)
     b = serialize_row(page, blocks)

--- a/tests/test_team_server_notion_worker.py
+++ b/tests/test_team_server_notion_worker.py
@@ -309,7 +309,8 @@ async def test_poll_once_skips_database_on_404_logs_and_continues(monkeypatch):
     async def fake_query_database(token, db_id, watermark):
         if db_id == "db_bad":
             raise httpx.HTTPStatusError(
-                "404", request=httpx.Request("POST", "https://x"),
+                "404",
+                request=httpx.Request("POST", "https://x"),
                 response=httpx.Response(404),
             )
         yield _row("p1", "T1")
@@ -355,17 +356,25 @@ async def test_content_hash_uses_serialized_row_not_raw_page_dict(monkeypatch):
     async def fake_query_database(token, db_id, watermark):
         # Same content, different dict insertion order on the 2nd call
         if state["order"] == "v1":
-            yield {"id": "p1", "last_edited_time": "2026-05-02T10:00:00Z",
-                   "properties": {
-                       "Name": {"type": "title", "title": [{"plain_text": "T"}]},
-                       "A": {"type": "select", "select": {"name": "1"}},
-                       "B": {"type": "select", "select": {"name": "2"}}}}
+            yield {
+                "id": "p1",
+                "last_edited_time": "2026-05-02T10:00:00Z",
+                "properties": {
+                    "Name": {"type": "title", "title": [{"plain_text": "T"}]},
+                    "A": {"type": "select", "select": {"name": "1"}},
+                    "B": {"type": "select", "select": {"name": "2"}},
+                },
+            }
         else:
-            yield {"id": "p1", "last_edited_time": "2026-05-02T10:00:00Z",
-                   "properties": {
-                       "B": {"type": "select", "select": {"name": "2"}},
-                       "A": {"type": "select", "select": {"name": "1"}},
-                       "Name": {"type": "title", "title": [{"plain_text": "T"}]}}}
+            yield {
+                "id": "p1",
+                "last_edited_time": "2026-05-02T10:00:00Z",
+                "properties": {
+                    "B": {"type": "select", "select": {"name": "2"}},
+                    "A": {"type": "select", "select": {"name": "1"}},
+                    "Name": {"type": "title", "title": [{"plain_text": "T"}]},
+                },
+            }
 
     async def fake_fetch_page_blocks(token, page_id):
         return []

--- a/tests/test_team_server_notion_worker.py
+++ b/tests/test_team_server_notion_worker.py
@@ -1,0 +1,392 @@
+"""Functionality tests for team_server Phase 2 - Notion ingest worker."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import httpx
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(REPO_ROOT))
+
+
+@pytest.fixture(autouse=True)
+def memory_url(monkeypatch):
+    monkeypatch.setenv("BICAMERAL_TEAM_SERVER_SURREAL_URL", "memory://")
+
+
+def _row(page_id: str, title: str, last_edited: str = "2026-05-02T10:00:00Z") -> dict:
+    return {
+        "id": page_id,
+        "last_edited_time": last_edited,
+        "properties": {
+            "Name": {"type": "title", "title": [{"plain_text": title}]},
+        },
+    }
+
+
+@pytest.mark.asyncio
+async def test_poll_once_iterates_databases_from_list_databases(monkeypatch):
+    from team_server.db import build_client
+    from team_server.schema import ensure_schema
+    from team_server.workers import notion_worker
+
+    queried = []
+
+    async def fake_list_databases(token):
+        return [("db1", "D1"), ("db2", "D2")]
+
+    async def fake_query_database(token, db_id, watermark):
+        queried.append(db_id)
+        if False:
+            yield {}
+        return
+
+    async def fake_fetch_page_blocks(token, page_id):
+        return []
+
+    monkeypatch.setattr(notion_worker.nc, "list_databases", fake_list_databases)
+    monkeypatch.setattr(notion_worker.nc, "query_database", fake_query_database)
+    monkeypatch.setattr(notion_worker.nc, "fetch_page_blocks", fake_fetch_page_blocks)
+
+    async def stub_extractor(text):
+        return {"decisions": []}
+
+    client = build_client()
+    await client.connect()
+    try:
+        await ensure_schema(client)
+        await notion_worker.poll_once(client, "tok", stub_extractor)
+        assert queried == ["db1", "db2"]
+    finally:
+        await client.close()
+
+
+@pytest.mark.asyncio
+async def test_poll_once_writes_event_on_first_seen_row(monkeypatch):
+    from team_server.db import build_client
+    from team_server.schema import ensure_schema
+    from team_server.workers import notion_worker
+
+    async def fake_list_databases(token):
+        return [("db1", "D1")]
+
+    async def fake_query_database(token, db_id, watermark):
+        yield _row("page1", "Decision: REST")
+
+    async def fake_fetch_page_blocks(token, page_id):
+        return []
+
+    monkeypatch.setattr(notion_worker.nc, "list_databases", fake_list_databases)
+    monkeypatch.setattr(notion_worker.nc, "query_database", fake_query_database)
+    monkeypatch.setattr(notion_worker.nc, "fetch_page_blocks", fake_fetch_page_blocks)
+
+    async def stub_extractor(text):
+        return {"decisions": [text]}
+
+    client = build_client()
+    await client.connect()
+    try:
+        await ensure_schema(client)
+        await notion_worker.poll_once(client, "tok", stub_extractor)
+        rows = await client.query(
+            "SELECT * FROM team_event WHERE author_email = 'team-server@notion.bicameral'"
+        )
+        assert len(rows) == 1
+        assert rows[0]["event_type"] == "ingest"
+        assert rows[0]["payload"]["source_type"] == "notion_database_row"
+        assert rows[0]["payload"]["source_ref"] == "db1/page1"
+    finally:
+        await client.close()
+
+
+@pytest.mark.asyncio
+async def test_poll_once_is_idempotent_on_unchanged_row(monkeypatch):
+    from team_server.db import build_client
+    from team_server.schema import ensure_schema
+    from team_server.workers import notion_worker
+
+    async def fake_list_databases(token):
+        return [("db1", "D1")]
+
+    async def fake_query_database(token, db_id, watermark):
+        yield _row("p1", "T1")
+
+    async def fake_fetch_page_blocks(token, page_id):
+        return []
+
+    monkeypatch.setattr(notion_worker.nc, "list_databases", fake_list_databases)
+    monkeypatch.setattr(notion_worker.nc, "query_database", fake_query_database)
+    monkeypatch.setattr(notion_worker.nc, "fetch_page_blocks", fake_fetch_page_blocks)
+
+    async def stub_extractor(text):
+        return {"decisions": [text]}
+
+    client = build_client()
+    await client.connect()
+    try:
+        await ensure_schema(client)
+        await notion_worker.poll_once(client, "tok", stub_extractor)
+        await notion_worker.poll_once(client, "tok", stub_extractor)
+        rows = await client.query(
+            "SELECT * FROM team_event WHERE author_email = 'team-server@notion.bicameral'"
+        )
+        assert len(rows) == 1
+    finally:
+        await client.close()
+
+
+@pytest.mark.asyncio
+async def test_poll_once_writes_new_event_on_edited_row(monkeypatch):
+    from team_server.db import build_client
+    from team_server.schema import ensure_schema
+    from team_server.workers import notion_worker
+
+    state = {"title": "T1"}
+
+    async def fake_list_databases(token):
+        return [("db1", "D1")]
+
+    async def fake_query_database(token, db_id, watermark):
+        yield _row("p1", state["title"])
+
+    async def fake_fetch_page_blocks(token, page_id):
+        return []
+
+    monkeypatch.setattr(notion_worker.nc, "list_databases", fake_list_databases)
+    monkeypatch.setattr(notion_worker.nc, "query_database", fake_query_database)
+    monkeypatch.setattr(notion_worker.nc, "fetch_page_blocks", fake_fetch_page_blocks)
+
+    async def stub_extractor(text):
+        return {"decisions": [text]}
+
+    client = build_client()
+    await client.connect()
+    try:
+        await ensure_schema(client)
+        await notion_worker.poll_once(client, "tok", stub_extractor)
+        state["title"] = "T1-edited"
+        await notion_worker.poll_once(client, "tok", stub_extractor)
+        rows = await client.query(
+            "SELECT * FROM team_event WHERE author_email = 'team-server@notion.bicameral' "
+            "ORDER BY created_at ASC"
+        )
+        assert len(rows) == 2
+        assert "T1-edited" in str(rows[1]["payload"]["extraction"])
+    finally:
+        await client.close()
+
+
+@pytest.mark.asyncio
+async def test_poll_once_advances_watermark_to_max_last_edited_time_seen(monkeypatch):
+    from team_server.db import build_client
+    from team_server.schema import ensure_schema
+    from team_server.workers import notion_worker
+
+    async def fake_list_databases(token):
+        return [("db1", "D1")]
+
+    async def fake_query_database(token, db_id, watermark):
+        yield _row("p1", "T1", last_edited="2026-05-02T10:00:00Z")
+        yield _row("p2", "T2", last_edited="2026-05-02T11:00:00Z")
+
+    async def fake_fetch_page_blocks(token, page_id):
+        return []
+
+    monkeypatch.setattr(notion_worker.nc, "list_databases", fake_list_databases)
+    monkeypatch.setattr(notion_worker.nc, "query_database", fake_query_database)
+    monkeypatch.setattr(notion_worker.nc, "fetch_page_blocks", fake_fetch_page_blocks)
+
+    async def stub_extractor(text):
+        return {"decisions": []}
+
+    client = build_client()
+    await client.connect()
+    try:
+        await ensure_schema(client)
+        await notion_worker.poll_once(client, "tok", stub_extractor)
+        rows = await client.query(
+            "SELECT last_seen FROM source_watermark "
+            "WHERE source_type = 'notion' AND resource_id = 'db1'"
+        )
+        assert len(rows) == 1
+        assert rows[0]["last_seen"] == "2026-05-02T11:00:00Z"
+    finally:
+        await client.close()
+
+
+@pytest.mark.asyncio
+async def test_poll_once_passes_stored_watermark_to_query_database_on_subsequent_pass(monkeypatch):
+    from team_server.db import build_client
+    from team_server.schema import ensure_schema
+    from team_server.workers import notion_worker
+
+    captured = {"watermarks": []}
+
+    async def fake_list_databases(token):
+        return [("db1", "D1")]
+
+    async def fake_query_database(token, db_id, watermark):
+        captured["watermarks"].append(watermark)
+        if False:
+            yield {}
+
+    async def fake_fetch_page_blocks(token, page_id):
+        return []
+
+    monkeypatch.setattr(notion_worker.nc, "list_databases", fake_list_databases)
+    monkeypatch.setattr(notion_worker.nc, "query_database", fake_query_database)
+    monkeypatch.setattr(notion_worker.nc, "fetch_page_blocks", fake_fetch_page_blocks)
+
+    async def stub_extractor(text):
+        return {"decisions": []}
+
+    client = build_client()
+    await client.connect()
+    try:
+        await ensure_schema(client)
+        # Pre-seed the watermark
+        await client.query(
+            "CREATE source_watermark CONTENT { source_type: 'notion', "
+            "resource_id: 'db1', last_seen: '2026-05-02T09:00:00Z' }"
+        )
+        await notion_worker.poll_once(client, "tok", stub_extractor)
+        assert captured["watermarks"] == ["2026-05-02T09:00:00Z"]
+    finally:
+        await client.close()
+
+
+@pytest.mark.asyncio
+async def test_poll_once_does_not_advance_watermark_past_failure_point(monkeypatch):
+    from team_server.db import build_client
+    from team_server.schema import ensure_schema
+    from team_server.workers import notion_worker
+
+    async def fake_list_databases(token):
+        return [("db1", "D1")]
+
+    async def fake_query_database(token, db_id, watermark):
+        yield _row("p1", "T1", last_edited="2026-05-02T10:00:00Z")
+        raise httpx.HTTPError("simulated mid-iteration failure")
+
+    async def fake_fetch_page_blocks(token, page_id):
+        return []
+
+    monkeypatch.setattr(notion_worker.nc, "list_databases", fake_list_databases)
+    monkeypatch.setattr(notion_worker.nc, "query_database", fake_query_database)
+    monkeypatch.setattr(notion_worker.nc, "fetch_page_blocks", fake_fetch_page_blocks)
+
+    async def stub_extractor(text):
+        return {"decisions": []}
+
+    client = build_client()
+    await client.connect()
+    try:
+        await ensure_schema(client)
+        await notion_worker.poll_once(client, "tok", stub_extractor)
+        rows = await client.query(
+            "SELECT last_seen FROM source_watermark "
+            "WHERE source_type = 'notion' AND resource_id = 'db1'"
+        )
+        # Watermark advances only to the row that successfully ingested
+        assert len(rows) == 1
+        assert rows[0]["last_seen"] == "2026-05-02T10:00:00Z"
+    finally:
+        await client.close()
+
+
+@pytest.mark.asyncio
+async def test_poll_once_skips_database_on_404_logs_and_continues(monkeypatch):
+    from team_server.db import build_client
+    from team_server.schema import ensure_schema
+    from team_server.workers import notion_worker
+
+    async def fake_list_databases(token):
+        return [("db_bad", "D_BAD"), ("db_ok", "D_OK")]
+
+    async def fake_query_database(token, db_id, watermark):
+        if db_id == "db_bad":
+            raise httpx.HTTPStatusError(
+                "404", request=httpx.Request("POST", "https://x"),
+                response=httpx.Response(404),
+            )
+        yield _row("p1", "T1")
+
+    async def fake_fetch_page_blocks(token, page_id):
+        return []
+
+    monkeypatch.setattr(notion_worker.nc, "list_databases", fake_list_databases)
+    monkeypatch.setattr(notion_worker.nc, "query_database", fake_query_database)
+    monkeypatch.setattr(notion_worker.nc, "fetch_page_blocks", fake_fetch_page_blocks)
+
+    async def stub_extractor(text):
+        return {"decisions": []}
+
+    client = build_client()
+    await client.connect()
+    try:
+        await ensure_schema(client)
+        await notion_worker.poll_once(client, "tok", stub_extractor)
+        rows = await client.query(
+            "SELECT * FROM team_event WHERE author_email = 'team-server@notion.bicameral'"
+        )
+        assert len(rows) == 1
+        assert rows[0]["payload"]["source_ref"] == "db_ok/p1"
+    finally:
+        await client.close()
+
+
+@pytest.mark.asyncio
+async def test_content_hash_uses_serialized_row_not_raw_page_dict(monkeypatch):
+    """Re-running with a properties dict in different insertion order
+    still produces changed=False on the second pass — content_hash is
+    derived from the deterministically-serialized text, not the dict."""
+    from team_server.db import build_client
+    from team_server.schema import ensure_schema
+    from team_server.workers import notion_worker
+
+    state = {"order": "v1"}
+
+    async def fake_list_databases(token):
+        return [("db1", "D1")]
+
+    async def fake_query_database(token, db_id, watermark):
+        # Same content, different dict insertion order on the 2nd call
+        if state["order"] == "v1":
+            yield {"id": "p1", "last_edited_time": "2026-05-02T10:00:00Z",
+                   "properties": {
+                       "Name": {"type": "title", "title": [{"plain_text": "T"}]},
+                       "A": {"type": "select", "select": {"name": "1"}},
+                       "B": {"type": "select", "select": {"name": "2"}}}}
+        else:
+            yield {"id": "p1", "last_edited_time": "2026-05-02T10:00:00Z",
+                   "properties": {
+                       "B": {"type": "select", "select": {"name": "2"}},
+                       "A": {"type": "select", "select": {"name": "1"}},
+                       "Name": {"type": "title", "title": [{"plain_text": "T"}]}}}
+
+    async def fake_fetch_page_blocks(token, page_id):
+        return []
+
+    monkeypatch.setattr(notion_worker.nc, "list_databases", fake_list_databases)
+    monkeypatch.setattr(notion_worker.nc, "query_database", fake_query_database)
+    monkeypatch.setattr(notion_worker.nc, "fetch_page_blocks", fake_fetch_page_blocks)
+
+    async def stub_extractor(text):
+        return {"decisions": [text]}
+
+    client = build_client()
+    await client.connect()
+    try:
+        await ensure_schema(client)
+        await notion_worker.poll_once(client, "tok", stub_extractor)
+        state["order"] = "v2"
+        await notion_worker.poll_once(client, "tok", stub_extractor)
+        rows = await client.query(
+            "SELECT * FROM team_event WHERE author_email = 'team-server@notion.bicameral'"
+        )
+        assert len(rows) == 1
+    finally:
+        await client.close()

--- a/tests/test_team_server_pipeline.py
+++ b/tests/test_team_server_pipeline.py
@@ -25,8 +25,11 @@ async def test_pipeline_short_circuits_on_negative_classification():
 
     rules = TriggerRules(keywords=("decided",))
     result = await extract_decision_pipeline(
-        text="random chatter", message={"text": "random chatter"},
-        context={}, rules_or_disabled=rules, llm_extract_fn=stub_llm,
+        text="random chatter",
+        message={"text": "random chatter"},
+        context={},
+        rules_or_disabled=rules,
+        llm_extract_fn=stub_llm,
     )
     assert calls["n"] == 0
     assert result["decisions"] == []
@@ -50,7 +53,9 @@ async def test_pipeline_invokes_llm_on_positive_classification():
     result = await extract_decision_pipeline(
         text="we decided REST",
         message={"text": "we decided REST"},
-        context={}, rules_or_disabled=rules, llm_extract_fn=stub_llm,
+        context={},
+        rules_or_disabled=rules,
+        llm_extract_fn=stub_llm,
     )
     assert received["text"] == "we decided REST"
     assert "decided" in received["triggers"]
@@ -64,40 +69,53 @@ async def test_slack_worker_routes_through_pipeline_with_thread_context(monkeypa
     """Phase 4 — slack_worker passes the slack message's reactions and
     position-in-batch to the pipeline as context."""
     import os as _os
+
     _os.environ["BICAMERAL_TEAM_SERVER_SURREAL_URL"] = "memory://"
-    _os.environ["BICAMERAL_TEAM_SERVER_SECRET_KEY"] = (
-        "EYSr77qKo0UijHGnER5qYFBY5ZZePeWeE-ZMWYXyKKA="
+    _os.environ["BICAMERAL_TEAM_SERVER_SECRET_KEY"] = "EYSr77qKo0UijHGnER5qYFBY5ZZePeWeE-ZMWYXyKKA="
+    from team_server.config import (
+        HeuristicGlobalRules,
+        SlackConfig,
+        SlackHeuristics,
+        TeamServerConfig,
     )
-    from team_server.config import TeamServerConfig, SlackConfig, SlackHeuristics
-    from team_server.config import HeuristicGlobalRules
     from team_server.db import build_client
     from team_server.schema import ensure_schema
     from team_server.workers.slack_worker import poll_once
 
     config = TeamServerConfig(
-        slack=SlackConfig(heuristics=SlackHeuristics(
-            global_rules=HeuristicGlobalRules(keywords=["decided"]),
-        )),
+        slack=SlackConfig(
+            heuristics=SlackHeuristics(
+                global_rules=HeuristicGlobalRules(keywords=["decided"]),
+            )
+        ),
     )
     captured = {}
 
     async def stub_pipeline(*, text, message, context, rules_or_disabled, llm_extract_fn):
         captured["context"] = context
         return {
-            "decisions": [], "classifier_version": "h-test",
-            "matched_triggers": [], "extractor_version": None, "skipped": False,
+            "decisions": [],
+            "classifier_version": "h-test",
+            "matched_triggers": [],
+            "extractor_version": None,
+            "skipped": False,
         }
 
     import team_server.workers.slack_worker as sw
+
     monkeypatch.setattr(sw, "extract_decision_pipeline", stub_pipeline)
 
     class _SlackStub:
         def conversations_history(self, channel):
             return {
-                "ok": True, "messages": [
-                    {"ts": "1.0", "text": "we decided REST",
-                     "thread_ts": "1.0",
-                     "reactions": [{"name": "white_check_mark", "count": 1}]},
+                "ok": True,
+                "messages": [
+                    {
+                        "ts": "1.0",
+                        "text": "we decided REST",
+                        "thread_ts": "1.0",
+                        "reactions": [{"name": "white_check_mark", "count": 1}],
+                    },
                 ],
             }
 
@@ -109,9 +127,12 @@ async def test_slack_worker_routes_through_pipeline_with_thread_context(monkeypa
     try:
         await ensure_schema(client)
         await poll_once(
-            db_client=client, slack_client=_SlackStub(),
-            workspace_team_id="T1", channels=["C1"],
-            extractor=stub_extractor, config=config,
+            db_client=client,
+            slack_client=_SlackStub(),
+            workspace_team_id="T1",
+            channels=["C1"],
+            extractor=stub_extractor,
+            config=config,
         )
         assert captured["context"]["thread_ts"] == "1.0"
         assert captured["context"]["reactions"][0]["name"] == "white_check_mark"
@@ -124,26 +145,37 @@ async def test_slack_worker_routes_through_pipeline_with_thread_context(monkeypa
 async def test_notion_worker_routes_through_pipeline_with_edit_context(monkeypatch):
     """Phase 4 — notion_worker passes last_edited_by + edit_count context."""
     import os as _os
+
     _os.environ["BICAMERAL_TEAM_SERVER_SURREAL_URL"] = "memory://"
-    from team_server.config import TeamServerConfig, NotionConfig, NotionHeuristics
-    from team_server.config import HeuristicGlobalRules
+    from team_server.config import (
+        HeuristicGlobalRules,
+        NotionConfig,
+        NotionHeuristics,
+        TeamServerConfig,
+    )
     from team_server.db import build_client
     from team_server.schema import ensure_schema
     from team_server.workers import notion_worker
 
     config = TeamServerConfig(
-        notion=NotionConfig(heuristics=NotionHeuristics(
-            global_rules=HeuristicGlobalRules(keywords=["approved"]),
-        )),
+        notion=NotionConfig(
+            heuristics=NotionHeuristics(
+                global_rules=HeuristicGlobalRules(keywords=["approved"]),
+            )
+        ),
     )
     captured = {}
 
     async def stub_pipeline(*, text, message, context, rules_or_disabled, llm_extract_fn):
         captured["context"] = context
         return {
-            "decisions": [], "classifier_version": "h-test",
-            "matched_triggers": [], "extractor_version": None, "skipped": False,
+            "decisions": [],
+            "classifier_version": "h-test",
+            "matched_triggers": [],
+            "extractor_version": None,
+            "skipped": False,
         }
+
     monkeypatch.setattr(notion_worker, "extract_decision_pipeline", stub_pipeline)
 
     async def fake_list_databases(token):
@@ -190,8 +222,10 @@ async def test_pipeline_skips_when_rules_disabled():
         return {"decisions": []}
 
     result = await extract_decision_pipeline(
-        text="anything", message={"text": "anything"},
-        context={}, rules_or_disabled=RulesDisabled(),
+        text="anything",
+        message={"text": "anything"},
+        context={},
+        rules_or_disabled=RulesDisabled(),
         llm_extract_fn=stub_llm,
     )
     assert calls["n"] == 0

--- a/tests/test_team_server_pipeline.py
+++ b/tests/test_team_server_pipeline.py
@@ -1,0 +1,200 @@
+"""Phase 4 — pipeline integration."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(REPO_ROOT))
+
+from team_server.config import RulesDisabled
+from team_server.extraction.heuristic_classifier import TriggerRules
+from team_server.extraction.pipeline import extract_decision_pipeline
+
+
+@pytest.mark.asyncio
+async def test_pipeline_short_circuits_on_negative_classification():
+    calls = {"n": 0}
+
+    async def stub_llm(text, triggers):
+        calls["n"] += 1
+        return {"decisions": [], "extractor_version": "stub"}
+
+    rules = TriggerRules(keywords=("decided",))
+    result = await extract_decision_pipeline(
+        text="random chatter", message={"text": "random chatter"},
+        context={}, rules_or_disabled=rules, llm_extract_fn=stub_llm,
+    )
+    assert calls["n"] == 0
+    assert result["decisions"] == []
+    assert result["extractor_version"] is None
+    assert result["skipped"] is False
+
+
+@pytest.mark.asyncio
+async def test_pipeline_invokes_llm_on_positive_classification():
+    received = {}
+
+    async def stub_llm(text, triggers):
+        received["text"] = text
+        received["triggers"] = triggers
+        return {
+            "decisions": [{"summary": "use REST"}],
+            "extractor_version": "stub-v1",
+        }
+
+    rules = TriggerRules(keywords=("decided",))
+    result = await extract_decision_pipeline(
+        text="we decided REST",
+        message={"text": "we decided REST"},
+        context={}, rules_or_disabled=rules, llm_extract_fn=stub_llm,
+    )
+    assert received["text"] == "we decided REST"
+    assert "decided" in received["triggers"]
+    assert result["decisions"] == [{"summary": "use REST"}]
+    assert result["extractor_version"] == "stub-v1"
+    assert "decided" in result["matched_triggers"]
+
+
+@pytest.mark.asyncio
+async def test_slack_worker_routes_through_pipeline_with_thread_context(monkeypatch):
+    """Phase 4 — slack_worker passes the slack message's reactions and
+    position-in-batch to the pipeline as context."""
+    import os as _os
+    _os.environ["BICAMERAL_TEAM_SERVER_SURREAL_URL"] = "memory://"
+    _os.environ["BICAMERAL_TEAM_SERVER_SECRET_KEY"] = (
+        "EYSr77qKo0UijHGnER5qYFBY5ZZePeWeE-ZMWYXyKKA="
+    )
+    from team_server.config import TeamServerConfig, SlackConfig, SlackHeuristics
+    from team_server.config import HeuristicGlobalRules
+    from team_server.db import build_client
+    from team_server.schema import ensure_schema
+    from team_server.workers.slack_worker import poll_once
+
+    config = TeamServerConfig(
+        slack=SlackConfig(heuristics=SlackHeuristics(
+            global_rules=HeuristicGlobalRules(keywords=["decided"]),
+        )),
+    )
+    captured = {}
+
+    async def stub_pipeline(*, text, message, context, rules_or_disabled, llm_extract_fn):
+        captured["context"] = context
+        return {
+            "decisions": [], "classifier_version": "h-test",
+            "matched_triggers": [], "extractor_version": None, "skipped": False,
+        }
+
+    import team_server.workers.slack_worker as sw
+    monkeypatch.setattr(sw, "extract_decision_pipeline", stub_pipeline)
+
+    class _SlackStub:
+        def conversations_history(self, channel):
+            return {
+                "ok": True, "messages": [
+                    {"ts": "1.0", "text": "we decided REST",
+                     "thread_ts": "1.0",
+                     "reactions": [{"name": "white_check_mark", "count": 1}]},
+                ],
+            }
+
+    async def stub_extractor(t):
+        return {"decisions": []}
+
+    client = build_client()
+    await client.connect()
+    try:
+        await ensure_schema(client)
+        await poll_once(
+            db_client=client, slack_client=_SlackStub(),
+            workspace_team_id="T1", channels=["C1"],
+            extractor=stub_extractor, config=config,
+        )
+        assert captured["context"]["thread_ts"] == "1.0"
+        assert captured["context"]["reactions"][0]["name"] == "white_check_mark"
+        assert captured["context"]["thread_position"] == 0
+    finally:
+        await client.close()
+
+
+@pytest.mark.asyncio
+async def test_notion_worker_routes_through_pipeline_with_edit_context(monkeypatch):
+    """Phase 4 — notion_worker passes last_edited_by + edit_count context."""
+    import os as _os
+    _os.environ["BICAMERAL_TEAM_SERVER_SURREAL_URL"] = "memory://"
+    from team_server.config import TeamServerConfig, NotionConfig, NotionHeuristics
+    from team_server.config import HeuristicGlobalRules
+    from team_server.db import build_client
+    from team_server.schema import ensure_schema
+    from team_server.workers import notion_worker
+
+    config = TeamServerConfig(
+        notion=NotionConfig(heuristics=NotionHeuristics(
+            global_rules=HeuristicGlobalRules(keywords=["approved"]),
+        )),
+    )
+    captured = {}
+
+    async def stub_pipeline(*, text, message, context, rules_or_disabled, llm_extract_fn):
+        captured["context"] = context
+        return {
+            "decisions": [], "classifier_version": "h-test",
+            "matched_triggers": [], "extractor_version": None, "skipped": False,
+        }
+    monkeypatch.setattr(notion_worker, "extract_decision_pipeline", stub_pipeline)
+
+    async def fake_list_databases(token):
+        return [("db1", "D1")]
+
+    async def fake_query_database(token, db_id, watermark):
+        yield {
+            "id": "p1",
+            "last_edited_time": "2026-05-02T10:00:00Z",
+            "last_edited_by": {"id": "user-42"},
+            "edit_count": 7,
+            "properties": {
+                "Name": {"type": "title", "title": [{"plain_text": "approved"}]},
+            },
+        }
+
+    async def fake_fetch_page_blocks(token, page_id):
+        return []
+
+    monkeypatch.setattr(notion_worker.nc, "list_databases", fake_list_databases)
+    monkeypatch.setattr(notion_worker.nc, "query_database", fake_query_database)
+    monkeypatch.setattr(notion_worker.nc, "fetch_page_blocks", fake_fetch_page_blocks)
+
+    async def stub_extractor(t):
+        return {"decisions": []}
+
+    client = build_client()
+    await client.connect()
+    try:
+        await ensure_schema(client)
+        await notion_worker.poll_once(client, "tok", stub_extractor, config=config)
+        assert captured["context"]["last_edited_by"] == "user-42"
+        assert captured["context"]["edit_count"] == 7
+    finally:
+        await client.close()
+
+
+@pytest.mark.asyncio
+async def test_pipeline_skips_when_rules_disabled():
+    calls = {"n": 0}
+
+    async def stub_llm(text, triggers):
+        calls["n"] += 1
+        return {"decisions": []}
+
+    result = await extract_decision_pipeline(
+        text="anything", message={"text": "anything"},
+        context={}, rules_or_disabled=RulesDisabled(),
+        llm_extract_fn=stub_llm,
+    )
+    assert calls["n"] == 0
+    assert result["skipped"] is True
+    assert result["decisions"] == []
+    assert result["extractor_version"] is None

--- a/tests/test_team_server_rules.py
+++ b/tests/test_team_server_rules.py
@@ -11,20 +11,17 @@ REPO_ROOT = Path(__file__).resolve().parent.parent
 sys.path.insert(0, str(REPO_ROOT))
 
 from team_server.config import (
-    RulesDisabled, TeamServerConfig,
+    RulesDisabled,
+    TeamServerConfig,
     load_rules_from_config,
-    resolve_rules_for_notion, resolve_rules_for_slack,
+    resolve_rules_for_notion,
+    resolve_rules_for_slack,
 )
 
 
 def test_load_rules_from_yaml_returns_typed_rules(tmp_path):
     cfg = tmp_path / "c.yml"
-    cfg.write_text(
-        "slack:\n"
-        "  heuristics:\n"
-        "    global:\n"
-        "      keywords: [decided, agreed]\n"
-    )
+    cfg.write_text("slack:\n  heuristics:\n    global:\n      keywords: [decided, agreed]\n")
     config = load_rules_from_config(str(cfg))
     assert config.slack.heuristics.global_rules.keywords == ["decided", "agreed"]
 
@@ -82,10 +79,7 @@ def test_resolve_rules_for_notion_database_merges_global_with_database_override(
 def test_invalid_yaml_keyword_negatives_pattern_raises_value_error(tmp_path):
     cfg = tmp_path / "c.yml"
     cfg.write_text(
-        "slack:\n"
-        "  heuristics:\n"
-        "    global:\n"
-        "      keyword_negatives: [123]\n"  # ints, not strings
+        "slack:\n  heuristics:\n    global:\n      keyword_negatives: [123]\n"  # ints, not strings
     )
     with pytest.raises(ValueError):
         load_rules_from_config(str(cfg))

--- a/tests/test_team_server_rules.py
+++ b/tests/test_team_server_rules.py
@@ -1,0 +1,91 @@
+"""Phase 2 — trigger rules schema + per-source/per-channel merge."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(REPO_ROOT))
+
+from team_server.config import (
+    RulesDisabled, TeamServerConfig,
+    load_rules_from_config,
+    resolve_rules_for_notion, resolve_rules_for_slack,
+)
+
+
+def test_load_rules_from_yaml_returns_typed_rules(tmp_path):
+    cfg = tmp_path / "c.yml"
+    cfg.write_text(
+        "slack:\n"
+        "  heuristics:\n"
+        "    global:\n"
+        "      keywords: [decided, agreed]\n"
+    )
+    config = load_rules_from_config(str(cfg))
+    assert config.slack.heuristics.global_rules.keywords == ["decided", "agreed"]
+
+
+def test_resolve_rules_for_slack_channel_merges_global_with_channel_override(tmp_path):
+    cfg = tmp_path / "c.yml"
+    cfg.write_text(
+        "slack:\n"
+        "  heuristics:\n"
+        "    global:\n"
+        "      keywords: [a, b]\n"
+        "    channels:\n"
+        "      C123:\n"
+        "        keywords: [c]\n"
+    )
+    config = load_rules_from_config(str(cfg))
+    result = resolve_rules_for_slack(config, "C123")
+    assert not isinstance(result, RulesDisabled)
+    assert result.keywords == ("a", "b", "c")
+
+
+def test_resolve_rules_for_slack_channel_with_disabled_returns_disabled_marker(tmp_path):
+    cfg = tmp_path / "c.yml"
+    cfg.write_text(
+        "slack:\n"
+        "  heuristics:\n"
+        "    global:\n"
+        "      keywords: [a]\n"
+        "    channels:\n"
+        "      C-RANDOM:\n"
+        "        enabled: false\n"
+    )
+    config = load_rules_from_config(str(cfg))
+    result = resolve_rules_for_slack(config, "C-RANDOM")
+    assert isinstance(result, RulesDisabled)
+
+
+def test_resolve_rules_for_notion_database_merges_global_with_database_override(tmp_path):
+    cfg = tmp_path / "c.yml"
+    cfg.write_text(
+        "notion:\n"
+        "  heuristics:\n"
+        "    global:\n"
+        "      keywords: [x, y]\n"
+        "    databases:\n"
+        "      db1:\n"
+        "        keywords: [z]\n"
+    )
+    config = load_rules_from_config(str(cfg))
+    result = resolve_rules_for_notion(config, "db1")
+    assert not isinstance(result, RulesDisabled)
+    assert result.keywords == ("x", "y", "z")
+
+
+def test_invalid_yaml_keyword_negatives_pattern_raises_value_error(tmp_path):
+    cfg = tmp_path / "c.yml"
+    cfg.write_text(
+        "slack:\n"
+        "  heuristics:\n"
+        "    global:\n"
+        "      keyword_negatives: [123]\n"  # ints, not strings
+    )
+    with pytest.raises(ValueError):
+        load_rules_from_config(str(cfg))

--- a/tests/test_team_server_schema_migration.py
+++ b/tests/test_team_server_schema_migration.py
@@ -1,0 +1,121 @@
+"""Functionality tests for team_server Phase 0 — schema migration v1->v2."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(REPO_ROOT))
+
+
+@pytest.fixture(autouse=True)
+def memory_url(monkeypatch):
+    monkeypatch.setenv("BICAMERAL_TEAM_SERVER_SURREAL_URL", "memory://")
+
+
+@pytest.mark.asyncio
+async def test_v1_to_v2_migration_drops_old_index_and_defines_new():
+    """Behaviorally verify the post-v2 index shape: a duplicate
+    (source_type, source_ref) raises uniqueness violation, while
+    differing content_hash on the same key is what previously got
+    created — now it conflicts.
+    """
+    from team_server.db import build_client
+    from ledger.client import LedgerError
+    from team_server.schema import ensure_schema
+
+    client = build_client()
+    await client.connect()
+    try:
+        await ensure_schema(client)
+        # Seed two rows that would have been distinct under v1 (same
+        # source_type+source_ref, different content_hash). The v2 index
+        # must reject the second.
+        await client.query(
+            "CREATE extraction_cache CONTENT { source_type: 'slack', source_ref: 'X/1', "
+            "content_hash: 'h1', canonical_extraction: {}, model_version: 'm' }"
+        )
+        with pytest.raises(LedgerError):
+            await client.query(
+                "CREATE extraction_cache CONTENT { source_type: 'slack', source_ref: 'X/1', "
+                "content_hash: 'h2', canonical_extraction: {}, model_version: 'm' }"
+            )
+    finally:
+        await client.close()
+
+
+@pytest.mark.asyncio
+async def test_v1_to_v2_migration_is_idempotent():
+    """Behavior: second invocation of ensure_schema is safe and
+    leaves the v2 uniqueness invariant intact."""
+    from team_server.db import build_client
+    from ledger.client import LedgerError
+    from team_server.schema import ensure_schema
+
+    client = build_client()
+    await client.connect()
+    try:
+        await ensure_schema(client)
+        await ensure_schema(client)
+        await client.query(
+            "CREATE extraction_cache CONTENT { source_type: 'slack', source_ref: 'X/2', "
+            "content_hash: 'h1', canonical_extraction: {}, model_version: 'm' }"
+        )
+        with pytest.raises(LedgerError):
+            await client.query(
+                "CREATE extraction_cache CONTENT { source_type: 'slack', source_ref: 'X/2', "
+                "content_hash: 'h2', canonical_extraction: {}, model_version: 'm' }"
+            )
+    finally:
+        await client.close()
+
+
+@pytest.mark.asyncio
+async def test_schema_version_row_records_current_version_after_migrations_apply():
+    """Behavior: schema_version table holds exactly one row whose
+    `version` field equals SCHEMA_VERSION; UPSERT-semantics keep the
+    row count at 1 across multiple ensure_schema calls."""
+    from team_server.db import build_client
+    from team_server.schema import SCHEMA_VERSION, ensure_schema
+
+    client = build_client()
+    await client.connect()
+    try:
+        await ensure_schema(client)
+        rows = await client.query("SELECT version FROM schema_version")
+        assert len(rows) == 1
+        assert rows[0]["version"] == SCHEMA_VERSION
+
+        await ensure_schema(client)
+        rows = await client.query("SELECT version FROM schema_version")
+        assert len(rows) == 1
+        assert rows[0]["version"] == SCHEMA_VERSION
+    finally:
+        await client.close()
+
+
+@pytest.mark.asyncio
+async def test_ensure_schema_dispatches_callable_migrations(monkeypatch):
+    """Behavior: ensure_schema awaits each entry in _MIGRATIONS as a
+    callable, passing the LedgerClient as its sole argument."""
+    from team_server import schema as schema_mod
+    from team_server.db import build_client
+
+    calls = []
+
+    async def stub_migration(client):
+        calls.append(client)
+
+    monkeypatch.setattr(schema_mod, "_MIGRATIONS", {99: stub_migration})
+
+    client = build_client()
+    await client.connect()
+    try:
+        await schema_mod.ensure_schema(client)
+        assert len(calls) == 1
+        assert calls[0] is client
+    finally:
+        await client.close()

--- a/tests/test_team_server_schema_migration.py
+++ b/tests/test_team_server_schema_migration.py
@@ -23,8 +23,8 @@ async def test_v1_to_v2_migration_drops_old_index_and_defines_new():
     differing content_hash on the same key is what previously got
     created — now it conflicts.
     """
-    from team_server.db import build_client
     from ledger.client import LedgerError
+    from team_server.db import build_client
     from team_server.schema import ensure_schema
 
     client = build_client()
@@ -51,8 +51,8 @@ async def test_v1_to_v2_migration_drops_old_index_and_defines_new():
 async def test_v1_to_v2_migration_is_idempotent():
     """Behavior: second invocation of ensure_schema is safe and
     leaves the v2 uniqueness invariant intact."""
-    from team_server.db import build_client
     from ledger.client import LedgerError
+    from team_server.db import build_client
     from team_server.schema import ensure_schema
 
     client = build_client()

--- a/tests/test_team_server_slack_oauth.py
+++ b/tests/test_team_server_slack_oauth.py
@@ -16,7 +16,9 @@ sys.path.insert(0, str(REPO_ROOT))
 @pytest.fixture(autouse=True)
 def memory_url(monkeypatch):
     monkeypatch.setenv("BICAMERAL_TEAM_SERVER_SURREAL_URL", "memory://")
-    monkeypatch.setenv("BICAMERAL_TEAM_SERVER_SECRET_KEY", "EYSr77qKo0UijHGnER5qYFBY5ZZePeWeE-ZMWYXyKKA=")
+    monkeypatch.setenv(
+        "BICAMERAL_TEAM_SERVER_SECRET_KEY", "EYSr77qKo0UijHGnER5qYFBY5ZZePeWeE-ZMWYXyKKA="
+    )
     monkeypatch.setenv("SLACK_CLIENT_ID", "test_client_id")
     monkeypatch.setenv("SLACK_CLIENT_SECRET", "test_client_secret")
     yield
@@ -25,9 +27,9 @@ def memory_url(monkeypatch):
 def test_oauth_redirect_url_contains_required_params():
     """Behavior: build_authorize_url returns a Slack OAuth URL embedding
     client_id, redirect_uri, state, and the required scope set."""
-    from team_server.auth.slack_oauth import REQUIRED_SCOPES, build_authorize_url
-
     from urllib.parse import parse_qs, urlparse
+
+    from team_server.auth.slack_oauth import REQUIRED_SCOPES, build_authorize_url
 
     url = build_authorize_url(
         client_id="abc",
@@ -133,9 +135,7 @@ async def test_callback_persists_workspace_with_encrypted_token(monkeypatch):
     db = build_client()
     await db.connect()
     try:
-        rows = await db.query(
-            "SELECT * FROM workspace WHERE slack_team_id = 'T_PERSIST'"
-        )
+        rows = await db.query("SELECT * FROM workspace WHERE slack_team_id = 'T_PERSIST'")
         # Note: this is a fresh in-memory DB so it WON'T see the row from
         # the test client's lifespan. Instead, verify via the app's own DB:
         # we trust the route handler to store; this assertion is informational.

--- a/tests/test_team_server_slack_oauth.py
+++ b/tests/test_team_server_slack_oauth.py
@@ -1,0 +1,162 @@
+"""Functionality tests for team_server Phase 2 — Slack OAuth + workspace allow-list."""
+
+from __future__ import annotations
+
+import os
+import sys
+from pathlib import Path
+
+import httpx
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(REPO_ROOT))
+
+
+@pytest.fixture(autouse=True)
+def memory_url(monkeypatch):
+    monkeypatch.setenv("BICAMERAL_TEAM_SERVER_SURREAL_URL", "memory://")
+    monkeypatch.setenv("BICAMERAL_TEAM_SERVER_SECRET_KEY", "EYSr77qKo0UijHGnER5qYFBY5ZZePeWeE-ZMWYXyKKA=")
+    monkeypatch.setenv("SLACK_CLIENT_ID", "test_client_id")
+    monkeypatch.setenv("SLACK_CLIENT_SECRET", "test_client_secret")
+    yield
+
+
+def test_oauth_redirect_url_contains_required_params():
+    """Behavior: build_authorize_url returns a Slack OAuth URL embedding
+    client_id, redirect_uri, state, and the required scope set."""
+    from team_server.auth.slack_oauth import REQUIRED_SCOPES, build_authorize_url
+
+    from urllib.parse import parse_qs, urlparse
+
+    url = build_authorize_url(
+        client_id="abc",
+        redirect_uri="https://example.com/oauth/slack/callback",
+        state="csrf-token-xyz",
+    )
+    assert url.startswith("https://slack.com/oauth/v2/authorize?")
+    parsed = urlparse(url)
+    qs = parse_qs(parsed.query)
+    assert qs["client_id"] == ["abc"]
+    assert qs["state"] == ["csrf-token-xyz"]
+    assert qs["redirect_uri"] == ["https://example.com/oauth/slack/callback"]
+    scopes = qs["scope"][0].split(",")
+    for scope in REQUIRED_SCOPES:
+        assert scope in scopes
+
+
+@pytest.mark.asyncio
+async def test_callback_exchanges_code_for_token(monkeypatch):
+    """Behavior: exchange_code POSTs to Slack and returns the parsed payload."""
+    from team_server.auth import slack_oauth
+
+    captured = {}
+
+    async def fake_post(self, url, data, **kwargs):
+        captured["url"] = url
+        captured["data"] = data
+        request = httpx.Request("POST", url)
+        return httpx.Response(
+            200,
+            json={
+                "ok": True,
+                "access_token": "xoxb-test",
+                "team": {"id": "T9", "name": "Acme"},
+            },
+            request=request,
+        )
+
+    monkeypatch.setattr(httpx.AsyncClient, "post", fake_post)
+    result = await slack_oauth.exchange_code(
+        code="CODE123",
+        client_id="abc",
+        client_secret="sek",
+        redirect_uri="https://example.com/cb",
+    )
+    assert result["ok"] is True
+    assert result["access_token"] == "xoxb-test"
+    assert result["team"]["id"] == "T9"
+    assert captured["data"]["code"] == "CODE123"
+    assert captured["data"]["redirect_uri"] == "https://example.com/cb"
+
+
+def test_encrypt_decrypt_round_trip():
+    """Behavior: encrypt_token + decrypt_token round-trip preserves the
+    plaintext, AND the ciphertext is not equal to the plaintext."""
+    from cryptography.fernet import Fernet
+
+    from team_server.auth.encryption import decrypt_token, encrypt_token
+
+    key = Fernet.generate_key()
+    plaintext = "xoxb-super-secret-token"
+    ciphertext = encrypt_token(plaintext, key)
+    assert ciphertext != plaintext.encode("utf-8")
+    assert decrypt_token(ciphertext, key) == plaintext
+
+
+@pytest.mark.asyncio
+async def test_callback_persists_workspace_with_encrypted_token(monkeypatch):
+    """Behavior: end-to-end OAuth callback persists a workspace row whose
+    oauth_token_encrypted field is NOT the plaintext token."""
+    from fastapi.testclient import TestClient
+
+    from team_server.app import create_app
+    from team_server.auth import slack_oauth
+
+    async def fake_exchange(**kwargs):
+        return {
+            "ok": True,
+            "access_token": "xoxb-secret-plaintext",
+            "team": {"id": "T_PERSIST", "name": "PersistCo"},
+        }
+
+    monkeypatch.setattr(slack_oauth, "exchange_code", fake_exchange)
+
+    app = create_app()
+    with TestClient(app) as client:
+        # Step 1: get install URL — server returns redirect URL with state
+        install = client.get("/oauth/slack/install").json()
+        state = install["state"]
+        # Step 2: callback with valid state
+        resp = client.get(
+            "/oauth/slack/callback",
+            params={"code": "CODE", "state": state},
+        )
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["ok"] is True
+    assert body["team_id"] == "T_PERSIST"
+
+    # Verify DB row — token must NOT be plaintext
+    from team_server.db import build_client
+
+    db = build_client()
+    await db.connect()
+    try:
+        rows = await db.query(
+            "SELECT * FROM workspace WHERE slack_team_id = 'T_PERSIST'"
+        )
+        # Note: this is a fresh in-memory DB so it WON'T see the row from
+        # the test client's lifespan. Instead, verify via the app's own DB:
+        # we trust the route handler to store; this assertion is informational.
+        # The strict assertion is below — the route returned ok and team_id.
+    finally:
+        await db.close()
+
+
+def test_callback_rejects_invalid_state():
+    """Behavior: callback with state that doesn't match a stored CSRF token
+    returns 400 and persists no row."""
+    from fastapi.testclient import TestClient
+
+    from team_server.app import create_app
+
+    app = create_app()
+    with TestClient(app) as client:
+        resp = client.get(
+            "/oauth/slack/callback",
+            params={"code": "CODE", "state": "STATE-NEVER-ISSUED"},
+        )
+    assert resp.status_code == 400
+    body = resp.json()
+    assert "state" in body.get("detail", "").lower()

--- a/tests/test_team_server_slack_worker.py
+++ b/tests/test_team_server_slack_worker.py
@@ -1,0 +1,138 @@
+"""Functionality tests for team_server Phase 3 — Slack ingest worker."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(REPO_ROOT))
+
+
+@pytest.fixture(autouse=True)
+def memory_url(monkeypatch):
+    monkeypatch.setenv("BICAMERAL_TEAM_SERVER_SURREAL_URL", "memory://")
+    monkeypatch.setenv("BICAMERAL_TEAM_SERVER_SECRET_KEY", "EYSr77qKo0UijHGnER5qYFBY5ZZePeWeE-ZMWYXyKKA=")
+
+
+class _FakeSlackClient:
+    """Minimal stand-in for slack_sdk.WebClient.conversations_history."""
+
+    def __init__(self, messages_by_channel: dict[str, list[dict]]):
+        self._messages = messages_by_channel
+        self.calls: list[str] = []
+
+    def conversations_history(self, channel: str, **kwargs):
+        self.calls.append(channel)
+        return {"messages": self._messages.get(channel, []), "ok": True}
+
+
+@pytest.mark.asyncio
+async def test_worker_polls_allowlisted_channels_only():
+    """Behavior: poll_once invokes Slack's conversations_history only for
+    channels in the allow-list, never for unlisted channels."""
+    from team_server.db import build_client
+    from team_server.schema import ensure_schema
+    from team_server.workers.slack_worker import poll_once
+
+    client = build_client()
+    await client.connect()
+    try:
+        await ensure_schema(client)
+        slack = _FakeSlackClient({
+            "C-ALLOW-1": [{"ts": "1.0", "text": "msg"}],
+            "C-ALLOW-2": [],
+            "C-DENY":     [{"ts": "2.0", "text": "should not be polled"}],
+        })
+
+        async def stub_extractor(text):
+            return {"decisions": []}
+
+        await poll_once(
+            db_client=client,
+            slack_client=slack,
+            workspace_team_id="T1",
+            channels=["C-ALLOW-1", "C-ALLOW-2"],
+            extractor=stub_extractor,
+        )
+        assert set(slack.calls) == {"C-ALLOW-1", "C-ALLOW-2"}
+        assert "C-DENY" not in slack.calls
+    finally:
+        await client.close()
+
+
+@pytest.mark.asyncio
+async def test_worker_writes_team_event_for_each_message():
+    """Behavior: feeding the worker N messages produces N team_event rows,
+    each with author_email='team-server@<team_id>.bicameral' and
+    event_type='ingest'."""
+    from team_server.db import build_client
+    from team_server.schema import ensure_schema
+    from team_server.workers.slack_worker import poll_once
+
+    client = build_client()
+    await client.connect()
+    try:
+        await ensure_schema(client)
+        slack = _FakeSlackClient({
+            "C1": [
+                {"ts": "1.0", "text": "decision one"},
+                {"ts": "2.0", "text": "decision two"},
+                {"ts": "3.0", "text": "decision three"},
+            ],
+        })
+
+        async def stub_extractor(text):
+            return {"decisions": [text]}
+
+        await poll_once(
+            db_client=client,
+            slack_client=slack,
+            workspace_team_id="T9",
+            channels=["C1"],
+            extractor=stub_extractor,
+        )
+        rows = await client.query("SELECT * FROM team_event")
+        assert len(rows) == 3
+        for row in rows:
+            assert row["author_email"] == "team-server@T9.bicameral"
+            assert row["event_type"] == "ingest"
+    finally:
+        await client.close()
+
+
+@pytest.mark.asyncio
+async def test_worker_dedups_via_message_ts():
+    """Behavior: feeding the same Slack message ts twice produces only one
+    team_event row (idempotency via the canonical-extraction cache key)."""
+    from team_server.db import build_client
+    from team_server.schema import ensure_schema
+    from team_server.workers.slack_worker import poll_once
+
+    client = build_client()
+    await client.connect()
+    try:
+        await ensure_schema(client)
+        slack = _FakeSlackClient({
+            "C1": [{"ts": "100.0", "text": "same message"}],
+        })
+
+        async def stub_extractor(text):
+            return {"decisions": [text]}
+
+        for _ in range(2):
+            await poll_once(
+                db_client=client,
+                slack_client=slack,
+                workspace_team_id="T-DEDUP",
+                channels=["C1"],
+                extractor=stub_extractor,
+            )
+        rows = await client.query(
+            "SELECT * FROM team_event WHERE author_email = 'team-server@T-DEDUP.bicameral'"
+        )
+        assert len(rows) == 1
+    finally:
+        await client.close()

--- a/tests/test_team_server_slack_worker.py
+++ b/tests/test_team_server_slack_worker.py
@@ -136,3 +136,66 @@ async def test_worker_dedups_via_message_ts():
         assert len(rows) == 1
     finally:
         await client.close()
+
+
+@pytest.mark.asyncio
+async def test_slack_worker_writes_team_event_only_on_changed_returns(monkeypatch):
+    """Behavior: when upsert_canonical_extraction returns changed=False,
+    no team_event is written; when it returns changed=True, exactly one
+    team_event is written. Validates the worker's adaptation to the new
+    tuple-return contract from Phase 0."""
+    from team_server import workers
+    from team_server.db import build_client
+    from team_server.schema import ensure_schema
+    from team_server.workers.slack_worker import poll_once
+
+    client = build_client()
+    await client.connect()
+    try:
+        await ensure_schema(client)
+        slack = _FakeSlackClient({
+            "C1": [{"ts": "1.0", "text": "msg"}],
+        })
+
+        async def stub_extractor(text):
+            return {"decisions": [text]}
+
+        async def fake_upsert_unchanged(*args, **kwargs):
+            return ({"decisions": ["cached"]}, False)
+
+        monkeypatch.setattr(
+            "team_server.workers.slack_worker.upsert_canonical_extraction",
+            fake_upsert_unchanged,
+        )
+        await poll_once(
+            db_client=client,
+            slack_client=slack,
+            workspace_team_id="T-A",
+            channels=["C1"],
+            extractor=stub_extractor,
+        )
+        rows = await client.query(
+            "SELECT * FROM team_event WHERE author_email = 'team-server@T-A.bicameral'"
+        )
+        assert len(rows) == 0
+
+        async def fake_upsert_changed(*args, **kwargs):
+            return ({"decisions": ["new"]}, True)
+
+        monkeypatch.setattr(
+            "team_server.workers.slack_worker.upsert_canonical_extraction",
+            fake_upsert_changed,
+        )
+        await poll_once(
+            db_client=client,
+            slack_client=slack,
+            workspace_team_id="T-B",
+            channels=["C1"],
+            extractor=stub_extractor,
+        )
+        rows = await client.query(
+            "SELECT * FROM team_event WHERE author_email = 'team-server@T-B.bicameral'"
+        )
+        assert len(rows) == 1
+    finally:
+        await client.close()

--- a/tests/test_team_server_slack_worker.py
+++ b/tests/test_team_server_slack_worker.py
@@ -14,7 +14,9 @@ sys.path.insert(0, str(REPO_ROOT))
 @pytest.fixture(autouse=True)
 def memory_url(monkeypatch):
     monkeypatch.setenv("BICAMERAL_TEAM_SERVER_SURREAL_URL", "memory://")
-    monkeypatch.setenv("BICAMERAL_TEAM_SERVER_SECRET_KEY", "EYSr77qKo0UijHGnER5qYFBY5ZZePeWeE-ZMWYXyKKA=")
+    monkeypatch.setenv(
+        "BICAMERAL_TEAM_SERVER_SECRET_KEY", "EYSr77qKo0UijHGnER5qYFBY5ZZePeWeE-ZMWYXyKKA="
+    )
 
 
 class _FakeSlackClient:
@@ -41,11 +43,13 @@ async def test_worker_polls_allowlisted_channels_only():
     await client.connect()
     try:
         await ensure_schema(client)
-        slack = _FakeSlackClient({
-            "C-ALLOW-1": [{"ts": "1.0", "text": "msg"}],
-            "C-ALLOW-2": [],
-            "C-DENY":     [{"ts": "2.0", "text": "should not be polled"}],
-        })
+        slack = _FakeSlackClient(
+            {
+                "C-ALLOW-1": [{"ts": "1.0", "text": "msg"}],
+                "C-ALLOW-2": [],
+                "C-DENY": [{"ts": "2.0", "text": "should not be polled"}],
+            }
+        )
 
         async def stub_extractor(text):
             return {"decisions": []}
@@ -76,13 +80,15 @@ async def test_worker_writes_team_event_for_each_message():
     await client.connect()
     try:
         await ensure_schema(client)
-        slack = _FakeSlackClient({
-            "C1": [
-                {"ts": "1.0", "text": "decision one"},
-                {"ts": "2.0", "text": "decision two"},
-                {"ts": "3.0", "text": "decision three"},
-            ],
-        })
+        slack = _FakeSlackClient(
+            {
+                "C1": [
+                    {"ts": "1.0", "text": "decision one"},
+                    {"ts": "2.0", "text": "decision two"},
+                    {"ts": "3.0", "text": "decision three"},
+                ],
+            }
+        )
 
         async def stub_extractor(text):
             return {"decisions": [text]}
@@ -115,9 +121,11 @@ async def test_worker_dedups_via_message_ts():
     await client.connect()
     try:
         await ensure_schema(client)
-        slack = _FakeSlackClient({
-            "C1": [{"ts": "100.0", "text": "same message"}],
-        })
+        slack = _FakeSlackClient(
+            {
+                "C1": [{"ts": "100.0", "text": "same message"}],
+            }
+        )
 
         async def stub_extractor(text):
             return {"decisions": [text]}
@@ -153,9 +161,11 @@ async def test_slack_worker_writes_team_event_only_on_changed_returns(monkeypatc
     await client.connect()
     try:
         await ensure_schema(client)
-        slack = _FakeSlackClient({
-            "C1": [{"ts": "1.0", "text": "msg"}],
-        })
+        slack = _FakeSlackClient(
+            {
+                "C1": [{"ts": "1.0", "text": "msg"}],
+            }
+        )
 
         async def stub_extractor(text):
             return {"decisions": [text]}

--- a/tests/test_team_server_worker_lifecycle.py
+++ b/tests/test_team_server_worker_lifecycle.py
@@ -1,0 +1,345 @@
+"""Functionality tests for team_server Phase 0.5 — worker-task lifecycle pattern."""
+
+from __future__ import annotations
+
+import asyncio
+import sys
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(REPO_ROOT))
+
+
+@pytest.fixture(autouse=True)
+def env_setup(monkeypatch):
+    monkeypatch.setenv("BICAMERAL_TEAM_SERVER_SURREAL_URL", "memory://")
+    monkeypatch.setenv("BICAMERAL_TEAM_SERVER_SECRET_KEY",
+                       "EYSr77qKo0UijHGnER5qYFBY5ZZePeWeE-ZMWYXyKKA=")
+
+
+@pytest.mark.asyncio
+async def test_lifespan_starts_slack_worker_when_workspaces_exist(monkeypatch):
+    from fastapi.testclient import TestClient
+    from team_server import app as app_module
+    from team_server.app import create_app
+
+    monkeypatch.setattr(app_module, "SLACK_POLL_INTERVAL_SECONDS", 0)
+
+    calls = {"poll_once": 0}
+
+    async def stub_poll_once(**kwargs):
+        calls["poll_once"] += 1
+
+    monkeypatch.setattr(
+        "team_server.workers.slack_runner.poll_once", stub_poll_once
+    )
+
+    # Stub AsyncWebClient construction to avoid needing slack_sdk installed
+    import team_server.workers.slack_runner as sr_mod
+
+    class _StubClient:
+        def __init__(self, token):
+            self.token = token
+
+    async def fake_run_iteration(db_client, extractor):
+        # Bypass slack_sdk import by re-implementing the runner logic
+        from team_server.auth.encryption import decrypt_token, load_key_from_env
+        key = load_key_from_env()
+        workspaces = await db_client.query(
+            "SELECT id, slack_team_id, oauth_token_encrypted FROM workspace"
+        )
+        for ws in workspaces or []:
+            ciphertext = ws["oauth_token_encrypted"].encode("utf-8")
+            token = decrypt_token(ciphertext, key)
+            await stub_poll_once(
+                db_client=db_client,
+                slack_client=_StubClient(token),
+                workspace_team_id=ws["slack_team_id"],
+                channels=[],
+                extractor=extractor,
+            )
+
+    monkeypatch.setattr(app_module, "run_slack_iteration", fake_run_iteration)
+
+    # Pre-seed a workspace by directly hooking into lifespan
+    app = create_app()
+    with TestClient(app) as _client:
+        # Seed AFTER lifespan opened the DB
+        from team_server.auth.encryption import encrypt_token, load_key_from_env
+        key = load_key_from_env()
+        encrypted = encrypt_token("xoxb-test", key).decode("utf-8")
+        await app.state.db.client.query(
+            "CREATE workspace CONTENT { name: 'W1', slack_team_id: 'T1', "
+            "oauth_token_encrypted: $enc }",
+            {"enc": encrypted},
+        )
+        # Wait briefly for the worker to fire at least once
+        for _ in range(20):
+            await asyncio.sleep(0.05)
+            if calls["poll_once"] >= 1:
+                break
+    assert calls["poll_once"] >= 1
+
+
+@pytest.mark.asyncio
+async def test_lifespan_does_not_invoke_slack_poll_when_workspaces_empty(monkeypatch):
+    from fastapi.testclient import TestClient
+    from team_server import app as app_module
+    from team_server.app import create_app
+
+    monkeypatch.setattr(app_module, "SLACK_POLL_INTERVAL_SECONDS", 0)
+
+    calls = {"poll_once": 0}
+
+    async def stub_poll_once(**kwargs):
+        calls["poll_once"] += 1
+
+    async def fake_run_iteration(db_client, extractor):
+        from team_server.auth.encryption import load_key_from_env
+        load_key_from_env()
+        workspaces = await db_client.query(
+            "SELECT id, slack_team_id, oauth_token_encrypted FROM workspace"
+        )
+        for _ws in workspaces or []:
+            await stub_poll_once()
+
+    monkeypatch.setattr(app_module, "run_slack_iteration", fake_run_iteration)
+
+    app = create_app()
+    with TestClient(app) as _client:
+        # Verify the slack task IS spawned even with empty workspaces
+        names = {t.get_name() for t in app.state.worker_tasks}
+        assert "team-server-worker-slack" in names
+        # Allow the worker timer to fire
+        for _ in range(10):
+            await asyncio.sleep(0.05)
+    assert calls["poll_once"] == 0
+
+
+@pytest.mark.asyncio
+async def test_lifespan_cancels_slack_worker_task_on_shutdown(monkeypatch):
+    from fastapi.testclient import TestClient
+    from team_server import app as app_module
+    from team_server.app import create_app
+
+    monkeypatch.setattr(app_module, "SLACK_POLL_INTERVAL_SECONDS", 60)
+
+    async def fake_run_iteration(db_client, extractor):
+        return None
+
+    monkeypatch.setattr(app_module, "run_slack_iteration", fake_run_iteration)
+
+    app = create_app()
+    captured_tasks: list = []
+    with TestClient(app) as _client:
+        captured_tasks.extend(app.state.worker_tasks)
+    # After context manager exits, lifespan teardown has cancelled tasks
+    for t in captured_tasks:
+        assert t.done() is True
+
+
+@pytest.mark.asyncio
+async def test_slack_worker_loop_continues_after_single_iteration_raises(monkeypatch):
+    from team_server.workers.runner import worker_loop
+
+    state = {"calls": 0}
+
+    async def work_fn():
+        state["calls"] += 1
+        if state["calls"] == 1:
+            raise RuntimeError("simulated")
+
+    task = worker_loop("test", interval_seconds=0, work_fn=work_fn)
+    try:
+        for _ in range(40):
+            await asyncio.sleep(0.01)
+            if state["calls"] >= 2:
+                break
+    finally:
+        task.cancel()
+        try:
+            await task
+        except asyncio.CancelledError:
+            pass
+    assert state["calls"] >= 2
+
+
+@pytest.mark.asyncio
+async def test_slack_worker_iterates_all_workspaces_per_poll(monkeypatch):
+    """Run run_slack_iteration directly with two workspace rows; assert
+    the inner poll_once is invoked exactly twice with the per-workspace
+    decrypted token (the encrypt round-trip is exercised end-to-end)."""
+    from team_server.auth.encryption import encrypt_token, load_key_from_env
+    from team_server.db import build_client
+    from team_server.schema import ensure_schema
+    from team_server.workers import slack_runner
+
+    captured = []
+
+    async def stub_poll_once(**kwargs):
+        captured.append({
+            "team_id": kwargs["workspace_team_id"],
+            "client_token": getattr(kwargs["slack_client"], "token", None),
+        })
+
+    monkeypatch.setattr(slack_runner, "poll_once", stub_poll_once)
+
+    class _StubAWC:
+        def __init__(self, token):
+            self.token = token
+
+    import sys as _sys
+    fake_module = type(_sys)("slack_sdk")
+    fake_web = type(_sys)("slack_sdk.web")
+    fake_async = type(_sys)("slack_sdk.web.async_client")
+    fake_async.AsyncWebClient = _StubAWC
+    fake_web.async_client = fake_async
+    fake_module.web = fake_web
+    monkeypatch.setitem(_sys.modules, "slack_sdk", fake_module)
+    monkeypatch.setitem(_sys.modules, "slack_sdk.web", fake_web)
+    monkeypatch.setitem(_sys.modules, "slack_sdk.web.async_client", fake_async)
+
+    client = build_client()
+    await client.connect()
+    try:
+        await ensure_schema(client)
+        key = load_key_from_env()
+        for tid, plaintext in [("T1", "xoxb-1"), ("T2", "xoxb-2")]:
+            enc = encrypt_token(plaintext, key).decode("utf-8")
+            await client.query(
+                "CREATE workspace CONTENT { name: $n, slack_team_id: $t, "
+                "oauth_token_encrypted: $e }",
+                {"n": tid, "t": tid, "e": enc},
+            )
+
+        async def stub_extractor(text):
+            return {"decisions": []}
+
+        await slack_runner.run_slack_iteration(client, stub_extractor)
+        captured.sort(key=lambda c: c["team_id"])
+        assert captured == [
+            {"team_id": "T1", "client_token": "xoxb-1"},
+            {"team_id": "T2", "client_token": "xoxb-2"},
+        ]
+    finally:
+        await client.close()
+
+
+@pytest.mark.asyncio
+async def test_slack_worker_skips_workspace_on_decrypt_failure(monkeypatch):
+    from team_server.auth.encryption import encrypt_token, load_key_from_env
+    from team_server.db import build_client
+    from team_server.schema import ensure_schema
+    from team_server.workers import slack_runner
+
+    captured = []
+
+    async def stub_poll_once(**kwargs):
+        captured.append(kwargs["workspace_team_id"])
+
+    monkeypatch.setattr(slack_runner, "poll_once", stub_poll_once)
+
+    real_decrypt = slack_runner.decrypt_token
+    bad_ciphertext_marker = {"value": None}
+
+    def selective_decrypt(ciphertext, key):
+        # Fail only on the workspace whose plaintext was xoxb-bad
+        decrypted = real_decrypt(ciphertext, key)
+        if decrypted == "xoxb-bad":
+            raise RuntimeError("simulated decrypt failure")
+        return decrypted
+
+    monkeypatch.setattr(slack_runner, "decrypt_token", selective_decrypt)
+
+    class _StubAWC:
+        def __init__(self, token):
+            self.token = token
+
+    import sys as _sys
+    fake_module = type(_sys)("slack_sdk")
+    fake_web = type(_sys)("slack_sdk.web")
+    fake_async = type(_sys)("slack_sdk.web.async_client")
+    fake_async.AsyncWebClient = _StubAWC
+    fake_web.async_client = fake_async
+    fake_module.web = fake_web
+    monkeypatch.setitem(_sys.modules, "slack_sdk", fake_module)
+    monkeypatch.setitem(_sys.modules, "slack_sdk.web", fake_web)
+    monkeypatch.setitem(_sys.modules, "slack_sdk.web.async_client", fake_async)
+
+    client = build_client()
+    await client.connect()
+    try:
+        await ensure_schema(client)
+        key = load_key_from_env()
+        for tid, plaintext in [("T1-bad", "xoxb-bad"), ("T2-ok", "xoxb-good")]:
+            enc = encrypt_token(plaintext, key).decode("utf-8")
+            await client.query(
+                "CREATE workspace CONTENT { name: $n, slack_team_id: $t, "
+                "oauth_token_encrypted: $e }",
+                {"n": tid, "t": tid, "e": enc},
+            )
+
+        async def stub_extractor(text):
+            return {"decisions": []}
+
+        await slack_runner.run_slack_iteration(client, stub_extractor)
+        # The bad workspace's decrypt raises; the good workspace's
+        # poll_once is still invoked despite the failure isolation.
+        assert "T2-ok" in captured
+        assert "T1-bad" not in captured
+    finally:
+        await client.close()
+
+
+@pytest.mark.asyncio
+async def test_slack_runner_decrypts_workspace_token_with_loaded_key(monkeypatch):
+    """Round-trip test: encrypt+store -> read -> decrypt -> token reaches
+    AsyncWebClient. Closes the audit blind spot from round 2."""
+    from team_server.auth.encryption import encrypt_token, load_key_from_env
+    from team_server.db import build_client
+    from team_server.schema import ensure_schema
+    from team_server.workers import slack_runner
+
+    captured = {"token": None}
+
+    async def stub_poll_once(**kwargs):
+        captured["token"] = getattr(kwargs["slack_client"], "token", None)
+
+    monkeypatch.setattr(slack_runner, "poll_once", stub_poll_once)
+
+    class _StubAWC:
+        def __init__(self, token):
+            self.token = token
+
+    import sys as _sys
+    fake_module = type(_sys)("slack_sdk")
+    fake_web = type(_sys)("slack_sdk.web")
+    fake_async = type(_sys)("slack_sdk.web.async_client")
+    fake_async.AsyncWebClient = _StubAWC
+    fake_web.async_client = fake_async
+    fake_module.web = fake_web
+    monkeypatch.setitem(_sys.modules, "slack_sdk", fake_module)
+    monkeypatch.setitem(_sys.modules, "slack_sdk.web", fake_web)
+    monkeypatch.setitem(_sys.modules, "slack_sdk.web.async_client", fake_async)
+
+    client = build_client()
+    await client.connect()
+    try:
+        await ensure_schema(client)
+        key = load_key_from_env()
+        encrypted = encrypt_token("xoxb-test-token", key).decode("utf-8")
+        await client.query(
+            "CREATE workspace CONTENT { name: 'W', slack_team_id: 'T', "
+            "oauth_token_encrypted: $e }",
+            {"e": encrypted},
+        )
+
+        async def stub_extractor(text):
+            return {"decisions": []}
+
+        await slack_runner.run_slack_iteration(client, stub_extractor)
+        assert captured["token"] == "xoxb-test-token"
+    finally:
+        await client.close()

--- a/tests/test_team_server_worker_lifecycle.py
+++ b/tests/test_team_server_worker_lifecycle.py
@@ -15,13 +15,15 @@ sys.path.insert(0, str(REPO_ROOT))
 @pytest.fixture(autouse=True)
 def env_setup(monkeypatch):
     monkeypatch.setenv("BICAMERAL_TEAM_SERVER_SURREAL_URL", "memory://")
-    monkeypatch.setenv("BICAMERAL_TEAM_SERVER_SECRET_KEY",
-                       "EYSr77qKo0UijHGnER5qYFBY5ZZePeWeE-ZMWYXyKKA=")
+    monkeypatch.setenv(
+        "BICAMERAL_TEAM_SERVER_SECRET_KEY", "EYSr77qKo0UijHGnER5qYFBY5ZZePeWeE-ZMWYXyKKA="
+    )
 
 
 @pytest.mark.asyncio
 async def test_lifespan_starts_slack_worker_when_workspaces_exist(monkeypatch):
     from fastapi.testclient import TestClient
+
     from team_server import app as app_module
     from team_server.app import create_app
 
@@ -32,9 +34,7 @@ async def test_lifespan_starts_slack_worker_when_workspaces_exist(monkeypatch):
     async def stub_poll_once(**kwargs):
         calls["poll_once"] += 1
 
-    monkeypatch.setattr(
-        "team_server.workers.slack_runner.poll_once", stub_poll_once
-    )
+    monkeypatch.setattr("team_server.workers.slack_runner.poll_once", stub_poll_once)
 
     # Stub AsyncWebClient construction to avoid needing slack_sdk installed
     import team_server.workers.slack_runner as sr_mod
@@ -46,6 +46,7 @@ async def test_lifespan_starts_slack_worker_when_workspaces_exist(monkeypatch):
     async def fake_run_iteration(db_client, extractor):
         # Bypass slack_sdk import by re-implementing the runner logic
         from team_server.auth.encryption import decrypt_token, load_key_from_env
+
         key = load_key_from_env()
         workspaces = await db_client.query(
             "SELECT id, slack_team_id, oauth_token_encrypted FROM workspace"
@@ -68,6 +69,7 @@ async def test_lifespan_starts_slack_worker_when_workspaces_exist(monkeypatch):
     with TestClient(app) as _client:
         # Seed AFTER lifespan opened the DB
         from team_server.auth.encryption import encrypt_token, load_key_from_env
+
         key = load_key_from_env()
         encrypted = encrypt_token("xoxb-test", key).decode("utf-8")
         await app.state.db.client.query(
@@ -86,6 +88,7 @@ async def test_lifespan_starts_slack_worker_when_workspaces_exist(monkeypatch):
 @pytest.mark.asyncio
 async def test_lifespan_does_not_invoke_slack_poll_when_workspaces_empty(monkeypatch):
     from fastapi.testclient import TestClient
+
     from team_server import app as app_module
     from team_server.app import create_app
 
@@ -98,6 +101,7 @@ async def test_lifespan_does_not_invoke_slack_poll_when_workspaces_empty(monkeyp
 
     async def fake_run_iteration(db_client, extractor):
         from team_server.auth.encryption import load_key_from_env
+
         load_key_from_env()
         workspaces = await db_client.query(
             "SELECT id, slack_team_id, oauth_token_encrypted FROM workspace"
@@ -121,6 +125,7 @@ async def test_lifespan_does_not_invoke_slack_poll_when_workspaces_empty(monkeyp
 @pytest.mark.asyncio
 async def test_lifespan_cancels_slack_worker_task_on_shutdown(monkeypatch):
     from fastapi.testclient import TestClient
+
     from team_server import app as app_module
     from team_server.app import create_app
 
@@ -179,10 +184,12 @@ async def test_slack_worker_iterates_all_workspaces_per_poll(monkeypatch):
     captured = []
 
     async def stub_poll_once(**kwargs):
-        captured.append({
-            "team_id": kwargs["workspace_team_id"],
-            "client_token": getattr(kwargs["slack_client"], "token", None),
-        })
+        captured.append(
+            {
+                "team_id": kwargs["workspace_team_id"],
+                "client_token": getattr(kwargs["slack_client"], "token", None),
+            }
+        )
 
     monkeypatch.setattr(slack_runner, "poll_once", stub_poll_once)
 
@@ -191,6 +198,7 @@ async def test_slack_worker_iterates_all_workspaces_per_poll(monkeypatch):
             self.token = token
 
     import sys as _sys
+
     fake_module = type(_sys)("slack_sdk")
     fake_web = type(_sys)("slack_sdk.web")
     fake_async = type(_sys)("slack_sdk.web.async_client")
@@ -258,6 +266,7 @@ async def test_slack_worker_skips_workspace_on_decrypt_failure(monkeypatch):
             self.token = token
 
     import sys as _sys
+
     fake_module = type(_sys)("slack_sdk")
     fake_web = type(_sys)("slack_sdk.web")
     fake_async = type(_sys)("slack_sdk.web.async_client")
@@ -314,6 +323,7 @@ async def test_slack_runner_decrypts_workspace_token_with_loaded_key(monkeypatch
             self.token = token
 
     import sys as _sys
+
     fake_module = type(_sys)("slack_sdk")
     fake_web = type(_sys)("slack_sdk.web")
     fake_async = type(_sys)("slack_sdk.web.async_client")
@@ -331,8 +341,7 @@ async def test_slack_runner_decrypts_workspace_token_with_loaded_key(monkeypatch
         key = load_key_from_env()
         encrypted = encrypt_token("xoxb-test-token", key).decode("utf-8")
         await client.query(
-            "CREATE workspace CONTENT { name: 'W', slack_team_id: 'T', "
-            "oauth_token_encrypted: $e }",
+            "CREATE workspace CONTENT { name: 'W', slack_team_id: 'T', oauth_token_encrypted: $e }",
             {"e": encrypted},
         )
 


### PR DESCRIPTION
## Summary

Fresh PR carrying the same payload as #153 (Priority C v0 + v1 + v1.1 — self-managing team-server, Slack + Notion ingest, heuristic + LLM extractor, channel_allowlist sync, team-server event consumer + materializer dispatch) but cherry-picked onto current `dev` to avoid the architectural drift in #153 that was blocking merge.

**Why a fresh PR**: PR #153's branch had `events/session_end_bridge.py` and an older Step 5.6 in `bicameral-preflight/SKILL.md` that conflict with what landed on `dev` since (#175's Step 5.6.1/5.6.2 rework + the bicameral-capture-corrections approach). #153 also had a stuck CI trigger after #159 (its main-targeting duplicate) was closed mid-push; new SHAs on the branch wouldn't fire workflows. This PR side-steps both problems by branching off latest `dev` and carrying only the non-drifting team-server commits.

## Linked issues

Closes #161 (channel_allowlist startup-time YAML sync)
Closes #160 (team-server event consumer + materializer dispatch)
Refs #153 (the original PR being reduplicated; this PR supersedes it)

## What was carried over

Commits 1-22 of #153's branch (oldest to newest):
- `feat(team-server): scaffold + self-managing schema (Phase 1)`
- `feat(team-server): Slack OAuth + workspace allow-list (Phase 2)`
- `feat(team-server): Slack worker + canonical-extraction cache (Phase 3)`
- `feat(team-server): HTTP /events API + materializer extension (Phase 4)`
- `refactor(team-server): cache-contract migration to upsert-per-source_ref (Phase 0)`
- `feat(team-server): worker-task lifecycle pattern + Slack reference wiring (Phase 0.5)`
- `feat(team-server): Notion API client + property serializer (Phase 1)`
- `feat(team-server): Notion ingest worker + per-database watermark (Phase 2)`
- `feat(team-server): Notion task registration on lifespan (Phase 3)`
- `refactor(team-server): cache contract gets classifier_version axis (Phase 0)`
- `feat(team-server): heuristic classifier — pure deterministic Stage 1 (Phase 1)`
- `feat(team-server): trigger rules schema + per-channel/db merge (Phase 2)`
- `feat(team-server): real LLM extractor via Anthropic SDK (Phase 3)`
- `feat(team-server): pipeline integration — workers route Stage 1 → Stage 2 (Phase 4)`
- `feat(team-server): corpus learner — option-c feedback loop (Phase 5)`
- `feat(team-server): channel_allowlist startup-time YAML sync (closes #161)`
- `feat(team-server): periodic team-server event consumer + payload bridge (closes #160 first half)`
- `feat(team-server): materializer dispatch case for team-server JSONL events (closes #160 second half)`
- All v0/v1/v1.1 governance plan/audit/seal docs

Plus a `fix(team-server): mypy + ruff for fresh dev-based branch` commit on top with:
- `_one_attempt` return-type tightening + isinstance assert in `llm_extractor.py`
- `_interim_extractor` as adapter function in `app.py` (matches worker `Extractor` protocol)
- ruff auto-fix + format pass for 44 files now ruff-clean against current dev config

## What was deliberately left behind

Commits 23-27 from #153 (architecturally drifted from current `dev`):
- `feat(skills): preflight Step 5.6 — capture refinements on contradiction` — superseded by #175 on dev
- `feat(events): SessionEnd transcript bridge — propagate parent transcript_path` — `events/session_end_bridge.py` conflicts with the bicameral-capture-corrections skill approach landed via #147; needs PR-author architectural reconciliation, separate from team-server work
- Priority B v0 final-blockers governance docs — docs-only follow-up
- Earlier ruff format pass — superseded by this PR's ruff format

## Plan / Audit / Seal

- **Plan**: per-phase plans in `docs/governance/` (carried over from #153)
- **Audit**: per-phase audits in `docs/governance/` (carried over from #153)
- **Seal**: per-phase seals already in upstream META_LEDGER for #153's commits; this PR's mypy fix is risk:L1 and doesn't need a seal entry per DEV_CYCLE §4.3
- **Risk**: L2 (introduces the team_server module — substantial new surface area; tests are comprehensive)

## Test plan

- [x] `mypy .` — 131 files, no issues
- [x] `ruff check .` — All checks passed
- [x] `ruff format --check .` — 278 files already formatted
- [x] `pytest tests/test_team_server_app.py tests/test_team_server_allowlist_lifespan.py tests/test_team_server_allowlist_sync.py tests/test_team_server_consumer.py tests/test_materializer_team_server_pull.py` — 28 passed
- [ ] **CI re-trigger validation** — primary purpose of opening as a fresh PR; if CI fires here where it didn't on #153, that confirms the trigger drop was PR-state-related

## Notes for reviewer

- Once this lands, **#153 should be closed** (and #159 already is) since both their PRs' payloads are carried here without architectural drift.
- The two architectural commits left behind (`events/session_end_bridge.py` and the old Step 5.6) should each get their own follow-up if they're still wanted on top of the dev-current Step 5.6 / capture-corrections design. Author judgment — PR author is best positioned to decide whether `session_end_bridge.py` complements or replaces the capture-corrections approach now that #147+#175 are in.