### PR TITLE
docs(README): demo video section + relocate star CTA mid-doc

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,5 @@
 ![Bicameral — without vs with](assets/bicameral-hero.png)
 
-<a href="https://github.com/BicameralAI/bicameral-mcp">
-  <img src="assets/star-on-github.svg" alt="Star Bicameral MCP on GitHub" />
-</a>
-
 <img src="assets/logo.png" width="96" align="right" alt="Bicameral logo">
 
 # Bicameral MCP
@@ -68,9 +64,25 @@ bicameral-mcp --smoke-test
     Source: Slack #payments 2026-03-20
 ```
 
-**At any time**, the dashboard gives you the full picture:
+**See it in motion** — the loop in three beats:
 
-![Bicameral Dashboard](assets/dashboard-preview.png)
+**1. Ingest (PM or dev).** A transcript, PRD, or Slack thread comes in; bicameral extracts decisions and writes them to the ledger.
+
+https://github.com/user-attachments/assets/e74ae39f-dd99-485b-8122-8c5211478eb1
+
+**2. Preflight (auto).** Before the agent edits code, bicameral surfaces prior decisions, drifted regions, and open questions for the file in scope.
+
+https://github.com/user-attachments/assets/8a0fdfb8-fc9a-49fc-9521-e5b5faf8646a
+
+**3. Ratify async (product owner).** The product owner reviews captured proposals and ratifies or rejects them on their own cadence. Drift tracking activates on ratification.
+
+https://github.com/user-attachments/assets/206e269e-49d6-407d-b338-ab3f2a2c70ec
+
+<p align="center">
+  <a href="https://github.com/BicameralAI/bicameral-mcp">
+    <img src="assets/star-on-github.svg" alt="Star Bicameral MCP on GitHub" />
+  </a>
+</p>
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -9,7 +9,9 @@
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](https://opensource.org/licenses/MIT)
 [![CI](https://img.shields.io/github/actions/workflow/status/BicameralAI/bicameral-mcp/test-mcp-regression.yml?branch=main&label=tests)](https://github.com/BicameralAI/bicameral-mcp/actions)
 
-A local-first [MCP server](https://spec.modelcontextprotocol.io/) that ingests your meeting transcripts, PRDs, and Slack threads, maps every decision to the code that implements it, and surfaces alignment gaps to your AI agent — before they become bugs.
+AI agents ship code fast. They forget what your team agreed — and most agreements emerge mid-flight, in corrections and side comments that never reach a doc.
+
+Bicameral MCP is a **spec compliance layer** for AI-assisted engineering. Local-first; runs as an [MCP server](https://spec.modelcontextprotocol.io/). It ingests your meeting transcripts, PRDs, and Slack threads, captures any mid-implementation decision that was not discussed, to be ratified async by your product owner, and pins each one to the code that implements it — so your agent finds out the moment it drifts from either the written spec or the spoken one.
 
 ---
 


### PR DESCRIPTION
## Summary
- Replaces the dashboard image at the bottom of "How It Feels" with a three-beat demo video section: **ingest** (PM/dev), **preflight** (auto), **async ratify** (product owner).
- Videos use GitHub `user-attachments` URLs (drag-drop minted) so they render as inline players on github.com regardless of repo layout — no asset path coupling, no submodule path issues.
- Relocates the "Star on GitHub" banner from the top header to a centered placement immediately after the demo videos. The banner now lands as a post-demo conversion beat instead of sitting awkwardly between the hero image and the logo.

## Test plan
- [ ] Open the rendered README on this PR and confirm all three videos render as inline players (scene-1 / scene-3 / scene-5).
- [ ] Confirm the star banner sits centered between the demo section and "Solo or Team mode".
- [ ] Confirm the README header (hero image -> logo -> title -> badges -> opener) reads cleanly without the old star banner element.

🤖 Generated with [Claude Code](https://claude.com/claude-code)