### PR TITLE
fix(preflight): refine render_source_attribution regex + flip default (#209)

### DIFF
--- a/context.py
+++ b/context.py
@@ -25,7 +25,9 @@ _RENDER_ATTRIBUTION_MODES = frozenset({"full", "redacted", "hidden"})
 # agent-parseable structure. Default flips to `redacted` once the regex
 # is refined to match only true name/date patterns. Tracked separately;
 # config field already exposes the privacy-positive options for opt-in.
-_DEFAULT_RENDER_ATTRIBUTION_MODE = "redacted"  # #209: flipped from "full"; positional-cue regex refined
+_DEFAULT_RENDER_ATTRIBUTION_MODE = (
+    "redacted"  # #209: flipped from "full"; positional-cue regex refined
+)
 
 _BYPASS_TRACKING_MODES = frozenset({"enabled", "disabled"})
 _DEFAULT_BYPASS_TRACKING_MODE = "enabled"

--- a/context.py
+++ b/context.py
@@ -25,7 +25,7 @@ _RENDER_ATTRIBUTION_MODES = frozenset({"full", "redacted", "hidden"})
 # agent-parseable structure. Default flips to `redacted` once the regex
 # is refined to match only true name/date patterns. Tracked separately;
 # config field already exposes the privacy-positive options for opt-in.
-_DEFAULT_RENDER_ATTRIBUTION_MODE = "full"
+_DEFAULT_RENDER_ATTRIBUTION_MODE = "redacted"  # #209: flipped from "full"; positional-cue regex refined
 
 _BYPASS_TRACKING_MODES = frozenset({"enabled", "disabled"})
 _DEFAULT_BYPASS_TRACKING_MODE = "enabled"

--- a/handlers/preflight.py
+++ b/handlers/preflight.py
@@ -77,11 +77,24 @@ _PRODUCT_STAGE_MSG = (
 _ONBOARDED_MARKER = Path.home() / ".bicameral" / "onboarded"
 
 
-# #200 Phase 3: render_source_attribution policy patterns. The redacted
-# mode preserves structural shape (so the operator can see "this is from
-# a meeting on a date" without seeing who or when).
-_NAME_PATTERN = re.compile(r"\b[A-Z][a-z]+\b")
+# #200 Phase 3 / #209 refinement: render_source_attribution policy patterns.
+# The redacted mode preserves structural shape (so the operator can see
+# "this is from a meeting on a date" without seeing who or when) while
+# leaving capitalized context tokens (Sprint, Linear, GitHub, etc.) intact.
+#
+# v1 used a broad `\b[A-Z][a-z]+\b` that redacted every capitalized lowercase
+# token — including platform/tool names — and broke the agent's structural
+# parsing of source_refs (#209). v2 uses four POSITIONAL-cue patterns: a name
+# only matches when it follows an explicit cue (`· `, `, ` adjacent to a date,
+# `^Speaker:\s`, `^From:\s`). Context tokens never follow these cues by
+# construction, so no allowlist is needed.
 _DATE_PATTERN = re.compile(r"\b\d{4}-\d{2}-\d{2}\b")
+_NAME_AFTER_BULLET = re.compile(r"(?<=· )[A-Z][a-z]+(?:[ \t]+[A-Z][a-z]+)*")
+_NAME_AFTER_COMMA = re.compile(
+    r"(?<=, )[A-Z][a-z]+(?:[ \t]+[A-Z][a-z]+)*(?=,?\s+\d{4}-\d{2}-\d{2})"
+)
+_SPEAKER_NAME = re.compile(r"(?<=^Speaker:\s)[A-Z][a-z]+(?:[ \t]+[A-Z][a-z]+)*", re.MULTILINE)
+_FROM_NAME = re.compile(r"(?<=^From:\s)[A-Z][a-z]+(?:[ \t]+[A-Z][a-z]+)*", re.MULTILINE)
 
 
 def _apply_attribution_policy(matches: list, mode: str) -> list:
@@ -89,9 +102,10 @@ def _apply_attribution_policy(matches: list, mode: str) -> list:
 
     Modes (from `.bicameral/config.yaml: render_source_attribution`):
       - `full`: pass through verbatim (legacy)
-      - `redacted` (default): replace name + date patterns with placeholders;
-        preserves structural shape so the operator sees "Source: <NAME_REDACTED>
-        review · <NAME_REDACTED>, <DATE_REDACTED>" instead of full attribution
+      - `redacted` (default since #209): replace name + date patterns with
+        placeholders. Names match only after explicit positional cues (`· `,
+        `, ` adjacent to a date, `Speaker:`, `From:`); context tokens like
+        Sprint/Linear/GitHub survive because they never follow these cues.
       - `hidden`: blank source_ref entirely
 
     Returns a new list of DecisionMatch instances (Pydantic copies via
@@ -105,8 +119,12 @@ def _apply_attribution_policy(matches: list, mode: str) -> list:
         if mode == "hidden":
             new_source_ref = ""
         else:  # redacted
-            stripped = _DATE_PATTERN.sub("<DATE_REDACTED>", m.source_ref)
-            new_source_ref = _NAME_PATTERN.sub("<NAME_REDACTED>", stripped)
+            redacted = _DATE_PATTERN.sub("<DATE_REDACTED>", m.source_ref)
+            redacted = _NAME_AFTER_BULLET.sub("<NAME_REDACTED>", redacted)
+            redacted = _NAME_AFTER_COMMA.sub("<NAME_REDACTED>", redacted)
+            redacted = _SPEAKER_NAME.sub("<NAME_REDACTED>", redacted)
+            redacted = _FROM_NAME.sub("<NAME_REDACTED>", redacted)
+            new_source_ref = redacted
         transformed.append(m.model_copy(update={"source_ref": new_source_ref}))
     return transformed
 

--- a/plan-B-preflight-attribution-regex-209.md
+++ b/plan-B-preflight-attribution-regex-209.md
@@ -1,0 +1,123 @@
+# Plan B: refine `render_source_attribution` redaction regex + flip default (#209)
+
+**change_class**: feature
+
+**doc_tier**: minimal
+
+**high_risk_target**: false
+
+**terms_introduced**: none (the refined plan introduces no new term-as-object; it replaces existing private regexes with more precise siblings)
+
+**boundaries**:
+- limitations:
+  - The refined regex is a heuristic, not a formal grammar over source_ref shapes. It targets the documented shape `"<context-words> · <Name>, <date>"` produced by the e2e harness ingest path; ingests with non-standard structures may still over- or under-redact. Platform/tool tokens (Sprint, Linear, GitHub, etc.) survive redaction by design — the positional-cue patterns require explicit cues (`· `, `, `, `Speaker:`, `From:`) to fire, which context tokens never follow.
+- non_goals:
+  - Cryptographic name-hash (would defeat operator-readable redaction).
+  - Per-locale name detection (e.g., non-Latin scripts).
+  - Reverse-mapping a redacted source_ref back to its original (intentional one-way transform).
+- exclusions:
+  - The `hidden` mode (already correct — blank string).
+  - The `full` mode (passes through verbatim — no transformation).
+
+## Open Questions
+
+None at plan time. The issue body is explicit about which tokens to preserve and which to redact; the e2e Flow 3 acceptance bound is concrete.
+
+## Phase 1: Refine regex + curated allowlist + flip default
+
+### Affected Files
+
+- `tests/test_preflight_attribution_redaction.py` (new) — functionality tests covering the refined regex against real source_ref shapes (the example from the issue body, plus 4–6 representative real-world strings); locks the preserved-vs-redacted boundaries
+- `handlers/preflight.py` —
+  - Replace `_NAME_PATTERN = re.compile(r"\b[A-Z][a-z]+\b")` with four positional-cue patterns (after `· `, after `, ` adjacent to a date, after `Speaker:` prefix, after `From:` prefix)
+  - Refine `_apply_attribution_policy` redacted branch to apply the new patterns in sequence
+- `context.py` — flip `_DEFAULT_RENDER_ATTRIBUTION_MODE = "full"` → `"redacted"` (line 28)
+- `setup_wizard.py` — line 1005: change `"render_source_attribution: full\n"` → `"render_source_attribution: redacted\n"` for fresh installs
+
+### Changes
+
+#### Refined regex strategy
+
+Replace the broad `_NAME_PATTERN` with three positional-cue patterns:
+
+```python
+# Names appearing after `· ` (decorative bullet separator before attribution)
+_NAME_AFTER_BULLET = re.compile(r"(?<=· )[A-Z][a-z]+(?:\s+[A-Z][a-z]+)*")
+
+# Names appearing after `, ` (comma-separator before name+date)
+_NAME_AFTER_COMMA = re.compile(r"(?<=, )[A-Z][a-z]+(?:\s+[A-Z][a-z]+)*(?=,?\s+\d{4}-\d{2}-\d{2})")
+
+# Names in `Speaker: Name` or `From: Name` prefix shape
+_SPEAKER_NAME = re.compile(r"(?<=^Speaker:\s)[A-Z][a-z]+(?:\s+[A-Z][a-z]+)*", re.MULTILINE)
+_FROM_NAME = re.compile(r"(?<=^From:\s)[A-Z][a-z]+(?:\s+[A-Z][a-z]+)*", re.MULTILINE)
+```
+
+These match the documented attribution shapes without consuming context-word capitalizations like "Sprint 14" or "Linear board."
+
+#### Why no platform-token allowlist
+
+A curated frozenset of platform/tool names ("Sprint", "Linear", "GitHub", etc.) was considered as a defense-in-depth post-redaction restoration step. **Rejected** for this PR per round-1 audit finding 1 (`specification-drift`):
+
+- The four positional-cue patterns above require explicit cues to fire (`· `, `, ` adjacent to a date, `^Speaker:\s`, `^From:\s`). Context tokens like "Sprint", "Linear", "GitHub" appearing in `<context-words>` position never follow these cues, so the patterns never over-match them by construction.
+- Adding a post-redaction restoration loop adds fragile post-hoc string replacement to handle a case the positional patterns don't trigger — complexity without provable value.
+- The test suite directly verifies this: `test_redacted_mode_preserves_platform_tokens`, `test_redacted_mode_preserves_capitalized_context_words` invoke `_apply_attribution_policy` with platform tokens in context-word position and assert passthrough. If the positional patterns ever over-match in practice, those tests fail and the regex gets refined — not a band-aid allowlist added.
+
+If a future ingest source produces a shape where platform tokens DO follow positional cues (e.g., `"From: Sprint Bot"`), the right fix is to refine the positional regex or add a per-token negative lookahead — not a global allowlist that fights the regex.
+
+Actual implementation order in `_apply_attribution_policy`'s `redacted` branch:
+
+```python
+stripped = _DATE_PATTERN.sub("<DATE_REDACTED>", m.source_ref)
+redacted = _NAME_AFTER_BULLET.sub("<NAME_REDACTED>", stripped)
+redacted = _NAME_AFTER_COMMA.sub("<NAME_REDACTED>", redacted)
+redacted = _SPEAKER_NAME.sub("<NAME_REDACTED>", redacted)
+redacted = _FROM_NAME.sub("<NAME_REDACTED>", redacted)
+new_source_ref = redacted
+```
+
+Date pattern unchanged (`\b\d{4}-\d{2}-\d{2}\b` is correct).
+
+#### Flip default
+
+```python
+# context.py
+_DEFAULT_RENDER_ATTRIBUTION_MODE = "redacted"  # was "full"
+```
+
+```python
+# setup_wizard.py:1005
+"render_source_attribution: redacted\n"  # was "full"
+```
+
+The deterministic gate is in place; flipping the default is the privacy-positive move that #200 audit finding A4 directed.
+
+### Unit Tests
+
+- `tests/test_preflight_attribution_redaction.py::test_redacted_mode_redacts_name_after_bullet_separator` — invokes `_apply_attribution_policy([DecisionMatch(source_ref="Sprint 14 architecture review · Ian, 2026-03-12")], "redacted")`; asserts result `source_ref == "Sprint 14 architecture review · <NAME_REDACTED>, <DATE_REDACTED>"`. The "Sprint" platform token survives; "Ian" is redacted.
+
+- `tests/test_preflight_attribution_redaction.py::test_redacted_mode_preserves_platform_tokens` — invokes against `"Linear board issue #143 · Bob"`; asserts "Linear" preserved, "Bob" redacted.
+
+- `tests/test_preflight_attribution_redaction.py::test_redacted_mode_redacts_speaker_prefix` — invokes against `"Speaker: Alice Bobson"` (multi-line, `re.MULTILINE` shape); asserts redaction.
+
+- `tests/test_preflight_attribution_redaction.py::test_redacted_mode_redacts_from_prefix` — invokes against `"From: Charlie\nBody text"`; asserts "Charlie" redacted but "Body" preserved (capitalization at start-of-line not after `From:` shouldn't trigger).
+
+- `tests/test_preflight_attribution_redaction.py::test_redacted_mode_preserves_capitalized_context_words` — invokes against `"GitHub PR #229 review notes · Eve, 2026-04-10"`; asserts "GitHub", "PR", "review", "notes" preserved (none follow positional cues for name); "Eve" redacted; date redacted.
+
+- `tests/test_preflight_attribution_redaction.py::test_redacted_mode_handles_no_attribution_shape` — invokes against a source_ref with no positional cues like `"Decision context: implement feature X"`; asserts no transformation (full passthrough since no positional cue triggered).
+
+- `tests/test_preflight_attribution_redaction.py::test_default_render_attribution_mode_is_redacted` — imports `context._DEFAULT_RENDER_ATTRIBUTION_MODE`; asserts equality with `"redacted"`. (Locks the default-flip contract; without the test, a future revert could silently regress.)
+
+- `tests/test_preflight_attribution_redaction.py::test_setup_wizard_fresh_install_writes_redacted_default` — invokes `setup_wizard._write_collaboration_config(tmp_path, mode="standard", guided=False, telemetry=False)` (or whichever signature it currently has — adjust kwargs to match). After the function returns, reads the resulting `.bicameral/config.yaml` file under `tmp_path` and asserts the rendered YAML content contains the substring `"render_source_attribution: redacted"` AND does NOT contain `"render_source_attribution: full"`. The unit under test is `_write_collaboration_config`'s YAML rendering — the assertion is on the rendered file content, not on the source file's literal. Acceptance question: if `_write_collaboration_config` were silently rewritten to emit `full`, would this test fail? YES — it reads the generated artifact, not the source.
+
+- `tests/test_preflight_attribution_redaction.py::test_full_mode_unchanged` — invokes `_apply_attribution_policy([DecisionMatch(source_ref="Sprint 14 review · Ian, 2026-03-12")], "full")`; asserts the source_ref passes through verbatim.
+
+- `tests/test_preflight_attribution_redaction.py::test_hidden_mode_blanks_source_ref` — invokes with `mode="hidden"`; asserts `source_ref == ""`.
+
+## CI Commands
+
+- `python -m pytest tests/test_preflight_attribution_redaction.py -v` — runs the new tests
+- `python -m pytest tests/test_preflight* -v` — broader preflight regression
+- `python -m pytest -v` — full regression (verifies the default-flip doesn't break any test that depended on `"full"` semantics implicitly)
+- `ruff check .` — lint gate
+- `ruff format --check .` — format gate
+- e2e Flow 3 acceptance: post-merge to dev, the `v0 user flow e2e` workflow runs `mcp_layer + agentic_layer` paths against the new default; passing Flow 3 confirms agent reasoning isn't broken by `redacted` becoming the default

--- a/setup_wizard.py
+++ b/setup_wizard.py
@@ -960,7 +960,7 @@ def _write_collaboration_config(
         f"guided: {'true' if guided else 'false'}\n"
         f"telemetry: {'true' if telemetry else 'false'}\n"
         "signer_email_fallback: local-part-only\n"
-        "render_source_attribution: full\n"
+        "render_source_attribution: redacted\n"  # #209: privacy-positive default (was "full")
         "preflight_bypass_tracking: enabled\n",
         encoding="utf-8",
     )
@@ -969,8 +969,9 @@ def _write_collaboration_config(
     print(f"  Telemetry: {'on — anonymous usage stats' if telemetry else 'off'}")
     print("  Signer-email fallback: local-part-only (privacy-positive default)")
     print(
-        "  Source-attribution rendering: full (legacy verbatim — flip to "
-        "`redacted` or `hidden` in config.yaml to opt into privacy-positive shape)"
+        "  Source-attribution rendering: redacted (privacy-positive default — "
+        "names + dates replaced with placeholders; flip to `full` or `hidden` "
+        "in config.yaml to change)"
     )
     print("  Preflight bypass tracking: enabled (writes ~/.bicameral/preflight_events.jsonl)")
 

--- a/tests/test_preflight_attribution_redaction.py
+++ b/tests/test_preflight_attribution_redaction.py
@@ -1,0 +1,135 @@
+"""Functionality tests for `handlers.preflight._apply_attribution_policy`
+refined positional-cue regex (#209).
+
+Locks the preserved-vs-redacted boundaries against drift:
+- Names following positional cues (`· `, `, ` adjacent to date, `Speaker:`,
+  `From:`) are redacted to `<NAME_REDACTED>`
+- Capitalized context tokens that don't follow positional cues survive
+  (Sprint, Linear, GitHub, etc.) — no allowlist needed because the
+  positional patterns require explicit cues by construction
+- Dates `YYYY-MM-DD` are redacted to `<DATE_REDACTED>`
+- The `_DEFAULT_RENDER_ATTRIBUTION_MODE` constant has flipped to `redacted`
+- Fresh `_write_collaboration_config` invocations write `render_source_attribution: redacted` (not `full`)
+
+Replaces the v1 overbroad `_NAME_PATTERN = re.compile(r"\b[A-Z][a-z]+\b")`
+which redacted ALL capitalized tokens including platform/tool names.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import context
+from contracts import DecisionMatch
+from handlers.preflight import _apply_attribution_policy
+
+
+def _match(source_ref: str) -> DecisionMatch:
+    """Build a minimal DecisionMatch for redaction-policy testing.
+
+    Only ``source_ref`` is exercised by `_apply_attribution_policy`;
+    other fields satisfy the Pydantic schema's required contract.
+    """
+    return DecisionMatch(
+        decision_id="d1",
+        description="test decision",
+        status="reflected",
+        confidence=1.0,
+        source_ref=source_ref,
+        code_regions=[],
+    )
+
+
+# ── Redacted-mode positional-cue patterns ────────────────────────────
+
+
+def test_redacted_mode_redacts_name_after_bullet_separator() -> None:
+    inp = "Sprint 14 architecture review · Ian, 2026-03-12"
+    out = _apply_attribution_policy([_match(inp)], "redacted")
+    assert out[0].source_ref == "Sprint 14 architecture review · <NAME_REDACTED>, <DATE_REDACTED>"
+
+
+def test_redacted_mode_preserves_platform_tokens() -> None:
+    """Platform tokens in context-word position survive: `Linear board issue
+    #143 · Bob` redacts only `Bob`."""
+    inp = "Linear board issue #143 · Bob"
+    out = _apply_attribution_policy([_match(inp)], "redacted")
+    assert "Linear" in out[0].source_ref
+    assert "Bob" not in out[0].source_ref
+    assert "<NAME_REDACTED>" in out[0].source_ref
+
+
+def test_redacted_mode_redacts_speaker_prefix() -> None:
+    inp = "Speaker: Alice Bobson"
+    out = _apply_attribution_policy([_match(inp)], "redacted")
+    assert "Alice" not in out[0].source_ref
+    assert "Bobson" not in out[0].source_ref
+    assert "<NAME_REDACTED>" in out[0].source_ref
+
+
+def test_redacted_mode_redacts_from_prefix() -> None:
+    """`From: Charlie\\nBody text` — `Charlie` redacted, `Body` preserved
+    (capitalization at start-of-line not after `From:` shouldn't trigger)."""
+    inp = "From: Charlie\nBody text"
+    out = _apply_attribution_policy([_match(inp)], "redacted")
+    assert "Charlie" not in out[0].source_ref
+    assert "Body" in out[0].source_ref
+
+
+def test_redacted_mode_preserves_capitalized_context_words() -> None:
+    """`GitHub PR #229 review notes · Eve, 2026-04-10` — only `Eve` and
+    the date are redacted; `GitHub`, `PR`, etc. survive."""
+    inp = "GitHub PR #229 review notes · Eve, 2026-04-10"
+    out = _apply_attribution_policy([_match(inp)], "redacted")
+    assert "GitHub" in out[0].source_ref
+    assert "PR" in out[0].source_ref
+    assert "review" in out[0].source_ref
+    assert "notes" in out[0].source_ref
+    assert "Eve" not in out[0].source_ref
+    assert "<NAME_REDACTED>" in out[0].source_ref
+    assert "<DATE_REDACTED>" in out[0].source_ref
+
+
+def test_redacted_mode_handles_no_attribution_shape() -> None:
+    """A source_ref with no positional cues passes through unchanged
+    (modulo date redaction, which is unambiguous and doesn't need cues)."""
+    inp = "Decision context: implement feature X"
+    out = _apply_attribution_policy([_match(inp)], "redacted")
+    assert out[0].source_ref == inp
+
+
+# ── Default flip ──────────────────────────────────────────────────────
+
+
+def test_default_render_attribution_mode_is_redacted() -> None:
+    """Lock the default-flip contract; without the test, a future revert
+    could silently regress."""
+    assert context._DEFAULT_RENDER_ATTRIBUTION_MODE == "redacted"
+
+
+def test_setup_wizard_fresh_install_writes_redacted_default(tmp_path: Path) -> None:
+    """Functional contract: invoke `_write_collaboration_config` with a
+    tmp_path data dir and verify the rendered YAML carries the redacted
+    default. Tests the unit's behavior (file-write rendering), not a
+    source-file substring presence."""
+    from setup_wizard import _write_collaboration_config
+
+    _write_collaboration_config(tmp_path, mode="standard", guided=False, telemetry=False)
+    rendered = (tmp_path / ".bicameral" / "config.yaml").read_text(encoding="utf-8")
+    assert "render_source_attribution: redacted" in rendered
+    assert "render_source_attribution: full" not in rendered
+
+
+# ── full / hidden modes (regression locks) ───────────────────────────
+
+
+def test_full_mode_unchanged() -> None:
+    inp = "Sprint 14 review · Ian, 2026-03-12"
+    out = _apply_attribution_policy([_match(inp)], "full")
+    assert out[0].source_ref == inp
+
+
+def test_hidden_mode_blanks_source_ref() -> None:
+    inp = "Sprint 14 review · Ian, 2026-03-12"
+    out = _apply_attribution_policy([_match(inp)], "hidden")
+    assert out[0].source_ref == ""

--- a/tests/test_preflight_render_source_attribution.py
+++ b/tests/test_preflight_render_source_attribution.py
@@ -43,9 +43,13 @@ def test_full_mode_passes_through_verbatim() -> None:
 
 
 def test_redacted_mode_replaces_name_and_date_patterns() -> None:
-    matches = [_make_match("Brian 2026-03-22")]
+    # #209 refinement: name redaction now requires a positional cue
+    # (`· `, `, ` adjacent to a date, `Speaker:`, `From:`). Bare names
+    # like "Brian 2026-03-22" without any cue pass through unchanged
+    # (modulo the date, which is unambiguous and doesn't need a cue).
+    # Use the canonical attribution shape so the name redaction fires.
+    matches = [_make_match("Sprint review · Brian, 2026-03-22")]
     result = _apply_attribution_policy(matches, mode="redacted")
-    # "Brian" → <NAME_REDACTED>, "2026-03-22" → <DATE_REDACTED>
     assert "Brian" not in result[0].source_ref
     assert "2026-03-22" not in result[0].source_ref
     assert "<NAME_REDACTED>" in result[0].source_ref


### PR DESCRIPTION
## Summary

Closes **#209**. Refines the `render_source_attribution` redaction regex from the v1 broad `\b[A-Z][a-z]+\b` to four POSITIONAL-cue patterns, then flips the default from `full` to `redacted` (privacy-positive per #200 audit finding A4).

## Plan / Audit

- **Plan**: [`plan-B-preflight-attribution-regex-209.md`](./plan-B-preflight-attribution-regex-209.md)
- **Audit**: round 1 VETO (spec-drift on `_PLATFORM_TOKEN_ALLOWLIST`; ambiguous test description) → round 2 PASS

## What ships

| Surface | Change |
|---|---|
| `handlers/preflight.py` | Replace broad `_NAME_PATTERN` with 4 positional-cue patterns: `(?<=· )...`, `(?<=, )...(?=,?\s+\d{4}-\d{2}-\d{2})`, `(?<=^Speaker:\s)...`, `(?<=^From:\s)...`. Multi-word continuation uses `[ \t]+` (not `\s+`) to avoid line-spanning |
| `context.py:28` | `_DEFAULT_RENDER_ATTRIBUTION_MODE = "redacted"` (was `"full"`) |
| `setup_wizard.py:1005` | YAML template flipped: `render_source_attribution: redacted` (was `full`) |
| `setup_wizard.py:972-974` | Banner print message updated to reflect new default and reverse the opt-in direction |
| `tests/test_preflight_attribution_redaction.py` | 10 new functional tests covering all 4 cues + preservation contracts + default-flip lock + fresh-install YAML render |
| `tests/test_preflight_render_source_attribution.py` | 1 pre-existing test updated for the new contract (bare names without positional cues are no longer redacted) |

## Why no platform-token allowlist

A curated allowlist (Sprint, Linear, GitHub, etc.) was considered as defense-in-depth. **Rejected** per round-1 audit finding 1: the positional-cue patterns require explicit cues to fire by construction. Context tokens like "Sprint" / "Linear" / "GitHub" appearing in `<context-words>` position never follow these cues, so they survive without an allowlist. Tests directly verify this contract.

## Test plan

- [x] 10 new functional tests pass (`tests/test_preflight_attribution_redaction.py`)
- [x] 96/96 preflight + setup_wizard regression tests pass (1 pre-existing test updated for new contract)
- [x] `ruff check` + `ruff format --check` clean
- [x] No new dependencies

## Acceptance per #209

- [x] Refined regex matches names + dates without stripping platform/tool tokens
- [x] New unit tests against representative real-world source_ref strings confirm preserved-vs-redacted boundaries
- [x] Default flipped to `redacted` in both context.py default and setup_wizard fresh-install YAML
- [ ] e2e Flow 3 still passes after the flip (CI will validate)

## OWASP A04 positive contribution

Closes a fail-open privacy posture: the prior `full` default leaked names + dates verbatim to the agent's chat surface. The deterministic gate is in place; flipping the default is the privacy-positive move directed by #200 audit finding A4.

🤖 Generated with [Claude Code](https://claude.com/claude-code)