### PR TITLE
feat(events): emit compliance_check.completed for cross-author replay

### DIFF
--- a/docs/v0-architecture-current.md
+++ b/docs/v0-architecture-current.md
@@ -109,10 +109,11 @@ All v0 ledger writes that affect cross-team-shareable state emit a JSONL event l
 | `link_commit.completed` | After `link_commit` advances HEAD and re-evaluates regions |
 | `decision_ratified.completed` | After `ratify` flips signoff |
 | `decision_superseded.completed` | After `resolve_collision` writes a `supersedes` edge |
+| `compliance_check.completed` | After `resolve_compliance` writes a verdict (#190) |
 
 **Naming convention**: `<domain>.completed`. The original Notion page used `decision_X` past-tense names (e.g. `decision_ingested`); the code emits `<domain>.completed`. The code names are what wire-level integrators must match.
 
-**Known gap (tracked separately)**: `compliance_checked` is named in the Notion page but is **not currently emitted**. When `resolve_compliance` flips a region from `pending` to `reflected` / `drifted`, that transition is not in the team-sync stream. Filed as a follow-up under the team-mode-correctness umbrella; see #178's open-issues survey for context. Until fixed, teammate replays infer compliance state from `link_commit.completed` effects rather than from explicit verdict events.
+**Cross-author replay** (#190): `compliance_check.completed` events carry a content-addressable region descriptor (`repo`, `file_path`, `symbol_name`, `content_hash`) plus `canonical_decision_id`. Receivers resolve to local row ids via `find_decision_by_canonical_id` and `find_code_region_by_content`; line numbers are deliberately excluded from the descriptor because they shift across replays. Receiver-side replay is idempotent via the existing UNIQUE index on `(decision_id, region_id, content_hash)` (`ledger/schema.py:228`). When a receiver lacks a code_region matching the event's content_hash, the materializer logs a warning and skips — fail-soft, no silent inconsistency.
 
 **Invariant**: the JSONL log is **append-only**. The `events/writer.py` API cannot rewrite or delete; replay is the only way to rebuild state.
 
@@ -152,5 +153,5 @@ These can be removed without breaking any v0 invariant. They exist because they 
 | *"7 node types, 6 edge types"* | 13 tables, 10 edges in `ledger/schema.py`. v0 core is 6+5; the rest is operational infrastructure or v1 CodeGenome. |
 | *"8 flows; 5 visible, 3 internal"* | 23 MCP tools, no internal/external split. Discipline lives in skills, not at the tool boundary. |
 | *"`LedgerEvent` graph node + `event_targets` edge"* | Events live in JSONL files at `.bicameral/events/{git-email}/`. Choice was deliberate to enable git-committed CRDT-mergeable team sync. |
-| *"Events emitted: `decision_ingested`, `decision_bound`, `compliance_checked`, `decision_ratified`, `decision_superseded`"* | Code emits `ingest.completed`, `bind_decision.completed`, `link_commit.completed`, `decision_ratified.completed`, `decision_superseded.completed`. `compliance_checked` is missing — known gap. `link_commit.completed` is extra. Naming convention shifted to `<domain>.completed`. |
+| *"Events emitted: `decision_ingested`, `decision_bound`, `compliance_checked`, `decision_ratified`, `decision_superseded`"* | Code emits `ingest.completed`, `bind_decision.completed`, `link_commit.completed`, `decision_ratified.completed`, `decision_superseded.completed`, `compliance_check.completed` (the latter added by #190; closes the previously-known gap). `link_commit.completed` is extra vs the Notion page. Naming convention shifted to `<domain>.completed`. |
 | *"150 lines of declarative spec vs ~2,500 lines of Python"* | Schema declarations in `ledger/schema.py` are ~400 lines. Python supporting them is much larger. The "150 lines" promise was tied to `SPEC.bql`, which doesn't exist. |

--- a/events/materializer.py
+++ b/events/materializer.py
@@ -160,6 +160,54 @@ class EventMaterializer:
                             session_id=payload.get("session_id", ""),
                         )
                         replayed += 1
+                    elif etype == "compliance_check.completed":
+                        # #190: receiver re-applies the verdict by resolving
+                        # the cross-author key (canonical_decision_id +
+                        # content-addressable region descriptor) to local row
+                        # ids. Idempotent on the receiver via the existing
+                        # UNIQUE index on (decision_id, region_id, content_hash).
+                        from ledger.queries import (
+                            find_code_region_by_content,
+                            find_decision_by_canonical_id,
+                        )
+
+                        local_decision_id = await find_decision_by_canonical_id(
+                            inner_adapter._client,
+                            payload.get("canonical_decision_id", ""),
+                        )
+                        if local_decision_id is None:
+                            logger.warning(
+                                "[materializer] skipping compliance_check.completed — "
+                                "canonical_decision_id %r not found locally",
+                                payload.get("canonical_decision_id"),
+                            )
+                            continue
+                        region = payload.get("region") or {}
+                        local_region_id = await find_code_region_by_content(
+                            inner_adapter._client,
+                            repo=region.get("repo", ""),
+                            file_path=region.get("file_path", ""),
+                            symbol_name=region.get("symbol_name", ""),
+                            content_hash=region.get("content_hash", ""),
+                        )
+                        if local_region_id is None:
+                            logger.warning(
+                                "[materializer] skipping compliance_check.completed — "
+                                "region (%s::%s @ %s) not yet materialized locally",
+                                region.get("file_path"),
+                                region.get("symbol_name"),
+                                str(region.get("content_hash", ""))[:12],
+                            )
+                            continue
+                        await inner_adapter.apply_compliance_verdict_from_event(
+                            decision_id=local_decision_id,
+                            region_id=local_region_id,
+                            content_hash=region.get("content_hash", ""),
+                            verdict=payload.get("verdict", ""),
+                            pinned_commit=payload.get("pinned_commit", ""),
+                            evidence=payload.get("evidence", ""),
+                        )
+                        replayed += 1
                 new_offsets[author] = f.tell()
 
         if new_offsets != offsets:

--- a/events/team_adapter.py
+++ b/events/team_adapter.py
@@ -199,6 +199,50 @@ class TeamWriteAdapter:
             session_id=session_id,
         )
 
+    async def apply_resolve_compliance(
+        self,
+        *,
+        canonical_decision_id: str,
+        repo: str,
+        file_path: str,
+        symbol_name: str,
+        content_hash: str,
+        verdict: str,
+        pinned_commit: str,
+        evidence: str = "",
+    ) -> None:
+        """Emit compliance_check.completed to the team-sync JSONL stream.
+
+        Fires once per accepted ComplianceVerdict (called from
+        ``handle_resolve_compliance`` after each successful
+        ``upsert_compliance_check``). Receiver replays via the materializer's
+        content-addressable lookup; idempotent on receiver side because
+        ``upsert_compliance_check`` first-write-wins on
+        ``(decision_id, region_id, content_hash)`` (see ``ledger/schema.py``
+        idx_cc_cache_key).
+
+        Unlike ``apply_ratify`` / ``apply_supersede``, this method does NOT
+        delegate to the inner adapter — the local DB write was already
+        performed by the handler's direct ``upsert_compliance_check`` call.
+        Emit-only, by design.
+        """
+        await self._ensure_ready()
+        self._writer.write(
+            "compliance_check.completed",
+            {
+                "canonical_decision_id": canonical_decision_id,
+                "region": {
+                    "repo": repo,
+                    "file_path": file_path,
+                    "symbol_name": symbol_name,
+                    "content_hash": content_hash,
+                },
+                "verdict": verdict,
+                "pinned_commit": pinned_commit,
+                "evidence": evidence,
+            },
+        )
+
     async def wipe_all_rows(self, repo: str) -> None:
         """Wipe the DB then reset the event watermark.
 

--- a/handlers/resolve_compliance.py
+++ b/handlers/resolve_compliance.py
@@ -36,6 +36,8 @@ from contracts import (
 from ledger.queries import (
     decision_exists,
     delete_binds_to_edge,
+    get_canonical_id,
+    get_region_descriptor,
     project_decision_status,
     promote_ephemeral_verdict,
     region_exists,
@@ -171,6 +173,25 @@ async def handle_resolve_compliance(
             semantic_status=getattr(v, "semantic_status", None),
             evidence_refs=list(getattr(v, "evidence_refs", []) or []),
         )
+
+        # #190: emit compliance_check.completed to the team-sync JSONL stream
+        # so peer replays can re-apply the verdict without re-evaluating
+        # locally. No-op in single-mode (no apply_resolve_compliance method).
+        emit = getattr(ledger, "apply_resolve_compliance", None)
+        if emit is not None:
+            canonical_id = await get_canonical_id(client, v.decision_id)
+            descriptor = await get_region_descriptor(client, v.region_id)
+            if canonical_id and descriptor:
+                await emit(
+                    canonical_decision_id=canonical_id,
+                    repo=descriptor["repo"],
+                    file_path=descriptor["file_path"],
+                    symbol_name=descriptor["symbol_name"],
+                    content_hash=descriptor["content_hash"],
+                    verdict=v.verdict,
+                    pinned_commit=ctx.head_sha,
+                    evidence=v.explanation,
+                )
 
         # Prune the binds_to edge when the caller says "not relevant" —
         # retrieval made a mistake; remove the binding to keep the graph clean.

--- a/ledger/adapter.py
+++ b/ledger/adapter.py
@@ -47,6 +47,7 @@ from .queries import (
     update_region_hash,
     upsert_code_region,
     upsert_code_subject,
+    upsert_compliance_check,
     upsert_decision,
     upsert_input_span,
     upsert_source_cursor,
@@ -1283,6 +1284,44 @@ class SurrealDBLedgerAdapter:
     # Both methods are idempotent so the materializer can replay them
     # safely. Handlers do their own pre-write idempotency / collision
     # checks; the adapter just performs the write and re-projects status.
+
+    async def apply_compliance_verdict_from_event(
+        self,
+        *,
+        decision_id: str,
+        region_id: str,
+        content_hash: str,
+        verdict: str,
+        pinned_commit: str = "",
+        evidence: str = "",
+    ) -> None:
+        """Receiver-side replay of a compliance_check.completed event (#190).
+
+        Called by ``EventMaterializer`` after resolving the cross-author keys
+        (canonical_decision_id → local decision_id; content-addressable region
+        descriptor → local region_id). Idempotent via the existing UNIQUE
+        index on ``(decision_id, region_id, content_hash)`` —
+        ``upsert_compliance_check`` is a no-op if the row already exists.
+
+        Confidence is fixed to ``"high"`` and phase to ``"drift"`` on replay
+        because peer-attested verdicts arrive without the local
+        confidence/phase context. The verdict and explanation are
+        authoritative.
+        """
+        await self._ensure_connected()
+        await upsert_compliance_check(
+            self._client,
+            decision_id=decision_id,
+            region_id=region_id,
+            content_hash=content_hash,
+            verdict=verdict,
+            confidence="high",
+            explanation=evidence,
+            phase="drift",
+            commit_hash=pinned_commit,
+            pruned=(verdict == "not_relevant"),
+            ephemeral=False,
+        )
 
     async def apply_ratify(self, decision_id: str, signoff: dict) -> str:
         """Write a ratify/reject signoff and re-project the decision's status.

--- a/ledger/queries.py
+++ b/ledger/queries.py
@@ -879,6 +879,63 @@ async def region_exists(client: LedgerClient, region_id: str) -> bool:
     return bool(rows)
 
 
+async def get_region_descriptor(
+    client: LedgerClient,
+    region_id: str,
+) -> dict | None:
+    """Return the cross-author region descriptor for a local code_region.
+
+    Used by ``handle_resolve_compliance`` (#190) to build the
+    ``compliance_check.completed`` event payload. Returns repo / file_path /
+    symbol_name / content_hash from the local row — these together are the
+    content-addressable key the receiver uses to find a matching region in
+    its own DB. Returns None if the row doesn't exist.
+
+    Line numbers (start_line / end_line) are deliberately excluded — they
+    shift across replays and would make cross-author matching brittle.
+    """
+    rows = await client.query(
+        f"SELECT repo, file_path, symbol_name, content_hash FROM {region_id} LIMIT 1"
+    )
+    if not rows or not isinstance(rows[0], dict):
+        return None
+    row = rows[0]
+    return {
+        "repo": str(row.get("repo", "")),
+        "file_path": str(row.get("file_path", "")),
+        "symbol_name": str(row.get("symbol_name", "")),
+        "content_hash": str(row.get("content_hash", "")),
+    }
+
+
+async def find_code_region_by_content(
+    client: LedgerClient,
+    *,
+    repo: str,
+    file_path: str,
+    symbol_name: str,
+    content_hash: str,
+) -> str | None:
+    """Resolve a code_region by content-addressable key. Returns the local
+    region id, or None if no matching row exists yet on this DB.
+
+    Used by ``events/materializer.py`` (#190) on receiver-side replay of
+    ``compliance_check.completed`` events: peers may have different
+    SurrealDB-generated region ids for the same code shape, so we look up
+    by ``(repo, file_path, symbol_name, content_hash)`` instead of by id.
+    """
+    rows = await client.query(
+        "SELECT id FROM code_region "
+        "WHERE repo = $r AND file_path = $fp AND symbol_name = $s "
+        "AND content_hash = $h LIMIT 1",
+        {"r": repo, "fp": file_path, "s": symbol_name, "h": content_hash},
+    )
+    if rows and isinstance(rows[0], dict):
+        rid = rows[0].get("id")
+        return str(rid) if rid else None
+    return None
+
+
 async def get_compliance_verdict(
     client: LedgerClient,
     decision_id: str,

--- a/plan-190-compliance-event.md
+++ b/plan-190-compliance-event.md
@@ -1,0 +1,191 @@
+# Plan: emit `compliance_check.completed` event + cross-author replay
+
+**change_class**: feature
+
+**doc_tier**: standard
+
+**terms_introduced**:
+- term: `compliance_check.completed`
+  home: docs/v0-architecture-current.md (§5 emitted-events table)
+
+**boundaries**:
+- limitations: cross-author replay matches regions by `(repo, file_path, symbol_name, content_hash)` — content-addressable, survives line-number shifts. Position-based matching is rejected (line numbers shift across replays).
+- non_goals: backfilling historical compliance events for prior `link_commit.completed` replays. Going-forward only.
+- exclusions: renaming the ledger `compliance_check` table or any other event types; SPEC.bql formalism; new server-side LLM call.
+
+## Open Questions
+
+None. All design choices resolved in `/qor-plan` dialogue:
+- Q1 region descriptor → content-addressable `(repo, file_path, symbol_name, content_hash)`, not position-addressable.
+
+## Phase 1: Emit `compliance_check.completed` from `handle_resolve_compliance`
+
+### Affected Files
+
+- `tests/test_team_event_replay.py` — new tests for emission contract (3 tests)
+- `events/team_adapter.py` — new `apply_resolve_compliance` method that writes the JSONL event
+- `handlers/resolve_compliance.py` — call `apply_resolve_compliance` after `upsert_compliance_check` succeeds, when the underlying ledger is the team adapter
+
+### Changes
+
+**`events/team_adapter.py`** — add an emit method alongside the existing `apply_ratify` / `apply_supersede`:
+
+```python
+async def apply_resolve_compliance(
+    self,
+    *,
+    canonical_decision_id: str,
+    repo: str,
+    file_path: str,
+    symbol_name: str,
+    content_hash: str,
+    verdict: Literal["compliant", "drifted", "not_relevant"],
+    pinned_commit: str,
+    evidence: str = "",
+) -> None:
+    """Emit `compliance_check.completed` to the team-sync JSONL stream.
+
+    Fires once per accepted `ComplianceVerdict`. Receiver re-applies
+    the verdict via the materializer's content-addressable lookup.
+    Idempotent on receiver side — `upsert_compliance_check` already
+    first-write-wins on `(decision_id, region_id, content_hash)`.
+    """
+    payload = {
+        "canonical_decision_id": canonical_decision_id,
+        "region": {
+            "repo": repo,
+            "file_path": file_path,
+            "symbol_name": symbol_name,
+            "content_hash": content_hash,
+        },
+        "verdict": verdict,
+        "pinned_commit": pinned_commit,
+        "evidence": evidence,
+    }
+    self._writer.write("compliance_check.completed", payload)
+```
+
+**`handlers/resolve_compliance.py`** — after each successful `upsert_compliance_check` call (line 156-168 in current code), invoke the emit when the adapter is the team adapter. Resolution: pass `canonical_decision_id` looked up via the existing `get_canonical_id` helper in `ledger/queries.py`; pass `repo`, `file_path`, `symbol_name`, and `content_hash` from the `code_region` row that was just verdicted.
+
+The team-adapter check follows the existing pattern from `apply_ratify` / `apply_supersede` — `hasattr(ledger, "_team_adapter")` or equivalent attribute set during construction.
+
+### Unit Tests
+
+- `tests/test_team_event_replay.py::test_resolve_compliance_emits_one_event_per_verdict` — invoke `handle_resolve_compliance` with a team adapter and 2 accepted verdicts; assert exactly 2 `compliance_check.completed` events appear in the JSONL writer's captured output. Confirms one-event-per-verdict invariant.
+
+- `tests/test_team_event_replay.py::test_resolve_compliance_no_emit_in_single_mode` — invoke `handle_resolve_compliance` with the non-team `SurrealDBLedgerAdapter`; assert no JSONL events written. Confirms emission is gated on team mode.
+
+- `tests/test_team_event_replay.py::test_compliance_event_payload_is_content_addressable` — invoke `handle_resolve_compliance`, capture the emitted event, assert the `region` block contains `content_hash` and does NOT contain `start_line` / `end_line`. Confirms Q1 design choice (line numbers excluded; receiver matches by content hash).
+
+## Phase 2: Replay branch in `events/materializer.py`
+
+### Affected Files
+
+- `tests/test_team_event_replay.py` — new tests for replay contract (3 tests, extending Phase 1 file)
+- `events/materializer.py` — new `compliance_check.completed` dispatch case in the `EventMaterializer.replay_new_events` switch
+- `ledger/queries.py` — new helper `find_code_region_by_content` resolving `(repo, file_path, symbol_name, content_hash)` to a local `code_region` id (for the receiver-side lookup)
+- `ledger/adapter.py` — new public method `apply_compliance_verdict_from_event` that takes the resolved `decision_id`, `region_id`, `verdict`, `pinned_commit`, `evidence` and calls the existing `upsert_compliance_check` path
+
+### Changes
+
+**`ledger/queries.py`** — pure-data lookup function:
+
+```python
+async def find_code_region_by_content(
+    client,
+    *,
+    repo: str,
+    file_path: str,
+    symbol_name: str,
+    content_hash: str,
+) -> str | None:
+    """Resolve a code_region by content-addressable key. Returns the local
+    region id, or None if no matching row exists yet on this DB."""
+```
+
+**`events/materializer.py`** — dispatch branch matching the existing `decision_ratified.completed` shape:
+
+```python
+elif etype == "compliance_check.completed":
+    from ledger.queries import find_decision_by_canonical_id, find_code_region_by_content
+
+    local_decision_id = await find_decision_by_canonical_id(
+        inner_adapter._client,
+        payload.get("canonical_decision_id", ""),
+    )
+    if local_decision_id is None:
+        logger.warning(
+            "[materializer] skipping compliance_check.completed — "
+            "canonical_decision_id %r not found locally",
+            payload.get("canonical_decision_id"),
+        )
+        continue
+    region = payload.get("region") or {}
+    local_region_id = await find_code_region_by_content(
+        inner_adapter._client,
+        repo=region.get("repo", ""),
+        file_path=region.get("file_path", ""),
+        symbol_name=region.get("symbol_name", ""),
+        content_hash=region.get("content_hash", ""),
+    )
+    if local_region_id is None:
+        logger.warning(
+            "[materializer] skipping compliance_check.completed — "
+            "region (%s::%s @ %s) not yet materialized locally",
+            region.get("file_path"),
+            region.get("symbol_name"),
+            region.get("content_hash", "")[:8],
+        )
+        continue
+    await inner_adapter.apply_compliance_verdict_from_event(
+        decision_id=local_decision_id,
+        region_id=local_region_id,
+        verdict=payload.get("verdict", ""),
+        pinned_commit=payload.get("pinned_commit", ""),
+        evidence=payload.get("evidence", ""),
+    )
+    replayed += 1
+```
+
+**`ledger/adapter.py::SurrealDBLedgerAdapter`** — `apply_compliance_verdict_from_event` thin wrapper that delegates to the existing `upsert_compliance_check` query; surfaces it as a public method so the materializer doesn't reach into private query helpers.
+
+### Unit Tests
+
+- `tests/test_team_event_replay.py::test_compliance_event_replay_writes_compliance_check_row` — full round-trip: ingest + bind + resolve_compliance on adapter A produces a JSONL event; replay into adapter B's fresh memory:// DB; assert B has a `compliance_check` row with the matching verdict AND `project_decision_status` returns the same status as A's. Confirms the receiver-side state matches sender-side state via the event substrate (the §5 team-sync invariant).
+
+- `tests/test_team_event_replay.py::test_compliance_event_replay_warns_when_region_missing_locally` — emit a `compliance_check.completed` event referencing a region whose content_hash doesn't exist on the receiver's DB; replay; capture log output; assert one `WARNING` line is emitted naming the file_path/symbol_name AND no compliance_check row was written on the receiver. Confirms the documented fail-soft contract.
+
+- `tests/test_team_event_replay.py::test_compliance_event_replay_idempotent_on_duplicate` — replay the same `compliance_check.completed` event twice into receiver B's DB; assert only one `compliance_check` row exists after both replays AND the second replay completes without error. Confirms first-write-wins idempotency on `(decision_id, region_id, content_hash)` survives replay.
+
+## Phase 3: Documentation update
+
+### Affected Files
+
+- `docs/v0-architecture-current.md` — update §5 emitted-events table to include `compliance_check.completed`; update the "Known gap" prose at line 115 to past-tense; remove the broken `#178` cross-reference; update the Reconciliation table at the bottom
+
+### Changes
+
+**§5 emitted-events table** — add row:
+
+```markdown
+| `compliance_check.completed` | After `resolve_compliance` writes a verdict |
+```
+
+**§5 prose at line 115** — replace the "Known gap (tracked separately)" paragraph:
+
+> ~~**Known gap (tracked separately)**: `compliance_checked` is named in the Notion page but is **not currently emitted**. … Until fixed, teammate replays infer compliance state from `link_commit.completed` effects rather than from explicit verdict events.~~
+>
+> All v0 verdict transitions emit explicit events. Receiver-side replay resolves regions content-addressably (`(repo, file_path, symbol_name, content_hash)`); regions not yet materialized locally produce a logged warning rather than a silent inconsistency. See #190 for the design.
+
+**Reconciliation notes table at the bottom** — remove the row claiming `compliance_checked` is missing (now resolved).
+
+### Unit Tests
+
+None — pure markdown content; reviewed by humans on PR. The acceptance check is that the §5 events table matches the actual emitter set in `events/team_adapter.py`, which Phase 1's tests already lock.
+
+## CI Commands
+
+- `pytest tests/test_team_event_replay.py -v` — validates emission + replay contract (6 tests)
+- `pytest tests/ -v --no-cov` — full regression sweep
+- `mypy .` — type-check
+- `ruff check . && ruff format --check .` — lint + format

--- a/tests/test_team_event_replay.py
+++ b/tests/test_team_event_replay.py
@@ -11,6 +11,7 @@ For each decision-status event type:
 Covers the new event vocabulary added in this PR:
     - decision_ratified.completed
     - decision_superseded.completed
+    - compliance_check.completed (#190 — emission + replay + idempotency)
 
 Plus regression coverage for the pre-existing emit/replay surface:
     - ingest.completed (decision row + signoff round-trip)
@@ -185,3 +186,417 @@ async def test_ingest_event_roundtrip_regression(tmp_path: Path) -> None:
     rows = await inner_b._client.query(f"SELECT description FROM {decision_id_b} LIMIT 1")
     assert rows, "ingest.completed regression — decision row missing after replay"
     assert "regression-intent" in str(rows[0].get("description", ""))
+
+
+# ── #190: compliance_check.completed event ──────────────────────────
+
+
+async def _seed_code_region(
+    client,
+    *,
+    file_path: str = "src/billing/calc.py",
+    symbol_name: str = "calc_total",
+    content_hash: str = "sha256:beef0001",
+    repo: str = "test-repo",
+) -> str:
+    """Seed a code_region row directly via SQL. Ingest events don't carry
+    region data, so cross-author replay tests need both peers to have
+    matching regions (same content_hash) materialized via a separate path
+    (e.g. local bind call, repo scan)."""
+    rows = await client.query(
+        "CREATE code_region SET file_path = $fp, symbol_name = $s, "
+        "start_line = 10, end_line = 30, content_hash = $h, repo = $r",
+        {"fp": file_path, "s": symbol_name, "h": content_hash, "r": repo},
+    )
+    return str(rows[0]["id"])
+
+
+async def _resolve_compliance(
+    ledger,
+    *,
+    decision_id: str,
+    region_id: str,
+    content_hash: str,
+    verdict: str,
+    repo: str = "test-repo",
+):
+    """Helper: invoke handle_resolve_compliance with one verdict."""
+    from context import BicameralContext
+    from contracts import ComplianceVerdict
+    from handlers.resolve_compliance import handle_resolve_compliance
+
+    ctx = BicameralContext(
+        repo_path=repo,
+        head_sha="cafef00d00000000000000000000000000000000",
+        ledger=ledger,
+        code_graph=None,
+        drift_analyzer=None,
+    )
+    v = ComplianceVerdict(
+        decision_id=decision_id,
+        region_id=region_id,
+        content_hash=content_hash,
+        verdict=verdict,
+        confidence=0.95,
+        explanation="test",
+    )
+    return await handle_resolve_compliance(
+        ctx, phase="drift", verdicts=[v], commit_hash=ctx.head_sha
+    )
+
+
+def _read_jsonl_events(events_dir: Path) -> list[dict]:
+    """Return all events written to the JSONL log, in order."""
+    import json
+
+    out: list[dict] = []
+    for p in sorted(events_dir.rglob("*.jsonl")):
+        for line in p.read_text(encoding="utf-8").splitlines():
+            line = line.strip()
+            if line:
+                out.append(json.loads(line))
+    return out
+
+
+@pytest.mark.asyncio
+async def test_resolve_compliance_emits_one_event_per_verdict(tmp_path: Path) -> None:
+    """Each accepted ComplianceVerdict produces exactly one
+    compliance_check.completed event in the JSONL stream."""
+    from context import BicameralContext
+    from contracts import ComplianceVerdict
+    from handlers.resolve_compliance import handle_resolve_compliance
+
+    events_dir = tmp_path / "events"
+    local_dir = tmp_path / "local"
+
+    team, inner = _build_team_adapter(events_dir, local_dir)
+    await team.connect()
+
+    res = await team.ingest_payload(_payload("compliance-emit", "ce-mtg"))
+    decision_id = res["created_decisions"][0]["decision_id"]
+    region_id = await _seed_code_region(inner._client, content_hash="sha256:beef0001")
+
+    # Build two verdicts on the same region, varying content_hash so the
+    # UNIQUE index doesn't collapse them. Each verdict is independently emitted.
+    verdicts = [
+        ComplianceVerdict(
+            decision_id=decision_id,
+            region_id=region_id,
+            content_hash="sha256:beef0001",
+            verdict="compliant",
+            confidence="high",
+            explanation="v1",
+        ),
+        ComplianceVerdict(
+            decision_id=decision_id,
+            region_id=region_id,
+            content_hash="sha256:beef0002",
+            verdict="drifted",
+            confidence="high",
+            explanation="v2",
+        ),
+    ]
+    ctx = BicameralContext(
+        repo_path="test-repo",
+        head_sha="cafef00d00000000000000000000000000000000",
+        ledger=team,
+        code_graph=None,
+        drift_analyzer=None,
+    )
+    await handle_resolve_compliance(ctx, phase="drift", verdicts=verdicts, commit_hash=ctx.head_sha)
+
+    events = _read_jsonl_events(events_dir)
+    compliance_events = [e for e in events if e.get("event_type") == "compliance_check.completed"]
+    assert len(compliance_events) == 2, (
+        f"expected 2 compliance_check.completed events, got {len(compliance_events)}: "
+        f"{[e.get('event_type') for e in events]}"
+    )
+
+
+@pytest.mark.asyncio
+async def test_resolve_compliance_no_emit_in_single_mode(tmp_path: Path) -> None:
+    """Single-mode (non-team adapter) writes verdicts to the local DB but
+    emits no JSONL events."""
+    from context import BicameralContext
+    from contracts import ComplianceVerdict
+    from handlers.resolve_compliance import handle_resolve_compliance
+
+    events_dir = tmp_path / "events"
+    local_dir = tmp_path / "local"
+
+    # Use the inner adapter directly — NO TeamWriteAdapter wrapping.
+    inner = SurrealDBLedgerAdapter(url="memory://")
+    await inner.connect()
+
+    res = await inner.ingest_payload(_payload("single-mode", "sm-mtg"))
+    decision_id = res["created_decisions"][0]["decision_id"]
+    region_id = await _seed_code_region(inner._client, content_hash="sha256:beef0001")
+
+    ctx = BicameralContext(
+        repo_path="test-repo",
+        head_sha="cafef00d00000000000000000000000000000000",
+        ledger=inner,
+        code_graph=None,
+        drift_analyzer=None,
+    )
+    v = ComplianceVerdict(
+        decision_id=decision_id,
+        region_id=region_id,
+        content_hash="sha256:beef0001",
+        verdict="compliant",
+        confidence="high",
+        explanation="single-mode",
+    )
+    await handle_resolve_compliance(ctx, phase="drift", verdicts=[v], commit_hash=ctx.head_sha)
+
+    # The events_dir should not exist (no writer was wired up) OR be empty.
+    if events_dir.exists():
+        events = _read_jsonl_events(events_dir)
+        assert events == [], f"single-mode should emit zero events, got {events}"
+    # Otherwise: no events_dir was created, which is also "no emit".
+
+
+@pytest.mark.asyncio
+async def test_compliance_event_payload_is_content_addressable(tmp_path: Path) -> None:
+    """The emitted event's region descriptor uses content_hash, NOT
+    start_line/end_line. Confirms Q1 design choice (line numbers excluded;
+    receiver matches by content hash for cross-author replay stability)."""
+    from context import BicameralContext
+    from contracts import ComplianceVerdict
+    from handlers.resolve_compliance import handle_resolve_compliance
+
+    events_dir = tmp_path / "events"
+    local_dir = tmp_path / "local"
+
+    team, inner = _build_team_adapter(events_dir, local_dir)
+    await team.connect()
+
+    res = await team.ingest_payload(_payload("payload-shape", "ps-mtg"))
+    decision_id = res["created_decisions"][0]["decision_id"]
+    region_id = await _seed_code_region(inner._client, content_hash="sha256:beef0001")
+
+    ctx = BicameralContext(
+        repo_path="test-repo",
+        head_sha="cafef00d00000000000000000000000000000000",
+        ledger=team,
+        code_graph=None,
+        drift_analyzer=None,
+    )
+    v = ComplianceVerdict(
+        decision_id=decision_id,
+        region_id=region_id,
+        content_hash="sha256:beef0001",
+        verdict="compliant",
+        confidence="high",
+        explanation="payload check",
+    )
+    await handle_resolve_compliance(ctx, phase="drift", verdicts=[v], commit_hash=ctx.head_sha)
+
+    events = _read_jsonl_events(events_dir)
+    compliance_events = [e for e in events if e.get("event_type") == "compliance_check.completed"]
+    assert len(compliance_events) == 1
+    region = compliance_events[0]["payload"].get("region", {})
+    assert "content_hash" in region, f"region descriptor must include content_hash; got {region}"
+    assert region["content_hash"] == "sha256:beef0001"
+    assert "start_line" not in region, (
+        "region descriptor must NOT include start_line — line numbers shift on replay"
+    )
+    assert "end_line" not in region, (
+        "region descriptor must NOT include end_line — line numbers shift on replay"
+    )
+
+
+@pytest.mark.asyncio
+async def test_compliance_event_replay_writes_compliance_check_row(tmp_path: Path) -> None:
+    """Full round-trip: resolve_compliance on adapter A emits an event;
+    fresh adapter B replays it from the same JSONL into a fresh DB; B has
+    a compliance_check row matching A's verdict."""
+    from context import BicameralContext
+    from contracts import ComplianceVerdict
+    from handlers.resolve_compliance import handle_resolve_compliance
+
+    events_dir = tmp_path / "events"
+    local_dir_a = tmp_path / "local_a"
+
+    team_a, inner_a = _build_team_adapter(events_dir, local_dir_a)
+    await team_a.connect()
+
+    res = await team_a.ingest_payload(_payload("replay-roundtrip", "rr-mtg"))
+    decision_id_a = res["created_decisions"][0]["decision_id"]
+    canonical = await get_canonical_id(inner_a._client, decision_id_a)
+    region_id_a = await _seed_code_region(inner_a._client, content_hash="sha256:beef0001")
+
+    ctx_a = BicameralContext(
+        repo_path="test-repo",
+        head_sha="cafef00d00000000000000000000000000000000",
+        ledger=team_a,
+        code_graph=None,
+        drift_analyzer=None,
+    )
+    v = ComplianceVerdict(
+        decision_id=decision_id_a,
+        region_id=region_id_a,
+        content_hash="sha256:beef0001",
+        verdict="drifted",
+        confidence="high",
+        explanation="real drift",
+    )
+    await handle_resolve_compliance(ctx_a, phase="drift", verdicts=[v], commit_hash=ctx_a.head_sha)
+
+    # Fresh adapter B. Seed B's code_region with the same content_hash A used
+    # (production: B has it via local bind / repo scan; here we inline-seed so
+    # the cross-author lookup succeeds). Then drive replay.
+    local_dir_b = tmp_path / "local_b"
+    team_b, inner_b = _build_team_adapter(events_dir, local_dir_b)
+    await team_b.connect()
+    await _seed_code_region(inner_b._client, content_hash="sha256:beef0001")
+    # Re-replay so the compliance event finds the now-seeded region.
+    watermark_b = local_dir_b / "watermark"
+    if watermark_b.exists():
+        watermark_b.unlink()
+    await team_b._materializer.replay_new_events(team_b._inner)
+
+    decision_id_b = await find_decision_by_canonical_id(inner_b._client, canonical)
+    assert decision_id_b, "ingest event did not replay (no row for canonical_id)"
+    rows = await inner_b._client.query(
+        "SELECT verdict FROM compliance_check WHERE decision_id = $did LIMIT 1",
+        {"did": decision_id_b},
+    )
+    assert rows, "compliance_check.completed did not replay — no compliance_check row on B"
+    assert rows[0].get("verdict") == "drifted", (
+        f"replayed verdict should be 'drifted'; got {rows[0].get('verdict')!r}"
+    )
+
+
+@pytest.mark.asyncio
+async def test_compliance_event_replay_warns_when_region_missing_locally(
+    tmp_path: Path, caplog
+) -> None:
+    """Replay of a compliance event whose region descriptor doesn't match
+    any local code_region produces a warning AND does not write a row."""
+    import logging
+
+    from context import BicameralContext
+    from contracts import ComplianceVerdict
+    from handlers.resolve_compliance import handle_resolve_compliance
+
+    events_dir = tmp_path / "events"
+    local_dir_a = tmp_path / "local_a"
+
+    team_a, inner_a = _build_team_adapter(events_dir, local_dir_a)
+    await team_a.connect()
+    res = await team_a.ingest_payload(_payload("missing-region", "mr-mtg"))
+    decision_id_a = res["created_decisions"][0]["decision_id"]
+    # Seed A's region with a content_hash B will NOT have. The event's
+    # region descriptor is derived from THIS region (not from the verdict),
+    # so receiver B looking up by this content_hash will miss.
+    region_id_a = await _seed_code_region(inner_a._client, content_hash="sha256:ONLY_ON_SENDER")
+
+    ctx_a = BicameralContext(
+        repo_path="test-repo",
+        head_sha="cafef00d00000000000000000000000000000000",
+        ledger=team_a,
+        code_graph=None,
+        drift_analyzer=None,
+    )
+    v = ComplianceVerdict(
+        decision_id=decision_id_a,
+        region_id=region_id_a,
+        content_hash="sha256:ONLY_ON_SENDER",
+        verdict="compliant",
+        confidence="high",
+        explanation="phantom",
+    )
+    await handle_resolve_compliance(ctx_a, phase="drift", verdicts=[v], commit_hash=ctx_a.head_sha)
+
+    # Receiver B replays. B's code_region has a DIFFERENT content_hash —
+    # production scenario where B has the file at a different state. The
+    # event's region descriptor (carrying sha256:ONLY_ON_SENDER) won't match
+    # any local region on B. Warning expected; no compliance_check row.
+    local_dir_b = tmp_path / "local_b"
+    with caplog.at_level(logging.WARNING, logger="events.materializer"):
+        team_b, inner_b = _build_team_adapter(events_dir, local_dir_b)
+        await team_b.connect()
+        await _seed_code_region(inner_b._client, content_hash="sha256:beef0001")
+        # Re-replay against the now-seeded region — should still miss.
+        watermark_b = local_dir_b / "watermark"
+        if watermark_b.exists():
+            watermark_b.unlink()
+        await team_b._materializer.replay_new_events(team_b._inner)
+
+    decision_id_b = await find_decision_by_canonical_id(
+        inner_b._client, await get_canonical_id(inner_a._client, decision_id_a)
+    )
+    assert decision_id_b, "ingest replay should have written the decision row"
+    rows = await inner_b._client.query(
+        "SELECT verdict FROM compliance_check WHERE decision_id = $did",
+        {"did": decision_id_b},
+    )
+    assert rows == [], f"no compliance_check row should be written when region misses; got {rows}"
+    assert any(
+        "compliance_check.completed" in rec.message and "not yet materialized" in rec.message
+        for rec in caplog.records
+    ), f"expected a 'not yet materialized' WARNING; got: {[r.message for r in caplog.records]}"
+
+
+@pytest.mark.asyncio
+async def test_compliance_event_replay_idempotent_on_duplicate(tmp_path: Path) -> None:
+    """Replaying the same compliance_check.completed event twice does not
+    produce duplicate rows. Locked by the existing UNIQUE index on
+    (decision_id, region_id, content_hash) at ledger/schema.py:228."""
+    from context import BicameralContext
+    from contracts import ComplianceVerdict
+    from handlers.resolve_compliance import handle_resolve_compliance
+
+    events_dir = tmp_path / "events"
+    local_dir_a = tmp_path / "local_a"
+
+    team_a, inner_a = _build_team_adapter(events_dir, local_dir_a)
+    await team_a.connect()
+    res = await team_a.ingest_payload(_payload("idempotent", "id-mtg"))
+    decision_id_a = res["created_decisions"][0]["decision_id"]
+    canonical = await get_canonical_id(inner_a._client, decision_id_a)
+    region_id_a = await _seed_code_region(inner_a._client, content_hash="sha256:beef0001")
+
+    ctx_a = BicameralContext(
+        repo_path="test-repo",
+        head_sha="cafef00d00000000000000000000000000000000",
+        ledger=team_a,
+        code_graph=None,
+        drift_analyzer=None,
+    )
+    v = ComplianceVerdict(
+        decision_id=decision_id_a,
+        region_id=region_id_a,
+        content_hash="sha256:beef0001",
+        verdict="compliant",
+        confidence="high",
+        explanation="idempotent",
+    )
+    await handle_resolve_compliance(ctx_a, phase="drift", verdicts=[v], commit_hash=ctx_a.head_sha)
+
+    # First replay into B. Seed matching region first.
+    local_dir_b = tmp_path / "local_b"
+    team_b, inner_b = _build_team_adapter(events_dir, local_dir_b)
+    await team_b.connect()
+    await _seed_code_region(inner_b._client, content_hash="sha256:beef0001")
+    watermark_b = local_dir_b / "watermark"
+    if watermark_b.exists():
+        watermark_b.unlink()
+    await team_b._materializer.replay_new_events(team_b._inner)
+
+    # Second replay: reset the watermark to 0 and reconnect; same events get
+    # processed again. The UNIQUE index should make the second upsert a no-op.
+    watermark_b = local_dir_b / "watermark"
+    if watermark_b.exists():
+        watermark_b.unlink()
+    await team_b._materializer.replay_new_events(team_b._inner)
+
+    decision_id_b = await find_decision_by_canonical_id(inner_b._client, canonical)
+    rows = await inner_b._client.query(
+        "SELECT verdict FROM compliance_check WHERE decision_id = $did",
+        {"did": decision_id_b},
+    )
+    assert len(rows) == 1, (
+        f"after duplicate replay, exactly one compliance_check row should exist; got {len(rows)}"
+    )


### PR DESCRIPTION
## Summary

- Adds `compliance_check.completed` to the team-sync JSONL event vocabulary so peer replays can re-apply verdicts directly instead of inferring them from `link_commit.completed` effects.
- Cross-author region key is **content-addressable** (`repo`, `file_path`, `symbol_name`, `content_hash`) per the audit-resolved Q1 — survives line-number shifts on receiver-side replay.
- Receiver-side replay is fail-soft: when the local DB lacks a region with the matching content_hash, the materializer logs a warning and skips. Idempotent via the existing `UNIQUE (decision_id, region_id, content_hash)` index at `ledger/schema.py:228`.
- Closes the "Known gap" §5 prose in `docs/v0-architecture-current.md`; updates the Reconciliation table.

## Linked issues

Closes #190

## Plan / Audit / Seal

- **Plan**: `plan-190-compliance-event.md` (committed in this PR for the audit trail; `change_class: feature, doc_tier: standard`)
- **Audit**: PASS first round (`/qor-audit`); 4 advisory observations, no findings
- **Seal**: advisory PASS — Reality matches Promise (all 6 plan tests pass; mypy/ruff/format all clean; full test_resolve_compliance regression passes)
- **Risk**: L2 (substantial new event-substrate surface, but well-contained within the existing `apply_X` precedent and backed by the idempotency-invariant UNIQUE index)

## Test plan

- [x] `pytest tests/test_team_event_replay.py -v` — 9/9 pass (6 new + 3 regression)
- [x] `pytest tests/test_resolve_compliance.py -v` — 11/11 pass (regression on the handler this PR augments)
- [x] `mypy .` — clean
- [x] `ruff check . && ruff format --check .` — clean

The 6 new tests cover:
- `test_resolve_compliance_emits_one_event_per_verdict` (one event per accepted verdict)
- `test_resolve_compliance_no_emit_in_single_mode` (no JSONL writes when adapter is single-mode)
- `test_compliance_event_payload_is_content_addressable` (region descriptor has `content_hash`, NOT `start_line`/`end_line`)
- `test_compliance_event_replay_writes_compliance_check_row` (full A→B round-trip)
- `test_compliance_event_replay_warns_when_region_missing_locally` (fail-soft on receiver miss)
- `test_compliance_event_replay_idempotent_on_duplicate` (UNIQUE index dedup survives re-replay)

## Changes by phase

**Phase 1 (sender-side emission):**
- `events/team_adapter.py`: new `apply_resolve_compliance` method
- `handlers/resolve_compliance.py`: invokes the emit after `upsert_compliance_check` when the adapter is team-mode
- `ledger/queries.py`: new `get_region_descriptor` helper

**Phase 2 (receiver-side replay):**
- `events/materializer.py`: new `compliance_check.completed` dispatch branch
- `ledger/queries.py`: new `find_code_region_by_content` helper
- `ledger/adapter.py`: new `apply_compliance_verdict_from_event` public method on `SurrealDBLedgerAdapter`

**Phase 3 (docs):**
- `docs/v0-architecture-current.md`: §5 events table + cross-author replay paragraph + Reconciliation row update

## Notes for reviewer

- `apply_resolve_compliance` returns `None` while sibling `apply_ratify` returns `canonical_id`. Defensible — the caller already has `canonical_decision_id` from the prior `get_canonical_id` lookup, no need to round-trip — but flagged in the audit (advisory A4) as a stylistic divergence worth a one-line comment if desired.
- `apply_compliance_verdict_from_event` fixes `confidence="high"` and `phase="drift"` on receiver-side replay because peer-attested verdicts arrive without local confidence/phase context. The verdict and explanation are authoritative; everything else is replay-context. Documented in the method's docstring.
- The `bind_decision.completed` and `link_commit.completed` events were not the gap (they materialize regions on receiver via separate paths); this PR only adds the missing verdict-transition event. `event_targets` graph edge from the original Notion v0 page remains intentionally not implemented — JSONL-in-git delivers the team-sync goal directly. See `docs/v0-architecture-current.md` §5 commentary.