### PR TITLE
feat(api): unify gap-judge findings into IngestResponse.brief envelope

### DIFF
--- a/contracts.py
+++ b/contracts.py
@@ -573,8 +573,7 @@ class IngestResponse(BaseModel):
     pending_grounding_decisions: list[dict] = []
     context_for_candidates: list[ContextForCandidate] = []
     source_cursor: SourceCursorSummary | None = None
-    judgment_payload: GapJudgmentPayload | None = None  # kept for backward compat
-    judgment_payloads: list[GapJudgmentPayload] = []  # one per feature_group topic
+    brief: BriefEnvelope | None = None  # #187: unified brief envelope; replaces judgment_payload[s]
     sync_status: LinkCommitResponse | None = None
 
 
@@ -608,6 +607,30 @@ class BriefDivergence(BaseModel):
     file_path: str
     conflicting_decisions: list[BriefDecision]
     summary: str
+
+
+class BriefEnvelope(BaseModel):
+    """Unified brief envelope returned inline on `IngestResponse.brief` (#187).
+
+    Shares its shape with the brief surface that `PreflightResponse` already
+    exposes via flat fields — same readers, one model. Server-side population
+    of `gaps` (via the gap-judge auto-chain) replaces the previously-fragile
+    dual-render contract where callers had to know to render
+    `IngestResponse.judgment_payload` separately from the brief decisions.
+
+    `rubric` carries the `GapRubric` reference that previously lived on
+    `judgment_payload.rubric` (5 fixed v0.4.19 categories; structurally
+    locked by `GapRubricCategory.key` Literal typing). `None` when no
+    gap-judge findings are present.
+    """
+
+    divergences: list[BriefDivergence] = []
+    drift_candidates: list[BriefDecision] = []
+    decisions: list[BriefDecision] = []
+    gaps: list[BriefGap] = []
+    rubric: GapRubric | None = None
+    action_hints: list[ActionHint] = []
+    suggested_questions: list[str] = []
 
 
 # ── Tool 7: /bicameral_reset ─────────────────────────────────────────
@@ -961,5 +984,6 @@ class SetDecisionLevelResponse(BaseModel):
 
 
 # Forward references
+BriefEnvelope.model_rebuild()  # forward ref to GapRubric defined later in file
 IngestResponse.model_rebuild()
 ResolveCollisionResponse.model_rebuild()

--- a/handlers/gap_judge.py
+++ b/handlers/gap_judge.py
@@ -20,9 +20,9 @@ Architectural anchor: the server never calls an LLM, never holds an
 API key, preserves the ``no-LLM-in-the-server`` invariant from
 ``git-for-specs.md``. This handler is a pure data-shape builder.
 
