### PR TITLE
release: v0.14.5 (triage) — bicameral_diagnose tool + reset --replay-from-events + README polish

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,26 @@
 All notable changes to bicameral-mcp are tracked here. Format loosely follows
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
+## v0.14.5 — bicameral_diagnose tool + reset --replay-from-events + README polish (triage)
+
+Triages the #296 ledger-resilience track and the #299 README pass onto main. New `bicameral_diagnose` MCP tool gives operators a privacy-preserving structural read of their ledger (recovery_path classification + table counts + recent audit events) without crashing on init when the ledger is corrupt — pairs with `bicameral_reset --replay-from-events` for the dataloss-avoidant recovery path. README opens with a position-take pitch + three-scene demo video drop-in (ingest → preflight → ratify async).
+
+### Added
+
+- **`bicameral_diagnose` MCP tool (#296).** Read-only structural diagnosis that opens a raw `LedgerClient` (no `init_schema` / `migrate`) so it works even when the normal adapter connect crashes during init. Returns `recovery_path` classification (`clean` / `fixable` / `reset_rebuild` / `reset_destructive`), `schema_meta` state, table counts, recent `warn`|`error` audit events, and a `next_action` recommendation. Slash alias `/bicameral-diagnose`. New skill at `skills/bicameral-diagnose/SKILL.md`. Privacy-preserving — only structural shape leaves the machine, never decision content.
+- **`bicameral_reset --replay-from-events` flag (#296).** Rebuild the ledger from the team-mode JSONL event substrate instead of nuking decision rows. Use when the binary store is corrupt but the event log is intact — recovers without dataloss in team mode.
+- **Legacy-ledger fixtures + replay tests (#296).** New `tests/fixtures/legacy_ledgers/` holds reproducible byte-level corruption fixtures (e.g. `v3_yields_source_span.py` for the v16→v17 yields integrity bug). `tests/test_legacy_ledger_fixtures.py` and `tests/test_schema_recoverable_errors.py` exercise the recovery paths against these fixtures.
+
+### Fixed
+
+- **`ledger/schema.py`: resilient init + v16→v17 yields integrity cleanup (#296).** v0.14.4 ledgers with stale `source_span:...` records on the `yields.in` field rejected `DEFINE INDEX OVERWRITE idx_yields_unique` on every connect, blocking `ingest` / `history` / `preflight` until manual reset. The migration now sweeps these stale rows during the v16→v17 step and the init path tolerates the recovery without aborting. Pairs with `bicameral_diagnose` for operator visibility into whether the migration ran.
+
+### Documentation
+
+- **README opener rewrite (#299).** Two-paragraph position-take: paragraph 1 names the failure mode ("requirement gaps surfaced mid-implementation are buried under thousands of lines of code"); paragraph 2 introduces Bicameral MCP as a **spec compliance layer** for AI-assisted engineering that ingests transcripts / PRDs / Slack threads, captures any mid-implementation decision that was not discussed (to be ratified async by the product owner), and pins each one to the implementing code.
+- **README demo video section (#299).** Replaces the dashboard image transition with a three-beat demo loop — ingest (PM/dev) → preflight (auto) → ratify async (product owner) — each as an inline `user-attachments` video drop-in so the videos render on github.com without asset-path coupling.
+- **README star CTA relocation (#299).** Moved from the top header (where it sat awkwardly between the hero image and the logo) to a centered placement immediately after the demo videos — natural post-demo conversion beat.
+
 ## v0.14.4 — Hotfix: skip install-time manifest verification until release-side sigstore wiring lands
 
 Hotfix on v0.14.3. Unblocks every fresh `bicameral-mcp setup` against the published wheel — the v0.14.x wheels ship `skills-manifest.toml` and `hooks-manifest.json` but no `.sig`/`.crt` companions yet (release-side sigstore signing is a deferred follow-up of #218 LLM-06 / #237 LLM-11). The install-time verifiers were hitting a missing-signature path their own docstrings claim is unreachable, raising `SignatureError` and aborting setup.

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](https://opensource.org/licenses/MIT)
 [![CI](https://img.shields.io/github/actions/workflow/status/BicameralAI/bicameral-mcp/test-mcp-regression.yml?branch=main&label=tests)](https://github.com/BicameralAI/bicameral-mcp/actions)
 
-AI agents ship code fast. They forget what your team agreed — and most agreements emerge mid-flight, in corrections and side comments that never reach a doc.
+AI agents ship code fast. They forget what your team agreed — and requirement gaps surfaced mid-implementation are buried under thousands of lines of code.
 
 Bicameral MCP is a **spec compliance layer** for AI-assisted engineering. Local-first; runs as an [MCP server](https://spec.modelcontextprotocol.io/). It ingests your meeting transcripts, PRDs, and Slack threads, captures any mid-implementation decision that was not discussed, to be ratified async by your product owner, and pins each one to the code that implements it — so your agent finds out the moment it drifts from either the written spec or the spoken one.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "bicameral-mcp"
-version = "0.14.4"
+version = "0.14.5"
 description = "Decision ledger MCP server — ingests meeting transcripts, maps decisions to code, tracks drift"
 readme = "README.md"
 requires-python = ">=3.10"


### PR DESCRIPTION
## Release v0.14.5 (triage)

### Headline
`bicameral_diagnose` MCP tool + `bicameral_reset --replay-from-events` flag + README polish (opener rewrite, demo video drop-ins, hotfix line on the buried-in-code framing).

### Included issues / PRs
- BicameralAI/bicameral-daemon#21 — Ledger resilience track (`bicameral_diagnose` tool, `reset --replay-from-events`, v16→v17 yields integrity cleanup, fixture-replay test suite)
- BicameralAI/bicameral-mcp#299 — README pass (opener rewrite, demo video section, star CTA relocation)
- This PR — README opener line hotfix: `"agreements emerge mid-flight, in corrections and side comments that never reach a doc"` → `"requirement gaps surfaced mid-implementation are buried under thousands of lines of code"`

### Schema
No new schema migration in this release. Ledger stays at v17 (introduced in v0.14.4 via BicameralAI/bicameral-daemon#21). The v16→v17 yields integrity cleanup is a fix to the v17 migration path, not a new version.

### Breaking changes
None.

### Documentation
- `CHANGELOG.md` — v0.14.5 section added.
- `README.md` — opener rewrite, three-beat demo video section, relocated star CTA, hotfix line.
- `skills/bicameral-diagnose/SKILL.md` — new skill landed via BicameralAI/bicameral-daemon#21.

### Pre-release checklist (DEV_CYCLE §6.4)
- [x] **CHANGELOG flip** — v0.14.5 section added at top of `CHANGELOG.md`
- [x] **Version bump** — `pyproject.toml` 0.14.4 → 0.14.5; `RECOMMENDED_VERSION` already at 0.14.5
- [x] **Skill files** — `skills/bicameral-diagnose/SKILL.md` shipped via BicameralAI/bicameral-daemon#21
- [ ] **CI on dev HEAD ≥ 24 h green** — verify before merge
- [ ] **Preflight eval, performance, security scan, MCP smoke** — CI-enforced gates on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)