### PR TITLE
[#278 Phase 2] bicameral.remove_decision + remove_source

### DIFF
--- a/assets/dashboard.html
+++ b/assets/dashboard.html
@@ -404,6 +404,84 @@ body {
 }
 .src-view-btn:hover { color: var(--accent); border-color: var(--accent); }
 
+/* ── REMOVE FLOWS (#278 Phase 2) ───────────────────────────────── */
+.rm-dec-btn, .rm-src-btn {
+  margin-left: 6px;
+  background: transparent;
+  border: 1px solid var(--border);
+  color: var(--text-dim);
+  font-family: var(--mono); font-size: 10px;
+  padding: 1px 7px; border-radius: 2px; cursor: pointer;
+}
+.rm-dec-btn:hover, .rm-src-btn:hover {
+  color: rgb(220, 38, 38); border-color: rgb(220, 38, 38);
+}
+.rm-dec-btn[disabled] {
+  opacity: 0.4; cursor: not-allowed; color: var(--text-light);
+}
+.rm-modal {
+  display: none;
+  position: fixed; inset: 0; z-index: 100;
+  background: rgba(0, 0, 0, 0.4);
+  align-items: center; justify-content: center;
+}
+.rm-modal[data-modal="open"] { display: flex; }
+.rm-modal-content {
+  background: var(--paper); border: 1px solid var(--border-dark);
+  width: min(560px, 90vw); max-height: 80vh; overflow-y: auto;
+  padding: 22px 26px; box-shadow: 0 8px 32px rgba(0,0,0,0.18);
+  display: flex; flex-direction: column; gap: 14px;
+}
+.rm-modal-hdr h2 {
+  font-family: var(--serif); font-size: 14px; font-weight: 700; color: var(--accent);
+  margin-bottom: 4px;
+}
+.rm-modal-hdr .rm-warn {
+  font-size: 11px; color: rgb(220, 38, 38);
+}
+.rm-modal label {
+  font-size: 11px; color: var(--text-dim); letter-spacing: 0.04em;
+  text-transform: uppercase;
+}
+.rm-modal input, .rm-modal textarea {
+  width: 100%; font-family: var(--mono); font-size: 12px;
+  border: 1px solid var(--border); padding: 6px 8px; background: var(--canvas);
+  color: var(--text);
+}
+.rm-modal textarea { resize: vertical; min-height: 60px; }
+.rm-modal-target {
+  background: var(--canvas); border-left: 3px solid var(--accent);
+  padding: 8px 12px; font-size: 12px; line-height: 1.6; color: var(--text);
+}
+.cascade-list {
+  list-style: none; padding: 0; margin: 0;
+  background: var(--canvas); border: 1px solid var(--border);
+  max-height: 160px; overflow-y: auto;
+}
+.cascade-list li {
+  font-size: 11px; padding: 4px 10px; border-bottom: 1px solid var(--border);
+  color: var(--text-dim);
+}
+.cascade-list li:last-child { border-bottom: none; }
+.cascade-empty { font-size: 11px; color: var(--text-light); font-style: italic; padding: 6px 10px; }
+.mcp-call {
+  display: block;
+  background: var(--canvas); border: 1px dashed var(--border-dark);
+  padding: 8px 12px; font-family: var(--mono); font-size: 11px;
+  white-space: pre-wrap; word-break: break-all; color: var(--text);
+  max-height: 140px; overflow-y: auto;
+}
+.rm-modal-actions {
+  display: flex; gap: 8px; justify-content: flex-end; margin-top: 6px;
+}
+.rm-modal-actions button {
+  font-family: var(--mono); font-size: 11px;
+  padding: 5px 12px; border: 1px solid var(--border); background: var(--paper);
+  color: var(--text); cursor: pointer; border-radius: 2px;
+}
+.rm-modal-actions button.rm-copy { color: var(--accent); border-color: var(--accent); }
+.rm-modal-actions button.rm-cancel:hover { color: var(--text-dim); }
+
 
 </style>
 </head>
@@ -447,6 +525,7 @@ body {
 <div id="src-panel" class="src-panel" data-src-panel="closed" aria-hidden="true">
   <div class="src-panel-hdr">
     <h2>Source</h2>
+    <button class="rm-src-btn" onclick="openRemoveSourceModal()" title="Remove this source (#278 Phase 2)">remove source</button>
     <button class="src-panel-close" onclick="closeSourceView()">close</button>
   </div>
   <div class="src-panel-meta">
@@ -458,6 +537,77 @@ body {
   <div id="src-panel-quote" class="src-panel-quote"></div>
   <div class="src-panel-related-hdr">Decisions from this source</div>
   <ul id="src-panel-related" class="src-panel-related"></ul>
+</div>
+
+<!-- ── REMOVE DECISION MODAL (#278 Phase 2) ────────────────────── -->
+<!-- Soft-delete a decision via the bicameral.remove_decision MCP tool.
+     Dashboard does NOT invoke writes itself — the modal surfaces the canonical
+     tool-call payload (built via JSON.stringify) and copy-to-clipboard for the
+     operator to run via their MCP-connected agent. -->
+<div id="rm-dec-modal" class="rm-modal" data-modal="closed" aria-hidden="true">
+  <div class="rm-modal-content">
+    <div class="rm-modal-hdr">
+      <h2>Remove decision</h2>
+      <div class="rm-warn">Soft-delete — signoff.state = "removed". Reason is required. No unremove.</div>
+    </div>
+    <div>
+      <label>Target decision</label>
+      <div id="rm-dec-target" class="rm-modal-target"></div>
+    </div>
+    <div>
+      <label for="rm-dec-signer">Signer (your identity)</label>
+      <input id="rm-dec-signer" type="text" placeholder="email@example.com">
+    </div>
+    <div>
+      <label for="rm-dec-reason">Reason (audit-trail; required)</label>
+      <textarea id="rm-dec-reason" placeholder="Why is this decision being removed?"></textarea>
+    </div>
+    <div>
+      <label>MCP tool call (copy &amp; run in your bicameral-connected agent)</label>
+      <code id="rm-dec-mcp-call" class="mcp-call"></code>
+    </div>
+    <div class="rm-modal-actions">
+      <button class="rm-cancel" onclick="closeRemoveModal('rm-dec-modal')">cancel</button>
+      <button class="rm-copy" onclick="buildAndCopyRemoveDecisionCall()">build &amp; copy call</button>
+    </div>
+  </div>
+</div>
+
+<!-- ── REMOVE SOURCE MODAL (#278 Phase 2) ──────────────────────── -->
+<!-- Hard-delete an input_span + cascade-soft-delete every decision derived
+     from it. The cascade list is populated by openRemoveSourceModal via
+     .textContent per decision summary (XSS discipline). -->
+<div id="rm-src-modal" class="rm-modal" data-modal="closed" aria-hidden="true">
+  <div class="rm-modal-content">
+    <div class="rm-modal-hdr">
+      <h2>Remove source</h2>
+      <div class="rm-warn">Cascading hard-delete of the source + soft-delete of every derived decision. Inspect the cascade carefully.</div>
+    </div>
+    <div>
+      <label>Source</label>
+      <div id="rm-src-target" class="rm-modal-target"></div>
+    </div>
+    <div>
+      <label>Decisions that will be cascade-removed</label>
+      <ul id="rm-src-cascade" class="cascade-list"></ul>
+    </div>
+    <div>
+      <label for="rm-src-signer">Signer (your identity)</label>
+      <input id="rm-src-signer" type="text" placeholder="email@example.com">
+    </div>
+    <div>
+      <label for="rm-src-reason">Reason (audit-trail; required)</label>
+      <textarea id="rm-src-reason" placeholder="Why is this source being removed?"></textarea>
+    </div>
+    <div>
+      <label>MCP tool call (copy &amp; run in your bicameral-connected agent — call once with confirm=false to verify the cascade, then with confirm=true)</label>
+      <code id="rm-src-mcp-call" class="mcp-call"></code>
+    </div>
+    <div class="rm-modal-actions">
+      <button class="rm-cancel" onclick="closeRemoveModal('rm-src-modal')">cancel</button>
+      <button class="rm-copy" onclick="buildAndCopyRemoveSourceCall()">build &amp; copy call</button>
+    </div>
+  </div>
 </div>
 
 <script>
@@ -663,7 +813,14 @@ function renderDec(d, idx, depth) {
   const lvlBadge = `<span class="lvl-badge ${lvlClass}">${lvlLabel}</span>`;
   const dataLevel = level || 'unclassified';
   const spacer   = depth > 0 ? `<span class="depth-spacer" style="width:${depth * 18}px"></span>` : '';
-  const body     = renderDetailSources(d) + renderCodeChips(d);
+  // #278 Phase 2: "Remove decision" button gated on signoff state.
+  // Already-removed decisions render the button as disabled — operation is
+  // a no-op (idempotent at the handler) and the UI should reflect that.
+  const isRemoved = d.signoff_state === 'removed' || (d.signoff && d.signoff.state === 'removed');
+  const rmBtn = isRemoved
+    ? `<button class="rm-dec-btn" disabled title="Already removed">remove</button>`
+    : `<button class="rm-dec-btn" onclick="event.stopPropagation(); openRemoveDecisionModal('${esc(d.id)}', this.dataset.summary, '${esc(d.signoff_state || '')}')" data-summary="${esc(d.summary || '')}" title="Soft-delete this decision (#278 Phase 2)">remove</button>`;
+  const body     = renderDetailSources(d) + renderCodeChips(d) + `<div class="dec-rm-row" style="margin-top:8px">${rmBtn}</div>`;
   return `
 <div class="dec decision-row ${stCls}${proposed ? ' is-proposed' : ''}${discovered ? ' is-discovered' : ''}${superseded ? ' is-superseded' : ''}${rejected ? ' is-rejected' : ''}" data-level="${dataLevel}" data-decision-id="${esc(d.id)}" id="d${idx}" onclick="toggleDec(this)">
   <div class="dec-hdr">
@@ -850,6 +1007,11 @@ function openSourceView(featureIdx, decIdx, srcIdx) {
     ).join('');
   }
 
+  // #278 Phase 2: stash the active source context so the panel's
+  // "remove source" button can target the right span without re-encoding
+  // server data through HTML.
+  _activeSourceContext = { src: src, related: related };
+
   const panel = document.getElementById('src-panel');
   panel.setAttribute('data-src-panel', 'open');
   panel.setAttribute('aria-hidden', 'false');
@@ -859,6 +1021,136 @@ function closeSourceView() {
   const panel = document.getElementById('src-panel');
   panel.setAttribute('data-src-panel', 'closed');
   panel.setAttribute('aria-hidden', 'true');
+}
+
+// ── remove flows (#278 Phase 2) ───────────────────────────────
+// Tracks the source the user opened most recently via openSourceView so the
+// "remove source" button in the panel knows which source to target.
+let _activeSourceContext = null;
+
+// Build the MCP tool-call payload via JSON.stringify (NOT raw template
+// interpolation of server data) and write it via .textContent into the
+// modal's code block. XSS-safe by construction: JSON.stringify escapes all
+// user-controlled values, and .textContent ensures the resulting string is
+// rendered as text, never parsed as HTML.
+function buildMcpCall(toolName, args, codeElId) {
+  const payload = JSON.stringify({ name: toolName, arguments: args }, null, 2);
+  const el = document.getElementById(codeElId);
+  if (el) el.textContent = payload;
+  return payload;
+}
+
+function copyMcpCall(codeElId) {
+  const el = document.getElementById(codeElId);
+  if (!el) return;
+  navigator.clipboard.writeText(el.textContent || '').catch(() => {});
+}
+
+function openRemoveDecisionModal(decisionId, summary, signoffState) {
+  // Already-removed decisions short-circuit (button is also rendered disabled,
+  // but defend the modal opener as well).
+  if (signoffState === 'removed') return;
+  // Populate user-controlled fields via .textContent (XSS discipline #1).
+  document.getElementById('rm-dec-target').textContent =
+    `${decisionId}\n${summary || ''}`;
+  document.getElementById('rm-dec-signer').value = '';
+  document.getElementById('rm-dec-reason').value = '';
+  document.getElementById('rm-dec-mcp-call').textContent = '';
+  // Stash the decision id on the modal so buildAndCopy can read it later
+  // without re-encoding it through HTML.
+  const modal = document.getElementById('rm-dec-modal');
+  modal.dataset.decisionId = decisionId;
+  modal.setAttribute('data-modal', 'open');
+  modal.setAttribute('aria-hidden', 'false');
+}
+
+function buildAndCopyRemoveDecisionCall() {
+  const modal = document.getElementById('rm-dec-modal');
+  const decisionId = modal.dataset.decisionId || '';
+  const signer = document.getElementById('rm-dec-signer').value.trim();
+  const reason = document.getElementById('rm-dec-reason').value.trim();
+  if (!signer || !reason) {
+    document.getElementById('rm-dec-mcp-call').textContent =
+      '(fill in signer and reason — both are required)';
+    return;
+  }
+  buildMcpCall(
+    'bicameral.remove_decision',
+    { decision_id: decisionId, signer: signer, reason: reason },
+    'rm-dec-mcp-call',
+  );
+  copyMcpCall('rm-dec-mcp-call');
+}
+
+function openRemoveSourceModal() {
+  // Reads the active source context stashed by openSourceView (Phase 1).
+  if (!_activeSourceContext) {
+    return;
+  }
+  const { src, related } = _activeSourceContext;
+  // The InputSpan record id is propagated through HistorySource by Phase A
+  // (handlers/history.py change). When absent (legacy ingest), bail out with
+  // an explanatory message.
+  if (!src.input_span_id) {
+    document.getElementById('rm-src-target').textContent =
+      '(source pre-dates Phase 2 — input_span_id is not on the wire; remove via SurrealQL admin panel when available)';
+    document.getElementById('rm-src-mcp-call').textContent = '';
+    const m = document.getElementById('rm-src-modal');
+    m.setAttribute('data-modal', 'open');
+    return;
+  }
+  // Populate user-controlled fields via .textContent.
+  document.getElementById('rm-src-target').textContent =
+    `${src.input_span_id}\n${src.source_type || ''} · ${src.source_ref || ''}\n${(src.quote || '').slice(0, 200)}`;
+  // Cascade list: each <li>'s text content is the decision summary, written
+  // via .textContent per item (NOT innerHTML interpolation).
+  const listEl = document.getElementById('rm-src-cascade');
+  listEl.textContent = '';  // clear
+  if (!related || related.length === 0) {
+    const li = document.createElement('li');
+    li.className = 'cascade-empty';
+    li.textContent = 'No decisions are derived from this source — only the span itself will be removed.';
+    listEl.appendChild(li);
+  } else {
+    related.forEach((entry) => {
+      const li = document.createElement('li');
+      // Composite text: id + summary, both via textContent (no HTML).
+      li.textContent = `${entry.id} — ${entry.summary || ''}`;
+      listEl.appendChild(li);
+    });
+  }
+  document.getElementById('rm-src-signer').value = '';
+  document.getElementById('rm-src-reason').value = '';
+  document.getElementById('rm-src-mcp-call').textContent = '';
+  const modal = document.getElementById('rm-src-modal');
+  modal.dataset.spanId = src.input_span_id;
+  modal.setAttribute('data-modal', 'open');
+  modal.setAttribute('aria-hidden', 'false');
+}
+
+function buildAndCopyRemoveSourceCall() {
+  const modal = document.getElementById('rm-src-modal');
+  const spanId = modal.dataset.spanId || '';
+  const signer = document.getElementById('rm-src-signer').value.trim();
+  const reason = document.getElementById('rm-src-reason').value.trim();
+  if (!signer || !reason || !spanId) {
+    document.getElementById('rm-src-mcp-call').textContent =
+      '(fill in signer and reason — both are required; span_id must be available)';
+    return;
+  }
+  buildMcpCall(
+    'bicameral.remove_source',
+    { span_id: spanId, signer: signer, reason: reason, confirm: false },
+    'rm-src-mcp-call',
+  );
+  copyMcpCall('rm-src-mcp-call');
+}
+
+function closeRemoveModal(modalId) {
+  const modal = document.getElementById(modalId);
+  if (!modal) return;
+  modal.setAttribute('data-modal', 'closed');
+  modal.setAttribute('aria-hidden', 'true');
 }
 
 // Discipline #3: jump-to-decision uses document.getElementById (DOM API, no

--- a/contracts.py
+++ b/contracts.py
@@ -785,6 +785,53 @@ class RatifyResponse(BaseModel):
     was_new: bool  # True if this call set the signoff; False if already set
     signoff: dict
     projected_status: Literal["reflected", "drifted", "pending", "ungrounded"]
+
+
+# #278 Phase 2 — remove flows
+class RemoveDecisionResponse(BaseModel):
+    """Response envelope for bicameral.remove_decision.
+
+    Soft-delete: decision row stays; signoff.state flips to "removed";
+    a decision_removed.completed event is appended to the event log when
+    team mode is active. Idempotent: calling remove_decision twice on the
+    same target returns was_new=False on the second call without
+    re-emitting an event.
+    """
+
+    decision_id: str
+    was_new: bool  # True if this call set state=removed; False if already removed
+    signoff: dict
+    projected_status: Literal["reflected", "drifted", "pending", "ungrounded"]
+
+
+class RemoveSourcePlan(BaseModel):
+    """Dry-run response for bicameral.remove_source (confirm=False).
+
+    Returned BEFORE any mutation. Lists the full input_span content and the
+    decision ids that would be soft-deleted on a subsequent confirm=True
+    call. The operator inspects this plan, then re-invokes with confirm=True.
+    """
+
+    span_id: str
+    span_existed: bool  # False if span is already gone (idempotent dry-run)
+    input_span_content: dict  # full row as-is (text, source_ref, source_type, ...)
+    decision_ids: list[str]  # decisions yielded by this span that will cascade
+    confirm_required: Literal[True] = True
+
+
+class RemoveSourceResponse(BaseModel):
+    """Post-confirm response for bicameral.remove_source (confirm=True).
+
+    The input_span row is hard-deleted; cascaded_decision_ids are
+    soft-deleted with signoff.state="removed" + removed_by_source=<span_id>.
+    A single source_removed.completed event carries the full pre-deletion
+    span content so the action is recoverable from the event log.
+    """
+
+    span_id: str
+    span_existed: bool  # False if span was already gone (idempotent confirm)
+    cascaded_decision_ids: list[str]
+    event_logged: bool
     # #65 — preflight telemetry plumb-through.
     preflight_id: str | None = None
 
@@ -822,6 +869,7 @@ class HistorySource(BaseModel):
     date: str  # ISO date
     speaker: str | None = None
     quote: str  # verbatim excerpt from source_span.text
+    input_span_id: str | None = None  # SurrealDB record id of the originating input_span (#278 Phase 2)
 
 
 class HistoryFulfillment(BaseModel):

--- a/contracts.py
+++ b/contracts.py
@@ -869,7 +869,9 @@ class HistorySource(BaseModel):
     date: str  # ISO date
     speaker: str | None = None
     quote: str  # verbatim excerpt from source_span.text
-    input_span_id: str | None = None  # SurrealDB record id of the originating input_span (#278 Phase 2)
+    input_span_id: str | None = (
+        None  # SurrealDB record id of the originating input_span (#278 Phase 2)
+    )
 
 
 class HistoryFulfillment(BaseModel):

--- a/handlers/history.py
+++ b/handlers/history.py
@@ -112,6 +112,10 @@ def _row_to_history_decision(
             raw_type = str(span.get("source_type") or row.get("source_type") or "manual")
             speakers = span.get("speakers") or []
             speaker = speakers[0] if speakers else None
+            # #278 Phase 2: propagate the input_span record id through to the
+            # HistorySource so remove_source can target the cascade.
+            span_id_raw = span.get("id")
+            input_span_id = str(span_id_raw) if span_id_raw else None
             sources.append(
                 HistorySource(
                     source_ref=str(span.get("source_ref") or row.get("source_ref") or ""),
@@ -119,6 +123,7 @@ def _row_to_history_decision(
                     date=str(span.get("meeting_date") or row.get("meeting_date") or ""),
                     speaker=speaker,
                     quote=text,
+                    input_span_id=input_span_id,
                 )
             )
     else:
@@ -209,7 +214,7 @@ async def _fetch_all_decisions_enriched(ledger) -> list[dict]:
                     purpose,
                     content_hash
                 } AS code_regions,
-                <-yields<-input_span.{text, source_ref, source_type, meeting_date, speakers} AS _source_spans
+                <-yields<-input_span.{id, text, source_ref, source_type, meeting_date, speakers} AS _source_spans
             FROM decision
             ORDER BY created_at ASC
             """,

--- a/handlers/remove_decision.py
+++ b/handlers/remove_decision.py
@@ -27,6 +27,7 @@ from __future__ import annotations
 
 import logging
 from datetime import UTC, datetime
+from typing import Literal, cast
 
 from contracts import RemoveDecisionResponse
 from ledger.queries import (
@@ -50,9 +51,7 @@ async def handle_remove_decision(
     "removed" signoff untouched.
     """
     if not reason or not reason.strip():
-        raise ValueError(
-            "remove_decision requires a non-empty 'reason' (audit-trail obligation)"
-        )
+        raise ValueError("remove_decision requires a non-empty 'reason' (audit-trail obligation)")
 
     ledger = ctx.ledger
     if hasattr(ledger, "connect"):
@@ -80,17 +79,15 @@ async def handle_remove_decision(
             decision_id=decision_id,
             was_new=False,
             signoff=existing_signoff,
-            projected_status=projected,
+            projected_status=cast(
+                Literal["reflected", "drifted", "pending", "ungrounded"], projected
+            ),
         )
 
     head_ref = getattr(ctx, "authoritative_sha", "") or ""
     session_id = getattr(ctx, "session_id", None) or ""
     now_iso = datetime.now(UTC).isoformat()
-    previous_state = (
-        existing_signoff.get("state")
-        if isinstance(existing_signoff, dict)
-        else None
-    )
+    previous_state = existing_signoff.get("state") if isinstance(existing_signoff, dict) else None
 
     signoff = {
         "state": "removed",
@@ -134,5 +131,5 @@ async def handle_remove_decision(
         decision_id=decision_id,
         was_new=True,
         signoff=signoff,
-        projected_status=projected,
+        projected_status=cast(Literal["reflected", "drifted", "pending", "ungrounded"], projected),
     )

--- a/handlers/remove_decision.py
+++ b/handlers/remove_decision.py
@@ -1,0 +1,138 @@
+"""Handler for /bicameral.remove_decision MCP tool — #278 Phase 2.
+
+Soft-delete a decision: the row stays, signoff.state flips to "removed",
+and a decision_removed.completed event is appended to the event log when
+team mode is active.
+
+Like rejection, removed decisions remain visible as negative signals — agents
+consult them to avoid re-introducing the same wrong decision. Restoration
+requires writing a new decision that supersedes the removed one (mirror of
+the ratify.py "No unratify" doctrine).
+
+Audit obligation:
+  - `reason` is required (empty string raises ValueError).
+  - Every state mutation appends decision_removed.completed to the event log
+    when ledger has an attached event writer (team mode); local-only mode
+    skips the event emission (no writer attached).
+  - The signoff dict carries `previous_state` so the event log payload
+    captures the full state transition.
+
+Idempotent:
+  - Calling remove_decision on an already-removed decision returns
+    was_new=False, does not write a new signoff, and does not emit a
+    second event.
+"""
+
+from __future__ import annotations
+
+import logging
+from datetime import UTC, datetime
+
+from contracts import RemoveDecisionResponse
+from ledger.queries import (
+    decision_exists,
+    project_decision_status,
+    update_decision_status,
+)
+
+logger = logging.getLogger(__name__)
+
+
+async def handle_remove_decision(
+    ctx,
+    decision_id: str,
+    signer: str,
+    reason: str,
+) -> RemoveDecisionResponse:
+    """Soft-delete a decision (signoff.state -> "removed").
+
+    Idempotent: a second call returns was_new=False and leaves the existing
+    "removed" signoff untouched.
+    """
+    if not reason or not reason.strip():
+        raise ValueError(
+            "remove_decision requires a non-empty 'reason' (audit-trail obligation)"
+        )
+
+    ledger = ctx.ledger
+    if hasattr(ledger, "connect"):
+        await ledger.connect()
+
+    inner = getattr(ledger, "_inner", ledger)
+    client = inner._client
+
+    if not await decision_exists(client, decision_id):
+        raise ValueError(f"No decision row for {decision_id}")
+
+    rows = await client.query(
+        f"SELECT signoff FROM {decision_id} LIMIT 1",
+    )
+    existing_signoff = (rows[0].get("signoff") if rows else None) or None
+
+    # Idempotent fast path — already removed
+    if (
+        existing_signoff
+        and isinstance(existing_signoff, dict)
+        and existing_signoff.get("state") == "removed"
+    ):
+        projected = await project_decision_status(client, decision_id)
+        return RemoveDecisionResponse(
+            decision_id=decision_id,
+            was_new=False,
+            signoff=existing_signoff,
+            projected_status=projected,
+        )
+
+    head_ref = getattr(ctx, "authoritative_sha", "") or ""
+    session_id = getattr(ctx, "session_id", None) or ""
+    now_iso = datetime.now(UTC).isoformat()
+    previous_state = (
+        existing_signoff.get("state")
+        if isinstance(existing_signoff, dict)
+        else None
+    )
+
+    signoff = {
+        "state": "removed",
+        "signer": signer,
+        "session_id": session_id,
+        "removed_at": now_iso,
+        "previous_state": previous_state,
+        "reason": reason,
+        "source_commit_ref": head_ref,
+    }
+
+    await client.query(
+        f"UPDATE {decision_id} SET signoff = $signoff",
+        {"signoff": signoff},
+    )
+    projected = await project_decision_status(client, decision_id)
+    await update_decision_status(client, decision_id, projected)
+
+    # Emit decision_removed.completed event when team mode is active.
+    # In local-only mode (no _writer on the adapter), audit-log obligation
+    # is satisfied by the ledger row's signoff history itself.
+    writer = getattr(ledger, "_writer", None)
+    if writer is not None:
+        writer.write(
+            "decision_removed.completed",
+            {
+                "decision_id": decision_id,
+                "signoff": signoff,
+            },
+        )
+
+    logger.info(
+        "[remove_decision] decision=%s signer=%s previous_state=%s projected_status=%s",
+        decision_id,
+        signer,
+        previous_state,
+        projected,
+    )
+
+    return RemoveDecisionResponse(
+        decision_id=decision_id,
+        was_new=True,
+        signoff=signoff,
+        projected_status=projected,
+    )

--- a/handlers/remove_source.py
+++ b/handlers/remove_source.py
@@ -59,9 +59,7 @@ async def handle_remove_source(
     ``confirm=True`` to perform the mutation.
     """
     if not reason or not reason.strip():
-        raise ValueError(
-            "remove_source requires a non-empty 'reason' (audit-trail obligation)"
-        )
+        raise ValueError("remove_source requires a non-empty 'reason' (audit-trail obligation)")
 
     ledger = ctx.ledger
     if hasattr(ledger, "connect"):
@@ -159,14 +157,8 @@ async def _apply_cascading_remove(
         existing = await client.query(
             f"SELECT signoff FROM {did} LIMIT 1",
         )
-        prev = (
-            existing[0].get("signoff")
-            if existing and isinstance(existing[0], dict)
-            else None
-        )
-        previous_state = (
-            prev.get("state") if isinstance(prev, dict) else None
-        )
+        prev = existing[0].get("signoff") if existing and isinstance(existing[0], dict) else None
+        previous_state = prev.get("state") if isinstance(prev, dict) else None
         # Idempotent per-decision: already-removed decisions are not re-written.
         if previous_state == "removed":
             cascaded.append(did)

--- a/handlers/remove_source.py
+++ b/handlers/remove_source.py
@@ -1,0 +1,197 @@
+"""Handler for /bicameral.remove_source MCP tool — #278 Phase 2.
+
+Hard-delete an input_span row + cascade-soft-delete every decision derived
+from it via the ``yields`` graph edge. Audit-logged with the full
+pre-deletion span content in the source_removed.completed event payload so
+the action is recoverable from the event log.
+
+Safety design (mirrors handlers/reset.py:42-91):
+  - ``confirm=False`` (default) returns a dry-run plan listing the full
+    input_span content + the cascaded decision ids. NO mutation.
+  - ``confirm=True`` performs the cascade: soft-delete each derived
+    decision (signoff.state="removed" + removed_by_source=<span_id> +
+    reason), then hard-delete the input_span row and its outgoing yields
+    edges. Emits ONE source_removed.completed event covering the entire
+    cascade.
+
+Idempotent:
+  - Missing span_id at confirm=False → returns RemoveSourcePlan with
+    span_existed=False, empty decision_ids, confirm_required=True.
+  - Missing span_id at confirm=True → returns RemoveSourceResponse with
+    span_existed=False, empty cascaded_decision_ids, event_logged=False.
+
+Audit obligation:
+  - ``reason`` is required (empty → ValueError).
+  - Per Phase 2 Discipline #3, the source_removed.completed event payload
+    contains the FULL input_span content so the action is recoverable from
+    the append-only event log.
+"""
+
+from __future__ import annotations
+
+import logging
+from datetime import UTC, datetime
+
+from contracts import RemoveSourcePlan, RemoveSourceResponse
+from ledger.queries import (
+    get_decisions_for_span,
+    get_input_span_row,
+    input_span_exists,
+    project_decision_status,
+    update_decision_status,
+)
+
+logger = logging.getLogger(__name__)
+
+
+async def handle_remove_source(
+    ctx,
+    span_id: str,
+    signer: str,
+    reason: str,
+    *,
+    confirm: bool = False,
+) -> RemoveSourcePlan | RemoveSourceResponse:
+    """Cascading remove of an input_span + every decision derived from it.
+
+    ``confirm=False`` (default) is a dry-run that returns the plan without
+    touching state. The operator inspects the plan and re-invokes with
+    ``confirm=True`` to perform the mutation.
+    """
+    if not reason or not reason.strip():
+        raise ValueError(
+            "remove_source requires a non-empty 'reason' (audit-trail obligation)"
+        )
+
+    ledger = ctx.ledger
+    if hasattr(ledger, "connect"):
+        await ledger.connect()
+
+    inner = getattr(ledger, "_inner", ledger)
+    client = inner._client
+
+    span_existed = await input_span_exists(client, span_id)
+    span_content: dict = {}
+    decision_ids: list[str] = []
+    if span_existed:
+        span_content = await get_input_span_row(client, span_id) or {}
+        decision_ids = await get_decisions_for_span(client, span_id)
+
+    if not confirm:
+        return RemoveSourcePlan(
+            span_id=span_id,
+            span_existed=span_existed,
+            input_span_content=span_content,
+            decision_ids=decision_ids,
+        )
+
+    # confirm=True path
+    if not span_existed:
+        # Idempotent: nothing to remove
+        return RemoveSourceResponse(
+            span_id=span_id,
+            span_existed=False,
+            cascaded_decision_ids=[],
+            event_logged=False,
+        )
+
+    cascaded = await _apply_cascading_remove(
+        client,
+        span_id=span_id,
+        decision_ids=decision_ids,
+        signer=signer,
+        session_id=getattr(ctx, "session_id", None) or "",
+        head_ref=getattr(ctx, "authoritative_sha", "") or "",
+        reason=reason,
+    )
+
+    # Emit one source_removed.completed event covering the entire cascade.
+    # Payload carries full pre-deletion span content per Discipline #3.
+    writer = getattr(ledger, "_writer", None)
+    event_logged = False
+    if writer is not None:
+        writer.write(
+            "source_removed.completed",
+            {
+                "span_id": span_id,
+                "input_span_content": span_content,
+                "cascaded_decision_ids": cascaded,
+                "signer": signer,
+                "reason": reason,
+                "removed_at": datetime.now(UTC).isoformat(),
+            },
+        )
+        event_logged = True
+
+    logger.info(
+        "[remove_source] span=%s signer=%s cascaded=%d event_logged=%s",
+        span_id,
+        signer,
+        len(cascaded),
+        event_logged,
+    )
+
+    return RemoveSourceResponse(
+        span_id=span_id,
+        span_existed=True,
+        cascaded_decision_ids=cascaded,
+        event_logged=event_logged,
+    )
+
+
+async def _apply_cascading_remove(
+    client,
+    *,
+    span_id: str,
+    decision_ids: list[str],
+    signer: str,
+    session_id: str,
+    head_ref: str,
+    reason: str,
+) -> list[str]:
+    """Soft-delete each decision in ``decision_ids`` and hard-delete the span
+    row + its outgoing ``yields`` edges. Returns the list of decision ids
+    that were actually mutated."""
+    now_iso = datetime.now(UTC).isoformat()
+    cascaded: list[str] = []
+
+    for did in decision_ids:
+        existing = await client.query(
+            f"SELECT signoff FROM {did} LIMIT 1",
+        )
+        prev = (
+            existing[0].get("signoff")
+            if existing and isinstance(existing[0], dict)
+            else None
+        )
+        previous_state = (
+            prev.get("state") if isinstance(prev, dict) else None
+        )
+        # Idempotent per-decision: already-removed decisions are not re-written.
+        if previous_state == "removed":
+            cascaded.append(did)
+            continue
+
+        signoff = {
+            "state": "removed",
+            "signer": signer,
+            "session_id": session_id,
+            "removed_at": now_iso,
+            "previous_state": previous_state,
+            "reason": reason,
+            "removed_by_source": span_id,
+            "source_commit_ref": head_ref,
+        }
+        await client.query(
+            f"UPDATE {did} SET signoff = $signoff",
+            {"signoff": signoff},
+        )
+        projected = await project_decision_status(client, did)
+        await update_decision_status(client, did, projected)
+        cascaded.append(did)
+
+    # Hard-delete outgoing yields edges from this span, then the span itself.
+    await client.query(f"DELETE yields WHERE in = {span_id}")
+    await client.query(f"DELETE {span_id}")
+
+    return cascaded

--- a/ledger/queries.py
+++ b/ledger/queries.py
@@ -855,6 +855,45 @@ async def decision_exists(client: LedgerClient, decision_id: str) -> bool:
     return bool(rows)
 
 
+async def get_decisions_for_span(
+    client: LedgerClient, span_id: str
+) -> list[str]:
+    """Return decision record ids yielded by the given input_span via the
+    ``yields`` graph edge.
+
+    Used by ``bicameral.remove_source`` (#278 Phase 2) to compute the
+    cascade: every decision derived from a removed source is soft-deleted.
+    Returns an empty list when the span has no derived decisions or does
+    not exist.
+    """
+    rows = await client.query(
+        f"SELECT type::string(id) AS decision_id FROM decision "
+        f"WHERE <-yields<-input_span CONTAINS {span_id}",
+    )
+    return [str(r["decision_id"]) for r in (rows or []) if r.get("decision_id")]
+
+
+async def input_span_exists(client: LedgerClient, span_id: str) -> bool:
+    """Return True iff an input_span row exists with the given record id."""
+    rows = await client.query(f"SELECT id FROM {span_id} LIMIT 1")
+    return bool(rows)
+
+
+async def get_input_span_row(
+    client: LedgerClient, span_id: str
+) -> dict | None:
+    """Return the full input_span row (text, source_ref, source_type,
+    meeting_date, speakers, created_at) for use in the source_removed.completed
+    event payload. Returns None when the row does not exist."""
+    rows = await client.query(
+        f"SELECT text, source_ref, source_type, meeting_date, speakers, created_at "
+        f"FROM {span_id} LIMIT 1",
+    )
+    if not rows:
+        return None
+    return dict(rows[0])
+
+
 async def get_decision_level(client: LedgerClient, decision_id: str) -> str | None:
     """Return ``decision.decision_level`` (one of ``"L1"``, ``"L2"``, ``"L3"``)
     or ``None`` if the row does not exist or the field is unset.

--- a/ledger/queries.py
+++ b/ledger/queries.py
@@ -855,9 +855,7 @@ async def decision_exists(client: LedgerClient, decision_id: str) -> bool:
     return bool(rows)
 
 
-async def get_decisions_for_span(
-    client: LedgerClient, span_id: str
-) -> list[str]:
+async def get_decisions_for_span(client: LedgerClient, span_id: str) -> list[str]:
     """Return decision record ids yielded by the given input_span via the
     ``yields`` graph edge.
 
@@ -879,9 +877,7 @@ async def input_span_exists(client: LedgerClient, span_id: str) -> bool:
     return bool(rows)
 
 
-async def get_input_span_row(
-    client: LedgerClient, span_id: str
-) -> dict | None:
+async def get_input_span_row(client: LedgerClient, span_id: str) -> dict | None:
     """Return the full input_span row (text, source_ref, source_type,
     meeting_date, speakers, created_at) for use in the source_removed.completed
     event payload. Returns None when the row does not exist."""

--- a/server.py
+++ b/server.py
@@ -45,6 +45,7 @@ from handlers.ingest import _IngestRefused, handle_ingest
 from handlers.link_commit import handle_link_commit
 from handlers.preflight import handle_preflight
 from handlers.ratify import handle_ratify
+from handlers.remove_decision import handle_remove_decision
 from handlers.reset import handle_reset
 from handlers.resolve_collision import handle_resolve_collision
 from handlers.resolve_compliance import handle_resolve_compliance
@@ -144,6 +145,8 @@ EXPECTED_TOOL_NAMES = [
     "bicameral.judge_gaps",
     "bicameral.resolve_compliance",
     "bicameral.ratify",
+    "bicameral.remove_decision",
+    "bicameral.remove_source",
     "bicameral.resolve_collision",
     "bicameral.history",
     "bicameral.dashboard",
@@ -577,6 +580,71 @@ async def list_tools() -> list[Tool]:
                     },
                 },
                 "required": ["decision_id", "signer"],
+            },
+        ),
+        Tool(
+            name="bicameral.remove_decision",
+            description=(
+                "Soft-delete a decision: signoff.state -> 'removed' + reason + audit event "
+                "(#278 Phase 2). The decision row stays as a negative signal (like rejection), "
+                "agents consult removed decisions to avoid re-introducing the same wrong "
+                "decision. Reason is required for audit-trail. Idempotent — calling on an "
+                "already-removed decision returns was_new=false. Restoration requires a "
+                "superseding decision, not a restore op (no unremove)."
+            ),
+            inputSchema={
+                "type": "object",
+                "properties": {
+                    "decision_id": {
+                        "type": "string",
+                        "description": "The decision to soft-delete (UUIDv5 decision ID from the ledger).",
+                    },
+                    "signer": {
+                        "type": "string",
+                        "description": "Identity of the operator or agent performing the removal.",
+                    },
+                    "reason": {
+                        "type": "string",
+                        "minLength": 1,
+                        "description": "Why this decision is being removed. Required (audit-trail obligation).",
+                    },
+                },
+                "required": ["decision_id", "signer", "reason"],
+            },
+        ),
+        Tool(
+            name="bicameral.remove_source",
+            description=(
+                "Hard-delete an input_span row + cascade-soft-delete every decision derived "
+                "from it (#278 Phase 2). confirm=false (default) returns a dry-run plan listing "
+                "the full span content and the cascaded decision ids; confirm=true performs the "
+                "mutation and emits source_removed.completed event carrying the full pre-deletion "
+                "span content (recoverable from event log). Reason is required. Idempotent on "
+                "missing spans."
+            ),
+            inputSchema={
+                "type": "object",
+                "properties": {
+                    "span_id": {
+                        "type": "string",
+                        "description": "The input_span record id to remove.",
+                    },
+                    "signer": {
+                        "type": "string",
+                        "description": "Identity of the operator or agent performing the removal.",
+                    },
+                    "reason": {
+                        "type": "string",
+                        "minLength": 1,
+                        "description": "Why this source is being removed. Required (audit-trail obligation).",
+                    },
+                    "confirm": {
+                        "type": "boolean",
+                        "default": False,
+                        "description": "False (default) = dry-run returning the cascade plan; True = perform the mutation.",
+                    },
+                },
+                "required": ["span_id", "signer", "reason"],
             },
         ),
         Tool(
@@ -1089,6 +1157,23 @@ async def _call_tool_impl(name: str, arguments: dict) -> list[TextContent]:
                 note=arguments.get("note", ""),
                 action=arguments.get("action", "ratify"),
                 preflight_id=arguments.get("preflight_id"),
+            )
+        elif name in ("bicameral.remove_decision", "remove_decision"):
+            result = await handle_remove_decision(
+                ctx,
+                decision_id=arguments["decision_id"],
+                signer=arguments["signer"],
+                reason=arguments["reason"],
+            )
+        elif name in ("bicameral.remove_source", "remove_source"):
+            from handlers.remove_source import handle_remove_source
+
+            result = await handle_remove_source(
+                ctx,
+                span_id=arguments["span_id"],
+                signer=arguments["signer"],
+                reason=arguments["reason"],
+                confirm=bool(arguments.get("confirm", False)),
             )
         elif name in ("bicameral.resolve_collision", "resolve_collision"):
             result = await handle_resolve_collision(

--- a/skills/remove-decision/SKILL.md
+++ b/skills/remove-decision/SKILL.md
@@ -1,0 +1,78 @@
+---
+name: bicameral-remove-decision
+description: Soft-delete a wrong decision via the `bicameral.remove_decision` tool. The decision row stays in the ledger with `signoff.state = "removed"` plus a reason — agents consult removed decisions as negative signals to avoid re-introducing the same mistake. Reason is required. Idempotent. No unremove (write a superseding decision if you need to reverse).
+---
+
+# Bicameral Remove Decision
+
+Soft-delete a wrong decision via the `bicameral.remove_decision` tool. Bridges the gap between accepting a wrong decision in the ledger forever and running `bicameral.reset` (full wipe).
+
+## When to use
+
+- Operator finds a decision that was extracted in error (transcript misread, hallucination, wrong ingest target) and wants to correct the ledger without nuking everything.
+- An agent ratified a decision and product owner wants to retract — write a superseding decision is the preferred path, but `remove_decision` is the right tool when the original is so wrong it should never have been ratified (rather than evolved past).
+- A test decision was ingested by accident during development and needs to come out without taking everything else with it.
+
+## When NOT to use
+
+- For GDPR right-to-erasure of PII — out of scope per `issue_221_design_directive.md`. The append-only ledger keeps the row; the removed-state is operator-correction, not legal-compliance erasure.
+- For decisions you want to evolve past — write a new decision that supersedes (via `bicameral.resolve_collision action=supersede`). Supersession preserves the historical lineage; removal severs it.
+- For hiding a decision from the UI without an audit trail — every removal writes an audit event. There is no quiet remove.
+- For undoing a removal — there is no unremove. If a removal was a mistake, write a new decision that captures the correct intent.
+
+## Mandatory verification
+
+Before calling `bicameral.remove_decision`:
+
+1. **Read the decision** via `bicameral.history` or the dashboard. Confirm `decision_id` matches the one you intend to remove. Decision IDs are deterministic (UUIDv5) but the dashboard surface is the human-readable cross-reference.
+2. **Compose a non-trivial reason.** A bare "wrong" is acceptable but unhelpful. Future-you (or a future operator) reads this reason to understand WHY the entry was removed. Recommended shape: `<symptom> — <cause> — <action taken>` (e.g., "Duplicate of decision:abc — transcript was ingested twice — keep the earlier one").
+3. **Verify idempotency expectations.** If `signoff.state` is already `"removed"`, the second call returns `was_new=false` and does not emit a duplicate event. This is intentional: re-running the tool is safe.
+
+## Format
+
+```json
+{
+  "name": "bicameral.remove_decision",
+  "arguments": {
+    "decision_id": "decision:abc123",
+    "signer": "your-email-or-agent-id",
+    "reason": "Duplicate of decision:def456 — transcript ingested twice."
+  }
+}
+```
+
+## Handler-side enforcement
+
+The handler rejects calls with:
+- empty `reason` → `ValueError("remove_decision requires a non-empty 'reason' …")`
+- unknown `decision_id` → `ValueError("No decision row for {decision_id}")`
+
+State changes are written to the ledger via the same `UPDATE … SET signoff` path that `bicameral.ratify` uses, plus a re-projection of `status` (matches the post-ratify projection contract).
+
+## Audit trail
+
+Every successful removal appends one event to the local event log:
+
+```
+.bicameral/events/<author>.jsonl
+{"event_type":"decision_removed.completed","author":"…","timestamp":"…","payload":{"decision_id":"…","signoff":{"state":"removed","signer":"…","reason":"…","previous_state":"…","removed_at":"…",…}}}
+```
+
+The event payload carries `previous_state` so reviewers can see what state the decision was in before removal (e.g., `ratified → removed` is a much stronger signal than `proposed → removed`).
+
+In team mode, the event is also replicated through the shared event-log backend (see `bicameral.history` skill for team-mode semantics).
+
+## After removal
+
+- The decision row remains in the ledger. `bicameral.history` and the dashboard render it with a "removed" visual indicator (Phase 2 of #278 dashboard work).
+- Agents that consult the ledger see `signoff.state="removed"` and treat the decision as a negative signal: do not re-introduce the same intent unless you can defend it (write a superseding decision).
+- The original signoff state (if any) is preserved in `signoff.previous_state` for forensic review.
+
+## Anti-patterns — REJECT these
+
+| Anti-pattern | Why it fails |
+|---|---|
+| Calling `remove_decision` to "hide" an embarrassing decision | Every removal is audit-logged with signer + reason; there is no hidden removal. |
+| Using `remove_decision` as a substitute for `bicameral.resolve_collision action=supersede` | Supersession preserves lineage and history; removal severs them. Pick supersession when the new decision evolves the old one; pick removal when the old decision should never have existed. |
+| Submitting an empty or single-word reason | The handler rejects empty reasons; single-word reasons technically pass but defeat the audit-trail purpose. Reviewers reading the event log months later need context. |
+| Calling `remove_decision` then expecting to call something to undo it | No unremove exists. The append-only event log makes "undo" semantically incoherent — the removal event happened. Write a new decision that captures the correct intent. |

--- a/skills/remove-source/SKILL.md
+++ b/skills/remove-source/SKILL.md
@@ -1,0 +1,112 @@
+---
+name: bicameral-remove-source
+description: Hard-delete an input_span row + cascade-soft-delete every decision derived from it via `bicameral.remove_source`. Confirm-first (dry-run returns the cascade plan). Reason is required. Audit-logged with the full pre-deletion span content in the source_removed.completed event payload. Idempotent on missing spans. No restore (write a superseding decision if you need to reverse).
+---
+
+# Bicameral Remove Source
+
+Hard-delete an input_span row and cascade-soft-delete every decision derived from it. Bridges the gap between accepting a bad source forever and running `bicameral.reset` (full wipe).
+
+## When to use
+
+- Operator finds a bad source — typo-ridden transcript, accidental Slack ingest, wrong document version, hallucinated content from a misconfigured agent — and wants to retract every decision that was derived from it.
+- Multiple decisions on the same source are all wrong for the same root cause (the source itself was bad). Removing the source is one atomic operation; remove_decision on each derived decision is N operations and easy to skip one.
+- Cleanup of test ingest during development that polluted the ledger.
+
+## When NOT to use
+
+- When only one decision out of many on the source is wrong — use `bicameral.remove_decision` on the specific decision instead. `remove_source` cascades unconditionally; a multi-source decision will be soft-deleted even if its other sources are still valid.
+- For GDPR right-to-erasure — out of scope per `issue_221_design_directive.md`. The append-only event log retains the full pre-deletion span content; this is operator-correction, not legal-compliance erasure.
+- For undoing a removal — there is no restore. The event log carries the audit trail; manual SurrealQL re-ingest is the recovery path if needed.
+
+## Mandatory verification
+
+1. **Dry-run first.** ALWAYS call with `confirm=false` first. The response is a `RemoveSourcePlan` with the full input_span content (verify it's the right one) and the list of every decision id that will be cascade-soft-deleted (verify the blast radius matches your intent).
+2. **Verify the cascade size.** If `decision_ids` has more entries than you expected, STOP. A surprising cascade is a signal that the source is more load-bearing than you realized; investigate the unexpected decisions before confirming.
+3. **Compose a non-trivial reason.** The reason is persisted in the source_removed.completed event payload. Future reviewers (or future-you) read it to understand the operator's intent. Recommended shape: `<symptom> — <cause> — <action taken>` (e.g., "Garbled OCR transcript — wrong PDF version was ingested — replaced by clean version in next ingest pass").
+4. **Re-invoke with confirm=true.** Only after dry-run inspection.
+
+## Format
+
+Dry-run:
+
+```json
+{
+  "name": "bicameral.remove_source",
+  "arguments": {
+    "span_id": "input_span:abc123",
+    "signer": "your-email-or-agent-id",
+    "reason": "Garbled OCR transcript — wrong PDF version ingested",
+    "confirm": false
+  }
+}
+```
+
+Confirm:
+
+```json
+{
+  "name": "bicameral.remove_source",
+  "arguments": {
+    "span_id": "input_span:abc123",
+    "signer": "your-email-or-agent-id",
+    "reason": "Garbled OCR transcript — wrong PDF version ingested",
+    "confirm": true
+  }
+}
+```
+
+## Handler-side enforcement
+
+- Empty `reason` → `ValueError`.
+- Unknown `span_id` is idempotent: dry-run returns `span_existed=false` with empty `decision_ids`; confirm returns `span_existed=false` with `event_logged=false`. No exception.
+- `confirm=true` performs three atomic operations:
+  1. For each derived decision, UPDATE signoff to `{state: "removed", removed_by_source: <span_id>, reason: ..., signer: ..., removed_at: ..., previous_state: ...}` and re-project status.
+  2. DELETE all `yields` edges with `in = <span_id>`.
+  3. DELETE the input_span row itself.
+- One `source_removed.completed` event is emitted (when adapter is in team mode) covering the entire cascade — NOT one event per decision. Operator's intent is "remove this source"; the cascade is a derived effect.
+
+## Audit trail
+
+Every successful confirm appends one event:
+
+```
+.bicameral/events/<author>.jsonl
+{
+  "event_type": "source_removed.completed",
+  "author": "...",
+  "timestamp": "...",
+  "payload": {
+    "span_id": "input_span:abc123",
+    "input_span_content": {
+      "text": "(full pre-deletion text)",
+      "source_ref": "...",
+      "source_type": "...",
+      "meeting_date": "...",
+      "speakers": [...],
+      "created_at": "..."
+    },
+    "cascaded_decision_ids": ["decision:xxx", "decision:yyy"],
+    "signer": "...",
+    "reason": "...",
+    "removed_at": "..."
+  }
+}
+```
+
+The `input_span_content` block is the recoverability anchor. If the operator made a mistake, the full source content survives in the event log and can be re-ingested manually.
+
+## After removal
+
+- The input_span row is gone from SurrealDB. `bicameral.history` no longer renders the source for any decision.
+- Cascaded decisions carry `signoff.state="removed"` with `signoff.removed_by_source=<span_id>` as a back-pointer. The pointed-to span no longer exists but the back-pointer preserves the audit relationship.
+- Agents that consult the ledger see removed decisions as negative signals.
+
+## Anti-patterns — REJECT these
+
+| Anti-pattern | Why it fails |
+|---|---|
+| Skipping the dry-run | The cascade is unconditional; a source with 100 derived decisions soft-deletes all 100. Without inspecting the plan you cannot know the blast radius until after you've fired. |
+| Using remove_source for a single wrong decision | Use `remove_decision` instead. `remove_source` is for the case where the SOURCE is the root cause. |
+| Submitting an empty or single-word reason | The handler rejects empty reasons; single-word reasons technically pass but defeat the audit-trail purpose. The event payload's reason is permanent. |
+| Expecting an unremove / restore call | No unremove exists. The event log captures the full span content; manual re-ingest is the recovery path. |

--- a/tests/test_dashboard_remove_flows.py
+++ b/tests/test_dashboard_remove_flows.py
@@ -107,9 +107,7 @@ def test_remove_decision_button_in_render_dec(html: str) -> None:
     to openRemoveDecisionModal. Gated so already-removed decisions render
     the button as disabled."""
     render_dec_body = _extract_function_body(html, "renderDec")
-    assert 'rm-dec-btn' in render_dec_body, (
-        "renderDec must include a remove-decision button"
-    )
+    assert "rm-dec-btn" in render_dec_body, "renderDec must include a remove-decision button"
     # Button invokes the modal opener
     assert re.search(
         r"openRemoveDecisionModal\(",

--- a/tests/test_dashboard_remove_flows.py
+++ b/tests/test_dashboard_remove_flows.py
@@ -1,0 +1,224 @@
+"""HTML-pattern tests for #278 Phase 2 — dashboard remove flows.
+
+Matches the harness pattern of test_dashboard_unclassified_rendering.py and
+test_dashboard_source_view.py: pure string assertions against
+assets/dashboard.html.
+
+Pins:
+  1. "Remove decision" button in renderDec body (gated by signoff.state).
+  2. "Remove source" button in the Phase 1 source-view panel.
+  3. Two confirmation modals (remove-decision, remove-source) with markup-vs-
+     JS state-attribute correlation (same dual-assertion pattern as Phase 1).
+  4. XSS discipline: modal user-facing fields written via .textContent.
+  5. MCP-call payload built via JSON.stringify (NOT raw template interpolation
+     of server data) and copied via navigator.clipboard.
+  6. Dashboard does NOT invoke writes directly — the modal's "confirm"
+     button writes the canonical tool-call payload into a code block for the
+     operator to run via their MCP-connected agent.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+import pytest
+
+DASHBOARD_HTML = Path(__file__).resolve().parent.parent / "assets" / "dashboard.html"
+
+
+@pytest.fixture(scope="module")
+def html() -> str:
+    assert DASHBOARD_HTML.exists(), f"missing dashboard template at {DASHBOARD_HTML}"
+    return DASHBOARD_HTML.read_text(encoding="utf-8")
+
+
+# ── helpers (mirror test_dashboard_source_view.py) ────────────────────────
+
+
+def _extract_function_body(html: str, fn_name: str) -> str:
+    match = re.search(rf"function\s+{re.escape(fn_name)}\s*\([^)]*\)\s*\{{", html)
+    if not match:
+        raise AssertionError(f"function {fn_name} not found in dashboard.html")
+    start = match.end() - 1
+    depth = 0
+    for i in range(start, len(html)):
+        ch = html[i]
+        if ch == "{":
+            depth += 1
+        elif ch == "}":
+            depth -= 1
+            if depth == 0:
+                return html[start : i + 1]
+    return html[start : start + 4000]
+
+
+# ── Modals: markup + state-attribute correlation ──────────────────────────
+
+
+def test_remove_decision_modal_markup_present(html: str) -> None:
+    """Modal container has id, initial closed state, and matching CSS rule."""
+    assert '<div id="rm-dec-modal"' in html, "expected remove-decision modal container"
+    assert 'data-modal="closed"' in html, 'expected data-modal="closed" initial state'
+    # CSS rule controlling visibility based on the attribute
+    assert re.search(
+        r'\.rm-modal\[data-modal\s*=\s*"open"\]\s*\{[^}]*'
+        r"(display\s*:\s*(block|flex|grid)|visibility\s*:\s*visible)",
+        html,
+        re.DOTALL,
+    ), 'expected .rm-modal[data-modal="open"] visible CSS rule'
+
+
+def test_remove_source_modal_markup_present(html: str) -> None:
+    """Source modal carries cascade-list block + matches state pattern."""
+    assert '<div id="rm-src-modal"' in html, "expected remove-source modal container"
+    assert 'class="cascade-list"' in html or "cascade-list" in html, (
+        "remove-source modal must include a .cascade-list block to render the cascade"
+    )
+
+
+def test_remove_modal_state_attribute_match_js(html: str) -> None:
+    """Modal open/close functions must reference the same `data-modal`
+    attribute and the canonical "open"/"closed" string values that the CSS
+    rule keys on. A silent rename on either side fails this test."""
+    open_dec = _extract_function_body(html, "openRemoveDecisionModal")
+    open_src = _extract_function_body(html, "openRemoveSourceModal")
+    close_fn = _extract_function_body(html, "closeRemoveModal")
+
+    for body in (open_dec, open_src):
+        assert re.search(
+            r"(setAttribute\(\s*['\"]data-modal['\"]\s*,\s*['\"]open['\"]"
+            r"|dataset\.modal\s*=\s*['\"]open['\"])",
+            body,
+        ), "modal open function must set data-modal='open'"
+
+    assert re.search(
+        r"(setAttribute\(\s*['\"]data-modal['\"]\s*,\s*['\"]closed['\"]"
+        r"|dataset\.modal\s*=\s*['\"]closed['\"])",
+        close_fn,
+    ), "closeRemoveModal must set data-modal='closed'"
+
+
+# ── Buttons ───────────────────────────────────────────────────────────────
+
+
+def test_remove_decision_button_in_render_dec(html: str) -> None:
+    """The decision row's expanded body carries a 'rm-dec-btn' button bound
+    to openRemoveDecisionModal. Gated so already-removed decisions render
+    the button as disabled."""
+    render_dec_body = _extract_function_body(html, "renderDec")
+    assert 'rm-dec-btn' in render_dec_body, (
+        "renderDec must include a remove-decision button"
+    )
+    # Button invokes the modal opener
+    assert re.search(
+        r"openRemoveDecisionModal\(",
+        render_dec_body,
+    ), "remove-decision button must call openRemoveDecisionModal(...)"
+
+
+def test_remove_decision_button_disabled_when_already_removed(html: str) -> None:
+    """A decision with signoff.state==='removed' must render the button as
+    disabled (or hidden) — the operation is a no-op and the UI should reflect
+    that."""
+    render_dec_body = _extract_function_body(html, "renderDec")
+    # Look for some form of disabled gating tied to the removed state
+    assert re.search(
+        r"signoff_state\s*===?\s*['\"]removed['\"]|signoff\?\.state\s*===?\s*['\"]removed['\"]",
+        render_dec_body,
+    ), (
+        "renderDec must gate the remove button on whether the decision is "
+        "already removed (signoff.state === 'removed')"
+    )
+
+
+def test_remove_source_button_in_src_panel(html: str) -> None:
+    """The Phase 1 source-view panel carries a remove-source button bound to
+    openRemoveSourceModal. Phase 2's button rides on top of Phase 1's panel."""
+    # Look for the button class anywhere in the file; the panel markup is
+    # static so a global match is sufficient.
+    assert "rm-src-btn" in html, "expected rm-src-btn class on the remove-source button"
+    assert re.search(
+        r'class\s*=\s*"[^"]*rm-src-btn[^"]*"[^>]*onclick\s*=\s*"openRemoveSourceModal',
+        html,
+    ), "remove-source button must be wired to openRemoveSourceModal(...)"
+
+
+# ── XSS discipline carries from Phase 1 ───────────────────────────────────
+
+
+def test_remove_modals_use_text_content_for_user_values(html: str) -> None:
+    """XSS discipline: modal field population uses .textContent for any
+    user-controlled value (decision summary, source quote, cascaded decision
+    summaries). Phase 1's discipline carries verbatim."""
+    open_dec = _extract_function_body(html, "openRemoveDecisionModal")
+    open_src = _extract_function_body(html, "openRemoveSourceModal")
+
+    # Both modal openers must populate at least one user value via .textContent
+    assert ".textContent" in open_dec, (
+        "openRemoveDecisionModal must populate user-facing fields via .textContent"
+    )
+    assert ".textContent" in open_src, (
+        "openRemoveSourceModal must populate user-facing fields via .textContent"
+    )
+    # And must NOT write user-controlled fields via .innerHTML
+    for body, name in [(open_dec, "openRemoveDecisionModal"), (open_src, "openRemoveSourceModal")]:
+        assert not re.search(
+            r"\.innerHTML\s*=\s*[^;]*\b(summary|quote|source_ref|source_type|cascade)\b",
+            body,
+        ), f"{name} must not write user-controlled fields via .innerHTML"
+
+
+# ── Architectural boundary: dashboard does NOT call MCP tools itself ──────
+
+
+def test_remove_modals_emit_mcp_tool_call_payload_via_json_stringify(html: str) -> None:
+    """On confirm, modals populate a `<code class="mcp-call">` block with
+    the canonical tool-call JSON built via JSON.stringify (NOT raw template
+    interpolation). The operator copies this block and runs it in their
+    MCP-connected agent.
+
+    This pins the architectural boundary: dashboard server is read-only;
+    write tools go through the agent layer.
+    """
+    assert "JSON.stringify" in html, (
+        "modal confirm must build the MCP tool-call payload via JSON.stringify"
+    )
+    assert re.search(
+        r'class\s*=\s*"[^"]*mcp-call[^"]*"',
+        html,
+    ), "expected a <code class='mcp-call'> block to hold the canonical tool-call payload"
+    # The buildMcpCall helper (or equivalent) must write into the mcp-call
+    # block via .textContent so the JSON payload is not interpreted as HTML.
+    build = _extract_function_body(html, "buildMcpCall")
+    assert ".textContent" in build, (
+        "buildMcpCall must write the JSON.stringify result via .textContent, "
+        "not innerHTML (XSS canary)"
+    )
+
+
+def test_copy_mcp_call_uses_clipboard_api(html: str) -> None:
+    """Copy-to-clipboard uses navigator.clipboard.writeText, not document.execCommand
+    or other deprecated approaches. Read-only access pattern."""
+    body = _extract_function_body(html, "copyMcpCall")
+    assert "navigator.clipboard.writeText" in body, (
+        "copyMcpCall must use navigator.clipboard.writeText"
+    )
+
+
+# ── Reason capture (Phase 2 audit obligation) ─────────────────────────────
+
+
+def test_remove_modals_capture_reason_via_textarea(html: str) -> None:
+    """Each modal includes a `<textarea>` for the operator's reason input.
+    The reason is mandatory at the handler layer; the dashboard makes that
+    obvious by requiring a textarea entry."""
+    # Both modals carry a reason textarea
+    assert re.search(
+        r"<textarea[^>]*id\s*=\s*\"rm-dec-reason\"",
+        html,
+    ), "remove-decision modal must include a reason textarea"
+    assert re.search(
+        r"<textarea[^>]*id\s*=\s*\"rm-src-reason\"",
+        html,
+    ), "remove-source modal must include a reason textarea"

--- a/tests/test_history_input_span_id.py
+++ b/tests/test_history_input_span_id.py
@@ -1,0 +1,122 @@
+"""Phase A of #278 Phase 2 — HistorySource carries input_span_id.
+
+Pins:
+  1. HistorySource has an optional `input_span_id` field that defaults to None
+     and serializes when set.
+  2. `_row_to_history_decision` (handlers/history.py) propagates the id when
+     present in the SurrealDB row, AND tolerates legacy rows that don't carry
+     it (back-compat for pre-Phase-2 ingest).
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from contracts import HistorySource
+
+
+def test_history_source_has_optional_input_span_id_default_none() -> None:
+    """Default-construction omits input_span_id; the field is None."""
+    src = HistorySource(
+        source_ref="sprint-14",
+        source_type="manual",
+        date="2026-05-14",
+        quote="some excerpt",
+    )
+    assert src.input_span_id is None
+
+
+def test_history_source_round_trips_input_span_id_via_model_dump() -> None:
+    """When set, input_span_id round-trips through .model_dump()."""
+    src = HistorySource(
+        source_ref="sprint-14",
+        source_type="manual",
+        date="2026-05-14",
+        quote="some excerpt",
+        input_span_id="input_span:abc123",
+    )
+    dumped = src.model_dump()
+    assert dumped["input_span_id"] == "input_span:abc123"
+
+
+def test_row_to_history_decision_populates_input_span_id_when_present() -> None:
+    """Feeding a SurrealDB row whose _source_spans entry carries an `id`
+    yields a HistorySource with that id propagated.
+
+    Invokes `_row_to_history_decision` directly with a fixture dict shaped
+    like a single decision row joined with its source spans.
+    """
+    from handlers.history import _row_to_history_decision
+
+    row = {
+        "decision_id": "decision:abc",
+        "description": "test decision",
+        "status": "ungrounded",
+        "_source_spans": [
+            {
+                "id": "input_span:span001",
+                "text": "verbatim excerpt",
+                "source_ref": "meeting-001",
+                "source_type": "transcript",
+                "meeting_date": "2026-05-14",
+                "speakers": ["Jin"],
+            }
+        ],
+    }
+    dec = _row_to_history_decision(row, feature_id="test-feature")
+    assert len(dec.sources) == 1
+    assert dec.sources[0].input_span_id == "input_span:span001"
+    assert dec.sources[0].quote == "verbatim excerpt"
+
+
+def test_row_to_history_decision_tolerates_missing_input_span_id() -> None:
+    """Legacy rows (pre-Phase-2 ingest) won't carry `id` in their span dicts.
+    The hydration code must produce HistorySource with input_span_id=None
+    rather than raising or coercing a falsy id to a string."""
+    from handlers.history import _row_to_history_decision
+
+    row = {
+        "decision_id": "decision:legacy",
+        "description": "legacy decision",
+        "status": "ungrounded",
+        "_source_spans": [
+            {
+                # No "id" key — legacy data shape
+                "text": "legacy excerpt",
+                "source_ref": "old-meeting",
+                "source_type": "transcript",
+                "meeting_date": "2026-01-01",
+                "speakers": [],
+            }
+        ],
+    }
+    dec = _row_to_history_decision(row, feature_id="test-feature")
+    assert len(dec.sources) == 1
+    assert dec.sources[0].input_span_id is None
+    assert dec.sources[0].quote == "legacy excerpt"
+
+
+def test_row_to_history_decision_tolerates_empty_string_id() -> None:
+    """A row where `id` is an empty string (SurrealDB null-coalesce artifact)
+    must produce input_span_id=None, not the empty string. Pins the
+    `str(span_id_raw) if span_id_raw else None` guard."""
+    from handlers.history import _row_to_history_decision
+
+    row = {
+        "decision_id": "decision:edge",
+        "description": "edge case",
+        "status": "ungrounded",
+        "_source_spans": [
+            {
+                "id": "",  # falsy — should become None, not ""
+                "text": "edge excerpt",
+                "source_ref": "edge-meeting",
+                "source_type": "manual",
+                "meeting_date": "2026-05-14",
+                "speakers": [],
+            }
+        ],
+    }
+    dec = _row_to_history_decision(row, feature_id="test-feature")
+    assert len(dec.sources) == 1
+    assert dec.sources[0].input_span_id is None

--- a/tests/test_remove_decision.py
+++ b/tests/test_remove_decision.py
@@ -94,12 +94,8 @@ def _stub_queries(monkeypatch):
         return None
 
     monkeypatch.setattr("handlers.remove_decision.decision_exists", _decision_exists)
-    monkeypatch.setattr(
-        "handlers.remove_decision.project_decision_status", _project
-    )
-    monkeypatch.setattr(
-        "handlers.remove_decision.update_decision_status", _update
-    )
+    monkeypatch.setattr("handlers.remove_decision.project_decision_status", _project)
+    monkeypatch.setattr("handlers.remove_decision.update_decision_status", _update)
 
 
 async def test_remove_decision_rejects_empty_reason() -> None:
@@ -109,9 +105,7 @@ async def test_remove_decision_rejects_empty_reason() -> None:
     ctx = _FakeCtx(ledger)
 
     with pytest.raises(ValueError, match="non-empty 'reason'"):
-        await handle_remove_decision(
-            ctx, decision_id="decision:abc", signer="x@y", reason=""
-        )
+        await handle_remove_decision(ctx, decision_id="decision:abc", signer="x@y", reason="")
 
 
 async def test_remove_decision_rejects_whitespace_only_reason() -> None:
@@ -200,9 +194,7 @@ async def test_remove_decision_emits_event_in_team_mode() -> None:
     )
     ctx = _FakeCtx(ledger)
 
-    await handle_remove_decision(
-        ctx, decision_id="decision:abc", signer="kim@x", reason="cleanup"
-    )
+    await handle_remove_decision(ctx, decision_id="decision:abc", signer="kim@x", reason="cleanup")
 
     assert len(writer.events) == 1
     event_type, payload = writer.events[0]
@@ -239,9 +231,7 @@ async def test_remove_decision_idempotent_does_not_emit_second_event() -> None:
 
     writer = _FakeWriter()
     existing_signoff = {"state": "removed", "signer": "first@x", "reason": "first"}
-    ledger = _FakeLedger(
-        {"decision:abc": {"signoff": existing_signoff}}, writer=writer
-    )
+    ledger = _FakeLedger({"decision:abc": {"signoff": existing_signoff}}, writer=writer)
     ctx = _FakeCtx(ledger)
 
     resp = await handle_remove_decision(

--- a/tests/test_remove_decision.py
+++ b/tests/test_remove_decision.py
@@ -1,0 +1,252 @@
+"""Phase B of #278 Phase 2 — bicameral.remove_decision handler tests.
+
+Pins:
+  1. Reason is required (empty/whitespace → ValueError).
+  2. Unknown decision_id → ValueError matching ratify.py's "No decision row" shape.
+  3. The handler writes signoff.state="removed" + reason + signer + removed_at
+     + previous_state, and re-projects decision status.
+  4. Idempotent: second call returns was_new=False, does not emit a second
+     event.
+  5. Emits decision_removed.completed event when adapter has a _writer
+     (team mode); skips emission in local-only mode without raising.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+pytestmark = pytest.mark.asyncio
+
+# Marker mirrors the project's existing phase2-needs-surrealdb convention.
+PHASE2 = pytest.mark.phase2
+
+
+class _FakeClient:
+    """Minimal stand-in for the SurrealDB client used by handle_remove_decision.
+
+    Records the queries the handler issues so the test can assert on the SQL
+    + parameter shape without spinning up a real SurrealDB. Backed by an
+    in-memory dict keyed by decision_id.
+    """
+
+    def __init__(self, decisions: dict[str, dict] | None = None) -> None:
+        self._rows = decisions or {}
+        self.queries: list[tuple[str, dict | None]] = []
+
+    async def query(self, sql: str, params: dict | None = None):
+        self.queries.append((sql, params))
+        sql_l = sql.lower()
+        if "select signoff from" in sql_l:
+            # SELECT signoff FROM decision:abc LIMIT 1
+            did = sql.split("FROM ", 1)[1].split(" ", 1)[0]
+            row = self._rows.get(did, {})
+            return [{"signoff": row.get("signoff")}]
+        if "update " in sql_l and "set signoff" in sql_l:
+            did = sql.split("UPDATE ", 1)[1].split(" SET")[0].strip()
+            row = self._rows.setdefault(did, {})
+            row["signoff"] = params["signoff"]
+            return [row]
+        # Fallback: just return empty
+        return []
+
+
+class _FakeLedger:
+    """Adapter stand-in. Implements just the surface handle_remove_decision touches."""
+
+    def __init__(self, decisions: dict[str, dict], writer=None) -> None:
+        self._inner = self  # handler does getattr(ledger, "_inner", ledger)
+        self._client = _FakeClient(decisions)
+        if writer is not None:
+            self._writer = writer
+
+    async def connect(self) -> None:
+        return None
+
+
+class _FakeWriter:
+    """Captures events the handler emits in team mode."""
+
+    def __init__(self) -> None:
+        self.events: list[tuple[str, dict]] = []
+
+    def write(self, event_type: str, payload: dict):
+        self.events.append((event_type, payload))
+
+
+class _FakeCtx:
+    def __init__(self, ledger, session_id: str = "sess-1", sha: str = "deadbeef") -> None:
+        self.ledger = ledger
+        self.session_id = session_id
+        self.authoritative_sha = sha
+
+
+# Patch ledger.queries functions to skip real DB work for these handler-shape tests.
+@pytest.fixture(autouse=True)
+def _stub_queries(monkeypatch):
+    async def _decision_exists(client, did):
+        rows = await client.query(f"SELECT id FROM {did} LIMIT 1")
+        return did in client._rows
+
+    async def _project(client, did):
+        return "ungrounded"
+
+    async def _update(client, did, status):
+        return None
+
+    monkeypatch.setattr("handlers.remove_decision.decision_exists", _decision_exists)
+    monkeypatch.setattr(
+        "handlers.remove_decision.project_decision_status", _project
+    )
+    monkeypatch.setattr(
+        "handlers.remove_decision.update_decision_status", _update
+    )
+
+
+async def test_remove_decision_rejects_empty_reason() -> None:
+    from handlers.remove_decision import handle_remove_decision
+
+    ledger = _FakeLedger({"decision:abc": {"signoff": {"state": "ratified"}}})
+    ctx = _FakeCtx(ledger)
+
+    with pytest.raises(ValueError, match="non-empty 'reason'"):
+        await handle_remove_decision(
+            ctx, decision_id="decision:abc", signer="x@y", reason=""
+        )
+
+
+async def test_remove_decision_rejects_whitespace_only_reason() -> None:
+    from handlers.remove_decision import handle_remove_decision
+
+    ledger = _FakeLedger({"decision:abc": {"signoff": {"state": "ratified"}}})
+    ctx = _FakeCtx(ledger)
+
+    with pytest.raises(ValueError, match="non-empty 'reason'"):
+        await handle_remove_decision(
+            ctx, decision_id="decision:abc", signer="x@y", reason="   \t\n"
+        )
+
+
+async def test_remove_decision_rejects_unknown_decision_id() -> None:
+    from handlers.remove_decision import handle_remove_decision
+
+    ledger = _FakeLedger({})  # empty store
+    ctx = _FakeCtx(ledger)
+
+    with pytest.raises(ValueError, match="No decision row for decision:missing"):
+        await handle_remove_decision(
+            ctx, decision_id="decision:missing", signer="x@y", reason="not here"
+        )
+
+
+async def test_remove_decision_writes_signoff_state_removed_with_all_fields() -> None:
+    from handlers.remove_decision import handle_remove_decision
+
+    ledger = _FakeLedger({"decision:abc": {"signoff": {"state": "ratified", "signer": "old"}}})
+    ctx = _FakeCtx(ledger)
+
+    resp = await handle_remove_decision(
+        ctx,
+        decision_id="decision:abc",
+        signer="kim@example.com",
+        reason="Duplicate of decision:def — transcript ingested twice",
+    )
+
+    assert resp.was_new is True
+    assert resp.decision_id == "decision:abc"
+    # The new signoff is the one persisted in the fake store
+    persisted = ledger._client._rows["decision:abc"]["signoff"]
+    assert persisted["state"] == "removed"
+    assert persisted["signer"] == "kim@example.com"
+    assert persisted["reason"] == "Duplicate of decision:def — transcript ingested twice"
+    assert persisted["previous_state"] == "ratified"
+    assert persisted["removed_at"]  # non-empty ISO timestamp
+    assert persisted["session_id"] == "sess-1"
+
+
+async def test_remove_decision_is_idempotent_on_already_removed() -> None:
+    from handlers.remove_decision import handle_remove_decision
+
+    existing_signoff = {
+        "state": "removed",
+        "signer": "first@x",
+        "reason": "first removal reason",
+        "removed_at": "2026-05-13T00:00:00+00:00",
+        "previous_state": "ratified",
+    }
+    ledger = _FakeLedger({"decision:abc": {"signoff": existing_signoff}})
+    ctx = _FakeCtx(ledger)
+
+    resp = await handle_remove_decision(
+        ctx, decision_id="decision:abc", signer="second@x", reason="second attempt"
+    )
+
+    assert resp.was_new is False
+    # The original signoff is unchanged — second call did not overwrite
+    persisted = ledger._client._rows["decision:abc"]["signoff"]
+    assert persisted == existing_signoff
+    # The returned signoff matches the existing one
+    assert resp.signoff == existing_signoff
+
+
+async def test_remove_decision_emits_event_in_team_mode() -> None:
+    """When the adapter exposes ._writer (team mode), the handler emits
+    decision_removed.completed with the new signoff in the payload."""
+    from handlers.remove_decision import handle_remove_decision
+
+    writer = _FakeWriter()
+    ledger = _FakeLedger(
+        {"decision:abc": {"signoff": {"state": "ratified"}}},
+        writer=writer,
+    )
+    ctx = _FakeCtx(ledger)
+
+    await handle_remove_decision(
+        ctx, decision_id="decision:abc", signer="kim@x", reason="cleanup"
+    )
+
+    assert len(writer.events) == 1
+    event_type, payload = writer.events[0]
+    assert event_type == "decision_removed.completed"
+    assert payload["decision_id"] == "decision:abc"
+    assert payload["signoff"]["state"] == "removed"
+    assert payload["signoff"]["reason"] == "cleanup"
+    assert payload["signoff"]["previous_state"] == "ratified"
+
+
+async def test_remove_decision_skips_event_in_local_mode() -> None:
+    """No _writer attached → no event emitted, no exception."""
+    from handlers.remove_decision import handle_remove_decision
+
+    ledger = _FakeLedger({"decision:abc": {"signoff": {"state": "ratified"}}})
+    # No writer attached
+    assert not hasattr(ledger, "_writer")
+    ctx = _FakeCtx(ledger)
+
+    resp = await handle_remove_decision(
+        ctx, decision_id="decision:abc", signer="kim@x", reason="cleanup"
+    )
+
+    assert resp.was_new is True
+    # Idempotency assertion is sufficient — no writer means no event capture path,
+    # but the test serves as a contract that the handler doesn't raise when
+    # the writer is absent.
+
+
+async def test_remove_decision_idempotent_does_not_emit_second_event() -> None:
+    """Second call on an already-removed decision must NOT emit a second event
+    even when team mode is active."""
+    from handlers.remove_decision import handle_remove_decision
+
+    writer = _FakeWriter()
+    existing_signoff = {"state": "removed", "signer": "first@x", "reason": "first"}
+    ledger = _FakeLedger(
+        {"decision:abc": {"signoff": existing_signoff}}, writer=writer
+    )
+    ctx = _FakeCtx(ledger)
+
+    resp = await handle_remove_decision(
+        ctx, decision_id="decision:abc", signer="second@x", reason="second"
+    )
+
+    assert resp.was_new is False
+    assert writer.events == []  # No event emitted on the no-op path

--- a/tests/test_remove_source.py
+++ b/tests/test_remove_source.py
@@ -115,18 +115,15 @@ def _stub_project_queries(monkeypatch):
     """Stub the status-projection helpers so tests don't need the full
     schema. These are exercised by other tests (project_decision_status
     is well-covered elsewhere)."""
+
     async def _project(client, did):
         return "ungrounded"
 
     async def _update(client, did, status):
         return None
 
-    monkeypatch.setattr(
-        "handlers.remove_source.project_decision_status", _project
-    )
-    monkeypatch.setattr(
-        "handlers.remove_source.update_decision_status", _update
-    )
+    monkeypatch.setattr("handlers.remove_source.project_decision_status", _project)
+    monkeypatch.setattr("handlers.remove_source.update_decision_status", _update)
 
 
 def _seed_fixture():
@@ -157,14 +154,12 @@ async def test_remove_source_rejects_empty_reason() -> None:
     ctx = _FakeCtx(_FakeLedger(client))
 
     with pytest.raises(ValueError, match="non-empty 'reason'"):
-        await handle_remove_source(
-            ctx, span_id=span_id, signer="x@y", reason="", confirm=True
-        )
+        await handle_remove_source(ctx, span_id=span_id, signer="x@y", reason="", confirm=True)
 
 
 async def test_remove_source_dry_run_returns_plan_with_cascaded_decision_ids() -> None:
-    from handlers.remove_source import handle_remove_source
     from contracts import RemoveSourcePlan
+    from handlers.remove_source import handle_remove_source
 
     span_id, span_row, decisions, edges = _seed_fixture()
     client = _FakeClient({span_id: span_row}, decisions, edges)
@@ -186,8 +181,8 @@ async def test_remove_source_dry_run_returns_plan_with_cascaded_decision_ids() -
 
 
 async def test_remove_source_dry_run_idempotent_on_missing_span() -> None:
-    from handlers.remove_source import handle_remove_source
     from contracts import RemoveSourcePlan
+    from handlers.remove_source import handle_remove_source
 
     client = _FakeClient({}, {}, [])  # empty store
     ctx = _FakeCtx(_FakeLedger(client))
@@ -201,8 +196,8 @@ async def test_remove_source_dry_run_idempotent_on_missing_span() -> None:
 
 
 async def test_remove_source_confirm_true_hard_deletes_span_and_soft_deletes_decisions() -> None:
-    from handlers.remove_source import handle_remove_source
     from contracts import RemoveSourceResponse
+    from handlers.remove_source import handle_remove_source
 
     span_id, span_row, decisions, edges = _seed_fixture()
     client = _FakeClient({span_id: span_row}, decisions, edges)
@@ -279,17 +274,15 @@ async def test_remove_source_dry_run_emits_no_event() -> None:
     client = _FakeClient({span_id: span_row}, decisions, edges)
     ctx = _FakeCtx(_FakeLedger(client, writer=writer))
 
-    await handle_remove_source(
-        ctx, span_id=span_id, signer="x@y", reason="check", confirm=False
-    )
+    await handle_remove_source(ctx, span_id=span_id, signer="x@y", reason="check", confirm=False)
     assert writer.events == []
 
 
 async def test_remove_source_confirm_idempotent_on_missing_span() -> None:
     """confirm=True on a non-existent span returns structured response, not
     an exception. Pins idempotency Discipline #1."""
-    from handlers.remove_source import handle_remove_source
     from contracts import RemoveSourceResponse
+    from handlers.remove_source import handle_remove_source
 
     writer = _FakeWriter()
     client = _FakeClient({}, {}, [])

--- a/tests/test_remove_source.py
+++ b/tests/test_remove_source.py
@@ -1,0 +1,365 @@
+"""Phase C of #278 Phase 2 — bicameral.remove_source handler tests.
+
+Pins:
+  1. Reason is required.
+  2. confirm=False is a pure dry-run — returns the plan, no mutation.
+  3. confirm=True performs the cascade: per-decision signoff UPDATE +
+     hard-delete of yields edges + hard-delete of the input_span row.
+  4. The single source_removed.completed event payload carries the FULL
+     pre-deletion span content (recoverability anchor).
+  5. Idempotent on missing span (no exception; structured response).
+  6. Cascaded decisions carry removed_by_source back-pointer to the span_id.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+pytestmark = pytest.mark.asyncio
+
+
+# Minimal fakes mirroring the test_remove_decision pattern. The fakes record
+# every SQL query the handler issues so tests can assert on the
+# cascade-mutation shape without spinning up a real SurrealDB.
+
+
+class _FakeClient:
+    def __init__(
+        self,
+        spans: dict[str, dict] | None = None,
+        decisions: dict[str, dict] | None = None,
+        edges: list[tuple[str, str]] | None = None,
+    ) -> None:
+        self._spans = spans or {}
+        self._decisions = decisions or {}
+        self._edges = list(edges or [])  # (span_id, decision_id) yields edges
+        self.queries: list[tuple[str, dict | None]] = []
+
+    async def query(self, sql: str, params: dict | None = None):
+        self.queries.append((sql, params))
+        sql_l = sql.lower()
+
+        # input_span_exists / get_input_span_row / decision_exists
+        if "select id from input_span:" in sql_l and "limit 1" in sql_l:
+            sid = sql.split("FROM ", 1)[1].split(" ", 1)[0]
+            return [{"id": sid}] if sid in self._spans else []
+        if sql_l.startswith("select text, source_ref, source_type") and "from input_span:" in sql_l:
+            sid = sql.split("FROM ", 1)[1].split(" ", 1)[0]
+            row = self._spans.get(sid)
+            return [row] if row else []
+        if "select id from decision:" in sql_l and "limit 1" in sql_l:
+            did = sql.split("FROM ", 1)[1].split(" ", 1)[0]
+            return [{"id": did}] if did in self._decisions else []
+
+        # get_decisions_for_span
+        if "from decision" in sql_l and "<-yields<-input_span contains" in sql_l:
+            span_id = sql.split("CONTAINS ", 1)[1].strip()
+            matching = [d for (s, d) in self._edges if s == span_id]
+            return [{"decision_id": d} for d in matching]
+
+        # SELECT signoff FROM decision:...
+        if "select signoff from decision:" in sql_l:
+            did = sql.split("FROM ", 1)[1].split(" ", 1)[0]
+            return [{"signoff": self._decisions.get(did, {}).get("signoff")}]
+
+        # UPDATE decision:... SET signoff = $signoff
+        if "update decision:" in sql_l and "set signoff" in sql_l:
+            did = sql.split("UPDATE ", 1)[1].split(" SET")[0].strip()
+            row = self._decisions.setdefault(did, {})
+            row["signoff"] = params["signoff"]
+            return [row]
+
+        # DELETE yields WHERE in = <span_id>
+        if sql_l.startswith("delete yields where in"):
+            span_id = sql.rsplit("=", 1)[1].strip()
+            self._edges = [(s, d) for (s, d) in self._edges if s != span_id]
+            return []
+
+        # DELETE input_span:... — hard delete the span row
+        if sql_l.startswith("delete input_span:"):
+            sid = sql.split("DELETE ", 1)[1].strip()
+            self._spans.pop(sid, None)
+            return []
+
+        return []
+
+
+class _FakeLedger:
+    def __init__(self, client, writer=None) -> None:
+        self._inner = self
+        self._client = client
+        if writer is not None:
+            self._writer = writer
+
+    async def connect(self) -> None:
+        return None
+
+
+class _FakeWriter:
+    def __init__(self) -> None:
+        self.events: list[tuple[str, dict]] = []
+
+    def write(self, event_type: str, payload: dict):
+        self.events.append((event_type, payload))
+
+
+class _FakeCtx:
+    def __init__(self, ledger, session_id="sess-1", sha="deadbeef") -> None:
+        self.ledger = ledger
+        self.session_id = session_id
+        self.authoritative_sha = sha
+
+
+@pytest.fixture(autouse=True)
+def _stub_project_queries(monkeypatch):
+    """Stub the status-projection helpers so tests don't need the full
+    schema. These are exercised by other tests (project_decision_status
+    is well-covered elsewhere)."""
+    async def _project(client, did):
+        return "ungrounded"
+
+    async def _update(client, did, status):
+        return None
+
+    monkeypatch.setattr(
+        "handlers.remove_source.project_decision_status", _project
+    )
+    monkeypatch.setattr(
+        "handlers.remove_source.update_decision_status", _update
+    )
+
+
+def _seed_fixture():
+    """One span with 3 decisions linked via yields."""
+    span_id = "input_span:span001"
+    span_row = {
+        "text": "verbatim transcript excerpt",
+        "source_ref": "meeting-001",
+        "source_type": "transcript",
+        "meeting_date": "2026-05-14",
+        "speakers": ["Jin"],
+        "created_at": "2026-05-14T00:00:00+00:00",
+    }
+    decisions = {
+        "decision:d1": {"signoff": {"state": "ratified", "signer": "old"}},
+        "decision:d2": {"signoff": {"state": "proposed"}},
+        "decision:d3": {"signoff": None},  # never signed off
+    }
+    edges = [(span_id, did) for did in decisions]
+    return span_id, span_row, decisions, edges
+
+
+async def test_remove_source_rejects_empty_reason() -> None:
+    from handlers.remove_source import handle_remove_source
+
+    span_id, span_row, decisions, edges = _seed_fixture()
+    client = _FakeClient({span_id: span_row}, decisions, edges)
+    ctx = _FakeCtx(_FakeLedger(client))
+
+    with pytest.raises(ValueError, match="non-empty 'reason'"):
+        await handle_remove_source(
+            ctx, span_id=span_id, signer="x@y", reason="", confirm=True
+        )
+
+
+async def test_remove_source_dry_run_returns_plan_with_cascaded_decision_ids() -> None:
+    from handlers.remove_source import handle_remove_source
+    from contracts import RemoveSourcePlan
+
+    span_id, span_row, decisions, edges = _seed_fixture()
+    client = _FakeClient({span_id: span_row}, decisions, edges)
+    ctx = _FakeCtx(_FakeLedger(client))
+
+    plan = await handle_remove_source(
+        ctx, span_id=span_id, signer="x@y", reason="bad ingest", confirm=False
+    )
+
+    assert isinstance(plan, RemoveSourcePlan)
+    assert plan.span_id == span_id
+    assert plan.span_existed is True
+    assert plan.input_span_content["text"] == "verbatim transcript excerpt"
+    assert plan.input_span_content["source_ref"] == "meeting-001"
+    assert set(plan.decision_ids) == {"decision:d1", "decision:d2", "decision:d3"}
+    # CRITICAL: dry-run must not mutate
+    assert span_id in client._spans
+    assert decisions["decision:d1"]["signoff"]["state"] == "ratified"
+
+
+async def test_remove_source_dry_run_idempotent_on_missing_span() -> None:
+    from handlers.remove_source import handle_remove_source
+    from contracts import RemoveSourcePlan
+
+    client = _FakeClient({}, {}, [])  # empty store
+    ctx = _FakeCtx(_FakeLedger(client))
+
+    plan = await handle_remove_source(
+        ctx, span_id="input_span:missing", signer="x@y", reason="ghost", confirm=False
+    )
+    assert isinstance(plan, RemoveSourcePlan)
+    assert plan.span_existed is False
+    assert plan.decision_ids == []
+
+
+async def test_remove_source_confirm_true_hard_deletes_span_and_soft_deletes_decisions() -> None:
+    from handlers.remove_source import handle_remove_source
+    from contracts import RemoveSourceResponse
+
+    span_id, span_row, decisions, edges = _seed_fixture()
+    client = _FakeClient({span_id: span_row}, decisions, edges)
+    ctx = _FakeCtx(_FakeLedger(client))
+
+    resp = await handle_remove_source(
+        ctx,
+        span_id=span_id,
+        signer="kim@x",
+        reason="duplicate transcript",
+        confirm=True,
+    )
+
+    assert isinstance(resp, RemoveSourceResponse)
+    assert resp.span_existed is True
+    assert set(resp.cascaded_decision_ids) == {"decision:d1", "decision:d2", "decision:d3"}
+    # input_span row is hard-deleted
+    assert span_id not in client._spans
+    # yields edges from this span are gone
+    assert not any(s == span_id for (s, _d) in client._edges)
+    # Every cascaded decision has signoff.state="removed" + back-pointer
+    for did in ("decision:d1", "decision:d2", "decision:d3"):
+        signoff = client._decisions[did]["signoff"]
+        assert signoff["state"] == "removed"
+        assert signoff["removed_by_source"] == span_id
+        assert signoff["reason"] == "duplicate transcript"
+        assert signoff["signer"] == "kim@x"
+        assert signoff["removed_at"]
+    # previous_state recorded for forensic review
+    assert client._decisions["decision:d1"]["signoff"]["previous_state"] == "ratified"
+    assert client._decisions["decision:d2"]["signoff"]["previous_state"] == "proposed"
+    assert client._decisions["decision:d3"]["signoff"]["previous_state"] is None
+
+
+async def test_remove_source_confirm_emits_single_event_with_full_span_content() -> None:
+    """Discipline #3: the source_removed.completed event payload carries the
+    FULL pre-deletion span content so the action is recoverable from the
+    event log."""
+    from handlers.remove_source import handle_remove_source
+
+    span_id, span_row, decisions, edges = _seed_fixture()
+    writer = _FakeWriter()
+    client = _FakeClient({span_id: span_row}, decisions, edges)
+    ctx = _FakeCtx(_FakeLedger(client, writer=writer))
+
+    resp = await handle_remove_source(
+        ctx, span_id=span_id, signer="kim@x", reason="bad", confirm=True
+    )
+
+    assert resp.event_logged is True
+    assert len(writer.events) == 1  # single event for the entire cascade
+    event_type, payload = writer.events[0]
+    assert event_type == "source_removed.completed"
+    assert payload["span_id"] == span_id
+    # Full pre-deletion span content is in the payload
+    assert payload["input_span_content"]["text"] == "verbatim transcript excerpt"
+    assert payload["input_span_content"]["source_ref"] == "meeting-001"
+    assert payload["input_span_content"]["source_type"] == "transcript"
+    assert set(payload["cascaded_decision_ids"]) == {
+        "decision:d1",
+        "decision:d2",
+        "decision:d3",
+    }
+    assert payload["signer"] == "kim@x"
+    assert payload["reason"] == "bad"
+    assert payload["removed_at"]
+
+
+async def test_remove_source_dry_run_emits_no_event() -> None:
+    from handlers.remove_source import handle_remove_source
+
+    span_id, span_row, decisions, edges = _seed_fixture()
+    writer = _FakeWriter()
+    client = _FakeClient({span_id: span_row}, decisions, edges)
+    ctx = _FakeCtx(_FakeLedger(client, writer=writer))
+
+    await handle_remove_source(
+        ctx, span_id=span_id, signer="x@y", reason="check", confirm=False
+    )
+    assert writer.events == []
+
+
+async def test_remove_source_confirm_idempotent_on_missing_span() -> None:
+    """confirm=True on a non-existent span returns structured response, not
+    an exception. Pins idempotency Discipline #1."""
+    from handlers.remove_source import handle_remove_source
+    from contracts import RemoveSourceResponse
+
+    writer = _FakeWriter()
+    client = _FakeClient({}, {}, [])
+    ctx = _FakeCtx(_FakeLedger(client, writer=writer))
+
+    resp = await handle_remove_source(
+        ctx,
+        span_id="input_span:missing",
+        signer="x@y",
+        reason="ghost cleanup",
+        confirm=True,
+    )
+
+    assert isinstance(resp, RemoveSourceResponse)
+    assert resp.span_existed is False
+    assert resp.cascaded_decision_ids == []
+    assert resp.event_logged is False
+    # No event emitted on the no-op path even though writer was attached
+    assert writer.events == []
+
+
+async def test_remove_source_skips_already_removed_decisions_in_cascade() -> None:
+    """If a decision was previously soft-deleted (e.g., by an earlier
+    remove_decision call), the cascade includes it in the returned list but
+    does not re-UPDATE the row. Pins per-decision idempotency inside the
+    cascade helper."""
+    from handlers.remove_source import handle_remove_source
+
+    span_id = "input_span:span001"
+    span_row = {
+        "text": "t",
+        "source_ref": "r",
+        "source_type": "manual",
+        "meeting_date": "",
+        "speakers": [],
+        "created_at": "",
+    }
+    pre_existing_removed = {
+        "state": "removed",
+        "signer": "earlier@x",
+        "reason": "earlier removal",
+        "previous_state": "ratified",
+    }
+    decisions = {
+        "decision:d1": {"signoff": pre_existing_removed},
+        "decision:d2": {"signoff": {"state": "proposed"}},
+    }
+    edges = [(span_id, "decision:d1"), (span_id, "decision:d2")]
+    client = _FakeClient({span_id: span_row}, decisions, edges)
+    ctx = _FakeCtx(_FakeLedger(client))
+
+    resp = await handle_remove_source(
+        ctx, span_id=span_id, signer="kim@x", reason="cascade", confirm=True
+    )
+
+    assert set(resp.cascaded_decision_ids) == {"decision:d1", "decision:d2"}
+    # d1's signoff was NOT overwritten — it kept its earlier removal record
+    assert client._decisions["decision:d1"]["signoff"] == pre_existing_removed
+    # d2 was newly removed
+    assert client._decisions["decision:d2"]["signoff"]["state"] == "removed"
+    assert client._decisions["decision:d2"]["signoff"]["reason"] == "cascade"
+
+
+async def test_get_decisions_for_span_returns_yield_traversal_ids() -> None:
+    """Unit test for the new ledger.queries helper. Independent of handler."""
+    from ledger.queries import get_decisions_for_span
+
+    span_id = "input_span:span001"
+    edges = [(span_id, "decision:a"), (span_id, "decision:b"), ("input_span:other", "decision:c")]
+    client = _FakeClient({}, {}, edges)
+    result = await get_decisions_for_span(client, span_id)
+    assert set(result) == {"decision:a", "decision:b"}
+    assert "decision:c" not in result


### PR DESCRIPTION
## Summary

Closes Phase 2 of #278. Stacks on #313.

Adds two MCP tools and matching dashboard surfaces to close the v0 Productization §4 gap between accepting a wrong decision in the ledger forever and running \`bicameral.reset\` (full wipe).

### Tools

- **bicameral.remove_decision** — soft-delete via \`signoff.state="removed"\` + reason. Idempotent; reason required; emits \`decision_removed.completed\` when team mode is active. No unremove — write a superseding decision to reverse.
- **bicameral.remove_source** — cascading hard-delete of an input_span + soft-delete of every decision derived from it. Confirm-first (\`confirm=False\` returns a dry-run plan listing the full cascade); reason required; emits one \`source_removed.completed\` event carrying the full pre-deletion span content as the recoverability anchor.

### HistorySource.input_span_id (closes Phase 1 Open Question)

Adds an optional \`input_span_id\` field surfaced via a new \`id\` field in the graph-traversal SELECT projection inside \`_fetch_all_decisions_enriched\`. Legacy ingest rows without the id are tolerated (back-compat).

### Dashboard

- "Remove decision" button in each decision body, gated disabled when \`signoff.state === "removed"\`.
- "Remove source" button in the Phase 1 source-view panel header.
- Two confirmation modals with reason textarea, signer input, MCP tool-call payload built via \`JSON.stringify\` and copied via \`navigator.clipboard.writeText\`.
- **Dashboard does NOT invoke writes itself** — the dashboard HTTP server remains read-only. Operators run the surfaced tool-call payload via their MCP-connected agent, preserving the existing trust boundary.

## Test plan

- [x] \`python -m pytest tests/test_remove_decision.py -v\` — 8 tests
- [x] \`python -m pytest tests/test_remove_source.py -v\` — 9 tests
- [x] \`python -m pytest tests/test_history_input_span_id.py -v\` — 5 tests
- [x] \`python -m pytest tests/test_dashboard_remove_flows.py -v\` — 10 tests
- [x] Phase 1 regression — 18/18 pass

## Discipline carries from Phase 1

XSS rules carry verbatim: all user-facing modal fields written via \`.textContent\` (never \`.innerHTML\`); cascade list built via DOM appendChild with per-li \`.textContent\`; mcp-call block populated via \`.textContent\` on the \`JSON.stringify\` result.

## Open question

Cascade semantics are unconditional: \`remove_source\` soft-deletes every derived decision even if it has other sources. Literal reading of #278 spec. If product wants "only soft-delete on last-source-removed", that's a future refinement.

🤖 Generated with [Claude Code](https://claude.com/claude-code)