### PR TITLE
fix(bind): reject caller-supplied lines that hallucinate symbols (#280 PR-1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,19 @@ All notable changes to bicameral-mcp are tracked here. Format loosely follows
 
 ## [Unreleased]
 
+### Fixed
+
+- **`handlers/bind.py`: caller-supplied line range cannot bypass symbol verification (#280, M2 grounding precision regression).** Pre-fix, when a caller supplied `start_line`/`end_line` alongside `symbol_name`, the handler verified only that the file existed at the SHA and accepted any `symbol_name` — silent corruption surface for caller-LLM grounding when the agent hallucinated a wrong symbol on a real file. Branch B now also calls `resolve_symbol_lines` (same tree-sitter path Branch A uses) and rejects two cases: (1) `symbol_name` doesn't resolve at all → `error="symbol '...' not found in <file> at <sha> — caller-supplied line range cannot bypass symbol verification (#280)"`; (2) symbol resolves but the caller-supplied span doesn't overlap the resolved span → `error="span mismatch (#280)"`. Overlap (not exact equality) is the matching rule, so legitimate sub-region binds stay accepted; only hallucinated ranges are rejected.
+
+### Added
+
+- **`skills/bicameral-bind/SKILL.md` (#280).** New skill that extracts the bind contract out of `skills/bicameral-ingest/SKILL.md` §2 and tightens it from advisory to mandatory: the agent must Read at least one candidate file end-to-end, confirm the symbol via `validate_symbols`, and abort on weak evidence. Documents the handler-side rejection contract added in this release. `bicameral-ingest` §2 now points at the new skill instead of duplicating the verification rules.
+
+### Changed
+
+- **`code_locator/tools/validate_symbols.py`: dropped unused `self._db` field.** The retention comment ("Retained so `code_locator.adapter.ground_mappings()` can reach `db.lookup_by_file()`") referenced a path deleted in v0.6.0; the field had zero readers.
+- **`tests/eval_decision_relevance.py`: docstring at L73 updated** to describe the post-v0.6.0 grounding pipeline (caller-LLM bind via `handle_bind`) instead of the deleted `code_graph.ground_mappings + ledger` pipeline.
+
 ## v0.14.1 — SBOM emitter fix + Layer 3 diagnose CLI + dependabot
 
 Fast-follow on v0.14.0. Restores CycloneDX SBOM generation in the publish pipeline (skipped in v0.14.0 by hotfixes #261/#262), lands #257 (Layer 3 `bicameral-mcp diagnose` CLI from #252), and dependabot floor bumps.

--- a/code_locator/tools/validate_symbols.py
+++ b/code_locator/tools/validate_symbols.py
@@ -37,9 +37,6 @@ class ValidateSymbolsTool:
 
     def __init__(self, db: SymbolDB, config: CodeLocatorConfig) -> None:
         self.config = config
-        # Retained so code_locator.adapter.ground_mappings() can reach
-        # db.lookup_by_file() during auto-grounding. See adapters/code_locator.py:190.
-        self._db = db
         # Cache symbol list at init (not per-call)
         self._symbols: list[tuple[int, str, str]] = db.get_all_symbol_names()
 

--- a/handlers/bind.py
+++ b/handlers/bind.py
@@ -11,6 +11,17 @@ from preflight_telemetry import telemetry_enabled, write_engagement
 logger = logging.getLogger(__name__)
 
 
+def _spans_overlap(a_start: int, a_end: int, b_start: int, b_end: int) -> bool:
+    """True when line spans [a_start, a_end] and [b_start, b_end] share any line.
+
+    Inclusive on both ends. Used by #280 Branch B to confirm a caller-supplied
+    line range overlaps the tree-sitter-resolved span for the named symbol —
+    rejecting hallucinated line ranges without forcing exact-equality, which
+    would block legitimate sub-region binds.
+    """
+    return a_start <= b_end and b_start <= a_end
+
+
 async def handle_bind(
     ctx,
     bindings: list[dict],
@@ -127,7 +138,7 @@ async def _do_bind(ctx, bindings: list[dict]) -> BindResponse:
             start_line, end_line = resolved
         else:
             start_line, end_line = int(start_line), int(end_line)
-            from ledger.status import get_git_content
+            from ledger.status import get_git_content, resolve_symbol_lines
 
             if get_git_content(file_path, 1, 1, repo, ref=authoritative_sha) is None:
                 results.append(
@@ -136,6 +147,35 @@ async def _do_bind(ctx, bindings: list[dict]) -> BindResponse:
                         region_id="",
                         content_hash="",
                         error=f"file '{file_path}' does not exist at {authoritative_sha} — only bind to existing code, never hypothetical files",
+                    )
+                )
+                continue
+
+            # #280 — caller-supplied line range cannot bypass symbol
+            # verification. Branch A (no lines) already runs tree-sitter via
+            # resolve_symbol_lines and rejects on miss; Branch B (with lines)
+            # used to skip that check, accepting any symbol_name as long as
+            # the file existed. That was the silent-acceptance surface for
+            # M2 grounding precision regressions.
+            resolved = resolve_symbol_lines(file_path, symbol_name, repo, ref=authoritative_sha)
+            if resolved is None:
+                results.append(
+                    BindResult(
+                        decision_id=decision_id,
+                        region_id="",
+                        content_hash="",
+                        error=f"symbol '{symbol_name}' not found in {file_path} at {authoritative_sha} — caller-supplied line range cannot bypass symbol verification (#280)",
+                    )
+                )
+                continue
+            resolved_start, resolved_end = resolved
+            if not _spans_overlap(start_line, end_line, resolved_start, resolved_end):
+                results.append(
+                    BindResult(
+                        decision_id=decision_id,
+                        region_id="",
+                        content_hash="",
+                        error=f"symbol '{symbol_name}' resolves at lines {resolved_start}-{resolved_end} but caller supplied {start_line}-{end_line} — span mismatch (#280)",
                     )
                 )
                 continue

--- a/skills/bicameral-bind/SKILL.md
+++ b/skills/bicameral-bind/SKILL.md
@@ -1,0 +1,144 @@
+---
+name: bicameral-bind
+description: Pin a decision to a specific code region via the `bicameral_bind` tool. Use after ingest when a decision wasn't pinned at extraction time, when a decision's intent now applies to existing code, or after a refactor moved a previously-bound symbol. Mandatory pre-bind verification — Read the candidate file, confirm the symbol via `validate_symbols`, abort on weak evidence. The handler rejects bindings whose `symbol_name` does not resolve at the supplied span (#280) — silent acceptance was the M2 grounding precision regression that motivated this contract.
+---
+
+# Bicameral Bind
+
+Pin a decision to a specific code region via the `bicameral_bind` tool.
+
+## When to use
+
+- After ingest when a decision wasn't pinned at extraction time (e.g. ingested in
+  natural format with no `code_regions`)
+- When a decision's intent now applies to existing code that didn't exist at
+  ingest time (deferred grounding)
+- After a refactor that moved a previously-bound symbol — re-bind to the new
+  location rather than letting drift detection re-fire on every preflight
+
+## When NOT to use
+
+- During `bicameral.ingest` itself — pass `code_regions` on the ingest payload
+  in **internal format** (see `skills/bicameral-ingest/SKILL.md` §3). Binding
+  during ingest is one round-trip; binding after is two.
+- For decisions that are genuinely abstract ("ship by Q3", "SOC2-compliant
+  session storage") and don't yet point at code — leave them ungrounded.
+  Honest empty state beats a false binding.
+
+## Mandatory pre-bind verification
+
+The handler rejects unverified bindings (#280). To avoid the rejection path,
+**before EVERY `bicameral_bind` call:**
+
+1. **Generate symbol hypotheses from the decision text.** If the decision says
+   *"all email dispatch functions filter via a single source-of-truth check,"*
+   your hypotheses are `dispatchReminders`, `dispatchInterventions`,
+   `dispatchNudge`, `resolveMemberStatus`, `isActiveSubscriber` — not just
+   the literal word "dispatch."
+2. **Read at least one candidate file end-to-end.** Use the Read tool — not a
+   grep snippet, not a fuzzy match. Confirm the candidate symbol's body
+   actually implements the decision's intent.
+3. **Confirm the symbol via `validate_symbols`.** A grep match is not proof
+   of existence in the symbol index; the index is the source of truth and is
+   what the handler queries to verify your binding.
+4. **If the candidate is ambiguous (multiple symbols match the intent),
+   `get_neighbors` to resolve scope** before binding. Surfaces callers and
+   callees so you can tell whether the decision is local to one function or
+   spans a call tree.
+5. **Abort on weak evidence.** If you can't point to a specific function body,
+   class definition, or module-level statement that implements the decision,
+   do NOT bind. Leave the decision ungrounded — a future ingest or
+   `bicameral_bind` call can pin it later.
+
+## Anti-patterns — REJECT these
+
+| Anti-pattern | Why it fails |
+|---|---|
+| Binding to a file because the file name keyword-matches the decision | File-level pins lose the symbol-level signal that drift detection needs |
+| Binding to a symbol because its name fuzzy-matches the decision text | A `dispatch` reducer is not the same as email dispatch — vocab overlap is not implementation overlap |
+| Submitting a binding with `symbol_name` you only saw in a grep result | The handler verifies symbols via the symbol index, not grep — the call will be rejected |
+| Submitting a binding with `start_line`/`end_line` ranges that don't overlap the symbol's resolved body | Pre-#280 this was silently accepted; now the handler rejects with `span mismatch` |
+| Binding ahead of code ("we'll bind it once the function lands") | Bind to existing code only. The handler rejects bindings to files that don't exist at the SHA |
+
+## Format
+
+`bicameral_bind` accepts a list of `bindings`. Each binding:
+
+```
+{
+  "decision_id": "...",          # required — must exist in the ledger
+  "file_path": "src/lib/...",    # required — must exist at HEAD (or ref)
+  "symbol_name": "ProcessOrder", # required — must resolve via validate_symbols
+  "start_line": 42,              # optional — if omitted, tree-sitter resolves
+  "end_line": 89,                #            from symbol_name
+  "purpose": "implements ..."    # optional — short rationale, indexed
+}
+```
+
+**Rules:**
+
+- All three of `decision_id`, `file_path`, `symbol_name` are required.
+- If you omit `start_line`/`end_line`, the handler resolves them via
+  tree-sitter from `symbol_name`. This is the safest call — let the handler
+  pin the exact span.
+- If you supply `start_line`/`end_line`, the handler still resolves the
+  symbol via tree-sitter and rejects unless your supplied span overlaps the
+  resolved span (#280 — closes the silent-acceptance branch where caller
+  hallucinated a wrong/non-existent symbol on a real file).
+- Submit only bindings to **existing** code at the authoritative SHA.
+  Hypothetical files / future code is rejected.
+
+## Handler-side enforcement (#280)
+
+The handler rejects with a structured `error` (and `region_id=""`) when:
+
+| Condition | Error message contains |
+|---|---|
+| `decision_id` is empty | `"decision_id, file_path, and symbol_name are required"` |
+| `decision_id` doesn't exist in the ledger | `"unknown_decision_id"` |
+| `file_path` doesn't exist at the SHA | `"does not exist at <sha> — only bind to existing code"` |
+| `symbol_name` doesn't resolve via tree-sitter | `"symbol '<name>' not found in <file> at <sha>"` |
+| Caller-supplied span doesn't overlap resolved span | `"span mismatch (#280)"` |
+
+Errors are returned per-binding (the handler keeps processing the rest of the
+list); a partial response is normal when one binding fails.
+
+## After binding
+
+Each successful binding returns a `pending_compliance_check` payload — read
+the bound code at `file_path` lines `start_line`-`end_line` and verify it
+actually implements the decision, then call `bicameral.resolve_compliance`
+with your verdict. See `skills/bicameral-sync/SKILL.md` for the verification
+contract.
+
+Unverified bindings stay in `pending` state — they don't yet count as
+`reflected`, so preflight retrieval and drift detection treat them as
+provisional until the verdict lands.
+
+## Example
+
+User: "Bind decision dec-checkout-retry-cap to the rate limiter — it caps
+checkout retries at 3 per Stripe's contract."
+
+Procedure:
+1. Hypotheses from text: `RateLimiter`, `checkout_rate_limit`, `retry_cap`,
+   `process_checkout`, `_check_retry_count`.
+2. Grep for hypotheses → `src/checkout/rate_limiter.py:CheckoutRateLimiter`
+   and `src/checkout/retry.py:CheckoutRetryGuard` are candidates.
+3. Read `src/checkout/rate_limiter.py` end-to-end → it limits requests
+   per minute, not retries per session. Wrong candidate.
+4. Read `src/checkout/retry.py` end-to-end → `CheckoutRetryGuard.check_cap()`
+   raises `MaxRetriesExceeded` after 3 attempts. ✓ matches intent.
+5. Call `validate_symbols(["CheckoutRetryGuard", "check_cap"])` → confirms
+   both exist, `check_cap` is at lines 24–47.
+6. Bind:
+   ```
+   bicameral_bind(bindings=[{
+     "decision_id": "dec-checkout-retry-cap",
+     "file_path": "src/checkout/retry.py",
+     "symbol_name": "CheckoutRetryGuard.check_cap",
+     "purpose": "implements 3-retry cap per Stripe contract clause"
+   }])
+   ```
+7. Read pending check, call `bicameral.resolve_compliance` with
+   `compliant=True, confidence=high` and a one-sentence explanation.

--- a/skills/bicameral-ingest/SKILL.md
+++ b/skills/bicameral-ingest/SKILL.md
@@ -457,38 +457,26 @@ code search — you (the caller LLM) resolve explicit `code_regions` before
 ingesting. You have full codebase context and real retrieval tools (Grep,
 Read, Glob); the server only has the decision text. Use your advantage.
 
-**Procedure per decision**:
+**The full pre-bind verification contract lives in
+`skills/bicameral-bind/SKILL.md`** — read it before resolving regions.
+The same rules apply whether you embed `code_regions` in this ingest
+payload (preferred when decisions are concrete) or defer to a later
+`bicameral.bind` call (acceptable when decisions are abstract / for
+code that doesn't exist yet):
 
-1. **Generate symbol hypotheses** from the decision text. If a decision says
-   *"all email dispatch functions filter via a single source-of-truth check,"*
-   your hypotheses are `dispatchReminders`, `dispatchInterventions`,
-   `dispatchNudge`, `resolveMemberStatus`, `isActiveSubscriber` — not just
-   the literal word "dispatch."
-2. **Use Grep / Read / Glob** (or equivalent native search) to find candidate
-   files and symbols in the repo. Open the real source to confirm what each
-   candidate actually does.
-3. **Call `validate_symbols`** with your resolved candidates to confirm each
-   exists in the server's symbol index and get back file/line spans.
-4. **Call `get_neighbors`** on a candidate's symbol_id if you need to
-   understand scope — surfaces callers/callees so you can tell whether the
-   decision is local to one function or spans a call tree.
-5. **Build explicit `code_regions`** — `{file_path, symbol, start_line, end_line, type}` —
-   from confirmed candidates. Prefer function-level pins over file-level;
-   bind to the tightest region that still covers the decision's surface area.
-
-**Grounding quality: filter out false positives before ingesting**. If a
-candidate keyword-matches but doesn't actually implement anything related
-to the decision, drop it. Example: a decision about email dispatch should
-NOT bind to a React `dispatch` reducer just because the word appears.
-Ingesting garbage bindings means every edit to that unrelated file
-triggers a drift alarm later — noise that drowns out real signal.
-
-**Skip decisions that don't bind to real code**. If after this procedure the
-decision has zero concrete regions AND names no valid symbols, it's either
-(a) strategic (drop it) or (b) a genuine "pending" decision for code that
-doesn't exist yet. For the pending case, ingest it with empty `code_regions`
-— it stays ungrounded until a future ingest or `bicameral.bind` call pins
-it to real code.
+1. Generate symbol hypotheses from the decision text — not just literal
+   keyword matches.
+2. **Read at least one candidate file end-to-end** — open the real source
+   with the Read tool, not a grep snippet, and confirm the symbol's body
+   implements the decision.
+3. Call `validate_symbols` to confirm the symbol exists in the server's
+   index — the handler queries this same index to verify your binding
+   (#280).
+4. Call `get_neighbors` if scope is ambiguous.
+5. **Abort on weak evidence.** A decision with zero concrete regions is
+   ingested as ungrounded — honest empty state beats a false binding.
+   Garbage bindings make every edit on the unrelated file fire drift
+   noise that drowns out real signal.
 
 ### 2.5 Post-ingest conflict check (v0.9.3+)
 

--- a/tests/eval_decision_relevance.py
+++ b/tests/eval_decision_relevance.py
@@ -69,8 +69,11 @@ def _build_payload_from_fixture(source_ref: str) -> dict:
 
     Used by --skill-variant none. Each fixture entry's `description` becomes
     one decision. The runner bypasses the LLM extraction stage and feeds these
-    directly into handle_ingest so we're measuring the grounding pipeline
-    (code_graph.ground_mappings + ledger) in isolation.
+    directly into handle_ingest so we're measuring the post-extraction
+    grounding pipeline — caller-LLM bind via ``handlers.bind.handle_bind``
+    plus the ledger write — in isolation. (Pre-v0.6.0 this measured a BM25
+    ``ground_mappings`` path; that pipeline was deleted, caller-LLM grounding
+    is the current substrate.)
     """
     fixture_decisions = _decisions_for_source_ref(source_ref)
     return {

--- a/tests/test_bind.py
+++ b/tests/test_bind.py
@@ -7,6 +7,8 @@ Covers:
 4. test_bind_symbol_not_found — resolve_symbol_lines returns None → error contains symbol name
 5. test_bind_idempotent — calling bind twice for same (decision, region) is a no-op
 6. test_bind_status_transition — after bind, decision status transitions to "pending"
+7. test_bind_branch_b_rejects_nonexistent_symbol (#280) — caller-supplied lines + bad symbol → reject
+8. test_bind_branch_b_rejects_span_mismatch (#280) — caller-supplied lines don't overlap resolved span → reject
 """
 
 from __future__ import annotations
@@ -52,8 +54,16 @@ class _StubCtx:
 
 @pytest.mark.phase2
 @pytest.mark.asyncio
-async def test_bind_success_with_explicit_lines():
-    """Supply start_line/end_line — server upserts region + edge + pending check."""
+@patch("ledger.status.resolve_symbol_lines", return_value=(10, 30))
+@patch("ledger.status.get_git_content", return_value="# stub")
+async def test_bind_success_with_explicit_lines(_mock_git, _mock_resolve):
+    """Supply start_line/end_line — server upserts region + edge + pending check.
+
+    Both ``get_git_content`` and ``resolve_symbol_lines`` are mocked: the
+    file-existence check (Branch B) and the #280 symbol-verification check
+    (Branch B post-fix) both query the real repo otherwise. Mocked spans
+    overlap the caller-supplied 10-30 so the span check passes.
+    """
     client = await _fresh_client()
     try:
         from ledger.adapter import SurrealDBLedgerAdapter
@@ -210,8 +220,9 @@ async def test_bind_symbol_not_found():
 
 @pytest.mark.phase2
 @pytest.mark.asyncio
+@patch("ledger.status.resolve_symbol_lines", return_value=(1, 20))
 @patch("ledger.status.get_git_content", return_value="# stub")
-async def test_bind_idempotent(_mock_git_content):
+async def test_bind_idempotent(_mock_git_content, _mock_resolve):
     """Calling bind twice for the same (decision, region) pair is idempotent."""
     client = await _fresh_client()
     try:
@@ -248,8 +259,9 @@ async def test_bind_idempotent(_mock_git_content):
 
 @pytest.mark.phase2
 @pytest.mark.asyncio
+@patch("ledger.status.resolve_symbol_lines", return_value=(1, 15))
 @patch("ledger.status.get_git_content", return_value="# stub")
-async def test_bind_status_transition(_mock_git_content):
+async def test_bind_status_transition(_mock_git_content, _mock_resolve):
     """After bind, decision status transitions from 'ungrounded' to 'pending'."""
     client = await _fresh_client()
     try:
@@ -284,5 +296,97 @@ async def test_bind_status_transition(_mock_git_content):
         # Status should now be "pending"
         rows = await client.query(f"SELECT status FROM {decision_id} LIMIT 1")
         assert rows and rows[0].get("status") == "pending"
+    finally:
+        await client.close()
+
+
+# ── 7. #280 Branch B rejects nonexistent symbol ───────────────────────────────
+
+
+@pytest.mark.phase2
+@pytest.mark.asyncio
+@patch("ledger.status.resolve_symbol_lines", return_value=None)
+@patch("ledger.status.get_git_content", return_value="# stub")
+async def test_bind_branch_b_rejects_nonexistent_symbol(_mock_git, _mock_resolve):
+    """#280 — caller-supplied lines + symbol_name that doesn't resolve via
+    tree-sitter must be rejected. Pre-#280 this branch silently accepted
+    any symbol_name as long as the file existed at the SHA.
+    """
+    client = await _fresh_client()
+    try:
+        from ledger.adapter import SurrealDBLedgerAdapter
+
+        adapter = SurrealDBLedgerAdapter(url="memory://")
+        adapter._client = client
+        adapter._connected = True
+
+        decision_id = await _seed_decision(client, "Email dispatch SSOT")
+        ctx = _StubCtx(adapter)
+
+        resp = await handle_bind(
+            ctx,
+            bindings=[
+                {
+                    "decision_id": decision_id,
+                    "file_path": "handlers/bind.py",
+                    "symbol_name": "totally_made_up_symbol",
+                    "start_line": 50,
+                    "end_line": 55,
+                }
+            ],
+        )
+
+        assert len(resp.bindings) == 1
+        b = resp.bindings[0]
+        assert b.error is not None
+        assert "totally_made_up_symbol" in b.error
+        assert "#280" in b.error
+        assert b.region_id == ""
+    finally:
+        await client.close()
+
+
+# ── 8. #280 Branch B rejects span mismatch ───────────────────────────────────
+
+
+@pytest.mark.phase2
+@pytest.mark.asyncio
+@patch("ledger.status.resolve_symbol_lines", return_value=(100, 150))
+@patch("ledger.status.get_git_content", return_value="# stub")
+async def test_bind_branch_b_rejects_span_mismatch(_mock_git, _mock_resolve):
+    """#280 — caller-supplied lines that don't overlap the resolved symbol's
+    span must be rejected. The symbol resolves at L100-150, caller supplied
+    L1-5 — no overlap, so the binding is hallucinated.
+    """
+    client = await _fresh_client()
+    try:
+        from ledger.adapter import SurrealDBLedgerAdapter
+
+        adapter = SurrealDBLedgerAdapter(url="memory://")
+        adapter._client = client
+        adapter._connected = True
+
+        decision_id = await _seed_decision(client, "Bind contract verification")
+        ctx = _StubCtx(adapter)
+
+        resp = await handle_bind(
+            ctx,
+            bindings=[
+                {
+                    "decision_id": decision_id,
+                    "file_path": "handlers/bind.py",
+                    "symbol_name": "handle_bind",
+                    "start_line": 1,
+                    "end_line": 5,
+                }
+            ],
+        )
+
+        assert len(resp.bindings) == 1
+        b = resp.bindings[0]
+        assert b.error is not None
+        assert "span mismatch" in b.error.lower()
+        assert "#280" in b.error
+        assert b.region_id == ""
     finally:
         await client.close()


### PR DESCRIPTION
## Summary

PR-1 of 3 for #280 (M2 grounding precision regression). Closes the **silent-acceptance branch** in `handlers/bind.py` where caller-supplied `start_line`/`end_line` could bind a hallucinated `symbol_name` to a real file — the entire silent-corruption surface for caller-LLM grounding.

## What's in this PR

### 1. Handler reject path (`handlers/bind.py`)

Branch B (caller-supplied lines) now also calls `resolve_symbol_lines` and rejects two cases:

| Condition | Error |
|---|---|
| `symbol_name` doesn't resolve via tree-sitter | `"symbol '<name>' not found in <file> at <sha> — caller-supplied line range cannot bypass symbol verification (#280)"` |
| Symbol resolves but caller's span doesn't overlap resolved span | `"symbol '<name>' resolves at lines <a>-<b> but caller supplied <x>-<y> — span mismatch (#280)"` |

New `_spans_overlap` helper uses overlap (not exact equality) as the matching rule, so legitimate sub-region binds (e.g. pinning a specific clause inside a larger function) stay accepted; only hallucinated ranges with zero shared lines are rejected.

### 2. New `skills/bicameral-bind/SKILL.md` (per CLAUDE.md skill-mandate)

Extracted out of `skills/bicameral-ingest/SKILL.md` §2 with mandatory pre-bind verification:

- Read at least one candidate file end-to-end (Read tool, not grep snippet)
- Confirm the symbol via `validate_symbols`
- `get_neighbors` if scope is ambiguous
- **Abort on weak evidence** — leave the decision ungrounded rather than create a false binding

`bicameral-ingest` §2 reduced from ~38 inline lines to a 16-line pointer at the new skill, matching the rest of the catalog (one tool ↔ one skill).

### 3. Stale `ground_mappings()` cleanup

- `code_locator/tools/validate_symbols.py:40-41` — deleted retention comment + unused `self._db` field (pointed at a v0.6.0-deleted path; field had zero readers)
- `tests/eval_decision_relevance.py:73` — docstring updated to describe post-v0.6.0 caller-LLM grounding pipeline

## Test plan

- [x] `_spans_overlap` helper: 8 boundary cases (exact match, disjoint, sub-region, super-region, touching, adjacent disjoint) verified locally
- [x] 3 existing `tests/test_bind.py` tests gained a `resolve_symbol_lines` mock since Branch B now exercises tree-sitter
- [x] 2 new tests cover the rejection paths: `test_bind_branch_b_rejects_nonexistent_symbol`, `test_bind_branch_b_rejects_span_mismatch`
- [ ] Full ledger-touching test run pending CI (local env lacks `surrealdb` module — same as PR #250)

## What's NOT in this PR (per `plan-280-grounding-precision-fix.md`)

- **PR-2** — `tests/eval_grounding_recall.py` synthetic-recall harness (20+ decisions, recall ≥ 0.80, precision ≥ 0.85). Intentionally measures *post-fix* baseline rather than pre-fix regression.
- **PR-3** — PostHog `m2_grounding_*` events + dashboard panel
- **Friction capture (≥ 5 cases)** — design-partner work, not engineering scope

## Refs

Refs #280. Branch was rebased onto current `dev` (`9b2b128`); auto-merged cleanly with `02b7ade` (`pending_grounding_decisions` rename) and `2252c82` (ingest ratify advisory) in non-overlapping sections.

🤖 Generated with [Claude Code](https://claude.com/claude-code)