### PR TITLE
fix(deps): pin surrealdb==2.0.0 — close wire-format drift surface (#252 Layer 1)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,7 +34,14 @@ dependencies = [
   "pydantic>=2.0.0",
   "pyyaml>=6.0",
   "python-dotenv",
-  "surrealdb>=2.0.0",
+  # Patch-level pin closes wire-format drift surface (#252 Layer 1).
+  # The on-disk SurrealKV record header carries a revision number that
+  # must match the surrealdb-py deserializer. A `>=` floor lets a routine
+  # `pip install --upgrade` swap the lib under an existing ledger and
+  # produces "Invalid revision N for type Value" deserialization errors.
+  # Future bumps require explicit migration via the schema-revision
+  # sentinel (#252 Layer 2) and operator-driven export/import (Layer 4).
+  "surrealdb==2.0.0",
   "questionary>=2.0.0",
   "sigstore>=3.0",
 ]


### PR DESCRIPTION
## Summary

**#252 Layer 1** of the privacy-preserving ledger-remediation strategy (\`docs/research-brief-252-privacy-preserving-ledger-remediation.md\`). One-line patch-level pin closes the wire-format drift surface that produced \`jaune24\`'s \`Invalid revision 116 for type Value\` deserialization error.

## Root cause class

\"Invalid revision N for type Value\" from SurrealDB's deserializer is a **wire-format version mismatch** between the surrealdb-py client and the on-disk SurrealKV record header. With \`surrealdb>=2.0.0\` (floor only), a routine \`pip install --upgrade\` can swap the lib under an existing ledger and silently introduce incompatibility — the failure mode that hit \`jaune24\`.

## What ships

One file changed: \`pyproject.toml\` — \`surrealdb>=2.0.0\` → \`surrealdb==2.0.0\` with inline rationale comment.

## Why \`==2.0.0\` is unambiguous

\`pip index versions surrealdb\` confirms \`2.0.0\` is the only published patch in the 2.x range:
\`\`\`
Available versions: 2.0.0, 1.0.8, 1.0.7, ..., 0.0.1
\`\`\`

The pin is a no-op for current installs (everyone is already on 2.0.0); the value is at install-time for future users — no upgrade can swap the wire format under an existing ledger.

## Privacy posture

This fix is privacy-preserving by construction:
- No customer data needed to ship
- No telemetry added
- No new code surface — purely a dependency-resolver constraint

This satisfies the operator directive on #252 (\"keep customer's private data private and fulfill security compliance concerns while still providing resolution\").

## Test plan

- [x] \`pip index versions surrealdb\` confirms 2.0.0 is the only 2.x patch
- [x] \`tomllib.loads(pyproject.toml)\` parses cleanly
- [x] Ledger / ingest / canary / audit_log test suites pass with the pin (no runtime behavior change — same version installed)
- [ ] After merge: smoke-test a fresh install (\`uv tool install bicameral-mcp\` from a clean env) — should resolve to 2.0.0 deterministically

## Future bump discipline

Bumping the pin requires (per the strategy brief):
1. Verify the new surrealdb-py version against the schema-revision sentinel (#252 Layer 2)
2. Ship operator-driven export/import migration path (#252 Layer 4)
3. Update this pin with explicit migration rationale in the commit message

## Closes

- **#252 Issue 2 Layer 1** (Layer 2 / 3 / 4 / 5 are separate PRs per the strategy brief)

## Related

- Strategy brief: [docs/research-brief-252-privacy-preserving-ledger-remediation.md](./docs/research-brief-252-privacy-preserving-ledger-remediation.md)
- #252 Issue 1 (RECOMMENDED_VERSION revert) → PR #254 (against \`main\`, awaiting review)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>