-Attached to ``IngestResponse.judgment_payload`` by the ingest auto-
-chain when the brief produced at least one decision. Also callable
-standalone via ``bicameral.judge_gaps(topic)``.
+Folded into ``IngestResponse.brief.gaps`` (and ``brief.rubric``) by
+the ingest auto-chain (#187) when the brief produced at least one
+decision. Also callable standalone via ``bicameral.judge_gaps(topic)``.
 """
 
 from __future__ import annotations

--- a/handlers/ingest.py
+++ b/handlers/ingest.py
@@ -10,6 +10,8 @@ import logging
 from datetime import UTC
 
 from contracts import (
+    BriefEnvelope,
+    BriefGap,
     ContextForCandidate,
     CreatedDecision,
     IngestPayload,
@@ -323,6 +325,8 @@ async def handle_ingest(
 
     # Auto-chain: fire judge_gaps per feature_group topic so the caller gets
     # one structured gap-judgment payload per segment. Failures are swallowed.
+    # #187: collected payloads are folded into the unified `brief` envelope
+    # below; the legacy flat `judgment_payload[s]` fields were removed.
     judgment_payloads: list = []
     try:
         topics = _derive_topics(payload)
@@ -335,7 +339,6 @@ async def handle_ingest(
                     judgment_payloads.append(jp)
     except Exception as exc:
         logger.warning("[ingest] post-ingest gap-judge chain failed: %s", exc)
-    judgment_payload = judgment_payloads[0] if judgment_payloads else None
 
     cursor_summary = None
     source_type = str(
@@ -373,6 +376,21 @@ async def handle_ingest(
         source_refs,
     )
 
+    # #187: build the unified brief envelope from the gap-judge findings.
+    # Future PR may also surface drift_candidates/divergences here once
+    # those are computed in the ingest path; today only gaps + rubric are
+    # populated server-side. brief stays None when there's nothing to render
+    # (silent-on-no-signal — matches PreflightResponse contract).
+    brief: BriefEnvelope | None = None
+    if judgment_payloads:
+        gaps: list[BriefGap] = []
+        for jp in judgment_payloads:
+            gaps.extend(jp.phrasing_gaps)
+        brief = BriefEnvelope(
+            gaps=gaps,
+            rubric=judgment_payloads[0].rubric,
+        )
+
     ingest_response = IngestResponse(
         ingested=bool(result.get("ingested", False)),
         repo=str(result.get("repo", repo)),
@@ -400,8 +418,7 @@ async def handle_ingest(
         ],
         context_for_candidates=context_for_candidates,
         source_cursor=cursor_summary,
-        judgment_payload=judgment_payload,
-        judgment_payloads=judgment_payloads,
+        brief=brief,
         sync_status=sync_status,
     )
 

--- a/plan-187-gap-brief-unification.md
+++ b/plan-187-gap-brief-unification.md
@@ -1,0 +1,200 @@
+# Plan: unify gap-judge findings into `IngestResponse.brief`
+
+**change_class**: breaking
+
+**doc_tier**: standard
+
+**terms_introduced**:
+- term: `BriefEnvelope`
+  home: contracts.py
+
+**boundaries**:
+- limitations: gap-judge findings are still computed by the caller-LLM via the existing rubric in `bicameral-judge-gaps`. The brief just bundles the rubric input so callers render a single section instead of two.
+- non_goals: reintroducing standalone `bicameral.brief` or `bicameral.judge_gaps` MCP tools — both stay as server-side auto-fires inside `ingest`. No new server-side LLM call.
+- exclusions: backwards-compat shim for `judgment_payload` / `judgment_payloads`. Removed cleanly per Simple Made Easy; no parallel-field carry.
+
+## Open Questions
+
+None. All design choices resolved in `/qor-plan` dialogue + audit-cycle amendment:
+- Q2 response shape → `BriefEnvelope` model with `decisions`, `drift_candidates`, `divergences`, `gaps`, `rubric`, `action_hints`, `suggested_questions`. Mirrors `PreflightResponse`'s brief surface (plus `rubric` to carry the GapRubric reference that previously lived on `judgment_payload.rubric`); one model, two consumers.
+- Q3 `judgment_payload` disposition → removed entirely. The existing `# kept for backward compat` comment is only a few minors of compat anyway; cleaner to remove than carry.
+- Audit-F2 resolution → rubric metadata carried on `BriefEnvelope.rubric: GapRubric | None`, allowing the existing `tests/test_v0416_gap_judge.py` assertions on `rubric.categories` to migrate cleanly to `response.brief.rubric.categories`. No information loss vs the legacy `judgment_payload.rubric` field.
+
+## Phase 1: Introduce `BriefEnvelope` + populate on `IngestResponse`
+
+### Affected Files
+
+- `tests/test_ingest_brief_unification.py` — new tests for the unified brief contract (4 tests)
+- `tests/test_v0416_gap_judge.py` — migrate 5+ existing assertions from `response.judgment_payload[s].*` to `response.brief.gaps[*]` / `response.brief.rubric.*`. Specifically: `test_ingest_chain_attaches_judgment_payload` (line 368-386) currently asserts `response.judgment_payload is not None`, `len(response.judgment_payload.decisions) >= 1`, `len(response.judgment_payload.rubric.categories) == 5` — migrated to `response.brief is not None`, `len(response.brief.gaps) >= 1`, `len(response.brief.rubric.categories) == 5`. The other 4 references in the file follow the same shape; rename in-place
+- `contracts.py` — add `BriefEnvelope` class with `rubric: GapRubric | None = None` field (carries the rubric reference that previously lived on `judgment_payload.rubric`); add `brief: BriefEnvelope | None` to `IngestResponse`; remove `judgment_payload` and `judgment_payloads` fields
+- `handlers/ingest.py` — populate `brief` from the assembled gap-judge findings + drift hints; remove the `judgment_payload[s]` assignments at the response site
+- `handlers/action_hints.py` — add `merge_drift_and_gap_hints(drift_hints, gap_hints) -> list[ActionHint]` helper that produces the unified action-hint list for the brief
+- `handlers/gap_judge.py` — docstring text update at line 23 (replace `IngestResponse.judgment_payload` reference with `IngestResponse.brief.gaps` / `IngestResponse.brief.rubric`)
+- **Out of scope but flagged**: `server.py:1119` contains `text=json.dumps({"judgment_payload": None, "topic": arguments["topic"]})` — this is the standalone `bicameral.judge_gaps` MCP tool's response shape, NOT `IngestResponse`. Same field name, different parent type, different contract. Implementer leaves this untouched. The `grep -rn "judgment_payload"` CI sanity check at the bottom of this plan will surface it; the implementer recognizes it as a non-cascading collision and skips
+
+### Changes
+
+**`contracts.py`** — new model just below `BriefDivergence`:
+
+```python
+class BriefEnvelope(BaseModel):
+    """Unified brief envelope returned by ingest (and shared shape with PreflightResponse).
+
+    The caller renders this single section instead of stitching together
+    separate `judgment_payload` + flat fields. Server-side population of
+    `gaps` removes the previously-fragile dual-render contract where agents
+    silently dropped Step 6 of the bicameral-ingest skill.
+
+    `rubric` carries the GapRubric reference that previously lived on
+    `judgment_payload.rubric` (5 fixed categories per v0.4.19; structurally
+    locked by Literal typing on GapRubricCategory.key). `None` when no
+    gap-judge findings are present.
+    """
+    divergences: list[BriefDivergence] = []
+    drift_candidates: list[BriefDecision] = []
+    decisions: list[BriefDecision] = []
+    gaps: list[BriefGap] = []
+    rubric: GapRubric | None = None
+    action_hints: list[ActionHint] = []
+    suggested_questions: list[str] = []
+```
+
+`IngestResponse` modified:
+
+```python
+class IngestResponse(BaseModel):
+    ingested: bool
+    repo: str
+    query: str
+    source_refs: list[str]
+    stats: IngestStats
+    created_decisions: list[CreatedDecision] = []
+    pending_grounding_decisions: list[dict] = []
+    context_for_candidates: list[ContextForCandidate] = []
+    source_cursor: SourceCursorSummary | None = None
+    brief: BriefEnvelope | None = None  # new — see #187
+    sync_status: LinkCommitResponse | None = None
+    # judgment_payload + judgment_payloads removed per #187
+```
+
+**`handlers/ingest.py`** — replace the existing `judgment_payload` / `judgment_payloads` assembly (lines ~324-338, 403-404 in current code) with a `BriefEnvelope` build site:
+
+```python
+# After gap-judge auto-chain produces judgment_payloads:
+gaps = []
+for jp in judgment_payloads:
+    gaps.extend(jp.findings)  # flatten across feature-group topics
+
+# Drift candidates / divergences / decisions come from the existing
+# brief-style assembly already running in handle_ingest. Action hints
+# are merged from drift + gap sources via the new helper.
+action_hints = merge_drift_and_gap_hints(
+    drift_hints=drift_action_hints,  # existing local var
+    gap_hints=[h for jp in judgment_payloads for h in jp.action_hints],
+)
+
+brief = BriefEnvelope(
+    divergences=divergences,
+    drift_candidates=drift_candidates,
+    decisions=brief_decisions,
+    gaps=gaps,
+    action_hints=action_hints,
+    suggested_questions=suggested_questions,
+) if (divergences or drift_candidates or brief_decisions or gaps) else None
+```
+
+`brief` is `None` when no signal — preserves the "silent on no signal" contract from preflight.
+
+**`handlers/action_hints.py`** — pure merge helper:
+
+```python
+def merge_drift_and_gap_hints(
+    drift_hints: list[ActionHint],
+    gap_hints: list[ActionHint],
+) -> list[ActionHint]:
+    """Combine drift and gap action hints into one list. Preserves order
+    (drift first, gaps after). Deduplicates by hint identity (`kind`, `text`)."""
+    seen = set()
+    merged = []
+    for h in (*drift_hints, *gap_hints):
+        key = (h.kind, h.text)
+        if key in seen:
+            continue
+        seen.add(key)
+        merged.append(h)
+    return merged
+```
+
+### Unit Tests
+
+- `tests/test_ingest_brief_unification.py::test_ingest_response_brief_populated_when_gaps_judged` — invoke `handle_ingest` with a payload that triggers gap-judge auto-fire (a feature_group present); assert `response.brief` is not None AND `response.brief.gaps` has at least one `BriefGap` entry. Confirms server-side population of the unified shape.
+
+- `tests/test_ingest_brief_unification.py::test_ingest_response_brief_action_hints_merge_drift_and_gaps` — invoke `handle_ingest` with a payload that produces both drift candidates AND gap-judge findings; assert `response.brief.action_hints` contains hints from BOTH sources, with drift hints first and gaps after, no duplicates. Confirms the merge contract.
+
+- `tests/test_ingest_brief_unification.py::test_ingest_response_brief_is_none_when_no_signal` — invoke `handle_ingest` with a payload that produces zero divergences, drift candidates, decisions, or gaps; assert `response.brief is None`. Confirms the silent-on-no-signal invariant.
+
+- `tests/test_ingest_brief_unification.py::test_ingest_response_has_no_judgment_payload_field` — invoke `handle_ingest`, get the response, assert that `model_dump(exclude_none=True)` for the response does NOT contain `judgment_payload` or `judgment_payloads` keys. Confirms the field removal — fails if a future change re-introduces the legacy fields.
+
+## Phase 2: Update `bicameral-ingest` skill to render unified brief
+
+### Affected Files
+
+- `skills/bicameral-ingest/SKILL.md` — replace the dual-step (Step 5 brief + Step 6 gap-judge) with a single-step unified render
+- `skills/bicameral-judge-gaps/SKILL.md` — update trigger-line reference (per §Changes below)
+
+### Changes
+
+**`skills/bicameral-ingest/SKILL.md`** — current Steps 5 + 6 replaced with one Step 5:
+
+```markdown
+### Step 5. Render the unified brief
+
+When `IngestResponse.brief` is non-null, render it as a single block.
+Sections in order:
+
+1. **Divergences** — `brief.divergences[]`. Surface each conflicting decision pair.
+2. **Drift candidates** — `brief.drift_candidates[]`. Surface drifted regions.
+3. **Decisions** — `brief.decisions[]`. Surface tracked decisions for context.
+4. **Gaps** — `brief.gaps[]`. Apply the v0.4.16 rubric (5 categories) inline; show category + finding for each gap.
+5. **Action hints** — `brief.action_hints[]`. Surface in guided-mode-aware tone.
+6. **Suggested questions** — `brief.suggested_questions[]`. Bulleted list at the bottom.
+
+When `brief` is null, do not render anything for the brief — silent-on-no-signal preserves the existing contract.
+
+The `judgment_payload` field that previously carried gap-judge data has been
+removed; gap findings are now in `brief.gaps[]`.
+```
+
+**`skills/bicameral-judge-gaps/SKILL.md`** — note that the rubric is invoked via the brief context, not as a standalone step. Remove the "fired automatically when an ingest response carries a `judgment_payload`" trigger line; replace with "fired automatically when an ingest response carries `brief.gaps`."
+
+### Unit Tests
+
+None. Phase 2 is text-only edits to two skill markdown files; skills are consumed by an LLM at runtime, not pytest-invocable. A static skill-vs-schema drift check (e.g. parsing the skill prose for field names and checking against `BriefEnvelope.model_json_schema()`) would be presence-only per `doctrine-test-functionality` (no unit invocation; the assertion is `<substring> in <derived-data>`-shaped). If skill-schema drift detection is wanted, structure it as a CI lint script outside pytest — separate concern, not in this plan.
+
+## Phase 3: Stale `/bicameral:report-bug` → `/bicameral-report-bug` rename
+
+### Affected Files
+
+- `skills/bicameral-report-bug/SKILL.md` — 4 line edits
+
+### Changes
+
+Replace `/bicameral:report-bug` → `/bicameral-report-bug` in 4 locations on `skills/bicameral-report-bug/SKILL.md`:
+- Line 3 (description trigger phrase)
+- Line 6 (header `# /bicameral:report-bug`)
+- Line 8 (trigger declaration)
+- Line 142 (trailer `_Reported via .../bicameral:report-bug._`)
+
+This is the single residual occurrence of the colon namespace form across `skills/`. The convention rename was completed in #178 except for this skill, which post-dated #178's sweep. After this Phase, no `/bicameral:` references remain in any tracked source file (per `grep -rn "/bicameral:" --include="*.md" --include="*.py" .` — 0 hits, excluding `CHANGELOG.md` archival entries and `.claude/worktrees/` clutter).
+
+### Unit Tests
+
+None — text rename in one skill file. The convention is enforced by the wider rename done in #178; this is mop-up. A presence-only "no `/bicameral:` in skills/" guard would violate `doctrine-test-functionality` (asserts string absence rather than unit behavior); skipped.
+
+## CI Commands
+
+- `pytest tests/test_ingest_brief_unification.py tests/test_v0416_gap_judge.py -v` — validates Phase 1's new tests AND the migrated assertions in the existing v0416 gap-judge tests
+- `pytest tests/ -v --no-cov` — full regression sweep (catches any test that asserts on the removed `judgment_payload` field outside the explicitly-migrated set)
+- `mypy .` — type-check (catches consumers reading `.judgment_payload` after removal)
+- `ruff check . && ruff format --check .` — lint + format
+- `grep -rn "judgment_payload" --include="*.py" .` — final sanity check. Expected hits after migration: `server.py:1119` only (the standalone judge_gaps tool's response shape — non-cascading collision, intentionally untouched per Phase 1 §Affected Files). Any other hits indicate a missed consumer

--- a/skills/bicameral-ingest/SKILL.md
+++ b/skills/bicameral-ingest/SKILL.md
@@ -734,14 +734,17 @@ the boxes. Two intensities, controlled by `guided: bool`:
 
 When `brief` is `null` (no derivable topic or chain failed), skip silently.
 
-### 6. Apply the gap-judge rubric (v0.4.16+)
+### 6. Apply the gap-judge rubric (v0.4.16+; unified brief shape from #187)
 
-When the ingest response contains a non-null `judgment_payload`, apply the
+When `IngestResponse.brief.gaps` is non-empty, apply the
 `bicameral-judge-gaps` rubric using the visual format from
-`skills/gap_visualization/SKILL.md`. Full contract is in
+`skills/gap_visualization/SKILL.md`. The rubric itself lives at
+`response.brief.rubric` (5 fixed v0.4.19 categories). Full contract is in
 `skills/bicameral-judge-gaps/SKILL.md`.
 
 **Key rendering rules for this flow:**
+- Iterate `response.brief.gaps[]` (a list of `BriefGap`) — each entry
+  corresponds to one finding the rubric should apply to.
 - Render each ask-gap as its corresponding box template (templates #1–#5).
 - **Skip empty categories entirely** — no header, no `✓ no gaps found`.
   The user only sees boxes for actual findings.
@@ -750,7 +753,14 @@ When the ingest response contains a non-null `judgment_payload`, apply the
 - Max 3 boxes per category; if more exist, surface the batched gate from
   `bicameral-judge-gaps` for the remainder.
 
-When `judgment_payload` is `null` (no decisions or chain failed), skip silently.
+When `response.brief` is `null` OR `response.brief.gaps` is empty (no
+decisions or chain failed), skip silently.
+
+**Migration note (#187)**: the legacy `IngestResponse.judgment_payload` and
+`IngestResponse.judgment_payloads` fields were removed. Gap findings now
+live at `response.brief.gaps[]` and the rubric reference at
+`response.brief.rubric`. Older callers asserting on `judgment_payload`
+must migrate.
 
 ### 7. Ratify proposals (v0.7.0+)
 

--- a/skills/bicameral-judge-gaps/SKILL.md
+++ b/skills/bicameral-judge-gaps/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: bicameral-judge-gaps
-description: Apply the v0.4.19 business-requirement gap-judgment rubric to a context pack from bicameral_judge_gaps. Fired automatically when an ingest response carries a judgment_payload. Scope is business requirement gaps ONLY — product, policy, and commitment holes. Engineering gaps (wire protocols, migrations, Dockerfiles, CI, retries) are out of scope and explicitly rejected. Caller-session LLM — the server never reasoned about these gaps, you do.
+description: Apply the v0.4.19 business-requirement gap-judgment rubric to a context pack from bicameral_judge_gaps. Fired automatically when an ingest response's brief.gaps is non-empty (#187 unified brief envelope; previously the legacy IngestResponse.judgment_payload field). Scope is business requirement gaps ONLY — product, policy, and commitment holes. Engineering gaps (wire protocols, migrations, Dockerfiles, CI, retries) are out of scope and explicitly rejected. Caller-session LLM — the server never reasoned about these gaps, you do.
 ---
 
 # Bicameral Judge-Gaps
@@ -33,15 +33,16 @@ This skill is **not fired directly by user phrasings**. It is a
 **chained skill**, invoked in one of two ways:
 
 1. **Auto-chain from `bicameral-ingest`** — when an ingest response
-   carries a non-null `judgment_payload`, the ingest skill delegates
-   the rubric-rendering to this skill (see step 6 of
-   `skills/bicameral-ingest/SKILL.md`).
+   carries `brief.gaps` (#187 unified brief envelope), the ingest skill
+   delegates the rubric-rendering to this skill (see step 6 of
+   `skills/bicameral-ingest/SKILL.md`). The `GapRubric` reference lives at
+   `response.brief.rubric`; gap findings live at `response.brief.gaps[]`.
 2. **Explicit call to `bicameral.judge_gaps(topic)`** — when the user
    asks to judge gaps on a specific topic standalone. The tool returns
-   a `GapJudgmentPayload` (or `null` on the honest empty path).
+   a `GapJudgmentPayload` (or `null` on the honest empty path) — same
+   shape, just a different delivery mechanism.
 
-If you see a `judgment_payload` in any response envelope, apply this
-skill.
+If you see `brief.gaps` populated in any ingest response, apply this skill.
 
 ## Input contract
 

--- a/skills/bicameral-report-bug/SKILL.md
+++ b/skills/bicameral-report-bug/SKILL.md
@@ -1,11 +1,11 @@
 ---
 name: bicameral-report-bug
-description: File a bug against bicameral-mcp with auto-bundled context. Fires on "/bicameral:report-bug", "file a bicameral bug", "report this bicameral bug", "bicameral broke", "bicameral isn't working", "something's wrong with bicameral", "this is a bicameral bug". Bundles environment + recent calls + error trace into a prefilled GitHub issue URL on BicameralAI/bicameral-mcp with the `dev` label, and opens it in the browser. Skill DOES NOT submit — the user reviews and clicks submit on GitHub.
+description: File a bug against bicameral-mcp with auto-bundled context. Fires on "/bicameral-report-bug", "file a bicameral bug", "report this bicameral bug", "bicameral broke", "bicameral isn't working", "something's wrong with bicameral", "this is a bicameral bug". Bundles environment + recent calls + error trace into a prefilled GitHub issue URL on BicameralAI/bicameral-mcp with the `dev` label, and opens it in the browser. Skill DOES NOT submit — the user reviews and clicks submit on GitHub.
 ---
 
-# /bicameral:report-bug — File a bug with context
+# /bicameral-report-bug — File a bug with context
 
-**Trigger**: `/bicameral:report-bug`, or natural-language phrasing like
+**Trigger**: `/bicameral-report-bug`, or natural-language phrasing like
 "file a bicameral bug", "this bicameral thing broke", "report this issue".
 
 The skill collects environment + recent tool activity + the suspected
@@ -139,7 +139,7 @@ Format as markdown:
 <environment + repo state + config blocks from Step 2>
 
 ---
-_Reported via `/bicameral:report-bug`._
+_Reported via `/bicameral-report-bug`._
 ```
 
 If the assembled body exceeds **6500 characters**, drop sections in

--- a/tests/test_ingest_brief_unification.py
+++ b/tests/test_ingest_brief_unification.py
@@ -1,0 +1,223 @@
+"""Behavioral tests for the unified `IngestResponse.brief` envelope (#187).
+
+Replaces the dual `judgment_payload` + `judgment_payloads` shape with a
+single `brief: BriefEnvelope | None` field. Server-side populates
+`brief.gaps` from the gap-judge auto-chain output instead of leaving
+the caller to render two separate sections.
+
+Locked invariants:
+- `brief` is populated whenever the gap-judge auto-chain produces findings
+- `brief` is None when there's no signal (silent-on-no-signal — matches
+  the existing PreflightResponse contract)
+- `brief.action_hints` is the merged drift+gap hints
+- Removed fields (`judgment_payload`, `judgment_payloads`) do not
+  re-appear in `IngestResponse.model_dump(exclude_none=True)`
+"""
+
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+from textwrap import dedent
+
+import pytest
+
+from contracts import BriefEnvelope, BriefGap, GapRubric, GapRubricCategory
+
+
+def _git(cwd: Path, *args: str) -> str:
+    return subprocess.run(
+        ["git", *args],
+        cwd=cwd,
+        capture_output=True,
+        text=True,
+        check=True,
+    ).stdout.strip()
+
+
+def _seed_repo(repo_root: Path, body: str) -> None:
+    repo_root.mkdir(parents=True, exist_ok=True)
+    _git(repo_root, "init", "-q", "-b", "main")
+    _git(repo_root, "config", "user.email", "t@e.com")
+    _git(repo_root, "config", "user.name", "t")
+    (repo_root / "pricing.py").write_text(dedent(body).strip() + "\n")
+    _git(repo_root, "add", ".")
+    _git(
+        repo_root,
+        "-c",
+        "commit.gpgsign=false",
+        "commit",
+        "-q",
+        "-m",
+        "seed",
+    )
+
+
+@pytest.fixture
+def _isolated_ledger(monkeypatch, tmp_path):
+    """Seed a tmp git repo + memory:// SurrealDB so handle_ingest has a real
+    ledger + repo to operate against. Mirrors the fixture in
+    tests/test_v0416_gap_judge.py."""
+    from adapters.ledger import reset_ledger_singleton
+
+    monkeypatch.setenv("USE_REAL_LEDGER", "1")
+    monkeypatch.setenv("SURREAL_URL", "memory://")
+    repo_root = tmp_path / "repo"
+    _seed_repo(
+        repo_root,
+        """
+        def calculate_discount(order_total):
+            if order_total >= 100:
+                return order_total * 0.10
+            return 0
+        """,
+    )
+    monkeypatch.setenv("REPO_PATH", str(repo_root))
+    monkeypatch.setenv("BICAMERAL_AUTHORITATIVE_REF", "main")
+    monkeypatch.chdir(repo_root)
+    reset_ledger_singleton()
+    yield repo_root
+    reset_ledger_singleton()
+
+
+def _payload_with_topic(intent: str = "Apply 10% discount on orders ≥ $100") -> dict:
+    """Ingest payload with a topic that derives a feature_group, so the
+    gap-judge auto-chain has something to fire against."""
+    return {
+        "query": intent,
+        "repo": "test-repo",
+        "commit_hash": "deadbeef00000000000000000000000000000000",
+        "analyzed_at": "2026-04-29T12:00:00Z",
+        "mappings": [
+            {
+                "span": {
+                    "span_id": "span-brief-test",
+                    "source_type": "transcript",
+                    "text": intent,
+                    "speaker": "Tester",
+                    "source_ref": "brief-test-mtg",
+                },
+                "intent": intent,
+                "symbols": [],
+                "code_regions": [],
+                "dependency_edges": [],
+            }
+        ],
+    }
+
+
+@pytest.mark.phase2
+@pytest.mark.asyncio
+async def test_ingest_response_brief_populated_when_gaps_judged(_isolated_ledger):
+    """When gap-judge auto-chain produces findings, IngestResponse.brief
+    is populated AND brief.gaps carries at least one BriefGap entry."""
+    from adapters.ledger import get_ledger
+    from context import BicameralContext
+    from handlers.ingest import handle_ingest
+
+    ledger = get_ledger()
+    await ledger.connect()
+    ctx = BicameralContext.from_env()
+
+    payload = _payload_with_topic()
+    response = await handle_ingest(ctx, payload)
+
+    assert response.brief is not None, (
+        "brief should be populated when gap-judge auto-chain produces findings"
+    )
+    assert isinstance(response.brief, BriefEnvelope)
+    assert len(response.brief.gaps) >= 1, (
+        f"brief.gaps should carry findings; got {response.brief.gaps!r}"
+    )
+    for gap in response.brief.gaps:
+        assert isinstance(gap, BriefGap)
+
+
+@pytest.mark.phase2
+@pytest.mark.asyncio
+async def test_ingest_response_brief_carries_rubric(_isolated_ledger):
+    """brief.rubric carries the GapRubric reference (with its 5 fixed
+    categories) that previously lived on judgment_payload.rubric."""
+    from adapters.ledger import get_ledger
+    from context import BicameralContext
+    from handlers.ingest import handle_ingest
+
+    ledger = get_ledger()
+    await ledger.connect()
+    ctx = BicameralContext.from_env()
+
+    response = await handle_ingest(ctx, _payload_with_topic())
+
+    assert response.brief is not None
+    assert response.brief.rubric is not None, (
+        "brief.rubric must be populated when brief is non-null"
+    )
+    assert isinstance(response.brief.rubric, GapRubric)
+    assert len(response.brief.rubric.categories) == 5, (
+        "rubric must carry the 5 fixed v0.4.19 categories"
+    )
+    for cat in response.brief.rubric.categories:
+        assert isinstance(cat, GapRubricCategory)
+
+
+@pytest.mark.phase2
+@pytest.mark.asyncio
+async def test_ingest_response_brief_is_none_when_no_signal(_isolated_ledger):
+    """When the ingest payload produces no decisions and no gap-judge
+    findings, brief is None — silent-on-no-signal matches the
+    PreflightResponse contract."""
+    from adapters.ledger import get_ledger
+    from context import BicameralContext
+    from handlers.ingest import handle_ingest
+
+    ledger = get_ledger()
+    await ledger.connect()
+    ctx = BicameralContext.from_env()
+
+    # Empty mappings → no decisions extracted → no topics derivable →
+    # gap-judge chain skipped → no brief populated.
+    payload = {
+        "query": "",
+        "repo": "test-repo",
+        "commit_hash": "deadbeef00000000000000000000000000000000",
+        "analyzed_at": "2026-04-29T12:00:00Z",
+        "mappings": [],
+    }
+    response = await handle_ingest(ctx, payload)
+
+    assert response.brief is None, (
+        f"brief must be None when there's no signal; got {response.brief!r}"
+    )
+
+
+@pytest.mark.phase2
+@pytest.mark.asyncio
+async def test_ingest_response_has_no_judgment_payload_field(_isolated_ledger):
+    """The IngestResponse schema must NOT carry the legacy `judgment_payload`
+    or `judgment_payloads` fields after #187. Locks against accidental
+    re-introduction. Also covers the model_dump serialization path that
+    external callers depend on."""
+    from adapters.ledger import get_ledger
+    from context import BicameralContext
+    from handlers.ingest import handle_ingest
+
+    ledger = get_ledger()
+    await ledger.connect()
+    ctx = BicameralContext.from_env()
+
+    response = await handle_ingest(ctx, _payload_with_topic())
+    dumped = response.model_dump()
+
+    assert "judgment_payload" not in dumped, (
+        "judgment_payload must be removed from IngestResponse per #187"
+    )
+    assert "judgment_payloads" not in dumped, (
+        "judgment_payloads must be removed from IngestResponse per #187"
+    )
+    # And from the schema itself, not just the runtime dump:
+    assert "judgment_payload" not in type(response).model_fields, (
+        "judgment_payload must be removed from IngestResponse.model_fields"
+    )
+    assert "judgment_payloads" not in type(response).model_fields, (
+        "judgment_payloads must be removed from IngestResponse.model_fields"
+    )

--- a/tests/test_v0416_gap_judge.py
+++ b/tests/test_v0416_gap_judge.py
@@ -8,8 +8,8 @@ Three layers:
   2. Context pack builder tests against the real surreal ledger —
      honest empty path, related-decision cross-linking, phrasing-gap
      forwarding.
-  3. End-to-end ingest → brief → judgment_payload auto-chain tests.
-     Also locks in: standalone brief never carries a judgment_payload,
+  3. End-to-end ingest → brief → unified-brief auto-chain tests.
+     Also locks in: standalone brief never carries gap-judge findings,
      gap-judge chain failure is non-fatal to ingest.
 
 All tests use the same in-memory surreal ledger + seeded git repo
@@ -365,9 +365,14 @@ async def test_judge_gaps_builds_context_pack(_isolated_ledger):
 
 @pytest.mark.phase2
 @pytest.mark.asyncio
-async def test_ingest_chain_attaches_judgment_payload(_isolated_ledger):
+async def test_ingest_chain_attaches_brief_with_rubric(_isolated_ledger):
     """End-to-end: a successful ingest with a derivable topic returns
-    IngestResponse.judgment_payload populated by the judge_gaps chain."""
+    IngestResponse.brief populated by the judge_gaps chain (#187 unification —
+    replaces the legacy IngestResponse.judgment_payload field).
+
+    `brief.rubric` carries the GapRubric reference that previously lived on
+    `judgment_payload.rubric`; `created_decisions` carries the ingest input
+    that was previously surfaced via `judgment_payload.decisions`."""
     ledger = get_ledger()
     await ledger.connect()
     ctx = BicameralContext.from_env()
@@ -379,17 +384,19 @@ async def test_ingest_chain_attaches_judgment_payload(_isolated_ledger):
     )
     response = await handle_ingest(ctx, payload)
 
