### PR TITLE
feat(install): one-line installer scripts (POSIX + Windows)

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,24 +20,22 @@ A local-first [MCP server](https://spec.modelcontextprotocol.io/) that ingests y
 ## Quickstart
 
 ```bash
-# Recommended: uv (single static binary, no Python prerequisite)
-curl -LsSf https://astral.sh/uv/install.sh | sh    # one-line install if you don't have uv
-uv tool install bicameral-mcp
-bicameral-mcp setup
-```
-
-```bash
-# Alternative: plain pip (installs into your current Python env)
-pip install bicameral-mcp
-bicameral-mcp setup
+# macOS / Linux
+curl -LsSf https://raw.githubusercontent.com/BicameralAI/bicameral-mcp/main/scripts/install.sh | sh
 ```
 
 ```powershell
-# Windows: substitute the uv installer line with PowerShell
-powershell -ExecutionPolicy ByPass -c "irm https://astral.sh/uv/install.ps1 | iex"
+# Windows
+irm https://raw.githubusercontent.com/BicameralAI/bicameral-mcp/main/scripts/install.ps1 | iex
 ```
 
-The setup wizard detects your repo, registers the MCP server with Claude Code, installs a git hook that auto-syncs the ledger after every commit, and adds a session-end hook that catches mid-session decisions you didn't explicitly ingest. Restart Claude Code and you're done.
+The installer detects [uv](https://docs.astral.sh/uv/) (installing it first if missing), runs `uv tool install bicameral-mcp`, then launches the setup wizard. The wizard detects your repo, registers the MCP server with Claude Code, installs a git hook that auto-syncs the ledger after every commit, and adds a session-end hook for mid-session decisions you didn't explicitly ingest. Restart Claude Code and you're done.
+
+Upgrade later:
+
+```bash
+bicameral-mcp update
+```
 
 Verify:
 

--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -1,0 +1,27 @@
+# Bicameral MCP one-line installer (Windows PowerShell).
+#
+# Usage:
+#   irm https://raw.githubusercontent.com/BicameralAI/bicameral-mcp/main/scripts/install.ps1 | iex
+#
+# What it does:
+#   1. Installs uv if not already on PATH (uv is a single-binary, no-Python-prereq Python toolchain).
+#   2. Runs `uv tool install bicameral-mcp`.
+#   3. Runs `bicameral-mcp setup` to register the MCP server with Claude Code,
+#      install the post-commit + session-end hooks, and wire up the slash commands.
+#
+# After install, upgrade with:
+#   bicameral-mcp update          (uses the same uv tool path)
+
+$ErrorActionPreference = "Stop"
+
+if (-not (Get-Command uv -ErrorAction SilentlyContinue)) {
+    Write-Host "==> Installing uv (single-binary Python toolchain)..."
+    Invoke-RestMethod https://astral.sh/uv/install.ps1 | Invoke-Expression
+    # uv's PowerShell installer adds itself to PATH for the current session.
+}
+
+Write-Host "==> Installing bicameral-mcp via uv..."
+uv tool install bicameral-mcp
+
+Write-Host "==> Running setup wizard..."
+bicameral-mcp setup @args

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -1,0 +1,38 @@
+#!/bin/sh
+# Bicameral MCP one-line installer (POSIX — macOS, Linux).
+#
+# Usage:
+#   curl -LsSf https://raw.githubusercontent.com/BicameralAI/bicameral-mcp/main/scripts/install.sh | sh
+#
+# What it does:
+#   1. Installs uv if not already on PATH (uv is a single-binary, no-Python-prereq Python toolchain).
+#   2. Runs `uv tool install bicameral-mcp`.
+#   3. Runs `bicameral-mcp setup` to register the MCP server with Claude Code,
+#      install the post-commit + session-end hooks, and wire up the slash commands.
+#
+# After install, upgrade with:
+#   bicameral-mcp update          (uses the same uv tool path)
+#
+# Re-running this script is safe — uv tool install will skip the install step
+# if bicameral-mcp is already present at the same version. To force-reinstall,
+# run `uv tool install --force bicameral-mcp` directly.
+
+set -e
+
+UV_BIN_DIR="$HOME/.local/bin"
+
+if ! command -v uv >/dev/null 2>&1; then
+  echo "==> Installing uv (single-binary Python toolchain)..."
+  curl -LsSf https://astral.sh/uv/install.sh | sh
+  # uv installs into ~/.local/bin by default; make it visible to this shell.
+  case ":$PATH:" in
+    *":$UV_BIN_DIR:"*) ;;
+    *) PATH="$UV_BIN_DIR:$PATH"; export PATH ;;
+  esac
+fi
+
+echo "==> Installing bicameral-mcp via uv..."
+uv tool install bicameral-mcp
+
+echo "==> Running setup wizard..."
+exec bicameral-mcp setup "$@"


### PR DESCRIPTION
Collapses the install path from 3 commands to 1 per OS.

\`\`\`bash
# macOS / Linux
curl -LsSf https://raw.githubusercontent.com/BicameralAI/bicameral-mcp/main/scripts/install.sh | sh
\`\`\`

\`\`\`powershell
# Windows
irm https://raw.githubusercontent.com/BicameralAI/bicameral-mcp/main/scripts/install.ps1 | iex
\`\`\`

Each script: detect uv → install uv if missing → \`uv tool install bicameral-mcp\` → \`bicameral-mcp setup\`. Forwards extra args to setup.

## Why uv as the single entry point

\`bicameral.update\` already resolves the upgrade installer in this order: \`uv tool install --force\` → \`pipx install --force\` → \`pip install --quiet\` (per #199). Standardizing fresh installs onto uv aligns the install + upgrade paths so \`bicameral-mcp update\` works without users having to know which install path they took.

Pip still works for anyone who runs their own toolchain — \`pip install bicameral-mcp && bicameral-mcp setup\` is unchanged. Just no longer the README's main path.

## Hosting

Today the canonical URL is the GitHub raw URL. A future redirect from \`bicameral-ai.com/install.sh\` (and \`.ps1\`) to those raw URLs would shorten the curl line — drop-in change, no code update needed.

## Test plan

- [x] \`sh -n scripts/install.sh\` clean
- [x] README Quickstart reflects new commands
- [ ] Manual: fresh macOS user without uv runs the curl line, ends up with \`bicameral-mcp\` on PATH and Claude Code wired up
- [ ] Manual: same on Windows PowerShell with the irm line
- [ ] Re-running on an already-installed machine — should be no-op or surface a clean "already installed" message