### PR TITLE
fix(skill): retire stale bicameral.search refs + auto-redact business context in report-bug

### DIFF
--- a/skills/bicameral-capture-corrections/SKILL.md
+++ b/skills/bicameral-capture-corrections/SKILL.md
@@ -103,13 +103,17 @@ Only `user` turns qualify. Claude's own responses are never corrections.
 For each **ask** correction:
 
 ```
-bicameral.search(query=<one-line paraphrase of correction>, top_k=3, min_confidence=0.4)
+bicameral.history(feature_filter=<short keyword from the correction>)
 ```
 
-If any result is returned → treat as already ingested, skip.
-`bicameral.search` uses full-text scoring; `min_confidence=0.4` sets the
-floor. Presence in the result set (not a score value) is the dedup signal.
-All corrections with no results → queue as `uningested_corrections`.
+(`bicameral.search` was retired — `history` with a substring `feature_filter`
+is the live equivalent. There is no `top_k` or `min_confidence`; the filter
+is a substring match over feature/decision text.)
+
+If any decision in the response describes the same correction → treat as
+already ingested, skip. Presence in the result set (not a score value) is
+the dedup signal. All corrections with no matching decision → queue as
+`uningested_corrections`.
 
 For **mechanical** corrections: skip the ledger check, auto-ingest directly.
 
@@ -217,10 +221,11 @@ gate at the end of every session.
 2. **Only user turns.** Claude's own text is never a correction source.
 3. **No double-ask.** If preflight already surfaced a correction this
    session, do not surface it again in the SessionEnd batch.
-4. **Dedup by presence, not score.** Call `bicameral.search` with
-   `min_confidence=0.4`. If any result is returned, treat the correction
-   as already ingested. Search scores are corpus-dependent and unbounded —
-   never gate on a numeric score value.
+4. **Dedup by presence, not score.** Call `bicameral.history` with a
+   short `feature_filter`. If any decision in the response describes the
+   same correction, treat it as already ingested. Never gate on a numeric
+   score value (the retired `bicameral.search` returned scores; `history`
+   does not).
 5. **Ingest as proposals.** Captured corrections enter as `proposed`
    and need explicit ratification — same as all other ingests.
 6. **Guard on `.bicameral/`.** Never run in repos without a bicameral

