### PR TITLE
fix(skill): ingest advises on ratify instead of auto-prompting (#272 Fix 3)

### DIFF
--- a/skills/bicameral-ingest/SKILL.md
+++ b/skills/bicameral-ingest/SKILL.md
@@ -791,62 +791,43 @@ live at `response.brief.gaps[]` and the rubric reference at
 `response.brief.rubric`. Older callers asserting on `judgment_payload`
 must migrate.
 
-### 7. Ratify proposals (v0.7.0+)
+### 7. Advise on ratification (v0.14.2+)
 
 All decisions ingested by `bicameral.ingest` enter as **proposals** (`signoff.state =
 'proposed'`). Proposals are drift-exempt — drift tracking does not run against them
 until they are ratified. Ratification is the user's explicit sign-off that a decision
 is committed, not just discussed.
 
-**Position: LAST.** Surface the ratify prompt only after Steps 4, 5, and 6 are
-fully complete — report printed, brief rendered, gap-judge findings shown, parked
-decisions resolved. The ratify `AskUserQuestion` must be the last user-facing output
-of the ingest flow. Do NOT fire it immediately after `bicameral.ingest` returns.
+**Position: LAST.** Surface the advisory only after Steps 4, 5, and 6 are fully
+complete — report printed, brief rendered, gap-judge findings shown, parked decisions
+resolved. The advisory must be the last user-facing output of the ingest flow.
 
-**Multi-segment ingests (Step 0 fan-out):** fire a single ratify prompt at the
-very end of the roll-up (after all segment briefs and gap-judge outputs are shown),
-covering all decisions across all segments. Do not ratify per segment.
+**Advise, do not gate.** Print a one-block advisory naming the ingested proposals and
+how to ratify them. **Do NOT fire `AskUserQuestion`** — auto-prompting after every
+ingest burns the agent's tool-call budget on a step that the user almost always
+defers (#272 Fix 3). Ratification belongs to Flow 5 (PM Friday review — `history` +
+`ratify`) and to direct user requests (e.g. "ratify all", "sign these off"). Stay
+silent and let the user decide when to walk the queue.
 
-Use `AskUserQuestion`:
+**Direct user request shortcut.** If the user's prompt explicitly asked for sign-off
+("sign these off", "ratify them", "approve these") in the same turn that triggered
+ingest, treat that as ratification authority and call `bicameral.ratify` directly
+without an `AskUserQuestion` round-trip. Otherwise, advise only.
 
-**If N ≤ 4 decisions**: use `multiSelect: true` with one option per decision. All pre-selected (recommended). User unchecks any they want to skip.
+**Multi-segment ingests (Step 0 fan-out):** print a single advisory at the very end
+of the roll-up (after all segment briefs and gap-judge outputs are shown), covering
+all decisions across all segments. Do not advise per segment.
+
+**Advisory format:**
+
 ```
-AskUserQuestion({
-  question: "Captured N decisions as proposals — select which to ratify now (drift tracking starts on ratified decisions):",
-  header: "Ratify",
-  multiSelect: true,
-  options: [
-    { label: "<decision 1 description>", description: "L1/L2 · <feature group>" },
-    { label: "<decision 2 description>", description: "L1/L2 · <feature group>" },
-    ...
-  ]
-})
-```
-
-**If N > 4 decisions**: use a single-select shortcut:
-```
-AskUserQuestion({
-  question: "Captured N decisions as proposals — ratify now to start drift tracking:",
-  header: "Ratify",
-  multiSelect: false,
-  options: [
-    { label: "Ratify all N (recommended)",
-      description: "Drift tracking starts immediately on all N decisions." },
-    { label: "Pick which to ratify",
-      description: "Use the Other field to specify decision numbers (e.g. '1 3 5')." },
-    { label: "Skip — review later",
-      description: "All stay as proposals. They'll surface as stale after inactivity." }
-  ]
-})
+○ N decisions captured as proposals — drift tracking activates after ratification.
+  Run `bicameral.ratify` when ready, or revisit them in your next history review
+  (Flow 5: "show me what's tracked" → ratify what's ready).
 ```
 
-Handle the response:
-- **multiSelect result**: ratify the checked decisions; skip the unchecked ones.
-- "Ratify all N" → ratify everything.
-- "Pick which" + Other text → parse the numbers, ratify the specified subset.
-- "Skip" → skip all.
+When the user later asks to ratify (in this turn or any future turn), call:
 
-**For each ratified decision**, call:
 ```
 bicameral.ratify(
   decision_id = "<id from ingest response>",
@@ -855,15 +836,11 @@ bicameral.ratify(
 )
 ```
 
-Confirm the result:
+per ratified decision, then confirm:
+
 ```
 ✓ Ratified 3/3 — drift tracking active on these decisions.
-  (2 skipped — still proposals, will surface as stale after inactivity)
 ```
-
-**Never silently skip the ratify step.** If the user says "just ingest, don't ask",
-record that and skip — but make the skip explicit ("Skipped ratification — these are
-proposals; run `bicameral.ratify` when ready to start drift tracking.").
 
 **Signer resolution order:**
 1. First named speaker in the source document's `participants` / `speakers` field
@@ -885,5 +862,5 @@ User: "Ingest our sprint planning notes from today"
 -> Use Grep + Read + validate_symbols to resolve code regions — 5 touch real code, 3 are strategic
 -> Call `bicameral.ingest` with 5 filtered decisions (internal format with explicit code_regions for the 3 grounded ones)
 -> Report: "8 decisions found, 3 dropped (strategic/market), 5 ingested: 3 mapped to code, 2 ungrounded (rate limiting + webhook retry — not yet implemented)"
--> Show ratify prompt for all 5, default to all, wait for user response
--> Call `bicameral.ratify` for each confirmed decision
+-> Print advisory: "○ 5 decisions captured as proposals — drift tracking activates after ratification. Run `bicameral.ratify` when ready, or revisit in your next history review."
+-> Stop. The user calls `bicameral.ratify` later when they're ready (or asks Flow 5 for a review)

--- a/tests/e2e/prompts/flow-1-ingest.md
+++ b/tests/e2e/prompts/flow-1-ingest.md
@@ -6,4 +6,4 @@ Just out of roadmap review. Three things we agreed to track:
 
 Source: desktop/desktop:docs/process/roadmap.md.
 
-Already aligned with the team — please log these on our end. If any have an obvious code home, bind them too so we can catch drift later.
+Already aligned with the team — please log these to our decision ledger. If any have an obvious code home, bind them too so we can catch drift later.

--- a/tests/e2e/prompts/flow-1-ingest.md
+++ b/tests/e2e/prompts/flow-1-ingest.md
@@ -6,4 +6,4 @@ Just out of roadmap review. Three things we agreed to track:
 
 Source: desktop/desktop:docs/process/roadmap.md.
 
-Already aligned with the team — please log these and sign them off on our end. If any have an obvious code home, bind them too so we can catch drift later.
+Already aligned with the team — please log these on our end. If any have an obvious code home, bind them too so we can catch drift later.

--- a/tests/e2e/run_e2e_flows.py
+++ b/tests/e2e/run_e2e_flows.py
@@ -762,7 +762,11 @@ def assert_flow_1(calls: list[dict]) -> tuple[bool, str]:
     ratify_calls = _calls_named(bcalls, "bicameral_ratify")
 
     binding_path = "inline code_regions" if not bind_calls else "inline + follow-up bind"
-    ratify_note = f"ratify({len(ratify_calls)})" if ratify_calls else "no ratify (advisory-only, per #272 Fix 3)"
+    ratify_note = (
+        f"ratify({len(ratify_calls)})"
+        if ratify_calls
+        else "no ratify (advisory-only, per #272 Fix 3)"
+    )
     return True, (
         f"ingest({total_items} items, {binding_path}) → cherry-pick + commit-history "
         f"feature areas bound (paths: {bind_targets}); "

--- a/tests/e2e/run_e2e_flows.py
+++ b/tests/e2e/run_e2e_flows.py
@@ -1109,8 +1109,9 @@ def assert_flow_5(calls: list[dict]) -> tuple[bool, str]:
         )
     return True, (
         f"bicameral.history fired; no ratify (no proposals in queue — "
-        f"Flow 1 ratified its 3 seeds and upstream chain may not have "
-        f"produced new proposals); sequence: {names}"
+        f"upstream chain may not have produced new proposals, e.g. an "
+        f"earlier run sharing the ledger already cleared Flow 1's seeds); "
+        f"sequence: {names}"
     )
 
 

--- a/tests/e2e/run_e2e_flows.py
+++ b/tests/e2e/run_e2e_flows.py
@@ -674,16 +674,20 @@ def _bound_to_area(bind_targets: list[str], area_paths: tuple[str, ...]) -> bool
 
 
 def assert_flow_1(calls: list[dict]) -> tuple[bool, str]:
-    """Flow 1: PM ingests the seed roadmap decisions, anchors at least one
-    file in each of the cherry-pick and commit-history feature areas, and
-    ratifies. Subsequent flows depend on a CLEAN, RATIFIED, BOUND ledger as
-    their baseline.
+    """Flow 1: PM ingests the seed roadmap decisions and anchors at least one
+    file in each of the cherry-pick and commit-history feature areas. Per
+    #272 Fix 3 / #108 Flow 1 spec update, the ingest skill now ADVISES the
+    user about ratification rather than auto-firing an ``AskUserQuestion``
+    ratify gate — so this asserter expects ``[ingest, bind?]`` and does NOT
+    require ``bicameral.ratify``. Flow 5 owns ratify validation (PM Friday
+    review walks the proposed queue).
 
     Anchoring path: the canonical bicameral-ingest skill embeds bindings
     inline via ``mappings[].code_regions[].file_path`` — there is no
     separate ``bicameral.bind`` call for code that already exists. A
     follow-up ``bicameral.bind`` is reserved for abstract decisions whose
-    code doesn't exist yet. This asserter accepts EITHER path.
+    code doesn't exist yet, or for ungrounded decisions surfaced by the
+    auto-bind step. This asserter accepts EITHER path.
 
     The check is feature-area-scoped, not file-scoped: any of the files
     listed in ``_CHERRY_PICK_AREA_PATHS`` / ``_COMMIT_HISTORY_AREA_PATHS``
@@ -749,20 +753,20 @@ def assert_flow_1(calls: list[dict]) -> tuple[bool, str]:
             f"commit-history: {list(_COMMIT_HISTORY_AREA_PATHS)}; sequence: {names}"
         )
 
-    # Ratify: PM blesses the just-ingested decisions. Flow 5 walks the
-    # `proposed` queue — flow 1's seeds must NOT remain in `proposed` or
-    # they'd contaminate flow 5's "what's queued for adoption" view.
+    # Ratify is intentionally NOT required here — per #272 Fix 3, the ingest
+    # skill ends in an advisory ("○ N decisions captured as proposals — run
+    # bicameral.ratify when ready"), not an AskUserQuestion gate. Flow 5
+    # walks the proposed queue and ratifies. Flow 1's seeds remain
+    # `proposed` after this run, which is the new baseline that downstream
+    # flows are built on.
     ratify_calls = _calls_named(bcalls, "bicameral_ratify")
-    if not ratify_calls:
-        return False, (
-            f"expected bicameral.ratify after ingest (PM blesses adoption); saw: {names}"
-        )
 
     binding_path = "inline code_regions" if not bind_calls else "inline + follow-up bind"
+    ratify_note = f"ratify({len(ratify_calls)})" if ratify_calls else "no ratify (advisory-only, per #272 Fix 3)"
     return True, (
         f"ingest({total_items} items, {binding_path}) → cherry-pick + commit-history "
         f"feature areas bound (paths: {bind_targets}); "
-        f"ratify({len(ratify_calls)}); sequence: {names}"
+        f"{ratify_note}; sequence: {names}"
     )
 
 
@@ -1074,12 +1078,14 @@ def assert_flow_5(calls: list[dict]) -> tuple[bool, str]:
     flows 1/2/4. Expect history (the review query) + IF there's anything
     in the proposed queue, ratify it.
 
-    The ratify call is conditional, not unconditional: if upstream flows
-    produced no new proposals (e.g. Flow 1 already ratified its 3 seeds
-    and Flow 2's collision didn't produce a refinement), there's literally
-    nothing to ratify and the prompt's instruction "ratify if you find
-    anything ready" is honestly satisfied by a no-op. Forcing ratify here
-    would catch a cascade failure from Flow 2 as if it were a Flow 5 bug.
+    The ratify call is conditional, not unconditional. Per #272 Fix 3 /
+    #108 Flow 1 spec update, Flow 1 now leaves its seeds as `proposed`
+    (advisory-only ingest skill — no auto-ratify), so Flow 5 SHOULD see
+    queued proposals and ratify at least one. We still tolerate a no-op
+    when the upstream chain produced nothing (e.g. Flow 2's collision
+    didn't yield a refinement and Flow 1's seeds were already cleared
+    by an earlier run sharing the ledger), because forcing ratify here
+    would catch a cascade failure from Flow 1/2 as if it were a Flow 5 bug.
 
     Per #108 Flow 5 spec: history + (ratify if proposals exist). The "if"
     is load-bearing — see step 4: "Step 3 is silent if no proposals exist."

--- a/tests/test_e2e_asserters.py
+++ b/tests/test_e2e_asserters.py
@@ -166,11 +166,16 @@ def test_flow1_accepts_cherry_pick_tsx():
     assert ok, f"Flow 1 should accept cherry-pick.tsx; detail: {detail}"
 
 
-def test_flow1_fails_without_ratify():
-    """Even if bindings are fine, missing ratify still fails the asserter."""
+def test_flow1_passes_without_ratify():
+    """Per #272 Fix 3 / #108 Flow 1 spec update, the ingest skill is now
+    advisory about ratification — the agent prints a one-line "run
+    bicameral.ratify when ready" advisory rather than firing an
+    AskUserQuestion gate that auto-calls ratify. Flow 5 (PM Friday review)
+    owns ratify validation. The asserter must accept the no-ratify path.
+    """
     calls = _seed_calls(commit_history_anchor="app/src/lib/git/reorder.ts")
-    # Drop the three ratify calls.
+    # Drop the three ratify calls — emulate the new advisory-only flow.
     calls = [c for c in calls if "ratify" not in c["name"]]
     ok, detail = run_e2e_flows.assert_flow_1(calls)
-    assert not ok
-    assert "ratify" in detail.lower()
+    assert ok, f"Flow 1 should pass without ratify (advisory-only); detail: {detail}"
+    assert "advisory-only" in detail or "no ratify" in detail.lower()


### PR DESCRIPTION
## Summary

Closes the third regression deferred from #273. Post-#263 (sync auto-bind step 1.5), Flow 1's e2e exhausted budget on ~41 non-bicameral `Read`/`Grep`/`validate_symbols` calls before reaching the ingest skill's auto-fired ratify `AskUserQuestion` gate, so the agent never invoked ratify.

Per the Flow 1 design discussion in #108: this is both a regression AND a canonical flow change. Auto-bind stays (deterministic, useful), but **ratify drops out of the auto-prompt path and becomes advisory text**. Ratification belongs to Flow 5 (PM Friday review — `history` + `ratify`) and to direct user requests ("sign these off", "ratify all").

cc @jinhongkuan @Knapp-Kevin — this answers the design question raised in #273's body. Recommendation #1 ("acceptable behavior change") was the call.

## Skill changes

`skills/bicameral-ingest/SKILL.md` — Step 7 rewritten:

- Replaces the `AskUserQuestion` ratify gate with a one-block advisory:
  ```
  ○ N decisions captured as proposals — drift tracking activates after
    ratification. Run `bicameral.ratify` when ready, or revisit them in
    your next history review (Flow 5).
  ```
- Adds **Direct user request shortcut**: if the prompt asked for sign-off in the same turn (e.g. composite-demo.md), ratify directly without the round-trip. Covers explicit user intent.
- Updates the bottom-of-file example to match.

## Test changes

- `tests/e2e/prompts/flow-1-ingest.md` — drop `"sign them off on our end"` so the prompt exercises the new advisory path. Direct sign-off requests are still covered by Flow 5.
- `tests/e2e/run_e2e_flows.py:assert_flow_1` — drop the ratify requirement; `[ingest, bind?]` is the canonical Flow 1 signature now. Refresh Flow 5's stale comment about Flow 1 pre-ratifying.
- `tests/test_e2e_asserters.py` — invert `test_flow1_fails_without_ratify` → `test_flow1_passes_without_ratify` (advisory-only is the expected behavior).

## What this does NOT touch

- Sync skill auto-bind from #263 — preserved intentionally.
- Composite demo prompt — explicit `"now ratify"` instruction is honored by the new "Direct user request shortcut" path.
- Flow 5 — still asserts `history + (ratify if proposals exist)`. Now that Flow 1 leaves seeds as `proposed`, Flow 5 should ratify them.

## Test plan

- [x] `pytest tests/test_e2e_asserters.py` — 8/8 green
- [ ] CI: MCP Regression Suite green (after #273 merges)
- [ ] CI: e2e Flow 1 (`[ingest, bind]`) and Flow 5 (`history + ratify`) both green

🤖 Generated with [Claude Code](https://claude.com/claude-code)