### PR TITLE
feat(skill): /bicameral:report-bug — one-click bug reports with context

### DIFF
--- a/skills/bicameral-report-bug/SKILL.md
+++ b/skills/bicameral-report-bug/SKILL.md
@@ -1,0 +1,303 @@
+---
+name: bicameral-report-bug
+description: File a bug against bicameral-mcp with auto-bundled context. Fires on "/bicameral:report-bug", "file a bicameral bug", "report this bicameral bug", "bicameral broke", "bicameral isn't working", "something's wrong with bicameral", "this is a bicameral bug". Bundles environment + recent calls + error trace into a prefilled GitHub issue URL on BicameralAI/bicameral-mcp with the `dev` label, and opens it in the browser. Skill DOES NOT submit — the user reviews and clicks submit on GitHub.
+---
+
+# /bicameral:report-bug — File a bug with context
+
+**Trigger**: `/bicameral:report-bug`, or natural-language phrasing like
+"file a bicameral bug", "this bicameral thing broke", "report this issue".
+
+The skill collects environment + recent tool activity + the suspected
+failure, formats them as a GitHub issue body, and opens a prefilled
+issue URL on the dev repo. The user lands on the GitHub new-issue form
+with everything filled in — they review, edit if needed, and click
+Submit. Nothing leaves the machine until the user clicks Submit.
+
+**Repo target**: `BicameralAI/bicameral-mcp` (the dev-facing MCP repo,
+not the parent `bicameral` monorepo).
+**Default labels**: `dev`, `bug`.
+
+---
+
+## Step 1 — Confirm intent + collect a one-line description
+
+Use `AskUserQuestion` to grab a one-line title and a short description.
+Default-select the most plausible title based on the recent error or
+tool activity in the current session.
+
+```
+AskUserQuestion({
+  questions: [
+    {
+      question: "One-line summary of what went wrong?",
+      header: "Title",
+      multiSelect: false,
+      options: [
+        { label: "<best guess from recent error/activity>",
+          description: "Suggested from the last failed tool call" },
+        { label: "Other (write my own)",
+          description: "I'll type a different title" }
+      ]
+    },
+    {
+      question: "What were you trying to do?",
+      header: "Intent",
+      multiSelect: false,
+      options: [
+        { label: "Ingest decisions from a transcript" },
+        { label: "Run preflight before implementing" },
+        { label: "Check drift / scan branch" },
+        { label: "Resolve compliance / sync after commit" },
+        { label: "Other (skip this question)" }
+      ]
+    }
+  ]
+})
+```
+
+If the user picks "Other" for the title, prompt freely for a one-liner.
+
+---
+
+## Step 2 — Collect diagnostic context
+
+Run a single Bash block to gather environment data. Output goes
+straight into the issue body — do not surface raw output to the user.
+
+```bash
+{
+  echo "## Environment"
+  echo
+  echo "- bicameral-mcp version: $(bicameral-mcp --version 2>/dev/null || pip show bicameral-mcp 2>/dev/null | awk '/^Version:/ {print $2}' || echo 'unknown')"
+  echo "- Python: $(python3 --version 2>/dev/null || echo 'unknown')"
+  echo "- OS: $(uname -srm 2>/dev/null || echo 'unknown')"
+  echo "- IDE: ${CLAUDE_CODE_VERSION:+Claude Code $CLAUDE_CODE_VERSION}${CURSOR_TRACE_ID:+Cursor}${TERM_PROGRAM:+ ($TERM_PROGRAM)}"
+  echo "- Shell: $SHELL"
+  echo
+  echo "## Repo state"
+  echo
+  echo '```'
+  git -C "$(pwd)" rev-parse --abbrev-ref HEAD 2>/dev/null && \
+    git -C "$(pwd)" log --oneline -3 2>/dev/null
+  echo '```'
+  echo
+  if [ -f .bicameral/config.yaml ]; then
+    echo "## .bicameral/config.yaml"
+    echo
+    echo '```yaml'
+    cat .bicameral/config.yaml
+    echo '```'
+  fi
+} 2>/dev/null
+```
+
+Then assemble in your head (do NOT print to user yet):
+
+- **Title**: from Step 1
+- **Intent**: from Step 1
+- **Symptom**: the most recent error / unexpected behavior the agent
+  observed in this conversation. Quote tool error output verbatim if
+  available — that's the highest-signal piece. If no error, describe
+  the unexpected output.
+- **Reproduction**: the last 3-5 bicameral tool calls in this session,
+  in order. Just the call signatures (tool name + key args), no
+  full bodies. Redact any obvious secrets (`ANTHROPIC_API_KEY=...`,
+  long bearer tokens, etc.).
+- **Environment** + **Repo state** + **config.yaml**: from the Bash
+  block above.
+
+---
+
+## Step 3 — Build the issue body
+
+Format as markdown:
+
+```markdown
+**Intent**: <from Step 1>
+
+## Symptom
+
+<recent error verbatim, or one-paragraph description>
+
+## Reproduction (recent calls)
+
+1. `bicameral.<tool>(...)`
+2. `bicameral.<tool>(...)`
+3. ...
+
+<environment + repo state + config blocks from Step 2>
+
+---
+_Reported via `/bicameral:report-bug`._
+```
+
+If the assembled body exceeds **6500 characters**, drop sections in
+this order until it fits:
+1. The git log (keep just the branch name)
+2. The config.yaml block
+3. Any tool-call argument bodies (keep just tool names)
+
+GitHub's URL prefill caps around 8KB, and we want headroom for the
+URL-encoded title.
+
+---
+
+## Step 3.5 — Transparency preview (consent gate)
+
+Before opening the browser, show the user exactly what will be in the
+issue body and what was redacted. Modeled on `setup_wizard._select_telemetry()`
+(the wizard's "exact payload that would be sent" pattern) — concrete
+preview, explicit non-collection list, single yes/no.
+
+Print this block verbatim, filling in `<...>` placeholders:
+
+```
+About to open a prefilled GitHub issue on BicameralAI/bicameral-mcp.
+Here's exactly what goes in the body — review it before anything leaves
+your machine.
+
+  Title:  <title from Step 1>
+  Labels: dev, bug
+
+  ── Body preview ─────────────────────────────────────────────
+  <full assembled markdown from Step 3, indented two spaces>
+  ─────────────────────────────────────────────────────────────
+
+Auto-redacted in this body:
+  - API keys, bearer tokens, secrets, passwords (regex-matched)
+  - <N> redaction(s) applied   ← print actual count, or "none detected"
+
+Never included by this skill:
+  - File contents, code snippets you didn't paste
+  - Decision text or ledger entries
+  - Environment variables (only the IDE name + version)
+  - Personal data, email, repo URL
+
+Nothing has been sent yet. The browser will open a GitHub *draft* —
+you can edit anything in the body, delete sections, or close the tab
+to abandon. The issue is only filed when you click Submit on GitHub.
+```
+
+Then call `AskUserQuestion`:
+
+```
+AskUserQuestion({
+  questions: [{
+    question: "Open the prefilled GitHub issue?",
+    header: "Open issue",
+    multiSelect: false,
+    options: [
+      { label: "Yes, open it",
+        description: "Browser opens to a GitHub draft — you review and submit there" },
+      { label: "Edit the body first",
+        description: "I want to revise the body in chat before opening" },
+      { label: "Cancel",
+        description: "Don't open anything; nothing leaves the machine" }
+    ]
+  }]
+})
+```
+
+- **Yes** → proceed to Step 4.
+- **Edit the body first** → ask the user what to change, regenerate
+  the body, return to this step.
+- **Cancel** → stop. Tell the user "Cancelled. Nothing was sent." and
+  emit the `errored=False` skill_end with `error_class="user_cancelled"`.
+
+---
+
+## Step 4 — Open the prefilled GitHub issue
+
+Build the URL. Use `python3 -c` to URL-encode safely (do NOT hand-roll
+encoding — `?` `&` `#` in the body will break it).
+
+```bash
+TITLE='<title from Step 1>'
+BODY='<assembled markdown from Step 3>'
+
+URL=$(python3 -c '
+import sys, urllib.parse
+title, body = sys.argv[1], sys.argv[2]
+q = urllib.parse.urlencode({
+    "title": title,
+    "body": body,
+    "labels": "dev,bug",
+})
+print("https://github.com/BicameralAI/bicameral-mcp/issues/new?" + q)
+' "$TITLE" "$BODY")
+
+case "$(uname -s)" in
+  Darwin)  open "$URL" ;;
+  Linux)   xdg-open "$URL" >/dev/null 2>&1 || echo "$URL" ;;
+  MINGW*|MSYS*|CYGWIN*) start "" "$URL" ;;
+  *) echo "$URL" ;;
+esac
+```
+
+If `open` / `xdg-open` is unavailable (CI, headless), print the URL
+so the user can copy it.
+
+---
+
+## Step 5 — Tell the user
+
+Short, factual confirmation. No emoji. Format:
+
+```
+Opened a prefilled GitHub issue on BicameralAI/bicameral-mcp with
+the `dev` label. Review, edit if needed, and submit on the page.
+
+If your browser didn't open, the URL is above.
+```
+
+**Do not** post the full body back to the user — they'll see it on
+the GitHub page. Posting it again is noise.
+
+---
+
+## Privacy & safety rules
+
+- **Never auto-submit.** The skill's whole contract is: assemble + open.
+  The user reviews on GitHub and clicks Submit. Anything that leaves
+  the machine leaves it through the user's hands.
+- **Redact obvious secrets** before placing them in the body: anything
+  matching `(api[_-]?key|token|secret|password|bearer)\s*[=:]\s*\S+`
+  → replace value with `***REDACTED***`.
+- **Do not include file contents** unless the user explicitly pastes
+  them in their description. Recent tool calls and error traces are OK
+  — file dumps are not.
+- **Do not include the full ledger.** If the bug needs ledger context,
+  the maintainer can ask in the issue thread.
+
+---
+
+## When NOT to fire
+
+- The user is asking how to use bicameral, not reporting a bug → answer
+  the question directly.
+- The user is reporting a code-level drift / spec gap inside their own
+  project → that's `bicameral-ingest` or `bicameral-doctor`, not a
+  bicameral bug.
+- The user wants to file an issue against a different project (their
+  own repo, GitHub Actions, etc.) → don't fire; this skill only files
+  against `BicameralAI/bicameral-mcp`.
+
+---
+
+## Telemetry
+
+**At skill start**:
+```
+bicameral.skill_begin(skill_name="bicameral-report-bug",
+  session_id=<uuid4>,
+  rationale="<one-liner: what triggered the report>")
+```
+
+**At skill end**:
+```
+bicameral.skill_end(skill_name="bicameral-report-bug",
+  session_id=<stored_id>,
+  errored=<bool>,
+  error_class="url_open_failed" if browser launch failed else None)
+```


