### PR TITLE
fix(eval): disable ingest rate limit in M6 seeder to unblock baseline (#58 followup)

### DIFF
--- a/tests/eval/_preflight_m6_seeder.py
+++ b/tests/eval/_preflight_m6_seeder.py
@@ -128,8 +128,19 @@ async def seed_m6_case_into_fresh_ctx(
     # fresh path / fresh ledger.
     prev_repo = os.environ.get("REPO_PATH")
     prev_surreal = os.environ.get("SURREAL_URL")
+    # #216 LLM-08 — the ingest rate limiter has burst=10 / refill=1/s by
+    # default. The eval runs 25 cases back-to-back in the same process;
+    # the first ~11 cases consume the burst + refills, and cases 12+
+    # raise `_IngestRefused("rate_limit_exceeded")` during seeding,
+    # corrupting the recall measurement (seeder errors aren't agent
+    # misses, but they DO eat the cases' slots). The rate limiter is
+    # for production agent-loop safety, not eval throughput. Disable for
+    # this run via the documented env var (see `handlers.ingest.
+    # _check_rate_limit` docstring).
+    prev_ingest_rate = os.environ.get("BICAMERAL_INGEST_RATE_LIMIT_DISABLE")
     os.environ["REPO_PATH"] = str(repo_root)
     os.environ["SURREAL_URL"] = "memory://"
+    os.environ["BICAMERAL_INGEST_RATE_LIMIT_DISABLE"] = "1"
     reset_ledger_singleton()
     reset_code_locator_cache()
 
@@ -227,5 +238,9 @@ async def seed_m6_case_into_fresh_ctx(
             os.environ.pop("SURREAL_URL", None)
         else:
             os.environ["SURREAL_URL"] = prev_surreal
+        if prev_ingest_rate is None:
+            os.environ.pop("BICAMERAL_INGEST_RATE_LIMIT_DISABLE", None)
+        else:
+            os.environ["BICAMERAL_INGEST_RATE_LIMIT_DISABLE"] = prev_ingest_rate
         reset_ledger_singleton()
         reset_code_locator_cache()


### PR DESCRIPTION
## Summary

Tail-end fix on top of PR #304. The first M6 baseline reading on dev surfaced overall recall **0.000 with 14/25 cases erroring** — root cause is the **LLM-08 ingest rate limiter** (#216, burst=10 / refill=1.0/s) refusing cases 12+ during seeding. The rate limiter is for production agent-loop safety, not eval throughput; there's already a documented env var to bypass it (`BICAMERAL_INGEST_RATE_LIMIT_DISABLE`).

## Math behind the brokenness

The seeder runs 25 cases back-to-back in one process. Bucket starts at 10 tokens, refills at 1/s. Seeding is fast, so:

```
10 cases burst-through  +  ~1 refill while seeding   =  11 cases pass
14 cases (U4-U8 + all 9 T*) hit empty bucket         →  _IngestRefused
```

Post-#304 CI on dev confirms the pattern exactly:

```
M6 preflight retrieval recall eval — 25 cases
  overall recall : 0.000   errors: 14
  transitive_relevance   : 0/9 surfaced, 9 errors  ← all rate-limited
  unbound_decision       : 0/8 surfaced, 5 errors  ← last 5 rate-limited
  vocabulary_mismatch    : 0/8 surfaced, 0 errors  ← first 8, ran clean
```

(The vocabulary_mismatch zero is the **honest** BM25-can't-bridge-vocab baseline — designed to surface that miss mode. The eval is working; it just can't measure the other two categories because the seeder doesn't reach them.)

## Fix

One-line env var in the seeder's per-case setup, saved + restored like `REPO_PATH` and `SURREAL_URL`:

```python
prev_ingest_rate = os.environ.get("BICAMERAL_INGEST_RATE_LIMIT_DISABLE")
os.environ["BICAMERAL_INGEST_RATE_LIMIT_DISABLE"] = "1"
```

Plus the matching restore block in the `finally:` clause. Total diff: 15 lines.

## Alternatives considered + rejected

| Alternative | Why rejected |
|---|---|
| Clear `_RATE_LIMIT_REGISTRY` between cases | Reaches into private module state; skips the documented env-var contract |
| Sleep between cases to allow refill | Slow; hides the design intent ("rate limiter doesn't apply to evals") |
| Lower burst/refill via `.bicameral/config.yaml` per fixture | Every Phase B eval surface would need to re-author the same config |

The env-var path is the documented API and one line.

## Expected after this fix

- **vocabulary_mismatch** stays at 0/8 surfaced (that's the honest BM25 baseline — the whole point of the category)
- **transitive_relevance** + **unbound_decision** produce non-zero recall once the seeder doesn't trip the limiter
- Phase B picks its direction from the now-readable per-category breakdown

## Local verification

- ✅ 16/16 sociable unit tests pass on the classifier + aggregator
- ✅ ruff check + format + mypy all green on the touched file
- ✅ `bicameral.link_commit` clean — 0 drift, 0 pending checks

## Refs

Refs #58 (Phase A baseline). Followup to PR #304.

🤖 Generated with [Claude Code](https://claude.com/claude-code)