--- a/skills/bicameral-ingest/SKILL.md
+++ b/skills/bicameral-ingest/SKILL.md
@@ -134,7 +134,7 @@ bicameral.skill_end(skill_name="bicameral-ingest", session_id=<stored_id>,
 
 1. Identify the dominant feature area from the source (same noun phrase you'd use in Step 1.5 — e.g. "Session Identity", "Accountable Live", "Checkout Flow").
 
-2. Call `bicameral.search(query=<feature_area>, top_k=10)`.
+2. Call `bicameral.history(feature_filter=<feature_area>)`. (`bicameral.search` was retired — `history` with a substring filter is the live equivalent. There is no `top_k` or `min_confidence` knob; the filter is a substring match over the feature/decision text.)
 
 3. Read the results and note:
    - **Business drivers already established** in this area (privacy, compliance, contract, SLA). A new candidate whose driver matches an established pattern is more likely to be real — even if the source is silent on the driver.
@@ -145,7 +145,7 @@ bicameral.skill_end(skill_name="bicameral-ingest", session_id=<stored_id>,
    - If ledger context establishes a privacy/compliance pattern and a new candidate is privacy-shaped → treat the ledger context as evidence for the business driver, even if the source is silent. Ingest as `proposed` with a note: `"business driver inferred from ledger: <prior decision description>"`.
    - If no ledger context → apply the filters strictly and park ambiguous cases.
 
-**Skip this step** (proceed directly to Step 1) when the source is a completely new domain with no plausible overlap with existing decisions (e.g. first-ever ingest into an empty ledger). The `bicameral.search` call is cheap — when in doubt, call it.
+**Skip this step** (proceed directly to Step 1) when the source is a completely new domain with no plausible overlap with existing decisions (e.g. first-ever ingest into an empty ledger). The `bicameral.history` call is cheap — when in doubt, call it.
 
 ### 1. Extract candidate decisions
 

--- a/skills/bicameral-report-bug/SKILL.md
+++ b/skills/bicameral-report-bug/SKILL.md
@@ -78,8 +78,12 @@ straight into the issue body — do not surface raw output to the user.
   echo "## Repo state"
   echo
   echo '```'
-  git -C "$(pwd)" rev-parse --abbrev-ref HEAD 2>/dev/null && \
-    git -C "$(pwd)" log --oneline -3 2>/dev/null
+  # Branch name and commit subjects often leak business context (initiative names,
+  # vendor partners, unannounced features). Redact by default; print only the shape
+  # of the state, not the content.
+  COMMIT_COUNT=$(git -C "$(pwd)" log --oneline -3 2>/dev/null | wc -l | tr -d ' ')
+  echo "branch: <REDACTED>"
+  echo "$COMMIT_COUNT recent commit(s) (titles redacted)"
   echo '```'
   echo
   if [ -f .bicameral/config.yaml ]; then
@@ -101,9 +105,15 @@ Then assemble in your head (do NOT print to user yet):
   available — that's the highest-signal piece. If no error, describe
   the unexpected output.
 - **Reproduction**: the last 3-5 bicameral tool calls in this session,
-  in order. Just the call signatures (tool name + key args), no
-  full bodies. Redact any obvious secrets (`ANTHROPIC_API_KEY=...`,
-  long bearer tokens, etc.).
+  in order. Just the call signatures (tool name + parameter *names*) —
+  **redact the parameter VALUES by default**. Replace `query="…"`,
+  `feature_filter="…"`, `topic="…"`, `intent="…"`, `description="…"`,
+  `text="…"`, `excerpt="…"`, `title="…"`, etc. with `<REDACTED>` or
+  short placeholders (`<feature_area_a>`, `<feature_area_b>`). The
+  diagnostic signal is which tool was called with which parameter
+  *names*, not the verbatim payload — payloads almost always leak
+  business context (feature names, vendor names, internal codenames).
+  Also redact obvious secrets (`ANTHROPIC_API_KEY=…`, bearer tokens).
 - **Environment** + **Repo state** + **config.yaml**: from the Bash
   block above.
 
@@ -165,6 +175,10 @@ your machine.
   ─────────────────────────────────────────────────────────────
 
 Auto-redacted in this body:
+  - Tool-call argument *values* in the Reproduction section (query, feature_filter,
+    topic, intent, description, text, excerpt, title — parameter names kept,
+    values replaced with <REDACTED>)
+  - Branch name and commit subject lines in the Repo state block
   - API keys, bearer tokens, secrets, passwords (regex-matched)
   - <N> redaction(s) applied   ← print actual count, or "none detected"
 
@@ -264,6 +278,16 @@ the GitHub page. Posting it again is noise.
 - **Redact obvious secrets** before placing them in the body: anything
   matching `(api[_-]?key|token|secret|password|bearer)\s*[=:]\s*\S+`
   → replace value with `***REDACTED***`.
+- **Redact business context by default**, even though it isn't a "secret":
+  - Tool-call argument values in the Reproduction section. Preserve parameter
+    names (so the maintainer sees which fields were used), but replace values
+    with `<REDACTED>` or `<feature_area_a>` placeholders.
+  - The current branch name and recent commit subject lines. These routinely
+    name initiatives, vendor partners, and unannounced features. Print only
+    the shape (`branch: <REDACTED>`, `N recent commit(s) (titles redacted)`).
+  - If the user explicitly wants the verbose context for a specific bug, they
+    can paste it back in during the "Edit the body first" branch of Step 3.5.
+    Default off — leak less, ask more.
 - **Do not include file contents** unless the user explicitly pastes
   them in their description. Recent tool calls and error traces are OK
   — file dumps are not.


### PR DESCRIPTION
## Summary

- Three skill files still instructed callers to invoke retired tools or leak business context. Patches them to live equivalents.
- `bicameral-ingest` Step 0.5 and `bicameral-capture-corrections` (Step C, Rule #4) swap `bicameral.search` for `bicameral.history(feature_filter=…)` — `search` was retired and now returns `No such tool available`.
- `bicameral-report-bug` Step 2/3.5/Privacy rules — auto-redact tool-call argument values, branch name, and commit subject lines by default. Previously only API-key-shape strings were scrubbed; the body still leaked feature names, vendor partners, and unannounced launches via `query=`/`feature_filter=`/`topic=` payloads, branch names like `jin/acme-launch`, and recent commit subjects.

## Linked issues

Closes #185
Closes #186

## Plan / Audit / Seal

- Plan: trivial; risk:L1 (skill-doc-only, no code paths)
- Audit: n/a (skill description fixes; no semantic behavior change beyond the explicit redaction policy)
- Seal: n/a

## Test plan

- [x] `git grep "bicameral\.search" skills/` shows zero remaining references after this PR (verify there are no operational call sites left in active skills)
- [ ] Manually invoke `/bicameral:report-bug` against a repo with a sensitive branch name + recent commits; verify the Step 3.5 preview shows `branch: <REDACTED>` and `<REDACTED>` placeholders for tool-call argument values
- [ ] Run the existing skills test pass (no automated coverage exists for skill-doc strings as far as I can tell — happy to add a regex assertion if useful)

## Notes for reviewer

- The 6 fully-orphaned skills (`bicameral-search`, `bicameral-drift`, `bicameral-scan-branch`, `bicameral-status`, `bicameral-brief`, `bicameral-doctor`) are already absent from `dev` skills/ — no work needed there. Only the references inside still-shipping skills needed scrubbing.
- `bicameral-guided/SKILL.md` also references retired `bicameral.search` and `bicameral.brief` in its description and body, but does not exist on `dev` either (only in the older bundled wheel that some local snapshots still carry). Not in scope here.
- A follow-up P0 (#187 — gap-brief consolidation) is filed separately and is out of scope for this PR.