### PR TITLE
feat(ingest): payload-size + token-bucket rate limit + boundary translation (#216 LLM-02 + LLM-08)

### DIFF
--- a/context.py
+++ b/context.py
@@ -37,6 +37,18 @@ _DEFAULT_INGEST_MAX_BYTES = 1024 * 1024  # 1 MiB
 _INGEST_MAX_BYTES_MIN = 1024  # 1 KiB; below this is meaningless / config error
 _INGEST_MAX_BYTES_MAX = 64 * 1024 * 1024  # 64 MiB; above this is operator footgun
 
+# #216 LLM-08: token-bucket rate limit per session_id.
+# Default 10-token burst with 1 token/sec refill: an agent can fire 10
+# ingests instantly, then sustain 1/sec. Tuned for single-user
+# developer-tool workflow shape; stricter sliding-window enforcement
+# is a team-server activation concern (revisit then).
+_DEFAULT_INGEST_RATE_LIMIT_BURST = 10
+_DEFAULT_INGEST_RATE_LIMIT_REFILL_PER_SEC = 1.0
+_INGEST_RATE_LIMIT_BURST_MIN = 1
+_INGEST_RATE_LIMIT_BURST_MAX = 1000
+_INGEST_RATE_LIMIT_REFILL_MIN = 0.01
+_INGEST_RATE_LIMIT_REFILL_MAX = 100.0
+
 
 def _read_yaml_string_field(repo_path: str, key: str, valid: frozenset[str], default: str) -> str:
     """Generic reader for a `.bicameral/config.yaml` string field with a
@@ -124,6 +136,60 @@ def _read_ingest_max_bytes(repo_path: str) -> int:
     if val < _INGEST_MAX_BYTES_MIN or val > _INGEST_MAX_BYTES_MAX:
         return _DEFAULT_INGEST_MAX_BYTES
     return val
+
+
+def _read_ingest_rate_limit_burst(repo_path: str) -> int:
+    """Resolve ``ingest_rate_limit_burst`` from ``.bicameral/config.yaml``.
+
+    Default 10. Clamped to ``[_INGEST_RATE_LIMIT_BURST_MIN,
+    _INGEST_RATE_LIMIT_BURST_MAX]``. Out-of-range / non-int / malformed
+    yaml all fall back to default (no silent acceptance).
+    """
+    config_path = Path(repo_path) / ".bicameral" / "config.yaml"
+    if not config_path.exists():
+        return _DEFAULT_INGEST_RATE_LIMIT_BURST
+    try:
+        import yaml
+
+        config = yaml.safe_load(config_path.read_text(encoding="utf-8")) or {}
+        val = config.get("ingest_rate_limit_burst", _DEFAULT_INGEST_RATE_LIMIT_BURST)
+    except Exception:
+        return _DEFAULT_INGEST_RATE_LIMIT_BURST
+    if not isinstance(val, int) or isinstance(val, bool):
+        return _DEFAULT_INGEST_RATE_LIMIT_BURST
+    if val < _INGEST_RATE_LIMIT_BURST_MIN or val > _INGEST_RATE_LIMIT_BURST_MAX:
+        return _DEFAULT_INGEST_RATE_LIMIT_BURST
+    return val
+
+
+def _read_ingest_rate_limit_refill_per_sec(repo_path: str) -> float:
+    """Resolve ``ingest_rate_limit_refill_per_sec`` from ``.bicameral/config.yaml``.
+
+    Default 1.0. Clamped to ``[_INGEST_RATE_LIMIT_REFILL_MIN,
+    _INGEST_RATE_LIMIT_REFILL_MAX]``. ``0.0`` would lock the bucket
+    forever after first burst — treated as malformed and falls back
+    to default. Out-of-range / non-numeric / malformed yaml all fall
+    back to default.
+    """
+    config_path = Path(repo_path) / ".bicameral" / "config.yaml"
+    if not config_path.exists():
+        return _DEFAULT_INGEST_RATE_LIMIT_REFILL_PER_SEC
+    try:
+        import yaml
+
+        config = yaml.safe_load(config_path.read_text(encoding="utf-8")) or {}
+        val = config.get(
+            "ingest_rate_limit_refill_per_sec",
+            _DEFAULT_INGEST_RATE_LIMIT_REFILL_PER_SEC,
+        )
+    except Exception:
+        return _DEFAULT_INGEST_RATE_LIMIT_REFILL_PER_SEC
+    if isinstance(val, bool) or not isinstance(val, (int, float)):
+        return _DEFAULT_INGEST_RATE_LIMIT_REFILL_PER_SEC
+    val_f = float(val)
+    if val_f < _INGEST_RATE_LIMIT_REFILL_MIN or val_f > _INGEST_RATE_LIMIT_REFILL_MAX:
+        return _DEFAULT_INGEST_RATE_LIMIT_REFILL_PER_SEC
+    return val_f
 
 
 def _read_guided_mode(repo_path: str) -> bool:
@@ -218,6 +284,13 @@ class BicameralContext:
     # over-cap payloads raise ``_IngestRefused`` and are translated to a
     # structured TextContent error at the MCP boundary.
     ingest_max_bytes: int = _DEFAULT_INGEST_MAX_BYTES
+    # #216 LLM-08: per-session token-bucket rate limit. ``burst`` is the
+    # initial / max-cap token count; ``refill_per_sec`` is the lazy refill
+    # rate. Enforced by ``handlers.ingest._check_rate_limit`` after the
+    # size-check passes. ``BICAMERAL_INGEST_RATE_LIMIT_DISABLE=1`` env
+    # bypasses the gate entirely (local debugging knob).
+    ingest_rate_limit_burst: int = _DEFAULT_INGEST_RATE_LIMIT_BURST
+    ingest_rate_limit_refill_per_sec: float = _DEFAULT_INGEST_RATE_LIMIT_REFILL_PER_SEC
     # v0.4.8: mutable cache for within-call sync dedup. Frozen-dataclass-safe
     # because the reference stays pinned; only the dict's contents mutate.
     # Keys: ``last_sync_sha`` (str). Cleared by any handler that mutates
@@ -260,6 +333,8 @@ class BicameralContext:
         render_source_attribution = _read_render_source_attribution(repo_path)
         preflight_bypass_tracking = _read_preflight_bypass_tracking(repo_path)
         ingest_max_bytes = _read_ingest_max_bytes(repo_path)
+        ingest_rate_limit_burst = _read_ingest_rate_limit_burst(repo_path)
+        ingest_rate_limit_refill_per_sec = _read_ingest_rate_limit_refill_per_sec(repo_path)
 
         return cls(
             repo_path=repo_path,
@@ -276,4 +351,6 @@ class BicameralContext:
             render_source_attribution=render_source_attribution,
             preflight_bypass_tracking=preflight_bypass_tracking,
             ingest_max_bytes=ingest_max_bytes,
+            ingest_rate_limit_burst=ingest_rate_limit_burst,
+            ingest_rate_limit_refill_per_sec=ingest_rate_limit_refill_per_sec,
         )

--- a/context.py
+++ b/context.py
@@ -187,6 +187,15 @@ def _read_ingest_rate_limit_refill_per_sec(repo_path: str) -> float:
     if isinstance(val, bool) or not isinstance(val, (int, float)):
         return _DEFAULT_INGEST_RATE_LIMIT_REFILL_PER_SEC
     val_f = float(val)
+    # NaN evades both `< MIN` and `> MAX` (every comparison with NaN is
+    # False), so an operator who writes ``refill: .nan`` would land NaN
+    # in the bucket and lock ingest forever (`min(burst, x + dt*nan) =
+    # nan`, and ``nan >= 1.0`` is False — bucket is permanently empty).
+    # ``math.isfinite()`` rejects NaN + inf in one check.
+    import math
+
+    if not math.isfinite(val_f):
+        return _DEFAULT_INGEST_RATE_LIMIT_REFILL_PER_SEC
     if val_f < _INGEST_RATE_LIMIT_REFILL_MIN or val_f > _INGEST_RATE_LIMIT_REFILL_MAX:
         return _DEFAULT_INGEST_RATE_LIMIT_REFILL_PER_SEC
     return val_f

--- a/context.py
+++ b/context.py
@@ -30,6 +30,13 @@ _DEFAULT_RENDER_ATTRIBUTION_MODE = "full"
 _BYPASS_TRACKING_MODES = frozenset({"enabled", "disabled"})
 _DEFAULT_BYPASS_TRACKING_MODE = "enabled"
 
+# #216 LLM-02: payload-size guardrail. 1 MiB cap is loose enough for
+# any legitimate transcript / decision dump but bounds DoS shape
+# (single oversized payload can't blow out the ledger writer).
+_DEFAULT_INGEST_MAX_BYTES = 1024 * 1024  # 1 MiB
+_INGEST_MAX_BYTES_MIN = 1024  # 1 KiB; below this is meaningless / config error
+_INGEST_MAX_BYTES_MAX = 64 * 1024 * 1024  # 64 MiB; above this is operator footgun
+
 
 def _read_yaml_string_field(repo_path: str, key: str, valid: frozenset[str], default: str) -> str:
     """Generic reader for a `.bicameral/config.yaml` string field with a
@@ -92,6 +99,31 @@ def _read_preflight_bypass_tracking(repo_path: str) -> str:
         _BYPASS_TRACKING_MODES,
         _DEFAULT_BYPASS_TRACKING_MODE,
     )
