### PR TITLE
fix(ci): SHA-pin test-summary action + rename eval_decision_relevance attr (#272)

### DIFF
--- a/.github/workflows/test-mcp-regression.yml
+++ b/.github/workflows/test-mcp-regression.yml
@@ -139,8 +139,11 @@ jobs:
         run: python tests/generate_e2e_report.py
 
       # ── Generate step summary from JUnit XML ───────────────────────
+      # SHA-pinned to v2.4 (target=dist with bundled index.js); v2 mutable
+      # tag was repointed to v2.5 (target=main) on 2026-05-07 which broke
+      # the bundled artifact (#272). Pin per OWASP-03 / install-trust-model.
       - name: Test Summary
-        uses: test-summary/action@v2
+        uses: test-summary/action@31493c76ec9e7aa675f1585d3ed6f1da69269a86  # v2.4
         if: always()
         with:
           paths: test-results/results.xml

--- a/tests/eval_decision_relevance.py
+++ b/tests/eval_decision_relevance.py
@@ -163,7 +163,7 @@ async def _ingest_one(
         "ungrounded": stats.ungrounded,
         "grounded_pct": round(stats.grounded_pct, 4),
         "grounding_deferred": stats.grounding_deferred,
-        "ungrounded_decisions": list(result.ungrounded_decisions),
+        "ungrounded_decisions": list(result.pending_grounding_decisions),
         "m2_fixture_size": m2_fixture_size,
         "extraction_metrics": extraction_metrics,
     }


### PR DESCRIPTION
## Summary

Closes 2 of 3 dev-baseline CI regressions tracked in #272. The third (e2e Flow 1 stale expectation post-#263) is deferred to @jinhongkuan for product-level discussion since it touches ingest skill choreography.

cc @jinhongkuan — Layer 4 PR #258 was the original blocker that surfaced these dev-baseline regressions when it rebased. This PR unblocks the two mechanical fixes; the e2e Flow 1 question is yours.

## Fix 1: SHA-pin `test-summary/action`

The `v2` mutable tag was repointed on 2026-05-07 22:09 UTC from a `dist`-targeted release (bundled `index.js`) to v2.5 targeting `main` (no bundled output). Every PR run after that fails the Test Summary step with `File not found: index.js`, marking MCP Regression Suite jobs red on both ubuntu and windows.

Pinned to v2.4 commit `31493c76ec9e7aa675f1585d3ed6f1da69269a86` (last `dist`-targeted release). Aligns with OWASP-03 / `docs/policies/install-trust-model.md` discipline (do not trust mutable action tags for security-load-bearing CI). 

```diff
-        uses: test-summary/action@v2
+        uses: test-summary/action@31493c76ec9e7aa675f1585d3ed6f1da69269a86  # v2.4
```

## Fix 2: `tests/eval_decision_relevance.py:166` attribute rename

`IngestResponse` schema field is `pending_grounding_decisions` per `contracts.py:571`. Eval script was reading the legacy internal name `ungrounded_decisions` off the response, raising `AttributeError` and failing the M1 adversarial corpus eval step. JSON-output key kept as `ungrounded_decisions` so downstream consumers see no change.

```diff
-        "ungrounded_decisions": list(result.ungrounded_decisions),
+        "ungrounded_decisions": list(result.pending_grounding_decisions),
```

## Deferred to @jinhongkuan: e2e Flow 1 expectation

`tests/e2e/run_e2e_flows.py:758` asserts `bicameral.ratify` after ingest. Post-#263 (`eabe7b5`), the agent calls `ingest → bind` (via the new auto-bind step 1.5) and exhausts its budget on ~41 non-bicameral Read/Grep/validate_symbols calls before reaching ingest skill Step 7 (Ratify, positioned LAST). The agent never invokes ratify in Flow 1's run.

Two design questions worth your read before patching:

1. Is this an **acceptable** behavior change (auto-bind pushes ratify out of Flow 1's headline path; Flow 5 already validates ratify in PM Friday review) — in which case relax Flow 1's assertion to require `[ingest, bind]` and rely on Flow 5 for ratify validation?

2. Or is it a **regression** (the user's prompt explicitly asks "please log these and sign them off") — in which case the ingest skill needs to be re-ordered so ratify happens before the budget-heavy bind path, OR the auto-bind step 1.5 needs to be deferred until after ratify?

Happy to ship whichever shape you decide; left it out of this PR so it gets the design review it deserves.

## Test plan

- [ ] CI: MCP Regression Suite (ubuntu + windows) green (Test Summary step now finds bundled `index.js`)
- [ ] CI: M1 adversarial corpus eval step exits 0 (the `IngestResponse.pending_grounding_decisions` access succeeds)
- [ ] CI: ruff + mypy + TruffleHog + Schema Persistence Smoke Test all green (unchanged scope)
- [ ] Once merged, re-run #258 CI — expect green except possibly e2e Flow 1 (deferred)

🤖 Generated with [Claude Code](https://claude.com/claude-code)