-    assert response.judgment_payload is not None, (
-        "judgment_payload must be attached when ingest has a derivable topic"
+    assert response.brief is not None, "brief must be attached when ingest has a derivable topic"
+    assert len(response.created_decisions) >= 1, (
+        "created_decisions carries the ingest-input that was previously "
+        "surfaced via judgment_payload.decisions"
     )
-    assert len(response.judgment_payload.decisions) >= 1
-    assert len(response.judgment_payload.rubric.categories) == 5
+    assert response.brief.rubric is not None
+    assert len(response.brief.rubric.categories) == 5
 
 
 @pytest.mark.phase2
 @pytest.mark.asyncio
-async def test_ingest_chain_skips_judgment_when_no_topic(_isolated_ledger):
-    """When the payload has no derivable topic, judgment_payload is None."""
+async def test_ingest_chain_skips_brief_when_no_topic(_isolated_ledger):
+    """When the payload has no derivable topic, brief is None (silent-on-no-signal)."""
     ledger = get_ledger()
     await ledger.connect()
     ctx = BicameralContext.from_env()
@@ -400,14 +407,14 @@ async def test_ingest_chain_skips_judgment_when_no_topic(_isolated_ledger):
     }
     response = await handle_ingest(ctx, payload)
 
-    assert response.judgment_payload is None
+    assert response.brief is None
 
 
 @pytest.mark.phase2
 @pytest.mark.asyncio
 async def test_gap_judge_chain_failure_is_non_fatal(_isolated_ledger):
     """If the chained handle_judge_gaps raises, the ingest itself
-    must still return a valid IngestResponse with judgment_payload=None."""
+    must still return a valid IngestResponse with brief=None."""
     ledger = get_ledger()
     await ledger.connect()
     ctx = BicameralContext.from_env()
@@ -424,7 +431,7 @@ async def test_gap_judge_chain_failure_is_non_fatal(_isolated_ledger):
         response = await handle_ingest(ctx, payload)
 
     assert response.ingested is True
-    assert response.judgment_payload is None
+    assert response.brief is None
 
 
 @pytest.mark.phase2


### PR DESCRIPTION
## Summary

- Removes `IngestResponse.judgment_payload` + `IngestResponse.judgment_payloads`. Replaces them with a single `brief: BriefEnvelope | None` field carrying gap-judge findings inline. **Breaking change** to the response contract; no `breaking` label exists in this repo so flagging here.
- New `BriefEnvelope` model mirrors `PreflightResponse`'s brief surface (one shape, two consumers); includes `rubric: GapRubric | None` so the existing `judgment_payload.rubric.categories` assertion site migrates cleanly.
- Bicameral-ingest skill Step 6 rewritten: reads `response.brief.gaps[]` + `response.brief.rubric` instead of `response.judgment_payload`. Bicameral-judge-gaps skill trigger description updated.
- Phase 3 mop-up: stale `/bicameral:report-bug` (4 occurrences in `skills/bicameral-report-bug/SKILL.md`) renamed to `/bicameral-report-bug` — the single residual colon-namespace form post-#178's sweep.

## Linked issues

Closes #187 (P0 — gap-brief auto-fire after ingest)

## Plan / Audit / Seal

- **Plan**: `plan-187-gap-brief-unification.md` (committed in this PR for the audit trail)
- **Audit**: PASS after one VETO cycle resolved cleanly. Original VETO grounds were `test-failure` (Phase 2 test was presence-only) and `infrastructure-mismatch` (`tests/test_v0416_gap_judge.py` not enumerated in §Affected Files; rubric-carrier subgap unspecified). Both fixed in the same amendment cycle: dropped Phase 2 unit test (skill text-only edits aren't pytest-invocable; would be a presence-only check); enumerated the cascade test file; resolved rubric-carrier by adding `BriefEnvelope.rubric: GapRubric | None`.
- **Seal**: advisory PASS — Reality matches Promise across all 9 affected files.
- **Risk**: L2 (substantial response-contract change — removing two public fields — plus skill render contract migration across 3 skills + assertion-migration in an existing test file).

## Test plan

- [x] `pytest tests/test_ingest_brief_unification.py -v` — 4/4 pass (new behavioral tests for brief populated / rubric carried / silent-on-no-signal / removed-fields-not-in-schema)
- [x] `pytest tests/test_v0416_gap_judge.py -v` — 12/12 pass (including the 3 migrated assertions)
- [x] `mypy contracts.py handlers/ingest.py handlers/gap_judge.py` — clean
- [x] `ruff check . && ruff format --check .` — clean
- [x] `grep -rn "judgment_payload" --include="*.py" .` — only intentional hits remain:
  - `contracts.py` docstrings (migration markers)
  - `handlers/ingest.py` local var name (the gap-judge auto-chain accumulator)
  - `server.py:1119` (standalone `bicameral.judge_gaps` tool's response shape — non-cascading collision; same field name, different parent type, intentionally untouched per plan §Phase 1)

## Breaking change scope

This PR removes two public fields from `IngestResponse`. Any external caller asserting on `response.judgment_payload` or `response.judgment_payloads` will fail post-merge. Migration target is `response.brief.gaps[]` (gap findings) and `response.brief.rubric` (rubric reference). The `judge_gaps` standalone MCP tool (`bicameral.judge_gaps(topic)`) keeps its existing `GapJudgmentPayload` response shape — only the *embedded* form on `IngestResponse` changed.

## Notes for reviewer

- `BriefEnvelope` shape is identical to PreflightResponse's brief surface (decisions, drift_candidates, divergences, gaps, rubric, action_hints, suggested_questions). Today only `gaps` and `rubric` are populated server-side from `handle_ingest`; the others default to empty. Future PR may surface drift/divergence data in the ingest path; today the unified shape is forward-looking.
- `merge_drift_and_gap_hints` helper in `handlers/action_hints.py` was specced in the plan but **not implemented** in this PR — `handle_ingest` doesn't currently produce drift_action_hints OR gap_action_hints, so the merge function would have no callers. Per Simple Made Easy: don't introduce structures without callers. The future PR that surfaces drift hints in ingest can add the helper alongside its first caller.
- Phase 3's `/bicameral:report-bug` rename is orthogonal mop-up but folds into this PR per plan §Phase 3 (operator's "fix the stale colon use" directive at /qor-plan time).