### PR TITLE
feat(preflight): dedup decision telemetry — #87 Phase 5

### DIFF
--- a/handlers/preflight.py
+++ b/handlers/preflight.py
@@ -45,6 +45,7 @@ from handlers.analysis import _to_brief_decision
 from preflight_telemetry import (
     new_preflight_id,
     telemetry_enabled,
+    write_dedup_event,
     write_preflight_event,
 )
 
@@ -325,6 +326,61 @@ def _check_dedup(
     return False
 
 
+def _dedup_miss_was_revision_bump(
+    ctx,
+    topic: str,
+    file_paths: list[str] | None,
+    ledger_revision: str | None,
+) -> bool:
+    """Classify a dedup miss: did it miss because ``ledger_revision``
+    advanced since the prior same-(topic, file_paths) call?
+
+    Returns True when:
+    - the current (topic, file_paths) prefix has been seen before within
+      ``_DEDUP_TTL_SECONDS``,
+    - but the prior entry's revision component differs from the current
+      ``ledger_revision``.
+
+    This is the M7a/M7c signal — a decision landed (M7a) or HITL state
+    cleared (M7c) between two same-topic/same-paths calls, and the new
+    `ledger_revision` invalidated the cache as intended. Phase 5
+    telemetry (#87) emits a ``preflight_dedup_decision`` event with
+    ``reason=invalidated_by_revision_bump`` on True.
+
+    False for: first-call misses (no prior prefix entry), expired
+    entries (older than TTL), and file_paths-shift misses (the prefix
+    itself differs, not the revision suffix).
+    """
+    sync_state = getattr(ctx, "_sync_state", None)
+    if not isinstance(sync_state, dict):
+        return False
+    topics: dict[str, float] = sync_state.get("preflight_topics") or {}
+    if not topics:
+        return False
+    current_key = _dedup_key_for(topic, file_paths, ledger_revision)
+    parts = current_key.split("||")
+    if len(parts) != 3:
+        return False
+    topic_norm, paths_norm, current_rev = parts
+    if not topic_norm:
+        return False
+    prefix = f"{topic_norm}||{paths_norm}||"
+    now = time.time()
+    for stored_key, ts in topics.items():
+        if not stored_key.startswith(prefix):
+            continue
+        if stored_key == current_key:
+            # Identical key — would have been a cache hit, not a miss.
+            continue
+        if now - ts >= _DEDUP_TTL_SECONDS:
+            continue
+        # Same prefix, different rev, within TTL → revision bump.
+        stored_rev = stored_key[len(prefix):]
+        if stored_rev != current_rev:
+            return True
+    return False
+
+
 async def _region_anchored_preflight(
     ctx,
     file_paths: list[str],
@@ -549,13 +605,19 @@ async def handle_preflight(
 
     if ledger_revision is None:
         # BYPASS: revision is unknown → cannot safely dedup. Loud warning
-        # for ops visibility; telemetry counter wiring lands in Phase 5
-        # (#87) so dashboards can quantify how often this happens in
-        # production.
+        # for ops visibility; #87 Phase 5 telemetry counter quantifies
+        # how often this happens in production. A sustained spike is the
+        # signal to look at ledger health (transient SurrealDB faults,
+        # schema mismatch, etc.).
         logger.warning(
             "[preflight] dedup bypassed — ledger_revision lookup failed for "
             "topic %r; the next same-topic call will re-evaluate fully",
             topic[:60],
+        )
+        write_dedup_event(
+            reason="bypassed_revision_unknown",
+            session_id=session_id,
+            preflight_id=pid,
         )
     elif _check_dedup(ctx, topic, file_paths, ledger_revision):
         logger.debug(
@@ -579,6 +641,24 @@ async def handle_preflight(
             fired=False,
             reason="recently_checked",
             guided_mode=guided_mode,
+            preflight_id=pid,
+        )
+
+    # Cache-miss classification (#87 Phase 5): if the miss was caused by
+    # a ledger_revision bump (same topic + file_paths seen before but
+    # with a different revision still within TTL), emit the M7a/c
+    # signal. This is the counter Kevin asked for — "so we can tell the
+    # new key is doing useful work in production". File-paths-shift
+    # misses (M7b) are intentionally NOT counted here; the file_paths
+    # component of the key is observable from preflight_events.jsonl
+    # via the existing ``file_paths_hash`` field if a follow-up wants
+    # to backfill that metric.
+    if ledger_revision is not None and _dedup_miss_was_revision_bump(
+        ctx, topic, file_paths, ledger_revision
+    ):
+        write_dedup_event(
+            reason="invalidated_by_revision_bump",
+            session_id=session_id,
             preflight_id=pid,
         )
 

--- a/handlers/preflight.py
+++ b/handlers/preflight.py
@@ -375,7 +375,7 @@ def _dedup_miss_was_revision_bump(
         if now - ts >= _DEDUP_TTL_SECONDS:
             continue
         # Same prefix, different rev, within TTL → revision bump.
-        stored_rev = stored_key[len(prefix):]
+        stored_rev = stored_key[len(prefix) :]
         if stored_rev != current_rev:
             return True
     return False

--- a/preflight_telemetry.py
+++ b/preflight_telemetry.py
@@ -400,6 +400,57 @@ def write_fallback_event(reason: str, session_id: str) -> None:
     _append(_EVENTS_FILE, record)
 
 
+# ── #87 Phase 5: preflight dedup-cache decision counters ─────────────
+
+
+def write_dedup_event(
+    reason: str,
+    session_id: str,
+    preflight_id: str | None = None,
+) -> None:
+    """Append a preflight-dedup decision event to
+    ``~/.bicameral/preflight_events.jsonl``.
+
+    Fires on the two dedup outcomes that matter for #87 Phase 5
+    instrumentation:
+
+    - ``invalidated_by_revision_bump`` — a same-(topic, file_paths) call
+      missed the cache because ``ledger_revision`` advanced since the
+      prior call. This is the M7a/M7c signal — proves the new key shape
+      is doing useful work in production (the metric Kevin asked for at
+      signoff: *"so we can tell the new key is doing useful work in
+      production"*).
+
+    - ``bypassed_revision_unknown`` — ``get_ledger_revision()`` returned
+      None and the handler short-circuited the dedup check per Kevin's
+      amendment (correctness over saving a preflight call). Watching
+      this counter lets ops detect transient SurrealDB faults or
+      schema-mismatch incidents — a sustained spike is a "look at the
+      ledger" signal.
+
+    Other dedup outcomes (cache hit, first-call miss, topic-changed,
+    file_paths-shift) are intentionally NOT emitted. Phase 5's scope is
+    the *change-detection signal*; hit/miss baselines are derivable
+    from ``write_preflight_event`` rows with ``reason="recently_checked"``
+    if needed later.
+
+    No-op when telemetry is disabled. Written into the same JSONL file
+    as other preflight events so operator triage joins on a single
+    substrate.
+    """
+    if not telemetry_enabled():
+        return
+    record: dict = {
+        "ts": datetime.now(UTC).isoformat(),
+        "event_type": "preflight_dedup_decision",
+        "reason": reason,
+        "session_id": session_id,
+    }
+    if preflight_id:
+        record["preflight_id"] = preflight_id
+    _append(_EVENTS_FILE, record)
+
+
 # ── Phase 4: #112 HITL bypass flow ───────────────────────────────────
 
 

--- a/tests/test_preflight_dedup_telemetry.py
+++ b/tests/test_preflight_dedup_telemetry.py
@@ -1,0 +1,420 @@
+"""#87 Phase 5 — dedup decision telemetry.
+
+Pin the contract for ``preflight_dedup_decision`` events emitted on the
+two dedup outcomes that matter for production attribution:
+
+1. ``invalidated_by_revision_bump`` — M7a/M7c signal: a same-(topic,
+   file_paths) call missed the cache because ``ledger_revision``
+   advanced. Confirms the new key shape (Phase 4) is doing useful work.
+2. ``bypassed_revision_unknown`` — safety signal: revision lookup
+   failed and the handler bypassed dedup entirely per Kevin's amendment.
+
+Other dedup outcomes (hit, first-call, topic-changed, file_paths-shift)
+are intentionally NOT emitted — keeping the telemetry signal-to-noise
+ratio tight on the metric Kevin asked for at signoff. File-paths-shift
+miss attribution can be backfilled from ``write_preflight_event`` rows
+later if needed (the file_paths_hash field already lives there).
+
+Sociable where it matters: we touch the real telemetry write path
+(``preflight_telemetry.write_dedup_event``) but mock ``_append`` so we
+don't write to the real ~/.bicameral/ JSONL file in tests. The seam is
+the file-handle layer, not the public API.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from handlers.preflight import _dedup_miss_was_revision_bump
+
+
+# ── _dedup_miss_was_revision_bump classification ─────────────────────
+
+
+def _ctx(state: dict | None = None) -> SimpleNamespace:
+    return SimpleNamespace(_sync_state=state if state is not None else {})
+
+
+def test_classifier_returns_false_when_no_prior_entry():
+    """First call → no prefix in cache → not a revision bump."""
+    ctx = _ctx()
+    assert _dedup_miss_was_revision_bump(
+        ctx, "topic words", ["a.py"], "rev-1"
+    ) is False
+
+
+def test_classifier_returns_true_when_only_revision_differs():
+    """M7a/c shape — same topic + same paths + different rev within TTL."""
+    ctx = _ctx()
+    # Seed cache with prior call at rev-1.
+    from handlers.preflight import _check_dedup
+
+    _check_dedup(ctx, "stripe webhook", ["payments/stripe.py"], "rev-1")
+    # Now classify a miss at rev-2 with same prefix.
+    assert _dedup_miss_was_revision_bump(
+        ctx, "stripe webhook", ["payments/stripe.py"], "rev-2"
+    ) is True
+
+
+def test_classifier_returns_false_when_file_paths_differ():
+    """M7b shape — same topic + different paths is a prefix change, not a
+    revision bump. We don't count this as the invalidation signal."""
+    ctx = _ctx()
+    from handlers.preflight import _check_dedup
+
+    _check_dedup(ctx, "refactor handler", ["auth/login.py"], "rev-1")
+    assert _dedup_miss_was_revision_bump(
+        ctx, "refactor handler", ["billing/subs.py"], "rev-1"
+    ) is False
+
+
+def test_classifier_returns_false_when_topic_differs():
+    """Entirely different topic → no prefix match."""
+    ctx = _ctx()
+    from handlers.preflight import _check_dedup
+
+    _check_dedup(ctx, "stripe webhook", ["a.py"], "rev-1")
+    assert _dedup_miss_was_revision_bump(
+        ctx, "auth jwt", ["a.py"], "rev-1"
+    ) is False
+
+
+def test_classifier_ignores_entries_outside_ttl(monkeypatch):
+    """Stale entries (older than _DEDUP_TTL_SECONDS) don't count as
+    prior — the cache would've expired them anyway."""
+    import handlers.preflight as pf
+    import time
+
+    ctx = _ctx()
+    # Seed cache, then rewind its timestamp past the TTL.
+    pf._check_dedup(ctx, "stripe webhook", ["a.py"], "rev-1")
+    topics = ctx._sync_state["preflight_topics"]
+    for k in list(topics.keys()):
+        topics[k] = time.time() - (pf._DEDUP_TTL_SECONDS + 60)
+
+    assert _dedup_miss_was_revision_bump(
+        ctx, "stripe webhook", ["a.py"], "rev-2"
+    ) is False
+
+
+def test_classifier_returns_false_for_identical_keys():
+    """If the current call's key matches an existing entry exactly, it
+    would have been a cache HIT — not a miss — so the classifier
+    correctly returns False (would never be invoked in production)."""
+    ctx = _ctx()
+    from handlers.preflight import _check_dedup
+
+    _check_dedup(ctx, "stripe webhook", ["a.py"], "rev-1")
+    assert _dedup_miss_was_revision_bump(
+        ctx, "stripe webhook", ["a.py"], "rev-1"
+    ) is False
+
+
+def test_classifier_returns_false_when_sync_state_missing():
+    """Defensive — ctx without _sync_state can't have a prior entry."""
+    ctx = SimpleNamespace()
+    assert _dedup_miss_was_revision_bump(
+        ctx, "topic", ["a.py"], "rev-1"
+    ) is False
+
+
+# ── End-to-end telemetry emission ────────────────────────────────────
+
+
+def _wire_common_mocks(monkeypatch):
+    """Mock the bits handle_preflight needs except for the seam under
+    test (write_dedup_event), which the test inspects."""
+    import handlers.preflight as pf
+    import handlers.sync_middleware as sm
+    import ledger.queries as lq
+
+    monkeypatch.setattr(
+        lq,
+        "get_collision_pending_decisions",
+        AsyncMock(return_value=[]),
+    )
+    monkeypatch.setattr(
+        lq,
+        "get_context_for_ready_decisions",
+        AsyncMock(return_value=[]),
+    )
+    monkeypatch.setattr(sm, "ensure_ledger_synced", AsyncMock(return_value=None))
+    monkeypatch.setattr(pf, "_should_show_product_stage", lambda: False)
+    monkeypatch.delenv("BICAMERAL_PREFLIGHT_MUTE", raising=False)
+
+
+def _ctx_for_handler(sync_state: dict) -> SimpleNamespace:
+    ledger = MagicMock()
+    ledger.get_decisions_for_files = AsyncMock(return_value=[])
+    inner = MagicMock()
+    inner._client = MagicMock()
+    ledger._inner = inner
+    return SimpleNamespace(
+        ledger=ledger,
+        guided_mode=False,
+        _sync_state=sync_state,
+    )
+
+
+def test_telemetry_bypass_emits_bypassed_revision_unknown(monkeypatch):
+    """Revision lookup → None → handler emits one
+    preflight_dedup_decision event with reason=bypassed_revision_unknown."""
+    import handlers.preflight as pf
+    import ledger.queries as lq
+
+    monkeypatch.setattr(lq, "get_ledger_revision", AsyncMock(return_value=None))
+    _wire_common_mocks(monkeypatch)
+
+    captured: list[tuple[str, str, str | None]] = []
+
+    def _capture(reason, session_id, preflight_id=None):
+        captured.append((reason, session_id, preflight_id))
+
+    monkeypatch.setattr(pf, "write_dedup_event", _capture)
+
+    ctx = _ctx_for_handler({})
+    asyncio.run(
+        pf.handle_preflight(ctx=ctx, topic="stripe webhook", file_paths=["a.py"])
+    )
+
+    bypass_events = [e for e in captured if e[0] == "bypassed_revision_unknown"]
+    assert len(bypass_events) == 1, (
+        f"expected exactly one bypassed_revision_unknown event, got {captured!r}"
+    )
+
+
+def test_telemetry_revision_bump_emits_invalidated_by_revision_bump(monkeypatch):
+    """Two calls: same topic + same paths, revision changes between them.
+    Second call must emit one preflight_dedup_decision event with
+    reason=invalidated_by_revision_bump (the M7a/c signal)."""
+    import handlers.preflight as pf
+    import ledger.queries as lq
+
+    # Different revision per call — first "rev-1", second "rev-2".
+    revisions = iter(["rev-1", "rev-2"])
+    monkeypatch.setattr(
+        lq,
+        "get_ledger_revision",
+        AsyncMock(side_effect=lambda *_a, **_kw: next(revisions)),
+    )
+    _wire_common_mocks(monkeypatch)
+
+    captured: list[tuple[str, str, str | None]] = []
+
+    def _capture(reason, session_id, preflight_id=None):
+        captured.append((reason, session_id, preflight_id))
+
+    monkeypatch.setattr(pf, "write_dedup_event", _capture)
+
+    sync_state: dict = {}
+    ctx1 = _ctx_for_handler(sync_state)
+    asyncio.run(
+        pf.handle_preflight(ctx=ctx1, topic="stripe webhook", file_paths=["a.py"])
+    )
+    ctx2 = _ctx_for_handler(sync_state)  # reuses sync_state — same session
+    asyncio.run(
+        pf.handle_preflight(ctx=ctx2, topic="stripe webhook", file_paths=["a.py"])
+    )
+
+    bump_events = [
+        e for e in captured if e[0] == "invalidated_by_revision_bump"
+    ]
+    assert len(bump_events) == 1, (
+        f"expected exactly one invalidated_by_revision_bump event, "
+        f"got {captured!r}"
+    )
+
+
+def test_telemetry_first_call_emits_nothing(monkeypatch):
+    """A fresh-session first call (no prior entry, revision known) is
+    not a revision-bump invalidation — no telemetry emitted."""
+    import handlers.preflight as pf
+    import ledger.queries as lq
+
+    monkeypatch.setattr(
+        lq, "get_ledger_revision", AsyncMock(return_value="stable-rev-1")
+    )
+    _wire_common_mocks(monkeypatch)
+
+    captured: list[tuple[str, str, str | None]] = []
+
+    def _capture(reason, session_id, preflight_id=None):
+        captured.append((reason, session_id, preflight_id))
+
+    monkeypatch.setattr(pf, "write_dedup_event", _capture)
+
+    ctx = _ctx_for_handler({})
+    asyncio.run(
+        pf.handle_preflight(ctx=ctx, topic="stripe webhook", file_paths=["a.py"])
+    )
+
+    assert captured == [], (
+        f"first call must not emit dedup events, got {captured!r}"
+    )
+
+
+def test_telemetry_cache_hit_emits_nothing(monkeypatch):
+    """A cache HIT (same key) returns recently_checked but is NOT
+    instrumented in Phase 5 — only invalidations matter for the
+    'is the new key doing useful work' question."""
+    import handlers.preflight as pf
+    import ledger.queries as lq
+
+    monkeypatch.setattr(
+        lq, "get_ledger_revision", AsyncMock(return_value="stable-rev-1")
+    )
+    _wire_common_mocks(monkeypatch)
+
+    captured: list[tuple[str, str, str | None]] = []
+
+    def _capture(reason, session_id, preflight_id=None):
+        captured.append((reason, session_id, preflight_id))
+
+    monkeypatch.setattr(pf, "write_dedup_event", _capture)
+
+    sync_state: dict = {}
+    asyncio.run(
+        pf.handle_preflight(
+            ctx=_ctx_for_handler(sync_state),
+            topic="stripe webhook",
+            file_paths=["a.py"],
+        )
+    )
+    response = asyncio.run(
+        pf.handle_preflight(
+            ctx=_ctx_for_handler(sync_state),
+            topic="stripe webhook",
+            file_paths=["a.py"],
+        )
+    )
+    # Confirm we got the hit (sanity).
+    assert response.reason == "recently_checked"
+    # No telemetry events should have fired across both calls.
+    assert captured == [], (
+        f"cache hit must not emit dedup events, got {captured!r}"
+    )
+
+
+def test_telemetry_file_paths_shift_does_not_emit_revision_bump(monkeypatch):
+    """M7b — same topic + different file_paths. The dedup correctly
+    invalidates via the file_paths component of the key, but Phase 5
+    telemetry intentionally does NOT count this as a revision bump
+    (it's a different signal class)."""
+    import handlers.preflight as pf
+    import ledger.queries as lq
+
+    monkeypatch.setattr(
+        lq, "get_ledger_revision", AsyncMock(return_value="stable-rev-1")
+    )
+    _wire_common_mocks(monkeypatch)
+
+    captured: list[tuple[str, str, str | None]] = []
+
+    def _capture(reason, session_id, preflight_id=None):
+        captured.append((reason, session_id, preflight_id))
+
+    monkeypatch.setattr(pf, "write_dedup_event", _capture)
+
+    sync_state: dict = {}
+    asyncio.run(
+        pf.handle_preflight(
+            ctx=_ctx_for_handler(sync_state),
+            topic="refactor handler",
+            file_paths=["auth/login.py"],
+        )
+    )
+    asyncio.run(
+        pf.handle_preflight(
+            ctx=_ctx_for_handler(sync_state),
+            topic="refactor handler",
+            file_paths=["billing/subs.py"],
+        )
+    )
+
+    bump_events = [
+        e for e in captured if e[0] == "invalidated_by_revision_bump"
+    ]
+    assert bump_events == [], (
+        f"file_paths shift must not be classified as revision bump, "
+        f"got {captured!r}"
+    )
+
+
+# ── write_dedup_event direct contract ────────────────────────────────
+
+
+def test_write_dedup_event_noops_when_telemetry_disabled(monkeypatch, tmp_path):
+    """The shared no-op-when-disabled contract every telemetry writer
+    honors."""
+    import preflight_telemetry as pt
+
+    monkeypatch.setenv("BICAMERAL_TELEMETRY", "0")
+    appended: list[dict] = []
+
+    def _spy_append(path, record):
+        appended.append(record)
+
+    monkeypatch.setattr(pt, "_append", _spy_append)
+    pt.write_dedup_event(reason="invalidated_by_revision_bump", session_id="s")
+    assert appended == []
+
+
+def test_write_dedup_event_writes_record_when_telemetry_enabled(
+    monkeypatch, tmp_path
+):
+    """When enabled, write one row with the expected shape."""
+    import preflight_telemetry as pt
+
+    monkeypatch.setenv("BICAMERAL_TELEMETRY", "preflight")
+    monkeypatch.setenv("HOME", str(tmp_path))
+
+    appended: list[dict] = []
+
+    def _spy_append(path, record):
+        appended.append(record)
+
+    monkeypatch.setattr(pt, "_append", _spy_append)
+
+    pt.write_dedup_event(
+        reason="invalidated_by_revision_bump",
+        session_id="session-xyz",
+        preflight_id="pf-123",
+    )
+
+    assert len(appended) == 1
+    rec = appended[0]
+    assert rec["event_type"] == "preflight_dedup_decision"
+    assert rec["reason"] == "invalidated_by_revision_bump"
+    assert rec["session_id"] == "session-xyz"
+    assert rec["preflight_id"] == "pf-123"
+    assert "ts" in rec
+
+
+def test_write_dedup_event_omits_preflight_id_when_unset(
+    monkeypatch, tmp_path
+):
+    """Empty / None preflight_id is not included in the record (cleaner
+    schema for events from sessions without telemetry preflight ids)."""
+    import preflight_telemetry as pt
+
+    monkeypatch.setenv("BICAMERAL_TELEMETRY", "preflight")
+    monkeypatch.setenv("HOME", str(tmp_path))
+
+    appended: list[dict] = []
+
+    def _spy_append(path, record):
+        appended.append(record)
+
+    monkeypatch.setattr(pt, "_append", _spy_append)
+
+    pt.write_dedup_event(
+        reason="bypassed_revision_unknown",
+        session_id="session-abc",
+    )
+
+    assert len(appended) == 1
+    assert "preflight_id" not in appended[0]

--- a/tests/test_preflight_dedup_telemetry.py
+++ b/tests/test_preflight_dedup_telemetry.py
@@ -42,9 +42,7 @@ def _ctx(state: dict | None = None) -> SimpleNamespace:
 def test_classifier_returns_false_when_no_prior_entry():
     """First call → no prefix in cache → not a revision bump."""
     ctx = _ctx()
-    assert _dedup_miss_was_revision_bump(
-        ctx, "topic words", ["a.py"], "rev-1"
-    ) is False
+    assert _dedup_miss_was_revision_bump(ctx, "topic words", ["a.py"], "rev-1") is False
 
 
 def test_classifier_returns_true_when_only_revision_differs():
@@ -55,9 +53,10 @@ def test_classifier_returns_true_when_only_revision_differs():
 
     _check_dedup(ctx, "stripe webhook", ["payments/stripe.py"], "rev-1")
     # Now classify a miss at rev-2 with same prefix.
-    assert _dedup_miss_was_revision_bump(
-        ctx, "stripe webhook", ["payments/stripe.py"], "rev-2"
-    ) is True
+    assert (
+        _dedup_miss_was_revision_bump(ctx, "stripe webhook", ["payments/stripe.py"], "rev-2")
+        is True
+    )
 
 
 def test_classifier_returns_false_when_file_paths_differ():
@@ -67,9 +66,10 @@ def test_classifier_returns_false_when_file_paths_differ():
     from handlers.preflight import _check_dedup
 
     _check_dedup(ctx, "refactor handler", ["auth/login.py"], "rev-1")
-    assert _dedup_miss_was_revision_bump(
-        ctx, "refactor handler", ["billing/subs.py"], "rev-1"
-    ) is False
+    assert (
+        _dedup_miss_was_revision_bump(ctx, "refactor handler", ["billing/subs.py"], "rev-1")
+        is False
+    )
 
 
 def test_classifier_returns_false_when_topic_differs():
@@ -78,9 +78,7 @@ def test_classifier_returns_false_when_topic_differs():
     from handlers.preflight import _check_dedup
 
     _check_dedup(ctx, "stripe webhook", ["a.py"], "rev-1")
-    assert _dedup_miss_was_revision_bump(
-        ctx, "auth jwt", ["a.py"], "rev-1"
-    ) is False
+    assert _dedup_miss_was_revision_bump(ctx, "auth jwt", ["a.py"], "rev-1") is False
 
 
 def test_classifier_ignores_entries_outside_ttl(monkeypatch):
@@ -96,9 +94,7 @@ def test_classifier_ignores_entries_outside_ttl(monkeypatch):
     for k in list(topics.keys()):
         topics[k] = time.time() - (pf._DEDUP_TTL_SECONDS + 60)
 
-    assert _dedup_miss_was_revision_bump(
-        ctx, "stripe webhook", ["a.py"], "rev-2"
-    ) is False
+    assert _dedup_miss_was_revision_bump(ctx, "stripe webhook", ["a.py"], "rev-2") is False
 
 
 def test_classifier_returns_false_for_identical_keys():
@@ -109,17 +105,13 @@ def test_classifier_returns_false_for_identical_keys():
     from handlers.preflight import _check_dedup
 
     _check_dedup(ctx, "stripe webhook", ["a.py"], "rev-1")
-    assert _dedup_miss_was_revision_bump(
-        ctx, "stripe webhook", ["a.py"], "rev-1"
-    ) is False
+    assert _dedup_miss_was_revision_bump(ctx, "stripe webhook", ["a.py"], "rev-1") is False
 
 
 def test_classifier_returns_false_when_sync_state_missing():
     """Defensive — ctx without _sync_state can't have a prior entry."""
     ctx = SimpleNamespace()
-    assert _dedup_miss_was_revision_bump(
-        ctx, "topic", ["a.py"], "rev-1"
-    ) is False
+    assert _dedup_miss_was_revision_bump(ctx, "topic", ["a.py"], "rev-1") is False
 
 
 # ── End-to-end telemetry emission ────────────────────────────────────
@@ -177,9 +169,7 @@ def test_telemetry_bypass_emits_bypassed_revision_unknown(monkeypatch):
     monkeypatch.setattr(pf, "write_dedup_event", _capture)
 
     ctx = _ctx_for_handler({})
-    asyncio.run(
-        pf.handle_preflight(ctx=ctx, topic="stripe webhook", file_paths=["a.py"])
-    )
+    asyncio.run(pf.handle_preflight(ctx=ctx, topic="stripe webhook", file_paths=["a.py"]))
 
     bypass_events = [e for e in captured if e[0] == "bypassed_revision_unknown"]
     assert len(bypass_events) == 1, (
@@ -212,20 +202,13 @@ def test_telemetry_revision_bump_emits_invalidated_by_revision_bump(monkeypatch)
 
     sync_state: dict = {}
     ctx1 = _ctx_for_handler(sync_state)
-    asyncio.run(
-        pf.handle_preflight(ctx=ctx1, topic="stripe webhook", file_paths=["a.py"])
-    )
+    asyncio.run(pf.handle_preflight(ctx=ctx1, topic="stripe webhook", file_paths=["a.py"]))
     ctx2 = _ctx_for_handler(sync_state)  # reuses sync_state — same session
-    asyncio.run(
-        pf.handle_preflight(ctx=ctx2, topic="stripe webhook", file_paths=["a.py"])
-    )
+    asyncio.run(pf.handle_preflight(ctx=ctx2, topic="stripe webhook", file_paths=["a.py"]))
 
-    bump_events = [
-        e for e in captured if e[0] == "invalidated_by_revision_bump"
-    ]
+    bump_events = [e for e in captured if e[0] == "invalidated_by_revision_bump"]
     assert len(bump_events) == 1, (
-        f"expected exactly one invalidated_by_revision_bump event, "
-        f"got {captured!r}"
+        f"expected exactly one invalidated_by_revision_bump event, got {captured!r}"
     )
 
 
@@ -235,9 +218,7 @@ def test_telemetry_first_call_emits_nothing(monkeypatch):
     import handlers.preflight as pf
     import ledger.queries as lq
 
-    monkeypatch.setattr(
-        lq, "get_ledger_revision", AsyncMock(return_value="stable-rev-1")
-    )
+    monkeypatch.setattr(lq, "get_ledger_revision", AsyncMock(return_value="stable-rev-1"))
     _wire_common_mocks(monkeypatch)
 
     captured: list[tuple[str, str, str | None]] = []
@@ -248,13 +229,9 @@ def test_telemetry_first_call_emits_nothing(monkeypatch):
     monkeypatch.setattr(pf, "write_dedup_event", _capture)
 
     ctx = _ctx_for_handler({})
-    asyncio.run(
-        pf.handle_preflight(ctx=ctx, topic="stripe webhook", file_paths=["a.py"])
-    )
+    asyncio.run(pf.handle_preflight(ctx=ctx, topic="stripe webhook", file_paths=["a.py"]))
 
-    assert captured == [], (
-        f"first call must not emit dedup events, got {captured!r}"
-    )
+    assert captured == [], f"first call must not emit dedup events, got {captured!r}"
 
 
 def test_telemetry_cache_hit_emits_nothing(monkeypatch):
@@ -264,9 +241,7 @@ def test_telemetry_cache_hit_emits_nothing(monkeypatch):
     import handlers.preflight as pf
     import ledger.queries as lq
 
-    monkeypatch.setattr(
-        lq, "get_ledger_revision", AsyncMock(return_value="stable-rev-1")
-    )
+    monkeypatch.setattr(lq, "get_ledger_revision", AsyncMock(return_value="stable-rev-1"))
     _wire_common_mocks(monkeypatch)
 
     captured: list[tuple[str, str, str | None]] = []
@@ -294,9 +269,7 @@ def test_telemetry_cache_hit_emits_nothing(monkeypatch):
     # Confirm we got the hit (sanity).
     assert response.reason == "recently_checked"
     # No telemetry events should have fired across both calls.
-    assert captured == [], (
-        f"cache hit must not emit dedup events, got {captured!r}"
-    )
+    assert captured == [], f"cache hit must not emit dedup events, got {captured!r}"
 
 
 def test_telemetry_file_paths_shift_does_not_emit_revision_bump(monkeypatch):
@@ -307,9 +280,7 @@ def test_telemetry_file_paths_shift_does_not_emit_revision_bump(monkeypatch):
     import handlers.preflight as pf
     import ledger.queries as lq
 
-    monkeypatch.setattr(
-        lq, "get_ledger_revision", AsyncMock(return_value="stable-rev-1")
-    )
+    monkeypatch.setattr(lq, "get_ledger_revision", AsyncMock(return_value="stable-rev-1"))
     _wire_common_mocks(monkeypatch)
 
     captured: list[tuple[str, str, str | None]] = []
@@ -335,12 +306,9 @@ def test_telemetry_file_paths_shift_does_not_emit_revision_bump(monkeypatch):
         )
     )
 
-    bump_events = [
-        e for e in captured if e[0] == "invalidated_by_revision_bump"
-    ]
+    bump_events = [e for e in captured if e[0] == "invalidated_by_revision_bump"]
     assert bump_events == [], (
-        f"file_paths shift must not be classified as revision bump, "
-        f"got {captured!r}"
+        f"file_paths shift must not be classified as revision bump, got {captured!r}"
     )
 
 
@@ -363,9 +331,7 @@ def test_write_dedup_event_noops_when_telemetry_disabled(monkeypatch, tmp_path):
     assert appended == []
 
 
-def test_write_dedup_event_writes_record_when_telemetry_enabled(
-    monkeypatch, tmp_path
-):
+def test_write_dedup_event_writes_record_when_telemetry_enabled(monkeypatch, tmp_path):
     """When enabled, write one row with the expected shape."""
     import preflight_telemetry as pt
 
@@ -394,9 +360,7 @@ def test_write_dedup_event_writes_record_when_telemetry_enabled(
     assert "ts" in rec
 
 
-def test_write_dedup_event_omits_preflight_id_when_unset(
-    monkeypatch, tmp_path
-):
+def test_write_dedup_event_omits_preflight_id_when_unset(monkeypatch, tmp_path):
     """Empty / None preflight_id is not included in the record (cleaner
     schema for events from sessions without telemetry preflight ids)."""
     import preflight_telemetry as pt

--- a/tests/test_preflight_dedup_telemetry.py
+++ b/tests/test_preflight_dedup_telemetry.py
@@ -31,7 +31,6 @@ import pytest
 
 from handlers.preflight import _dedup_miss_was_revision_bump
 
-
 # ── _dedup_miss_was_revision_bump classification ─────────────────────
 
 
@@ -84,8 +83,9 @@ def test_classifier_returns_false_when_topic_differs():
 def test_classifier_ignores_entries_outside_ttl(monkeypatch):
     """Stale entries (older than _DEDUP_TTL_SECONDS) don't count as
     prior — the cache would've expired them anyway."""
-    import handlers.preflight as pf
     import time
+
+    import handlers.preflight as pf
 
     ctx = _ctx()
     # Seed cache, then rewind its timestamp past the TTL.


### PR DESCRIPTION
## Summary

Adds the production-attribution counter Kevin asked for at #87 signoff: *"so we can tell the new key is doing useful work in production"*.

**Stacked on #309** (Phase 4) which is stacked on **#308** (v18 precondition). Once #308 → #309 merge to `dev`, retarget this PR's base to `dev`.

## Two outcomes emitted

Both go to `~/.bicameral/preflight_events.jsonl` with `event_type=preflight_dedup_decision`:

| `reason` | When | Why it matters |
|---|---|---|
| `invalidated_by_revision_bump` | A same-(topic, file_paths) call missed the cache because `ledger_revision` advanced | **M7a/M7c signal** — proves Phase 4's new key shape is invalidating correctly on real ledger mutations and HITL state changes |
| `bypassed_revision_unknown` | Revision lookup returned None → handler short-circuited per Kevin's amendment | **Safety counter** — sustained spike = transient SurrealDB faults / schema mismatch / connection issues; actionable ops signal |

## What's intentionally NOT instrumented

- Cache hits (`recently_checked`) — already in `write_preflight_event` rows
- First-call misses — baseline noise
- Topic-changed misses — different topic = different intent
- File-paths-shift misses (M7b) — derivable from existing `file_paths_hash` on preflight events if a follow-up wants the denominator

Phase 5's scope is the **change-detection signal**, not the hit/miss baseline.

## What changed

### `preflight_telemetry.py`
- `write_dedup_event(reason, session_id, preflight_id=None)` — new. Matches the existing per-event pattern (`write_fallback_event`, `write_bypass_event`). No-op when telemetry disabled. `preflight_id` omitted when None for cleaner schema.

### `handlers/preflight.py`
- Import `write_dedup_event`
- `_dedup_miss_was_revision_bump()` — new classifier. Returns True iff `ctx._sync_state` holds a same-(topic, file_paths) prefix with a different revision suffix within TTL. Skips identical keys (would have been a HIT) and expired entries (TTL boundary).
- `handle_preflight()` emits at two decision points:
  - BYPASS branch (`ledger_revision=None`) → `bypassed_revision_unknown`
  - MISS classified as revision bump → `invalidated_by_revision_bump`. Classification happens AFTER `_check_dedup` writes the current key; the classifier's skip-identical-keys rule prevents false positives.

### `tests/test_preflight_dedup_telemetry.py` (new, 15 tests)
- **7 classification tests**: first call, revision differs only (M7a/c), file_paths differ (M7b — must NOT classify as revision bump), topic differs, TTL expiry, identical keys, missing `_sync_state`
- **5 end-to-end emission tests**: bypass emits one `bypassed_revision_unknown`; two-call revision-bump scenario emits one `invalidated_by_revision_bump`; first call alone emits nothing; cache hit emits nothing; file_paths shift does NOT emit revision_bump
- **3 `write_dedup_event` direct contract tests**: no-op when disabled, full-record shape when enabled, `preflight_id` omitted when None

## Test results

| Suite | Result |
|---|---|
| `tests/test_preflight_dedup_telemetry.py` (new) | **15/15 pass** |
| Phase 4+5 + schema + dedup cluster regression | **143/143 pass** |

## Dashboard hookup

Out of scope for this PR — that's a separate operations task. The emitted JSON shape:

```json
{
  "ts": "2026-05-12T...",
  "event_type": "preflight_dedup_decision",
  "reason": "invalidated_by_revision_bump",
  "session_id": "session-xyz",
  "preflight_id": "pf-abc"
}
```

Aggregate by `(reason, day)` for the time-series dashboard panel. Pair with the `recently_checked` events to compute the **invalidation ratio** = `invalidated_by_revision_bump / (invalidated_by_revision_bump + recently_checked)`. A healthy ratio means the new key shape is catching real mutations; near-zero means either no mutations are happening or the new key is too coarse.

## Out of scope

- Dashboard panel wiring (operations PR)
- File-paths-shift attribution counter (M7b) — not in Kevin's signoff
- Per-key TTL tuning — defer until telemetry shows it matters
- Cross-session dedup cache — defer

## Test plan

- [ ] CI green
- [ ] Manual: enable `BICAMERAL_TELEMETRY=preflight`, force a revision bump (ratify a decision mid-session), trigger second same-topic preflight, confirm one `invalidated_by_revision_bump` row in `~/.bicameral/preflight_events.jsonl`
- [ ] Manual: temporarily break the `decision` schema (rename `updated_at`), confirm a `bypassed_revision_unknown` row appears

🤖 Generated with [Claude Code](https://claude.com/claude-code)