+
+
+def _read_ingest_max_bytes(repo_path: str) -> int:
+    """Resolve ``ingest_max_bytes`` from ``.bicameral/config.yaml``.
+
+    Default 1 MiB. Clamped to ``[_INGEST_MAX_BYTES_MIN, _INGEST_MAX_BYTES_MAX]``;
+    out-of-range values (negative, non-integer, beyond clamp) fall back
+    to the default with no silent acceptance. Read by
+    ``handlers.ingest._check_payload_size``.
+    """
+    config_path = Path(repo_path) / ".bicameral" / "config.yaml"
+    if not config_path.exists():
+        return _DEFAULT_INGEST_MAX_BYTES
+    try:
+        import yaml
+
+        config = yaml.safe_load(config_path.read_text(encoding="utf-8")) or {}
+        val = config.get("ingest_max_bytes", _DEFAULT_INGEST_MAX_BYTES)
+    except Exception:
+        return _DEFAULT_INGEST_MAX_BYTES
+    if not isinstance(val, int) or isinstance(val, bool):
+        return _DEFAULT_INGEST_MAX_BYTES
+    if val < _INGEST_MAX_BYTES_MIN or val > _INGEST_MAX_BYTES_MAX:
+        return _DEFAULT_INGEST_MAX_BYTES
+    return val
 
 
 def _read_guided_mode(repo_path: str) -> bool:
@@ -180,6 +212,12 @@ class BicameralContext:
     # with reason="tracking_disabled"). Operator privacy choice; deterministic
     # at config-load time.
     preflight_bypass_tracking: str = _DEFAULT_BYPASS_TRACKING_MODE
+    # #216 LLM-02: max serialized-JSON byte size for an inbound ingest
+    # payload. 1 MiB default. Clamped to [1 KiB, 64 MiB]. Enforced by
+    # ``handlers.ingest._check_payload_size`` before payload normalization;
+    # over-cap payloads raise ``_IngestRefused`` and are translated to a
+    # structured TextContent error at the MCP boundary.
+    ingest_max_bytes: int = _DEFAULT_INGEST_MAX_BYTES
     # v0.4.8: mutable cache for within-call sync dedup. Frozen-dataclass-safe
     # because the reference stays pinned; only the dict's contents mutate.
     # Keys: ``last_sync_sha`` (str). Cleared by any handler that mutates
@@ -221,6 +259,7 @@ class BicameralContext:
         signer_email_fallback = _read_signer_email_fallback(repo_path)
         render_source_attribution = _read_render_source_attribution(repo_path)
         preflight_bypass_tracking = _read_preflight_bypass_tracking(repo_path)
+        ingest_max_bytes = _read_ingest_max_bytes(repo_path)
 
         return cls(
             repo_path=repo_path,
@@ -236,4 +275,5 @@ class BicameralContext:
             signer_email_fallback=signer_email_fallback,
             render_source_attribution=render_source_attribution,
             preflight_bypass_tracking=preflight_bypass_tracking,
+            ingest_max_bytes=ingest_max_bytes,
         )

--- a/handlers/ingest.py
+++ b/handlers/ingest.py
@@ -8,6 +8,9 @@ from __future__ import annotations
 
 import json
 import logging
+import os
+import threading
+import time
 from datetime import UTC
 
 import preflight_telemetry
@@ -65,6 +68,62 @@ def _check_payload_size(payload: dict, max_bytes: int) -> None:
         raise _IngestRefused(
             "size_limit_exceeded",
             detail=f"{size} bytes > {max_bytes} cap",
+        )
+
+
+class _TokenBucket:
+    """Lazy-refill token bucket — single counter, single timestamp.
+
+    ``take()`` returns True when a token is available (and consumes it),
+    False when the bucket is empty. Refill is computed on access, no
+    background timer. Thread-safe via internal lock for concurrent
+    handler dispatches in the same process.
+    """
+
+    def __init__(self, burst: int, refill_per_sec: float) -> None:
+        self._burst = float(burst)
+        self._refill = refill_per_sec
+        self._tokens = float(burst)
+        self._last = time.monotonic()
+        self._lock = threading.Lock()
+
+    def take(self) -> bool:
+        with self._lock:
+            now = time.monotonic()
+            elapsed = now - self._last
+            self._tokens = min(self._burst, self._tokens + elapsed * self._refill)
+            self._last = now
+            if self._tokens >= 1.0:
+                self._tokens -= 1.0
+                return True
+            return False
+
+
+# Module-level registry: one bucket per session_id. Reset on server
+# restart by design — rate-limit state is in-process only (LLM-08
+# threat model is agent loops, not malicious restart-loops).
+_RATE_LIMIT_REGISTRY: dict[str, _TokenBucket] = {}
+_RATE_LIMIT_REGISTRY_LOCK = threading.Lock()
+
+
+def _check_rate_limit(session_id: str, burst: int, refill_per_sec: float) -> None:
+    """Raise ``_IngestRefused('rate_limit_exceeded', ...)`` when the bucket
+    for ``session_id`` has no tokens. Disabled entirely by setting
+    ``BICAMERAL_INGEST_RATE_LIMIT_DISABLE=1`` (local debugging knob).
+    """
+    if os.getenv("BICAMERAL_INGEST_RATE_LIMIT_DISABLE", "").strip() == "1":
+        return
+    with _RATE_LIMIT_REGISTRY_LOCK:
+        bucket = _RATE_LIMIT_REGISTRY.get(session_id)
+        if bucket is None:
+            bucket = _TokenBucket(burst, refill_per_sec)
+            _RATE_LIMIT_REGISTRY[session_id] = bucket
+    if not bucket.take():
+        raise _IngestRefused(
+            "rate_limit_exceeded",
+            detail=(
+                f"session {session_id} bucket empty (burst={burst}, refill={refill_per_sec}/s)"
+            ),
         )
 
 
