### PR TITLE
hotfix(publish): skip SBOM gen + attest for v0.14.0

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -42,12 +42,18 @@ jobs:
             --output-certificate dist/share/bicameral-mcp/hooks-manifest.json.crt \
             dist/share/bicameral-mcp/hooks-manifest.json
 
+      # SBOM gen + attest disabled for v0.14.0 — release.sbom_emit invokes
+      # `cyclonedx-py environment <wheel>` which fails (cyclonedx-py expects a
+      # Python executable, not a wheel). Proper fix ships in v0.14.1.
+      # Track in #248 (SBOM regression) when filed.
       - name: Generate CycloneDX 1.5 SBOM
+        if: false
         run: |
           WHEEL=$(ls dist/bicameral_mcp-*.whl)
           python -m release.sbom_emit "$WHEEL" "dist/bicameral-mcp.sbom.json"
 
       - name: Cosign attest SBOM (Rekor transparency log)
+        if: false
         run: |
           WHEEL=$(ls dist/bicameral_mcp-*.whl)
           cosign attest-blob --yes \


### PR DESCRIPTION
v0.14.0 publish run [25522980858](https://github.com/BicameralAI/bicameral-mcp/actions/runs/25522980858/job/74911631942) failed at the SBOM gen step. Root cause: `release.sbom_emit` invokes `cyclonedx-py environment <wheel>` but `cyclonedx-py environment` expects a Python executable as the positional arg, not a wheel — there is no `cyclonedx-py wheel` subcommand. The wheel was built but never reached PyPI; the GitHub Release has no signed artifacts attached.

This PR makes both the SBOM gen step and the dependent **Cosign attest SBOM** step `if: false` for the v0.14.0 publish run only. The remaining steps (build, hooks-manifest sign, release-tag-commit cosign sign, GitHub Release attach, PyPI trusted publish) run unaffected.

Once merged:
1. Force-move v0.14.0 tag to the new main tip
2. Re-fire the publish workflow (delete + recreate the GitHub Release at the new tag commit)
3. v0.14.0 wheel ships to PyPI

Proper fix lands in v0.14.1 — `sbom_emit` will install the wheel into a temp venv and point `cyclonedx-py environment` at the venv's python so the SBOM correctly reflects the wheel's dependency closure (not the build environment's).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Addressed Software Bill of Materials generation regression identified in v0.14.0; fix included in v0.14.1 release.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->