### PR DESCRIPTION
## Summary

- New agent skill `/bicameral:report-bug` bundles environment + recent tool calls + last error trace into a prefilled GitHub issue URL on `BicameralAI/bicameral-mcp` with `dev,bug` labels, then opens it in the user's browser. User reviews/edits on GitHub and clicks Submit — **nothing leaves the machine** until they do.
- Step 3.5 transparency preview gate modeled on `setup_wizard._select_telemetry()`: concrete body preview, explicit redaction count, explicit non-collection list, three-option Y/Edit/Cancel prompt — same trust register as the existing telemetry consent.
- Auto-discovered by `setup_wizard._install_skills`; no wizard or handler code changes needed.

## Linked issues

(no friction issue yet — skill scaffolded in response to landing-page UX discussion about lowering the bar to file MCP bug reports with context)

## Plan / Audit / Seal

Plan: trivial; risk:L1.

This is a single new `SKILL.md` file under `skills/bicameral-report-bug/`. No Python code, no schema changes, no telemetry payload changes (uses the existing `bicameral.skill_begin` / `bicameral.skill_end` channel already documented in other skills). The skill body itself never auto-submits — the user reviews on GitHub before anything sends.

## Test plan

- [ ] `pytest -q` (regression — no Python touched, expect baseline pass)
- [ ] Manual: run `bicameral-mcp setup` against a fresh repo, verify `skills/bicameral-report-bug/SKILL.md` lands in `.claude/skills/bicameral-report-bug/`
- [ ] Manual: trigger `/bicameral:report-bug` in Claude Code, confirm the Step 3.5 preview block renders, redaction count is honest, and Cancel actually cancels
- [ ] Manual: confirm the opened GitHub URL prefills `?labels=dev,bug` and lands on the issue draft (not auto-submitted)

## Privacy posture

The skill's consent gate borrows directly from `consent.py:_NOTICE_TEXT` and `setup_wizard._select_telemetry()`'s "show the exact payload, list what's not included, give an escape hatch" pattern — same convention, same tone, same trust contract. Worth a sanity-check pass to confirm the inheritance reads correctly.