### PR TITLE
feat(infra): post to Slack #telemetry when a bug ticket is filed

### DIFF
--- a/.github/workflows/notify-slack-on-bug.yml
+++ b/.github/workflows/notify-slack-on-bug.yml
@@ -1,0 +1,61 @@
+name: Notify Slack on bug filed
+
+# Posts a message to the #telemetry Slack channel whenever an issue is
+# opened with — or later labeled — `bug`. Covers both manual filings
+# and the `/bicameral-report-bug` skill (which files with labels
+# `dev,bug` per skills/bicameral-report-bug/SKILL.md).
+#
+# Setup (one-time): create an incoming webhook for #telemetry on Slack,
+# then add the URL as a repo secret named SLACK_TELEMETRY_WEBHOOK_URL.
+# Without that secret the job is a no-op (the slack-github-action step
+# fails closed; no spurious notifications).
+
+on:
+  issues:
+    types: [opened, labeled]
+
+permissions:
+  contents: read
+
+jobs:
+  notify:
+    runs-on: ubuntu-latest
+    if: |
+      (github.event.action == 'opened' && contains(github.event.issue.labels.*.name, 'bug'))
+      || (github.event.action == 'labeled' && github.event.label.name == 'bug')
+    steps:
+      - name: Post to #telemetry
+        uses: slackapi/slack-github-action@v1.27.0
+        with:
+          payload: |
+            {
+              "text": ":lady_beetle: New bug filed: <${{ github.event.issue.html_url }}|#${{ github.event.issue.number }} ${{ github.event.issue.title }}>",
+              "blocks": [
+                {
+                  "type": "header",
+                  "text": {
+                    "type": "plain_text",
+                    "text": ":lady_beetle: New bug — #${{ github.event.issue.number }}"
+                  }
+                },
+                {
+                  "type": "section",
+                  "text": {
+                    "type": "mrkdwn",
+                    "text": "*<${{ github.event.issue.html_url }}|${{ github.event.issue.title }}>*"
+                  }
+                },
+                {
+                  "type": "context",
+                  "elements": [
+                    {
+                      "type": "mrkdwn",
+                      "text": "Filed by *${{ github.event.issue.user.login }}* in `${{ github.repository }}`"
+                    }
+                  ]
+                }
+              ]
+            }
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_TELEMETRY_WEBHOOK_URL }}
+          SLACK_WEBHOOK_TYPE: INCOMING_WEBHOOK


### PR DESCRIPTION
Adds `.github/workflows/notify-slack-on-bug.yml` that posts to the #telemetry Slack channel whenever an issue is opened with — or later labeled — \`bug\`.

## Coverage

- Manual issue filings labeled \`bug\`
- \`/bicameral-report-bug\` skill submissions (which file with \`dev,bug\` labels)
- Late-labeled issues (in case triage adds \`bug\` after the fact)

## Setup required (one-time, by repo admin — can't automate)

1. Slack: create an [incoming webhook](https://api.slack.com/messaging/webhooks) for the #telemetry channel
2. GitHub: Repo Settings → Secrets and variables → Actions → New repository secret:
   - Name: \`SLACK_TELEMETRY_WEBHOOK_URL\`
   - Value: the webhook URL from step 1

Until the secret exists, the job is a no-op (the slack-github-action step fails closed when the webhook URL is empty).

## Message shape

Header: ":lady_beetle: New bug — #N"
Section: bold issue title (linked)
Context: "Filed by @user in BicameralAI/bicameral-mcp"

## Test plan

- [ ] After merge + secret added: open a test issue with \`bug\` label, verify it posts to #telemetry
- [ ] Strip the \`bug\` label, re-add it: should NOT re-fire (only fires on \`opened\` + \`labeled\` events; re-labeling adds a new event but the if-clause only triggers when the label being added IS \`bug\`)
- [ ] Open an issue WITHOUT \`bug\`, then add \`bug\` label: should fire once on the labeled event