@@ -271,11 +330,19 @@ async def handle_ingest(
     if hasattr(ledger, "connect"):
         await ledger.connect()
 
-    # #216 LLM-02: enforce serialized-byte cap before any ledger work.
-    # Telemetry-emit on refusal then re-raise; MCP boundary translates
-    # ``_IngestRefused`` to a structured TextContent error.
+    # #216: enforce entry-time guardrails before any ledger work.
+    # LLM-02 size check first (cheaper short-circuit on oversized
+    # payloads); LLM-08 rate check second. Both raise ``_IngestRefused``
+    # with distinct ``reason`` strings; telemetry-emit on refusal then
+    # re-raise so the MCP boundary translates to a structured
+    # TextContent error.
     try:
         _check_payload_size(payload, ctx.ingest_max_bytes)
+        _check_rate_limit(
+            getattr(ctx, "session_id", ""),
+            ctx.ingest_rate_limit_burst,
+            ctx.ingest_rate_limit_refill_per_sec,
+        )
     except _IngestRefused as exc:
         _emit_ingest_refusal_telemetry(exc.reason, getattr(ctx, "session_id", ""))
         raise

--- a/handlers/ingest.py
+++ b/handlers/ingest.py
@@ -52,6 +52,22 @@ def _emit_ingest_refusal_telemetry(reason: str, session_id: str) -> None:
     preflight_telemetry.write_ingest_refusal_event(reason=reason, session_id=session_id)
 
 
+def _check_payload_size(payload: dict, max_bytes: int) -> None:
+    """Raise ``_IngestRefused`` if the serialized payload exceeds ``max_bytes``.
+
+    Measurement is ``len(json.dumps(payload).encode("utf-8"))`` — captures
+    every field the agent might supply, language-agnostic, single
+    comparison. Pure: no telemetry side-effect; the wrapping try/except
+    in ``handle_ingest`` records the refusal event before re-raising.
+    """
+    size = len(json.dumps(payload, default=str).encode("utf-8"))
+    if size > max_bytes:
+        raise _IngestRefused(
+            "size_limit_exceeded",
+            detail=f"{size} bytes > {max_bytes} cap",
+        )
+
+
 def _normalize_payload(payload: dict) -> dict:
     """Validate and normalize ingest payload using Pydantic contracts.
 
@@ -254,6 +270,15 @@ async def handle_ingest(
     ledger = ctx.ledger
     if hasattr(ledger, "connect"):
         await ledger.connect()
+
+    # #216 LLM-02: enforce serialized-byte cap before any ledger work.
+    # Telemetry-emit on refusal then re-raise; MCP boundary translates
+    # ``_IngestRefused`` to a structured TextContent error.
+    try:
+        _check_payload_size(payload, ctx.ingest_max_bytes)
+    except _IngestRefused as exc:
+        _emit_ingest_refusal_telemetry(exc.reason, getattr(ctx, "session_id", ""))
+        raise
 
     payload = _normalize_payload(payload)
     repo = str(payload.get("repo") or ctx.repo_path)

--- a/handlers/ingest.py
+++ b/handlers/ingest.py
@@ -326,16 +326,22 @@ async def handle_ingest(
     source_scope: str = "",
     cursor: str = "",
 ) -> IngestResponse:
-    ledger = ctx.ledger
-    if hasattr(ledger, "connect"):
-        await ledger.connect()
-
-    # #216: enforce entry-time guardrails before any ledger work.
-    # LLM-02 size check first (cheaper short-circuit on oversized
-    # payloads); LLM-08 rate check second. Both raise ``_IngestRefused``
-    # with distinct ``reason`` strings; telemetry-emit on refusal then
-    # re-raise so the MCP boundary translates to a structured
-    # TextContent error.
+    # #216: enforce entry-time guardrails BEFORE any ledger work, including
+    # the SurrealDB connection handshake. A refused payload should cost zero
+    # downstream resources. LLM-02 size check first (cheaper short-circuit
+    # on oversized payloads); LLM-08 rate check second. Both raise
+    # ``_IngestRefused`` with distinct ``reason`` strings; telemetry-emit
+    # on refusal then re-raise so the MCP boundary translates to a
+    # structured TextContent error.
+    #
+    # Per-session bucket scoping note: ``ctx.session_id`` defaults to the
+    # module-level ``_SESSION_ID`` (one UUID per server process). The rate
+    # gate is therefore effectively per-server-process under the current
+    # runtime — multiple concurrent agents over one MCP transport share
+    # one bucket. This is acceptable for the single-user-developer-tool
+    # deployment shape declared in plan-216 boundaries; team-server
+    # activation will need a per-agent session-id source for true
+    # per-agent isolation. Documented in plan-216 § Open Questions.
     try:
         _check_payload_size(payload, ctx.ingest_max_bytes)
         _check_rate_limit(
@@ -346,6 +352,10 @@ async def handle_ingest(
     except _IngestRefused as exc:
         _emit_ingest_refusal_telemetry(exc.reason, getattr(ctx, "session_id", ""))
         raise
+
+    ledger = ctx.ledger
+    if hasattr(ledger, "connect"):
+        await ledger.connect()
 
     payload = _normalize_payload(payload)
     repo = str(payload.get("repo") or ctx.repo_path)

--- a/handlers/ingest.py
+++ b/handlers/ingest.py
@@ -6,9 +6,11 @@ Auto-grounding removed in caller-LLM binding flow (v0.5.1+).
 
 from __future__ import annotations
 
+import json
 import logging
 from datetime import UTC
 
+import preflight_telemetry
 from contracts import (
     BriefEnvelope,
     BriefGap,
@@ -21,6 +23,33 @@ from contracts import (
 )
 
 logger = logging.getLogger(__name__)
+
+
+class _IngestRefused(Exception):
+    """Raised when an ingest is rejected by an entry-time guardrail.
+
+    Carries a structured ``reason`` string for the MCP-boundary response
+    translation and an optional human-readable ``detail`` describing the
+    specific cause (byte counts, bucket state, etc.). Caught at the
+    ``server.call_tool`` boundary; never bubbles to the agent as a raw
+    exception.
+    """
+
+    def __init__(self, reason: str, *, detail: str = "") -> None:
+        self.reason = reason
+        self.detail = detail
+        super().__init__(f"{reason}: {detail}" if detail else reason)
+
+
+def _emit_ingest_refusal_telemetry(reason: str, session_id: str) -> None:
+    """Append a refusal event to ``~/.bicameral/preflight_events.jsonl``.
+
+    Side-effect-only helper invoked by ``handle_ingest`` after a guard
+    raises ``_IngestRefused`` and before the exception re-propagates to
+    the MCP boundary. Kept out of the gate helpers themselves so those
+    stay pure (raise on fail; reusable in non-ingest contexts).
+    """
+    preflight_telemetry.write_ingest_refusal_event(reason=reason, session_id=session_id)
 
 
 def _normalize_payload(payload: dict) -> dict:

--- a/preflight_telemetry.py
+++ b/preflight_telemetry.py
@@ -319,6 +319,29 @@ def write_engagement(
     _append(_ENGAGEMENTS_FILE, record)
 
 
+# ── #216: ingest-boundary refusal events ─────────────────────────────
+
+
+def write_ingest_refusal_event(reason: str, session_id: str) -> None:
+    """Append an ingest-refusal event to ``~/.bicameral/preflight_events.jsonl``.
+
+    Reason-agnostic: handles ``size_limit_exceeded`` (LLM-02),
+    ``rate_limit_exceeded`` (LLM-08), and any future entry-time
+    guardrail that raises ``_IngestRefused``. No-op when telemetry is
+    disabled. Written into the same JSONL file as preflight + bypass
+    events so operator triage joins on a single substrate.
+    """
+    if not telemetry_enabled():
+        return
+    record = {
+        "ts": datetime.now(UTC).isoformat(),
+        "event_type": "ingest_refused",
+        "reason": reason,
+        "session_id": session_id,
+    }
+    _append(_EVENTS_FILE, record)
+
+
 # ── Phase 4: #112 HITL bypass flow ───────────────────────────────────
 
 

--- a/server.py
+++ b/server.py
@@ -43,7 +43,7 @@ from handlers.bind import handle_bind
 from handlers.evaluate_governance import handle_evaluate_governance
 from handlers.gap_judge import handle_judge_gaps
 from handlers.history import handle_history
-from handlers.ingest import handle_ingest
+from handlers.ingest import _IngestRefused, handle_ingest
 from handlers.link_commit import handle_link_commit
 from handlers.list_unclassified_decisions import handle_list_unclassified_decisions
 from handlers.preflight import handle_preflight
@@ -61,6 +61,21 @@ SERVER_NAME = "bicameral-mcp"
 # In-process map of session_id → {t0} for skill timing.
 # Populated by bicameral.skill_begin, consumed by bicameral.skill_end.
 _skill_sessions: dict[str, dict] = {}
+
+# #216: operator-actionable guidance per ingest-refusal reason. Read by
+# the ``except _IngestRefused`` arm in ``call_tool`` to populate the
+# ``action`` field of the returned TextContent. Default falls back to a
+# generic "review .bicameral/config.yaml limits and retry" message.
+_ACTION_FOR_REFUSAL_REASON: dict[str, str] = {
+    "size_limit_exceeded": (
+        "split the payload into smaller ingests or raise ingest_max_bytes in .bicameral/config.yaml"
+    ),
+    "rate_limit_exceeded": (
+        "slow ingest cadence or raise ingest_rate_limit_burst / "
+        "ingest_rate_limit_refill_per_sec in .bicameral/config.yaml, or set "
+        "BICAMERAL_INGEST_RATE_LIMIT_DISABLE=1 for local debugging"
+    ),
+}
 
 
 def _resolve_server_version() -> str:
@@ -1247,6 +1262,27 @@ async def call_tool(name: str, arguments: dict) -> list[TextContent]:
 
         return [TextContent(type="text", text=json.dumps(payload, indent=2))]
 
+    except _IngestRefused as exc:
+        # #216: translate entry-time ingest guardrail refusals (size +
+        # rate limits) into a structured TextContent error. No
+        # IngestResponse schema change — refusals propagate via
+        # exception and surface here only.
+        return [
+            TextContent(
+                type="text",
+                text=json.dumps(
+                    {
+                        "error": exc.reason,
+                        "detail": exc.detail,
+                        "action": _ACTION_FOR_REFUSAL_REASON.get(
+                            exc.reason,
+                            "review .bicameral/config.yaml limits and retry",
+                        ),
+                    },
+                    indent=2,
+                ),
+            )
+        ]
     except (DestructiveMigrationRequired, SchemaVersionTooNew) as exc:
         action = (
             "run bicameral_reset(confirm=True) to apply the breaking migration and clear legacy data"

--- a/tests/test_context_ingest_max_bytes.py
+++ b/tests/test_context_ingest_max_bytes.py
@@ -1,0 +1,47 @@
+"""Functionality tests for ``_read_ingest_max_bytes`` (#216 Phase 1).
+
+Locks the precedence: missing file → default; valid value → returned;
+out-of-range → default (fail-closed); malformed yaml → default (fail-soft).
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from context import _DEFAULT_INGEST_MAX_BYTES, _read_ingest_max_bytes
+
+
+def _write_config(tmp_path: Path, content: str) -> str:
+    """Write ``.bicameral/config.yaml`` under ``tmp_path``; return repo path."""
+    config_dir = tmp_path / ".bicameral"
+    config_dir.mkdir(parents=True, exist_ok=True)
+    (config_dir / "config.yaml").write_text(content, encoding="utf-8")
+    return str(tmp_path)
+
+
+def test_read_ingest_max_bytes_defaults_when_config_missing(tmp_path: Path) -> None:
+    # No config file at all.
+    assert _read_ingest_max_bytes(str(tmp_path)) == _DEFAULT_INGEST_MAX_BYTES
+    assert _DEFAULT_INGEST_MAX_BYTES == 1024 * 1024
+
+
+def test_read_ingest_max_bytes_honors_valid_yaml_value(tmp_path: Path) -> None:
+    repo = _write_config(tmp_path, "ingest_max_bytes: 524288\n")
+    assert _read_ingest_max_bytes(repo) == 524288
+
+
+def test_read_ingest_max_bytes_clamps_below_minimum(tmp_path: Path) -> None:
+    # 100 bytes is below the 1 KiB minimum — fall back to default.
+    repo = _write_config(tmp_path, "ingest_max_bytes: 100\n")
+    assert _read_ingest_max_bytes(repo) == _DEFAULT_INGEST_MAX_BYTES
+
+
+def test_read_ingest_max_bytes_clamps_above_maximum(tmp_path: Path) -> None:
+    # 1 GB is well past the 64 MiB maximum — operator-footgun protection.
+    repo = _write_config(tmp_path, "ingest_max_bytes: 999999999\n")
+    assert _read_ingest_max_bytes(repo) == _DEFAULT_INGEST_MAX_BYTES
+
+
+def test_read_ingest_max_bytes_falls_back_on_non_integer(tmp_path: Path) -> None:
+    repo = _write_config(tmp_path, 'ingest_max_bytes: "not-an-int"\n')
+    assert _read_ingest_max_bytes(repo) == _DEFAULT_INGEST_MAX_BYTES

--- a/tests/test_context_ingest_rate_limit.py
+++ b/tests/test_context_ingest_rate_limit.py
@@ -79,3 +79,32 @@ def test_read_ingest_rate_limit_refill_clamps_out_of_range(tmp_path: Path) -> No
         _read_ingest_rate_limit_refill_per_sec(repo_high)
         == _DEFAULT_INGEST_RATE_LIMIT_REFILL_PER_SEC
     )
+
+
+def test_read_ingest_rate_limit_refill_rejects_nan(tmp_path: Path) -> None:
+    """NaN evades min/max comparisons (every NaN comparison returns False),
+    so without an `isfinite()` guard NaN would slip past the clamp and lock
+    the bucket forever (`min(burst, x + dt*nan) = nan`, and `nan >= 1.0` is
+    False — bucket is permanently empty). Regression test for the
+    devil's-advocate-found bypass."""
+    nan_dir = tmp_path / "nan"
+    nan_dir.mkdir()
+    repo_nan = _write_config(nan_dir, "ingest_rate_limit_refill_per_sec: .nan\n")
+    assert (
+        _read_ingest_rate_limit_refill_per_sec(repo_nan)
+        == _DEFAULT_INGEST_RATE_LIMIT_REFILL_PER_SEC
+    )
+
+
+def test_read_ingest_rate_limit_refill_rejects_inf(tmp_path: Path) -> None:
+    """Same bypass shape as NaN — inf > MAX is True so the existing clamp
+    would actually catch positive infinity, but `-inf < MIN` would also
+    be caught. Lock the regression test on `+inf` for completeness; the
+    `isfinite` guard is the load-bearing check."""
+    inf_dir = tmp_path / "inf"
+    inf_dir.mkdir()
+    repo_inf = _write_config(inf_dir, "ingest_rate_limit_refill_per_sec: .inf\n")
+    assert (
+        _read_ingest_rate_limit_refill_per_sec(repo_inf)
+        == _DEFAULT_INGEST_RATE_LIMIT_REFILL_PER_SEC
+    )

--- a/tests/test_context_ingest_rate_limit.py
+++ b/tests/test_context_ingest_rate_limit.py
@@ -1,0 +1,81 @@
+"""Functionality tests for ``_read_ingest_rate_limit_burst`` and
+``_read_ingest_rate_limit_refill_per_sec`` (#216 Phase 2).
+
+Locks: missing file → default; valid value → returned; out-of-range
+or malformed → default (fail-soft / fail-closed-on-config-error).
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from context import (
+    _DEFAULT_INGEST_RATE_LIMIT_BURST,
+    _DEFAULT_INGEST_RATE_LIMIT_REFILL_PER_SEC,
+    _read_ingest_rate_limit_burst,
+    _read_ingest_rate_limit_refill_per_sec,
+)
+
+
+def _write_config(tmp_path: Path, content: str) -> str:
+    config_dir = tmp_path / ".bicameral"
+    config_dir.mkdir(parents=True, exist_ok=True)
+    (config_dir / "config.yaml").write_text(content, encoding="utf-8")
+    return str(tmp_path)
+
+
+# ── burst ────────────────────────────────────────────────────────────
+
+
+def test_read_ingest_rate_limit_burst_defaults_when_config_missing(tmp_path: Path) -> None:
+    assert _read_ingest_rate_limit_burst(str(tmp_path)) == _DEFAULT_INGEST_RATE_LIMIT_BURST
+    assert _DEFAULT_INGEST_RATE_LIMIT_BURST == 10
+
+
+def test_read_ingest_rate_limit_burst_honors_valid_yaml_value(tmp_path: Path) -> None:
+    repo = _write_config(tmp_path, "ingest_rate_limit_burst: 25\n")
+    assert _read_ingest_rate_limit_burst(repo) == 25
+
+
+def test_read_ingest_rate_limit_burst_clamps_out_of_range(tmp_path: Path) -> None:
+    repo_low = _write_config(tmp_path, "ingest_rate_limit_burst: 0\n")
+    assert _read_ingest_rate_limit_burst(repo_low) == _DEFAULT_INGEST_RATE_LIMIT_BURST
+
+    # Use a separate tmp dir so the two cases don't share config.
+    high_dir = tmp_path / "high"
+    high_dir.mkdir()
+    repo_high = _write_config(high_dir, "ingest_rate_limit_burst: 99999\n")
+    assert _read_ingest_rate_limit_burst(repo_high) == _DEFAULT_INGEST_RATE_LIMIT_BURST
+
+
+# ── refill ───────────────────────────────────────────────────────────
+
+
+def test_read_ingest_rate_limit_refill_defaults_when_config_missing(tmp_path: Path) -> None:
+    assert (
+        _read_ingest_rate_limit_refill_per_sec(str(tmp_path))
+        == _DEFAULT_INGEST_RATE_LIMIT_REFILL_PER_SEC
+    )
+    assert _DEFAULT_INGEST_RATE_LIMIT_REFILL_PER_SEC == 1.0
+
+
+def test_read_ingest_rate_limit_refill_honors_valid_yaml_value(tmp_path: Path) -> None:
+    repo = _write_config(tmp_path, "ingest_rate_limit_refill_per_sec: 0.5\n")
+    assert _read_ingest_rate_limit_refill_per_sec(repo) == 0.5
+
+
+def test_read_ingest_rate_limit_refill_clamps_out_of_range(tmp_path: Path) -> None:
+    # 0.0 would lock the bucket forever after first burst — fall back.
+    repo_zero = _write_config(tmp_path, "ingest_rate_limit_refill_per_sec: 0.0\n")
+    assert (
+        _read_ingest_rate_limit_refill_per_sec(repo_zero)
+        == _DEFAULT_INGEST_RATE_LIMIT_REFILL_PER_SEC
+    )
+
+    high_dir = tmp_path / "high"
+    high_dir.mkdir()
+    repo_high = _write_config(high_dir, "ingest_rate_limit_refill_per_sec: 1000.0\n")
+    assert (
+        _read_ingest_rate_limit_refill_per_sec(repo_high)
+        == _DEFAULT_INGEST_RATE_LIMIT_REFILL_PER_SEC
+    )

--- a/tests/test_ingest_rate_limit.py
+++ b/tests/test_ingest_rate_limit.py
@@ -1,0 +1,234 @@
+"""Functionality tests for the LLM-08 token-bucket rate limit (#216 Phase 2).
+
+Covers:
+- ``_TokenBucket`` internals (consume, exhaust, refill, cap)
+- ``_check_rate_limit`` (env-disable, exhaust, per-session isolation)
+- ``handle_ingest`` integration (drive-to-empty + telemetry + ordering)
+- ``server.call_tool`` boundary translation for the rate-limit reason
+"""
+
+from __future__ import annotations
+
+import json
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from mcp.types import TextContent
+
+import server
+from handlers import ingest as ingest_module
+from handlers.ingest import (
+    _RATE_LIMIT_REGISTRY,
+    _check_rate_limit,
+    _IngestRefused,
+    _TokenBucket,
+    handle_ingest,
+)
+
+
+@pytest.fixture(autouse=True)
+def _reset_rate_limit_registry():
+    """Tests share module state; clear it between cases."""
+    _RATE_LIMIT_REGISTRY.clear()
+    yield
+    _RATE_LIMIT_REGISTRY.clear()
+
+
+@pytest.fixture(autouse=True)
+def _ensure_rate_limit_enabled(monkeypatch):
+    """Default to enabled so individual tests don't have to fight the
+    debug-disable env var if it leaks in from the shell."""
+    monkeypatch.delenv("BICAMERAL_INGEST_RATE_LIMIT_DISABLE", raising=False)
+
+
+def _ctx_with_rate_limit(
+    burst: int = 10,
+    refill: float = 1.0,
+    session_id: str = "test-session",
+    max_bytes: int = 1024 * 1024,
+):
+    ctx = MagicMock()
+    ctx.ingest_max_bytes = max_bytes
+    ctx.ingest_rate_limit_burst = burst
+    ctx.ingest_rate_limit_refill_per_sec = refill
+    ctx.session_id = session_id
+    ctx.repo_path = "."
+    ctx.ledger = object()
+    return ctx
+
+
+# ── _TokenBucket internals ────────────────────────────────────────────
+
+
+def test_token_bucket_take_consumes_one_when_full() -> None:
+    bucket = _TokenBucket(burst=10, refill_per_sec=1.0)
+    assert bucket.take() is True
+    # Internal counter should drop from 10.0 to 9.0 (no refill yet at this
+    # microsecond granularity).
+    assert bucket._tokens < 10.0
+    assert bucket._tokens >= 8.99  # tolerate a few microseconds of refill
+
+
+def test_token_bucket_returns_false_when_empty() -> None:
+    bucket = _TokenBucket(burst=10, refill_per_sec=0.0)
+    for _ in range(10):
+        assert bucket.take() is True
+    # Refill 0.0 means no replenishment; 11th call must fail.
+    assert bucket.take() is False
+
+
+def test_token_bucket_refills_over_time() -> None:
+    bucket = _TokenBucket(burst=10, refill_per_sec=1.0)
+    for _ in range(10):
+        bucket.take()
+    # Bucket is now empty.
+    assert bucket.take() is False
+
+    # Mock time to advance by 5 seconds; expect 5 successful takes.
+    with patch.object(ingest_module.time, "monotonic", return_value=bucket._last + 5.0):
+        successes = sum(1 for _ in range(10) if bucket.take())
+    assert successes == 5
+
+
+def test_token_bucket_caps_at_burst() -> None:
+    bucket = _TokenBucket(burst=10, refill_per_sec=1.0)
+    # Drain a few tokens.
+    bucket.take()
+    bucket.take()
+    # Advance 100s — naive accumulation would put _tokens at 8 + 100 = 108;
+    # cap must hold at 10.
+    with patch.object(ingest_module.time, "monotonic", return_value=bucket._last + 100.0):
+        # Force a refill computation by attempting a take.
+        bucket.take()
+    # After that take, _tokens is at most burst - 1 = 9.0.
+    assert bucket._tokens <= 9.0
+    assert bucket._tokens > 8.0  # confirm the refill actually happened
+
+
+# ── _check_rate_limit ────────────────────────────────────────────────
+
+
+def test_check_rate_limit_passes_when_disabled_via_env(monkeypatch) -> None:
+    monkeypatch.setenv("BICAMERAL_INGEST_RATE_LIMIT_DISABLE", "1")
+    # Even with burst=1 / refill=0 (would normally exhaust on second call)
+    # the env override must let every call through.
+    for _ in range(100):
+        _check_rate_limit("sid", burst=1, refill_per_sec=0.0)
+
+
+def test_check_rate_limit_raises_when_session_bucket_empty() -> None:
+    # burst=1, refill=0.0: first call passes, second guaranteed empty.
+    _check_rate_limit("sid-empty", burst=1, refill_per_sec=0.0)
+    with pytest.raises(_IngestRefused) as exc_info:
+        _check_rate_limit("sid-empty", burst=1, refill_per_sec=0.0)
+    assert exc_info.value.reason == "rate_limit_exceeded"
+    assert "sid-empty" in exc_info.value.detail
+
+
+def test_check_rate_limit_isolates_sessions() -> None:
+    # Exhaust session_a's bucket entirely.
+    _check_rate_limit("session_a", burst=1, refill_per_sec=0.0)
+    with pytest.raises(_IngestRefused):
+        _check_rate_limit("session_a", burst=1, refill_per_sec=0.0)
+    # session_b is independent; first call must pass.
+    _check_rate_limit("session_b", burst=1, refill_per_sec=0.0)
+
+
+# ── handle_ingest integration ────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_handle_ingest_raises_ingest_refused_on_rate_limit() -> None:
+    ctx = _ctx_with_rate_limit(burst=2, refill=0.0, session_id="sid-drive")
+    payload = {"k": "v"}
+
+    # First two ingests pass the rate gate (but fail later when they hit
+    # the real ledger). We don't care about that — patch _normalize_payload
+    # to short-circuit by raising a sentinel that we catch.
+    class _Sentinel(Exception):
+        pass
+
+    with patch("handlers.ingest._normalize_payload", side_effect=_Sentinel()):
+        for _ in range(2):
+            with pytest.raises(_Sentinel):
+                await handle_ingest(ctx, payload)
+        # Third call: rate gate must fire first.
+        with pytest.raises(_IngestRefused) as exc_info:
+            await handle_ingest(ctx, payload)
+    assert exc_info.value.reason == "rate_limit_exceeded"
+    assert "sid-drive" in exc_info.value.detail
+    assert "bucket empty" in exc_info.value.detail
+
+
+@pytest.mark.asyncio
+async def test_handle_ingest_emits_refusal_telemetry_before_reraise_on_rate_limit() -> None:
+    ctx = _ctx_with_rate_limit(burst=1, refill=0.0, session_id="sid-tele")
+    payload = {"k": "v"}
+
+    class _Sentinel(Exception):
+        pass
+
+    # Drain the single token via one passing call.
+    with patch("handlers.ingest._normalize_payload", side_effect=_Sentinel()):
+        with pytest.raises(_Sentinel):
+            await handle_ingest(ctx, payload)
+
+    # Next call: rate-limit gate fires; telemetry must be invoked
+    # before the exception leaves handle_ingest.
+    with patch("handlers.ingest.preflight_telemetry") as telemetry_mock:
+        with pytest.raises(_IngestRefused):
+            await handle_ingest(ctx, payload)
+        telemetry_mock.write_ingest_refusal_event.assert_called_once_with(
+            reason="rate_limit_exceeded", session_id="sid-tele"
+        )
+
+
+@pytest.mark.asyncio
+async def test_handle_ingest_size_check_runs_before_rate_check() -> None:
+    # Empty bucket AND oversized payload; size check must fire first
+    # so the rate-bucket state is not consumed.
+    ctx = _ctx_with_rate_limit(burst=1, refill=0.0, session_id="sid-order", max_bytes=10)
+    oversized = {"decisions": [{"description": "x" * 500}]}
+
+    with pytest.raises(_IngestRefused) as exc_info:
+        await handle_ingest(ctx, oversized)
+    assert exc_info.value.reason == "size_limit_exceeded"
+
+    # Bucket for sid-order should still hold its single token: rate check
+    # was unreached. We verify by calling _check_rate_limit directly —
+    # the registry entry created on the FIRST size-exceeding call would
+    # only exist if the rate gate had run.
+    assert "sid-order" not in _RATE_LIMIT_REGISTRY
+
+
+# ── server.call_tool boundary translation ────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_call_tool_translates_rate_limit_refusal_to_text_content_error() -> None:
+    raised = _IngestRefused(
+        "rate_limit_exceeded",
+        detail="session sid-x bucket empty (burst=1, refill=1.0/s)",
+    )
+    sync_stub = AsyncMock(return_value=None)
+    handle_stub = AsyncMock(side_effect=raised)
+    ctx_stub = MagicMock()
+    ctx_stub.repo_path = "."
+
+    with (
+        patch.object(server.BicameralContext, "from_env", return_value=ctx_stub),
+        patch("handlers.sync_middleware.ensure_ledger_synced", sync_stub),
+        patch.object(server, "handle_ingest", handle_stub),
+    ):
+        result = await server.call_tool("bicameral.ingest", {"payload": {"k": "v"}})
+
+    assert isinstance(result, list) and len(result) == 1
+    entry = result[0]
+    assert isinstance(entry, TextContent)
+    body = json.loads(entry.text)
+    assert body["error"] == "rate_limit_exceeded"
+    assert "bucket empty" in body["detail"]
+    action = body["action"]
+    assert "ingest_rate_limit_burst" in action
+    assert "ingest_rate_limit_refill_per_sec" in action
+    assert "BICAMERAL_INGEST_RATE_LIMIT_DISABLE" in action

--- a/tests/test_ingest_size_limit.py
+++ b/tests/test_ingest_size_limit.py
@@ -109,6 +109,10 @@ async def test_handle_ingest_raises_ingest_refused_on_size_excess() -> None:
     assert str(cap) in exc_info.value.detail
     # No ledger write should have happened — the gate ran before connect.
     ledger_mock.ingest_payload.assert_not_called()
+    # Per-216 ordering invariant (devil's-advocate finding): a refused payload
+    # must NOT pay the ledger-connect handshake either. Locks the gate-before-
+    # connect ordering against drift.
+    ledger_mock.connect.assert_not_called()
 
 
 @pytest.mark.asyncio

--- a/tests/test_ingest_size_limit.py
+++ b/tests/test_ingest_size_limit.py
@@ -1,0 +1,125 @@
+"""Functionality tests for the LLM-02 payload-size guardrail (#216 Phase 1).
+
+Covers ``_check_payload_size`` (pure helper) and ``handle_ingest``
+integration (gate + telemetry emission + propagation). The MCP-boundary
+translation lives in ``test_server_ingest_refusal.py``.
+"""
+
+from __future__ import annotations
+
+import json
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from handlers.ingest import _check_payload_size, _IngestRefused, handle_ingest
+
+
+def _ctx_with_max_bytes(max_bytes: int, session_id: str = "test-session"):
+    """Stub BicameralContext that only exposes the fields handle_ingest
+    reads before any ledger or normalization work runs."""
+    ctx = MagicMock()
+    ctx.ingest_max_bytes = max_bytes
+    ctx.session_id = session_id
+    ctx.repo_path = "."
+    # ledger has no `connect`; we want handle_ingest to skip the connect
+    # branch entirely. spec=[] would block AsyncMock attr lookup; instead
+    # use a plain object whose hasattr("connect") is False.
+    ctx.ledger = object()
+    return ctx
+
+
+def test_check_payload_size_passes_when_under_cap() -> None:
+    # Small payload, generous cap — must not raise.
+    _check_payload_size({"k": "v"}, 1024)
+
+
+def test_check_payload_size_raises_at_exact_excess() -> None:
+    # Build a payload that serializes to exactly cap + 1 bytes.
+    cap = 50
+    # `{"k": "<padding>"}` — figure out the padding length so the
+    # serialized form is cap + 1 bytes.
+    skeleton = json.dumps({"k": ""}).encode("utf-8")
+    padding_len = (cap + 1) - len(skeleton)
+    payload = {"k": "x" * padding_len}
+    serialized_size = len(json.dumps(payload).encode("utf-8"))
+    assert serialized_size == cap + 1, (
+        f"test setup wrong: got {serialized_size}, expected {cap + 1}"
+    )
+
+    with pytest.raises(_IngestRefused) as exc_info:
+        _check_payload_size(payload, cap)
+    assert exc_info.value.reason == "size_limit_exceeded"
+    assert "bytes" in exc_info.value.detail
+
+
+def test_check_payload_size_uses_serialized_byte_count() -> None:
+    # The gate measures the serialized JSON form, not the raw string
+    # content of any single field. With unicode chars the serialized form
+    # is multiple bytes per char (either UTF-8 multi-byte or escaped
+    # ``\uXXXX``); both routes produce byte counts strictly greater than
+    # the inner-string char count. Pick a cap between the inner char
+    # count and the serialized byte count: a naive char-based check would
+    # pass, the byte-based check must refuse.
+    raw = "\U0001f600" * 30  # 30 grinning-face chars, 30 chars long
+    payload = {"k": raw}
+    inner_char_count = len(raw)
+    serialized_byte_count = len(json.dumps(payload, default=str).encode("utf-8"))
+    assert serialized_byte_count > inner_char_count, "test setup needs multi-byte chars"
+
+    cap = (inner_char_count + serialized_byte_count) // 2
+    assert inner_char_count <= cap < serialized_byte_count
+
+    with pytest.raises(_IngestRefused) as exc_info:
+        _check_payload_size(payload, cap)
+    assert exc_info.value.reason == "size_limit_exceeded"
+
+
+def test_check_payload_size_includes_schema_overhead() -> None:
+    # Tiny inner text, but nested-object overhead pushes past cap.
+    payload = {"decisions": [{"id": f"d-{i}", "title": "x", "description": "y"} for i in range(50)]}
+    serialized_size = len(json.dumps(payload).encode("utf-8"))
+    # Pick a cap that the inner text alone (~50 chars total) is well under
+    # but the serialized form (with all the JSON braces / quotes / keys)
+    # exceeds.
+    cap = 200
+    assert serialized_size > cap
+
+    with pytest.raises(_IngestRefused) as exc_info:
+        _check_payload_size(payload, cap)
+    assert exc_info.value.reason == "size_limit_exceeded"
+
+
+@pytest.mark.asyncio
+async def test_handle_ingest_raises_ingest_refused_on_size_excess() -> None:
+    cap = 100
+    oversized = {"decisions": [{"description": "x" * 500}]}
+    ctx = _ctx_with_max_bytes(cap)
+    # Replace the ledger with a recording mock so we can assert no write happened.
+    ledger_mock = MagicMock()
+    ledger_mock.connect = AsyncMock()
+    ledger_mock.ingest_payload = AsyncMock()
+    ctx.ledger = ledger_mock
+
+    with pytest.raises(_IngestRefused) as exc_info:
+        await handle_ingest(ctx, oversized)
+
+    assert exc_info.value.reason == "size_limit_exceeded"
+    assert "bytes" in exc_info.value.detail
+    assert str(cap) in exc_info.value.detail
+    # No ledger write should have happened — the gate ran before connect.
+    ledger_mock.ingest_payload.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_handle_ingest_emits_refusal_telemetry_before_reraise_on_size_excess() -> None:
+    cap = 100
+    oversized = {"decisions": [{"description": "y" * 500}]}
+    ctx = _ctx_with_max_bytes(cap, session_id="sid-abc")
+
+    with patch("handlers.ingest.preflight_telemetry") as telemetry_mock:
+        with pytest.raises(_IngestRefused):
+            await handle_ingest(ctx, oversized)
+        telemetry_mock.write_ingest_refusal_event.assert_called_once_with(
+            reason="size_limit_exceeded", session_id="sid-abc"
+        )

--- a/tests/test_server_ingest_refusal.py
+++ b/tests/test_server_ingest_refusal.py
@@ -1,0 +1,72 @@
+"""Functionality tests for the MCP-boundary translation of
+``_IngestRefused`` (#216 Phase 1 + Phase 2).
+
+The handler raises ``_IngestRefused``; ``server.call_tool`` translates
+to a ``TextContent`` carrying ``error`` / ``detail`` / ``action``
+fields. Schema (``IngestResponse``) is unchanged — refusals never
+return a populated IngestResponse.
+"""
+
+from __future__ import annotations
+
+import json
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from mcp.types import TextContent
+
+import server
+from handlers.ingest import _IngestRefused
+
+
+def _stub_ctx() -> MagicMock:
+    """Minimal ctx; the server-boundary tests never touch its inner state."""
+    ctx = MagicMock()
+    ctx.repo_path = "."
+    return ctx
+
+
+@pytest.mark.asyncio
+async def test_call_tool_translates_size_limit_refusal_to_text_content_error() -> None:
+    raised = _IngestRefused("size_limit_exceeded", detail="2048 bytes > 1024 cap")
+    sync_stub = AsyncMock(return_value=None)
+    handle_stub = AsyncMock(side_effect=raised)
+    ctx_stub = _stub_ctx()
+
+    with (
+        patch.object(server.BicameralContext, "from_env", return_value=ctx_stub),
+        patch("handlers.sync_middleware.ensure_ledger_synced", sync_stub),
+        patch.object(server, "handle_ingest", handle_stub),
+    ):
+        result = await server.call_tool("bicameral.ingest", {"payload": {"k": "v"}})
+
+    assert isinstance(result, list)
+    assert len(result) == 1
+    entry = result[0]
+    assert isinstance(entry, TextContent)
+    body = json.loads(entry.text)
+    assert body["error"] == "size_limit_exceeded"
+    assert body["detail"] == "2048 bytes > 1024 cap"
+    assert isinstance(body["action"], str) and body["action"]
+
+
+@pytest.mark.asyncio
+async def test_call_tool_action_string_for_size_limit_directs_operator_to_config_knob() -> None:
+    raised = _IngestRefused("size_limit_exceeded", detail="x bytes > y cap")
+    sync_stub = AsyncMock(return_value=None)
+    handle_stub = AsyncMock(side_effect=raised)
+    ctx_stub = _stub_ctx()
+
+    with (
+        patch.object(server.BicameralContext, "from_env", return_value=ctx_stub),
+        patch("handlers.sync_middleware.ensure_ledger_synced", sync_stub),
+        patch.object(server, "handle_ingest", handle_stub),
+    ):
+        result = await server.call_tool("bicameral.ingest", {"payload": {"k": "v"}})
+
+    body = json.loads(result[0].text)
+    action = body["action"]
+    # Operator-actionable guidance: must mention BOTH the config remedy
+    # (raise the cap) and the operator-side remedy (split the payload).
+    assert "ingest_max_bytes" in action
+    assert "split the payload" in action


### PR DESCRIPTION
## Summary

First two sub-tasks of epic BicameralAI/bicameral-mcp#216 (ingest boundary guardrails) — server-side gates on the durable write surface.

- **LLM-02 payload-size guardrail** — `_check_payload_size` measures `len(json.dumps(payload, default=str).encode("utf-8"))`; default cap 1 MiB clamped to [1 KiB, 64 MiB] via `.bicameral/config.yaml: ingest_max_bytes`.
- **LLM-08 token-bucket rate limit** — `_TokenBucket` (lazy-refill, threading.Lock); per-session-id registry; default burst 10, refill 1.0/s. Two config knobs + `BICAMERAL_INGEST_RATE_LIMIT_DISABLE=1` env override for local debugging.
- **Path-C exception-to-boundary translation** — `_IngestRefused` propagates from `handle_ingest`; `server.call_tool` translates to a `TextContent` with `{error, detail, action}` JSON, following the existing `DestructiveMigrationRequired`/`SchemaVersionTooNew` precedent at `server.py:1250-1261`. **No `IngestResponse` schema change.**

## Plan / audit / observer / devil's-advocate / implement

- Plan: `plan-216-ingest-size-and-rate-limit.md`
- Audit round 1: VETO (`infrastructure-mismatch` — `IngestResponse.ok` field doesn't exist on the contract)
- Plan amended: path-C selected (raise to MCP boundary, no contract change)
- Audit round 2: PASS @ L1
- Implementation: agent-team parallel mode (specialist + observer + devil's-advocate)
- Devil's-advocate findings folded in: NaN bypass on `refill_per_sec` clamp closed via `math.isfinite()`, `ledger.connect()` reordered to run after gates so refused payloads cost zero downstream, `_SESSION_ID`-is-process-wide note added to handler docstring

## Test plan

- [x] `pytest tests/test_ingest_size_limit.py tests/test_context_ingest_max_bytes.py tests/test_server_ingest_refusal.py -v` — Phase 1 + boundary translation
- [x] `pytest tests/test_ingest_rate_limit.py tests/test_context_ingest_rate_limit.py -v` — Phase 2
- [x] `pytest tests/ -k ingest` — full ingest regression: 58 passed, 2 skipped (pre-existing), 0 failures
- [x] `ruff check` + `ruff format --check` clean on all 9 touched files
- [ ] CI to confirm

## Commits (5)

- `3955ae4` shared infra (`_IngestRefused`, telemetry helper)
- `d34a64e` LLM-02 size limit
- `8e71eb7` MCP-boundary translation
- `0536a27` LLM-08 rate limit
- `3fa2c0f` follow-up: NaN-bypass close + connect-before-gate fix + session-scoping note

## Linked issues

Refs: BicameralAI/bicameral-mcp#216, BicameralAI/bicameral-daemon#34, BicameralAI/bicameral-mcp#199 (precedent for ruff-format CI parity), BicameralAI/bicameral-mcp#200 (precedent for config-knob shape)
Folds (sub-tasks of BicameralAI/bicameral-mcp#216): closes nothing on its own (the epic stays open until LLM-01 BicameralAI/bicameral-mcp#212 + LLM-04 BicameralAI/bicameral-mcp#213 also ship)

🤖 Generated with [Claude Code](https://claude.com/claude-code)