### PR TITLE
[#278 Phase 3] Raw SurrealQL admin panel

### DIFF
--- a/assets/dashboard.html
+++ b/assets/dashboard.html
@@ -482,6 +482,90 @@ body {
 .rm-modal-actions button.rm-copy { color: var(--accent); border-color: var(--accent); }
 .rm-modal-actions button.rm-cancel:hover { color: var(--text-dim); }
 
+/* ── ADMIN SURREALQL PANEL (#278 Phase 3) ──────────────────── */
+/* Off by default at server level (env flag); UI panel additionally
+   hidden via data-state="closed". Two-step toggle: Advanced opens
+   the panel; a separate Enable-writes flow requires typing the
+   exact phrase before mutations are allowed. */
+.adm-toggle {
+  display: flex; align-items: center; gap: 8px;
+  margin-top: 16px; font-size: 11px;
+  color: var(--text-dim); cursor: pointer; user-select: none;
+}
+#adm-panel {
+  display: none;
+  margin-top: 12px;
+  border: 1px solid var(--border-dark);
+  background: var(--paper);
+  padding: 14px 18px;
+}
+#adm-panel[data-state="open"] { display: block; }
+#adm-panel h3 {
+  font-family: var(--serif); font-size: 13px; font-weight: 700; color: var(--accent);
+  margin-bottom: 4px;
+}
+#adm-panel .adm-warn-banner {
+  font-size: 11px; color: rgb(220, 38, 38);
+  margin: 6px 0 10px;
+}
+#adm-panel label {
+  font-size: 11px; color: var(--text-dim);
+  letter-spacing: 0.04em; text-transform: uppercase;
+  display: block; margin-top: 8px;
+}
+#adm-quickref, #adm-sql {
+  width: 100%; font-family: var(--mono); font-size: 12px;
+  border: 1px solid var(--border); padding: 6px 8px; background: var(--canvas);
+  color: var(--text); margin-top: 4px;
+}
+#adm-sql { min-height: 80px; resize: vertical; }
+.adm-controls {
+  display: flex; gap: 8px; align-items: center; margin-top: 10px;
+}
+.adm-controls button {
+  font-family: var(--mono); font-size: 11px;
+  padding: 5px 12px; border: 1px solid var(--accent); background: var(--paper);
+  color: var(--accent); cursor: pointer; border-radius: 2px;
+}
+.adm-write-warn {
+  display: none;
+  font-size: 11px; color: rgb(220, 38, 38);
+  padding: 4px 8px; border: 1px dashed rgb(220, 38, 38);
+}
+#adm-panel[data-write="enabled"] .adm-write-warn { display: inline-block; }
+.adm-result {
+  margin-top: 14px;
+  background: var(--canvas); border: 1px solid var(--border);
+  padding: 8px 12px; font-family: var(--mono); font-size: 11px;
+}
+.adm-result-hdr {
+  display: flex; gap: 16px; font-size: 11px; color: var(--text-dim);
+  margin-bottom: 6px;
+}
+#adm-result-rows {
+  max-height: 300px; overflow: auto; white-space: pre-wrap; word-break: break-word;
+}
+.adm-risk-modal {
+  display: none;
+  position: fixed; inset: 0; z-index: 110;
+  background: rgba(0, 0, 0, 0.5);
+  align-items: center; justify-content: center;
+}
+.adm-risk-modal[data-state="open"] { display: flex; }
+.adm-risk-modal-content {
+  background: var(--paper); border: 2px solid rgb(220, 38, 38);
+  width: min(480px, 90vw); padding: 22px 26px;
+  display: flex; flex-direction: column; gap: 12px;
+}
+.adm-risk-modal-content h2 {
+  font-family: var(--serif); font-size: 14px; color: rgb(220, 38, 38);
+}
+.adm-risk-modal-content input {
+  font-family: var(--mono); font-size: 12px;
+  padding: 6px 10px; border: 1px solid var(--border);
+  background: var(--canvas); color: var(--text);
+}
+
 
 </style>
 </head>
@@ -518,6 +602,70 @@ body {
 <main class="main" id="root">
   <div class="empty">Loading decision ledger…</div>
 </main>
+
+<!-- ── ADMIN SURREALQL PANEL (#278 Phase 3) ──────────────────── -->
+<!-- Off by default at the server level (requires BICAMERAL_ENABLE_ADMIN_PANEL=1).
+     The UI additionally hides the panel via data-state="closed" until the
+     operator toggles Advanced mode. Write capability requires a SECOND env
+     flag (BICAMERAL_ENABLE_ADMIN_PANEL_WRITES=1) AND typing the literal
+     phrase "I accept the risk" in the risk-confirmation modal. -->
+<div class="main">
+  <label class="adm-toggle">
+    <input type="checkbox" id="adv-toggle" onchange="toggleAdvancedPanel()">
+    Advanced (raw SurrealQL panel)
+  </label>
+  <div id="adm-panel" data-state="closed" data-write="disabled">
+    <h3>Raw SurrealQL admin panel</h3>
+    <div class="adm-warn-banner">
+      ⚠ Direct DB access. Read-only by default. Every query is audit-logged.
+      Mutations require <code>BICAMERAL_ENABLE_ADMIN_PANEL_WRITES=1</code> at server start.
+    </div>
+    <label for="adm-quickref">Quickref</label>
+    <select id="adm-quickref" onchange="loadQuickref(this.value)">
+      <option value="">-- pick a starter query --</option>
+      <option value="SELECT * FROM decision LIMIT 50">SELECT * FROM decision LIMIT 50</option>
+      <option value="SELECT count() FROM decision GROUP ALL">SELECT count() FROM decision GROUP ALL</option>
+      <option value="INFO FOR DB">INFO FOR DB</option>
+      <option value="SELECT * FROM input_span LIMIT 50">SELECT * FROM input_span LIMIT 50</option>
+      <option value="SELECT id, signoff FROM decision WHERE signoff.state = 'removed'">SELECT id, signoff FROM decision WHERE signoff.state = 'removed'</option>
+    </select>
+    <label for="adm-sql">SurrealQL</label>
+    <textarea id="adm-sql" placeholder="SELECT * FROM decision LIMIT 10"></textarea>
+    <label for="adm-signer">Signer (required for write mode)</label>
+    <input id="adm-signer" type="text" placeholder="email@example.com" style="width:100%;font-family:var(--mono);font-size:12px;border:1px solid var(--border);padding:6px 8px;background:var(--canvas);margin-top:4px">
+    <div class="adm-controls">
+      <button onclick="runAdminQuery()">execute</button>
+      <button onclick="openWriteRiskModal()">enable writes…</button>
+      <span class="adm-write-warn">⚠ WRITES ENABLED — queries will mutate the ledger</span>
+    </div>
+    <div class="adm-result">
+      <div class="adm-result-hdr">
+        <span id="adm-result-mode"></span>
+        <span id="adm-result-elapsed"></span>
+        <span id="adm-result-error" style="color:rgb(220,38,38)"></span>
+      </div>
+      <div id="adm-result-rows"></div>
+    </div>
+  </div>
+</div>
+
+<!-- ── ADMIN WRITE-MODE RISK CONFIRMATION MODAL ──────────────── -->
+<div id="adm-risk-modal" class="adm-risk-modal" data-state="closed" aria-hidden="true">
+  <div class="adm-risk-modal-content">
+    <h2>Enable write mode</h2>
+    <p style="font-size:12px;color:var(--text)">
+      Write mode will let this panel mutate the ledger directly.
+      Mutations bypass the normal decision/source remove flows but are still
+      audit-logged. To proceed, type the literal phrase below.
+    </p>
+    <label for="adm-risk-input" style="font-size:11px;color:var(--text-dim)">Type: <code>I accept the risk</code></label>
+    <input id="adm-risk-input" type="text" placeholder="">
+    <div style="display:flex;gap:8px;justify-content:flex-end">
+      <button onclick="closeWriteRiskModal()" style="font-family:var(--mono);font-size:11px;padding:5px 12px;border:1px solid var(--border);background:var(--paper);cursor:pointer">cancel</button>
+      <button onclick="confirmWriteRisk()" style="font-family:var(--mono);font-size:11px;padding:5px 12px;border:1px solid rgb(220,38,38);background:var(--paper);color:rgb(220,38,38);cursor:pointer">confirm</button>
+    </div>
+  </div>
+</div>
 
 <!-- ── SOURCE VIEW PANEL (#278 Phase 1) ───────────────────────── -->
 <!-- Hidden by default via .src-panel CSS; opens when data-src-panel="open".
@@ -1152,6 +1300,90 @@ function closeRemoveModal(modalId) {
   modal.setAttribute('data-modal', 'closed');
   modal.setAttribute('aria-hidden', 'true');
 }
+
+// ── admin SurrealQL panel (#278 Phase 3) ──────────────────────
+// The server-side route at /admin/query is off by default; this UI is also
+// hidden via data-state="closed" until the operator opens the Advanced
+// toggle. Write capability requires a SECOND env flag at the server AND
+// typing the literal "I accept the risk" phrase below.
+let _writeModeEnabled = false;
+
+function toggleAdvancedPanel() {
+  const panel = document.getElementById('adm-panel');
+  const toggle = document.getElementById('adv-toggle');
+  panel.setAttribute('data-state', toggle.checked ? 'open' : 'closed');
+}
+
+function loadQuickref(value) {
+  if (!value) return;
+  document.getElementById('adm-sql').value = value;
+}
+
+function openWriteRiskModal() {
+  const modal = document.getElementById('adm-risk-modal');
+  document.getElementById('adm-risk-input').value = '';
+  modal.setAttribute('data-state', 'open');
+}
+
+function closeWriteRiskModal() {
+  document.getElementById('adm-risk-modal').setAttribute('data-state', 'closed');
+}
+
+function confirmWriteRisk() {
+  // The literal phrase below is the operator's typed confirmation. It is
+  // pinned by tests/test_dashboard_admin_panel.py::test_admin_panel_write_mode_requires_typed_confirmation —
+  // do not change the wording without updating that test.
+  const typed = (document.getElementById('adm-risk-input').value || '').trim();
+  if (typed === 'I accept the risk') {
+    _writeModeEnabled = true;
+    document.getElementById('adm-panel').setAttribute('data-write', 'enabled');
+    closeWriteRiskModal();
+  } else {
+    document.getElementById('adm-risk-input').placeholder =
+      "Phrase didn't match — try again or cancel";
+  }
+}
+
+async function runAdminQuery() {
+  const sql = document.getElementById('adm-sql').value.trim();
+  const signer = document.getElementById('adm-signer').value.trim();
+  const mode = _writeModeEnabled ? 'write' : 'read';
+  if (!sql) {
+    renderAdminResult({ mode: 'read-only', rows: [], elapsed_ms: 0, error: 'SQL is empty' });
+    return;
+  }
+  let response;
+  try {
+    const res = await fetch('/admin/query', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ sql: sql, mode: mode, signer: signer }),
+    });
+    response = await res.json();
+  } catch (e) {
+    response = { mode: 'read-only', rows: [], elapsed_ms: 0, error: String(e) };
+  }
+  renderAdminResult(response);
+}
+
+function renderAdminResult(response) {
+  // XSS discipline: all user-controlled values (rows from the DB, error
+  // messages from the server) written via .textContent. The rows are
+  // JSON.stringify'd and rendered as text in a single <pre>-like block.
+  document.getElementById('adm-result-mode').textContent =
+    'mode: ' + (response.mode || '');
+  document.getElementById('adm-result-elapsed').textContent =
+    'elapsed: ' + (response.elapsed_ms != null ? response.elapsed_ms.toFixed(2) + ' ms' : '');
+  document.getElementById('adm-result-error').textContent =
+    response.error ? ('error: ' + response.error) : '';
+  const rowsEl = document.getElementById('adm-result-rows');
+  if (!response.rows || response.rows.length === 0) {
+    rowsEl.textContent = '(no rows)';
+  } else {
+    rowsEl.textContent = JSON.stringify(response.rows, null, 2);
+  }
+}
+
 
 // Discipline #3: jump-to-decision uses document.getElementById (DOM API, no
 // HTML concatenation). The id namespace is generated by renderDec / orphan

--- a/contracts.py
+++ b/contracts.py
@@ -832,6 +832,29 @@ class RemoveSourceResponse(BaseModel):
     span_existed: bool  # False if span was already gone (idempotent confirm)
     cascaded_decision_ids: list[str]
     event_logged: bool
+
+
+# #278 Phase 3 — raw SurrealQL admin panel
+class AdminQueryRequest(BaseModel):
+    """Request envelope for the dashboard /admin/query endpoint.
+
+    The admin panel is off-by-default; reachability requires
+    BICAMERAL_ENABLE_ADMIN_PANEL=1 at MCP server start. Write mode requires
+    BICAMERAL_ENABLE_ADMIN_PANEL_WRITES=1 AND an in-UI typed confirmation.
+    """
+
+    sql: str
+    mode: Literal["read", "write"] = "read"
+    signer: str = ""  # Required for write mode (handler rejects empty)
+
+
+class AdminQueryResponse(BaseModel):
+    """Response envelope for the /admin/query endpoint."""
+
+    mode: Literal["read-only", "write"]
+    rows: list[dict]
+    elapsed_ms: float
+    error: str | None = None
     # #65 — preflight telemetry plumb-through.
     preflight_id: str | None = None
 

--- a/dashboard/admin.py
+++ b/dashboard/admin.py
@@ -1,0 +1,231 @@
+"""Admin SurrealQL panel — server-side logic (#278 Phase 3).
+
+The dashboard HTTP sidecar exposes a single read/write surface to the
+operator at `/admin/query` when explicitly enabled via env flags. The bulk
+of the safety logic lives here so it can be unit-tested without spinning
+up the asyncio TCP server.
+
+Safety model (defense in depth):
+  1. `admin_route_enabled()` reads BICAMERAL_ENABLE_ADMIN_PANEL — false
+     disables the route entirely (server returns 404).
+  2. `admin_writes_enabled()` reads BICAMERAL_ENABLE_ADMIN_PANEL_WRITES —
+     false forces every query into read-only mode.
+  3. `check_admin_origin()` enforces same-origin: requests with missing
+     or mismatched Origin header are rejected before any DB work.
+  4. Write mode requires a non-empty `signer` (handler rejects empty).
+  5. Read mode wraps the SQL in a transaction that rolls back, so even
+     `DELETE` queries leave the DB unchanged.
+  6. Every executed query (success or failure) is audit-logged:
+     - team mode → goes through the ledger adapter's attached `_writer`
+     - local mode → falls back to `<repo>/.bicameral/events/_admin.jsonl`
+
+Per #278 Phase 3 audit Pass 1 (resolved Pass 2): there is NO unaudited
+admin-query code path.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+import time
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Any
+
+from events.writer import EventEnvelope, _lock_exclusive, _unlock
+
+logger = logging.getLogger(__name__)
+
+
+# ── env-flag gates ────────────────────────────────────────────────────────
+
+
+def admin_route_enabled() -> bool:
+    """True iff BICAMERAL_ENABLE_ADMIN_PANEL is set to a truthy value."""
+    return _truthy_env("BICAMERAL_ENABLE_ADMIN_PANEL")
+
+
+def admin_writes_enabled() -> bool:
+    """True iff BICAMERAL_ENABLE_ADMIN_PANEL_WRITES is set to a truthy value."""
+    return _truthy_env("BICAMERAL_ENABLE_ADMIN_PANEL_WRITES")
+
+
+def _truthy_env(name: str) -> bool:
+    raw = (os.environ.get(name) or "").strip().lower()
+    return raw in ("1", "true", "yes", "on")
+
+
+# ── origin lock ───────────────────────────────────────────────────────────
+
+
+def check_admin_origin(origin: str | None, dashboard_port: int) -> bool:
+    """Strict same-origin check for the admin route.
+
+    Returns True iff `origin` equals `http://localhost:<dashboard_port>`.
+    Missing/empty origin returns False. The dashboard's own JS supplies
+    Origin automatically on same-origin fetch.
+    """
+    if not origin:
+        return False
+    expected = f"http://localhost:{dashboard_port}"
+    return origin == expected
+
+
+# ── read-only transaction wrap ────────────────────────────────────────────
+
+
+def wrap_read_only(sql: str) -> str:
+    """Wrap the user's SQL in BEGIN/CANCEL TRANSACTION so any mutations
+    roll back. The result rows are still returned from inside the
+    transaction body before CANCEL fires.
+
+    Caveat (plan Open Question #1): a `DELETE` inside this wrap returns
+    the "deleted" rows in the result set even though CANCEL rolls back
+    the actual delete. The response payload's `mode: "read-only"` field
+    is the operator-facing label that prevents misinterpretation.
+    """
+    return f"BEGIN TRANSACTION; {sql}; CANCEL TRANSACTION;"
+
+
+# ── audit-log emission ────────────────────────────────────────────────────
+
+
+def emit_admin_event_local(payload: dict, repo_path: str | Path) -> Path:
+    """Local-mode audit fallback. Appends one JSONL line to
+    `<repo>/.bicameral/events/_admin.jsonl` using the same EventEnvelope
+    schema team mode uses. Creates the directory on first write.
+
+    Required by audit Pass 1 Finding 1: no admin query may execute without
+    leaving an audit trail.
+    """
+    repo = Path(repo_path)
+    events_dir = repo / ".bicameral" / "events"
+    events_dir.mkdir(parents=True, exist_ok=True)
+    path = events_dir / "_admin.jsonl"
+    envelope = EventEnvelope(
+        event_type="admin_query.executed",
+        author="local-admin",
+        payload=payload,
+    )
+    line = json.dumps(envelope.model_dump(), separators=(",", ":"), default=str) + "\n"
+    with open(path, "ab") as f:
+        _lock_exclusive(f)
+        try:
+            f.write(line.encode("utf-8"))
+        finally:
+            _unlock(f)
+    return path
+
+
+def _emit_admin_event(ledger: Any, payload: dict, repo_path: str | Path) -> str:
+    """Dispatch the audit event to team writer if attached, else local file.
+
+    Returns 'team' or 'local' to indicate which path was used (test surface).
+    """
+    writer = getattr(ledger, "_writer", None)
+    if writer is not None:
+        writer.write("admin_query.executed", payload)
+        return "team"
+    emit_admin_event_local(payload, repo_path)
+    return "local"
+
+
+# ── top-level orchestrator ────────────────────────────────────────────────
+
+
+async def process_admin_query(
+    *,
+    payload_in: dict,
+    origin: str | None,
+    dashboard_port: int,
+    ledger: Any,
+    repo_path: str | Path,
+) -> tuple[int, dict]:
+    """Process one admin query request.
+
+    Returns (http_status, response_body_dict). The HTTP wrapper in
+    dashboard/server.py converts these into wire bytes.
+    """
+    if not admin_route_enabled():
+        return 404, {"error": "Admin panel not enabled"}
+
+    if not check_admin_origin(origin, dashboard_port):
+        return 403, {"error": "Origin not permitted for /admin/query"}
+
+    sql = str(payload_in.get("sql") or "").strip()
+    mode = str(payload_in.get("mode") or "read").lower()
+    signer = str(payload_in.get("signer") or "")
+
+    if not sql:
+        return 400, {"error": "sql field is required"}
+
+    if mode not in ("read", "write"):
+        return 400, {"error": f"mode must be 'read' or 'write', got {mode!r}"}
+
+    if mode == "write" and not admin_writes_enabled():
+        return 403, {
+            "error": (
+                "Write mode requires BICAMERAL_ENABLE_ADMIN_PANEL_WRITES=1 at MCP server start."
+            )
+        }
+
+    if mode == "write" and not signer.strip():
+        return 400, {"error": "signer is required for write-mode queries (audit obligation)."}
+
+    # Resolve the inner SurrealDB client (mirror handlers/ratify.py:50-55).
+    inner = getattr(ledger, "_inner", ledger)
+    if hasattr(ledger, "connect"):
+        await ledger.connect()
+    client = inner._client
+
+    executed_sql = sql if mode == "write" else wrap_read_only(sql)
+    response_mode = "write" if mode == "write" else "read-only"
+
+    started = time.perf_counter()
+    rows: list[dict] = []
+    error: str | None = None
+    try:
+        result = await client.query(executed_sql)
+        rows = _normalize_rows(result)
+    except Exception as exc:
+        error = f"{type(exc).__name__}: {exc}"
+        logger.warning("[admin] query failed: %s", error)
+
+    elapsed_ms = (time.perf_counter() - started) * 1000.0
+
+    # Emit one audit event — success or failure, both modes.
+    audit_payload = {
+        "sql": sql,
+        "mode": response_mode,
+        "elapsed_ms": elapsed_ms,
+        "error": error,
+        "signer": signer,
+        "ts": datetime.now(UTC).isoformat(),
+    }
+    _emit_admin_event(ledger, audit_payload, repo_path)
+
+    body = {
+        "mode": response_mode,
+        "rows": rows,
+        "elapsed_ms": elapsed_ms,
+        "error": error,
+    }
+    return 200, body
+
+
+def _normalize_rows(result: Any) -> list[dict]:
+    """Coerce SurrealDB query results into a list[dict] suitable for JSON."""
+    if result is None:
+        return []
+    if isinstance(result, list):
+        out: list[dict] = []
+        for r in result:
+            if isinstance(r, dict):
+                out.append(r)
+            else:
+                out.append({"value": str(r)})
+        return out
+    if isinstance(result, dict):
+        return [result]
+    return [{"value": str(result)}]

--- a/dashboard/server.py
+++ b/dashboard/server.py
@@ -133,6 +133,9 @@ class DashboardServer:
                 await self._serve_history(writer)
             elif method == "GET" and path == "/events":
                 await self._serve_sse(writer)
+            elif method == "POST" and path == "/admin/query":
+                # #278 Phase 3 — off-by-default admin SurrealQL panel.
+                await self._serve_admin_query(writer, raw)
             else:
                 writer.write(_HTTP_404.encode())
                 await writer.drain()
@@ -169,6 +172,55 @@ class DashboardServer:
         except Exception as exc:
             body = json.dumps({"error": str(exc)}).encode()
         writer.write(_send_body(_HTTP_200_JSON, body))
+        await writer.drain()
+
+    async def _serve_admin_query(self, writer: asyncio.StreamWriter, raw: bytes) -> None:
+        """Dispatch a POST /admin/query request to the admin module.
+
+        Parses the Origin header + JSON body from the raw HTTP request,
+        delegates to ``dashboard.admin.process_admin_query``, and writes
+        the JSON response back. The admin module enforces the env-flag
+        gates, origin check, signer requirement, and audit-log emission.
+        """
+        from dashboard.admin import process_admin_query
+
+        # Parse headers to extract Origin
+        head, _, body = raw.partition(b"\r\n\r\n")
+        origin: str | None = None
+        for line in head.split(b"\r\n")[1:]:
+            if line.lower().startswith(b"origin:"):
+                origin = line.split(b":", 1)[1].decode(errors="replace").strip()
+                break
+
+        try:
+            payload_in = json.loads(body.decode("utf-8")) if body else {}
+        except Exception:
+            payload_in = {}
+
+        ctx = self._ctx_factory()
+        status, response_body = await process_admin_query(
+            payload_in=payload_in,
+            origin=origin,
+            dashboard_port=self._port,
+            ledger=ctx.ledger,
+            repo_path=getattr(ctx, "repo_path", "."),
+        )
+
+        body_bytes = json.dumps(response_body, default=str).encode()
+        # No CORS allow-origin on admin responses (Phase 3 Discipline #3).
+        status_line = {
+            200: "HTTP/1.1 200 OK",
+            400: "HTTP/1.1 400 Bad Request",
+            403: "HTTP/1.1 403 Forbidden",
+            404: "HTTP/1.1 404 Not Found",
+        }.get(status, "HTTP/1.1 500 Internal Server Error")
+        headers = (
+            f"{status_line}\r\n"
+            f"Content-Type: application/json; charset=utf-8\r\n"
+            f"Cache-Control: no-store\r\n"
+            f"Content-Length: {len(body_bytes)}\r\n\r\n"
+        )
+        writer.write(headers.encode() + body_bytes)
         await writer.drain()
 
     async def _serve_sse(self, writer: asyncio.StreamWriter) -> None:

--- a/skills/admin-surrealql/SKILL.md
+++ b/skills/admin-surrealql/SKILL.md
@@ -1,0 +1,95 @@
+---
+name: bicameral-admin-surrealql
+description: Raw SurrealQL execution surface in the dashboard for operator debugging and emergency-correction tasks. Off-by-default; requires BICAMERAL_ENABLE_ADMIN_PANEL=1 at MCP server start. Read-only by default; mutations require BICAMERAL_ENABLE_ADMIN_PANEL_WRITES=1 PLUS in-UI typed confirmation PLUS a non-empty signer. Every query is audit-logged.
+---
+
+# Bicameral Admin SurrealQL Panel
+
+Raw SurrealQL panel embedded in the dashboard for operator debugging without leaving the dashboard. This is the bottom-of-the-escape-hatch surface — the last resort when the structured tools (`bicameral.history`, `bicameral.remove_decision`, `bicameral.remove_source`, `bicameral.reset`) don't cover the situation.
+
+## When to use
+
+- Investigating a stale ledger entry that the dashboard renders incorrectly and you want to inspect the raw row before deciding how to act.
+- Verifying that an event log replay produced the expected DB state after a `bicameral.reset --replay-from-events`.
+- Spot-checking schema migrations during development.
+- Reading the `_admin.jsonl` audit log (or its team-mode counterpart) via a `SELECT … FROM …` against a derived table.
+
+## When NOT to use
+
+- For routine corrections that the structured tools handle. Removing a decision: use `bicameral.remove_decision`. Removing a source: use `bicameral.remove_source`. Wiping the ledger: use `bicameral.reset`. The structured tools enforce idempotency, attribution, and event emission with semantics that match the rest of the system.
+- For data exfiltration. Read mode is intentionally not authenticated beyond same-origin + env-flag — if the panel can run, anything on the same machine that knows the dashboard port can read all decisions. Treat it like a local debug pry-bar, not a production query surface.
+- For ad-hoc DELETE/UPDATE without a backup. Write mode mutations bypass the normal handler validation; if you wreck the schema, the only recovery is `bicameral.reset` or a manual restore.
+- In team mode without coordinating with co-authors. Writes from the admin panel emit `admin_query.executed` events into the shared event log, but a write that races with another author's `bicameral.ingest` can leave the local DBs out of sync until the next replay.
+
+## Mandatory verification
+
+1. **Verify both env flags before relying on write mode.** Reachability requires `BICAMERAL_ENABLE_ADMIN_PANEL=1` at MCP server start. Without it, the route returns 404. Mutations additionally require `BICAMERAL_ENABLE_ADMIN_PANEL_WRITES=1`. If the second flag is missing, the panel will reject `mode: "write"` requests with HTTP 403.
+
+2. **Always start in read mode.** Read mode wraps the SQL in `BEGIN TRANSACTION ... CANCEL TRANSACTION` so even `DELETE` queries leave the DB unchanged. Use read mode to PROVE the SQL does what you expect before flipping write mode.
+
+3. **Type the confirmation phrase verbatim.** Write mode in the dashboard requires typing the literal phrase `I accept the risk` into the confirmation modal. The modal pins this phrase against the JS check; misspellings won't toggle write mode.
+
+4. **Provide a non-empty signer for every write.** The handler rejects write-mode queries with empty/whitespace `signer` field with HTTP 400. Use your email or agent id — this string is permanent in the audit log.
+
+5. **Inspect the audit log after each write.** In team mode the events flow through `.bicameral/events/<author>.jsonl`. In local-only mode the panel writes to `.bicameral/events/_admin.jsonl`. The event carries `sql`, `mode`, `signer`, `elapsed_ms`, `error`, and `ts`. Confirm the entry you expect is there.
+
+## Format
+
+Direct HTTP (same-origin from the dashboard UI):
+
+```http
+POST /admin/query HTTP/1.1
+Host: localhost:<dashboard_port>
+Origin: http://localhost:<dashboard_port>
+Content-Type: application/json
+
+{"sql": "SELECT * FROM decision LIMIT 10", "mode": "read", "signer": ""}
+```
+
+Response:
+
+```json
+{
+  "mode": "read-only",
+  "rows": [...],
+  "elapsed_ms": 4.23,
+  "error": null
+}
+```
+
+## Handler-side enforcement
+
+- `BICAMERAL_ENABLE_ADMIN_PANEL` unset → 404 (the route is not even routable).
+- `Origin` header missing or not `http://localhost:<dashboard_port>` → 403.
+- `mode: "write"` without `BICAMERAL_ENABLE_ADMIN_PANEL_WRITES=1` → 403.
+- `mode: "write"` with empty/whitespace `signer` → 400.
+- Read mode wraps SQL in `BEGIN TRANSACTION; <sql>; CANCEL TRANSACTION;` (mutations roll back).
+- Every executed query, success or failure, emits one `admin_query.executed` event:
+  - Team mode: through the attached ledger writer (`<author>.jsonl`).
+  - Local-only mode: appended to `.bicameral/events/_admin.jsonl`.
+- The response payload's `mode` field is `"read-only"` or `"write"` and is the canonical operator-facing label (the SurrealDB result set may contain rows from a `DELETE` query even though the transaction rolled back; trust the `mode` field, not the row content).
+
+## Audit trail
+
+Every query writes one event:
+
+```jsonl
+{"schema_version":2,"event_type":"admin_query.executed","author":"<author>","timestamp":"...","payload":{"sql":"...","mode":"read-only"|"write","elapsed_ms":4.23,"error":null,"signer":"...","ts":"..."}}
+```
+
+In team mode the events replicate via the shared event-log backend (same path as `decision_ratified.completed`, `decision_removed.completed`, `source_removed.completed`).
+
+## After execution
+
+- Read mode: the operator sees the result rows in the dashboard, and the audit event records what was inspected. No DB state change.
+- Write mode: the DB row state reflects the query, the audit event captures the full SQL + signer, and any downstream `bicameral.preflight` / `bicameral.history` calls render the new state. Note that admin writes do NOT participate in the normal handler-level event types (e.g., a direct `UPDATE decision:abc SET signoff.state = 'ratified'` will not emit `decision_ratified.completed`); the `admin_query.executed` event is the only record.
+
+## Anti-patterns — REJECT these
+
+| Anti-pattern | Why it fails |
+|---|---|
+| Running write-mode queries without dry-running them in read mode first | Read mode is the safety net; skip it and you've signed up for the consequences. |
+| Using admin queries instead of `bicameral.remove_decision` / `bicameral.remove_source` | The structured tools emit canonical events (`decision_removed.completed`, `source_removed.completed`) that downstream agents key on. Admin writes only emit `admin_query.executed`, which is generic. |
+| Running write mode without `BICAMERAL_ENABLE_ADMIN_PANEL_WRITES=1` at the server | The handler rejects with 403; no work is done. This is the gate working as designed. |
+| Submitting an empty `signer` for a write | The handler rejects with 400 before any DB call. Provide your email or agent id. |
+| Exposing the dashboard port to other machines on the LAN | The dashboard binds to 127.0.0.1 by default but is otherwise un-authenticated; the admin panel inherits that posture. Treat it like a local-only debug surface. |

--- a/tests/test_admin_surrealql_route.py
+++ b/tests/test_admin_surrealql_route.py
@@ -1,0 +1,355 @@
+"""Phase 3 — admin SurrealQL route tests.
+
+Pins (Phase 3 Security Disciplines #1–#6 + audit Pass 2 amendments):
+  1. Route returns 404 when BICAMERAL_ENABLE_ADMIN_PANEL is unset.
+  2. Foreign-origin requests are rejected 403; missing origin → 403.
+  3. Read-only mode wraps SQL in BEGIN/CANCEL TRANSACTION.
+  4. Write mode rejected without BICAMERAL_ENABLE_ADMIN_PANEL_WRITES.
+  5. Write mode rejected with empty/whitespace signer (audit-trail obligation).
+  6. Every executed query emits audit event — team writer if attached,
+     otherwise local `<repo>/.bicameral/events/_admin.jsonl`.
+  7. Error path captures the exception in response.error AND the audit event.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+pytestmark = pytest.mark.asyncio
+
+
+# ── helpers ───────────────────────────────────────────────────────────────
+
+
+class _FakeClient:
+    """Records every query and returns canned rows."""
+
+    def __init__(self, response_rows=None, raise_on=None) -> None:
+        self._rows = response_rows if response_rows is not None else []
+        self._raise_on = raise_on  # substring; if present in SQL, raise
+        self.queries: list[str] = []
+
+    async def query(self, sql: str, params=None):
+        self.queries.append(sql)
+        if self._raise_on and self._raise_on in sql:
+            raise RuntimeError(f"simulated failure: {self._raise_on}")
+        return list(self._rows)
+
+
+class _FakeLedger:
+    def __init__(self, client, writer=None) -> None:
+        self._inner = self
+        self._client = client
+        if writer is not None:
+            self._writer = writer
+
+    async def connect(self) -> None:
+        return None
+
+
+class _FakeWriter:
+    def __init__(self) -> None:
+        self.events: list[tuple[str, dict]] = []
+
+    def write(self, event_type: str, payload: dict):
+        self.events.append((event_type, payload))
+
+
+# ── helper unit tests ─────────────────────────────────────────────────────
+
+
+def test_check_admin_origin_strict_match() -> None:
+    from dashboard.admin import check_admin_origin
+
+    assert check_admin_origin("http://localhost:12345", 12345) is True
+    assert check_admin_origin("http://localhost:12345", 9999) is False
+    assert check_admin_origin("http://evil.local", 12345) is False
+    assert check_admin_origin("", 12345) is False
+    assert check_admin_origin(None, 12345) is False
+
+
+def test_wrap_read_only_emits_begin_cancel() -> None:
+    from dashboard.admin import wrap_read_only
+
+    wrapped = wrap_read_only("SELECT * FROM decision")
+    assert wrapped.startswith("BEGIN TRANSACTION")
+    assert "CANCEL TRANSACTION" in wrapped
+    assert "SELECT * FROM decision" in wrapped
+
+
+def test_emit_admin_event_local_writes_jsonl(tmp_path: Path) -> None:
+    from dashboard.admin import emit_admin_event_local
+
+    payload = {"sql": "SELECT 1", "mode": "read-only", "signer": ""}
+    out = emit_admin_event_local(payload, tmp_path)
+    assert out.exists()
+    assert out.parent.name == "events"
+    assert out.parent.parent.name == ".bicameral"
+    assert out.name == "_admin.jsonl"
+    line = out.read_text(encoding="utf-8").strip()
+    decoded = json.loads(line)
+    assert decoded["event_type"] == "admin_query.executed"
+    assert decoded["payload"] == payload
+    # Second event appends without overwriting
+    emit_admin_event_local({"sql": "SELECT 2", "mode": "write", "signer": "x"}, tmp_path)
+    lines = out.read_text(encoding="utf-8").strip().split("\n")
+    assert len(lines) == 2
+
+
+# ── env-flag gating ──────────────────────────────────────────────────────
+
+
+async def test_admin_route_returns_404_without_env_flag(monkeypatch, tmp_path: Path) -> None:
+    from dashboard.admin import process_admin_query
+
+    monkeypatch.delenv("BICAMERAL_ENABLE_ADMIN_PANEL", raising=False)
+    client = _FakeClient()
+    ledger = _FakeLedger(client)
+    status, body = await process_admin_query(
+        payload_in={"sql": "SELECT 1", "mode": "read"},
+        origin="http://localhost:8080",
+        dashboard_port=8080,
+        ledger=ledger,
+        repo_path=tmp_path,
+    )
+    assert status == 404
+    assert "not enabled" in body["error"]
+    # No DB call when route is disabled
+    assert client.queries == []
+
+
+async def test_admin_route_rejects_foreign_origin(monkeypatch, tmp_path: Path) -> None:
+    from dashboard.admin import process_admin_query
+
+    monkeypatch.setenv("BICAMERAL_ENABLE_ADMIN_PANEL", "1")
+    client = _FakeClient()
+    ledger = _FakeLedger(client)
+    status, body = await process_admin_query(
+        payload_in={"sql": "SELECT 1", "mode": "read"},
+        origin="http://evil.local",
+        dashboard_port=8080,
+        ledger=ledger,
+        repo_path=tmp_path,
+    )
+    assert status == 403
+    assert "Origin not permitted" in body["error"]
+    assert client.queries == []
+
+
+async def test_admin_route_rejects_missing_origin(monkeypatch, tmp_path: Path) -> None:
+    from dashboard.admin import process_admin_query
+
+    monkeypatch.setenv("BICAMERAL_ENABLE_ADMIN_PANEL", "1")
+    client = _FakeClient()
+    ledger = _FakeLedger(client)
+    status, body = await process_admin_query(
+        payload_in={"sql": "SELECT 1", "mode": "read"},
+        origin=None,
+        dashboard_port=8080,
+        ledger=ledger,
+        repo_path=tmp_path,
+    )
+    assert status == 403
+
+
+# ── read-only execution path ──────────────────────────────────────────────
+
+
+async def test_admin_read_only_query_wraps_in_transaction(monkeypatch, tmp_path: Path) -> None:
+    from dashboard.admin import process_admin_query
+
+    monkeypatch.setenv("BICAMERAL_ENABLE_ADMIN_PANEL", "1")
+    monkeypatch.delenv("BICAMERAL_ENABLE_ADMIN_PANEL_WRITES", raising=False)
+    client = _FakeClient(response_rows=[{"id": "decision:abc"}])
+    ledger = _FakeLedger(client)
+    status, body = await process_admin_query(
+        payload_in={"sql": "SELECT * FROM decision", "mode": "read"},
+        origin="http://localhost:8080",
+        dashboard_port=8080,
+        ledger=ledger,
+        repo_path=tmp_path,
+    )
+    assert status == 200
+    assert body["mode"] == "read-only"
+    assert body["rows"] == [{"id": "decision:abc"}]
+    # SQL was wrapped in BEGIN/CANCEL
+    assert len(client.queries) == 1
+    assert "BEGIN TRANSACTION" in client.queries[0]
+    assert "CANCEL TRANSACTION" in client.queries[0]
+
+
+# ── write-mode gating ────────────────────────────────────────────────────
+
+
+async def test_admin_write_rejected_without_writes_flag(monkeypatch, tmp_path: Path) -> None:
+    from dashboard.admin import process_admin_query
+
+    monkeypatch.setenv("BICAMERAL_ENABLE_ADMIN_PANEL", "1")
+    monkeypatch.delenv("BICAMERAL_ENABLE_ADMIN_PANEL_WRITES", raising=False)
+    client = _FakeClient()
+    ledger = _FakeLedger(client)
+    status, body = await process_admin_query(
+        payload_in={"sql": "UPDATE decision:x SET x = 1", "mode": "write", "signer": "kim@x"},
+        origin="http://localhost:8080",
+        dashboard_port=8080,
+        ledger=ledger,
+        repo_path=tmp_path,
+    )
+    assert status == 403
+    assert "WRITES" in body["error"]
+    assert client.queries == []
+
+
+async def test_admin_write_rejects_empty_signer(monkeypatch, tmp_path: Path) -> None:
+    """Audit Pass 1 Finding 2 — write mode requires non-empty signer."""
+    from dashboard.admin import process_admin_query
+
+    monkeypatch.setenv("BICAMERAL_ENABLE_ADMIN_PANEL", "1")
+    monkeypatch.setenv("BICAMERAL_ENABLE_ADMIN_PANEL_WRITES", "1")
+    client = _FakeClient()
+    ledger = _FakeLedger(client)
+    status, body = await process_admin_query(
+        payload_in={"sql": "UPDATE decision:x SET x = 1", "mode": "write", "signer": ""},
+        origin="http://localhost:8080",
+        dashboard_port=8080,
+        ledger=ledger,
+        repo_path=tmp_path,
+    )
+    assert status == 400
+    assert "signer" in body["error"].lower()
+    assert client.queries == []
+
+
+async def test_admin_write_rejects_whitespace_only_signer(monkeypatch, tmp_path: Path) -> None:
+    from dashboard.admin import process_admin_query
+
+    monkeypatch.setenv("BICAMERAL_ENABLE_ADMIN_PANEL", "1")
+    monkeypatch.setenv("BICAMERAL_ENABLE_ADMIN_PANEL_WRITES", "1")
+    client = _FakeClient()
+    ledger = _FakeLedger(client)
+    status, body = await process_admin_query(
+        payload_in={"sql": "UPDATE x", "mode": "write", "signer": "   \t\n"},
+        origin="http://localhost:8080",
+        dashboard_port=8080,
+        ledger=ledger,
+        repo_path=tmp_path,
+    )
+    assert status == 400
+    assert client.queries == []
+
+
+async def test_admin_write_executes_when_both_flags_and_signer_set(
+    monkeypatch, tmp_path: Path
+) -> None:
+    from dashboard.admin import process_admin_query
+
+    monkeypatch.setenv("BICAMERAL_ENABLE_ADMIN_PANEL", "1")
+    monkeypatch.setenv("BICAMERAL_ENABLE_ADMIN_PANEL_WRITES", "1")
+    client = _FakeClient(response_rows=[{"updated": 1}])
+    ledger = _FakeLedger(client)
+    status, body = await process_admin_query(
+        payload_in={
+            "sql": "UPDATE decision:abc SET feature_group = 'test'",
+            "mode": "write",
+            "signer": "kim@example.com",
+        },
+        origin="http://localhost:8080",
+        dashboard_port=8080,
+        ledger=ledger,
+        repo_path=tmp_path,
+    )
+    assert status == 200
+    assert body["mode"] == "write"
+    # Write mode runs the SQL directly — no BEGIN/CANCEL wrap
+    assert "BEGIN TRANSACTION" not in client.queries[0]
+    assert "UPDATE decision:abc" in client.queries[0]
+
+
+# ── audit-log obligation (audit Pass 1 Finding 1) ─────────────────────────
+
+
+async def test_admin_query_emits_audit_event_in_team_mode(monkeypatch, tmp_path: Path) -> None:
+    from dashboard.admin import process_admin_query
+
+    monkeypatch.setenv("BICAMERAL_ENABLE_ADMIN_PANEL", "1")
+    writer = _FakeWriter()
+    client = _FakeClient(response_rows=[{"id": "x"}])
+    ledger = _FakeLedger(client, writer=writer)
+
+    await process_admin_query(
+        payload_in={"sql": "SELECT * FROM decision", "mode": "read"},
+        origin="http://localhost:8080",
+        dashboard_port=8080,
+        ledger=ledger,
+        repo_path=tmp_path,
+    )
+
+    assert len(writer.events) == 1
+    event_type, payload = writer.events[0]
+    assert event_type == "admin_query.executed"
+    assert payload["sql"] == "SELECT * FROM decision"
+    assert payload["mode"] == "read-only"
+    assert payload["error"] is None
+    assert "elapsed_ms" in payload
+    # In team mode the LOCAL audit file is NOT written (event goes through writer)
+    assert not (tmp_path / ".bicameral" / "events" / "_admin.jsonl").exists()
+
+
+async def test_admin_query_emits_local_audit_file_when_no_team_writer(
+    monkeypatch, tmp_path: Path
+) -> None:
+    """Audit Pass 1 Finding 1 — no unaudited admin path exists in local-only mode."""
+    from dashboard.admin import process_admin_query
+
+    monkeypatch.setenv("BICAMERAL_ENABLE_ADMIN_PANEL", "1")
+    client = _FakeClient(response_rows=[{"id": "x"}])
+    ledger = _FakeLedger(client)  # NO writer attached
+    assert not hasattr(ledger, "_writer")
+
+    await process_admin_query(
+        payload_in={"sql": "SELECT * FROM decision", "mode": "read"},
+        origin="http://localhost:8080",
+        dashboard_port=8080,
+        ledger=ledger,
+        repo_path=tmp_path,
+    )
+
+    audit_path = tmp_path / ".bicameral" / "events" / "_admin.jsonl"
+    assert audit_path.exists(), "local-mode admin queries must fall back to _admin.jsonl"
+    lines = audit_path.read_text(encoding="utf-8").strip().split("\n")
+    assert len(lines) == 1
+    decoded = json.loads(lines[0])
+    assert decoded["event_type"] == "admin_query.executed"
+    assert decoded["payload"]["sql"] == "SELECT * FROM decision"
+    assert decoded["payload"]["mode"] == "read-only"
+
+
+async def test_admin_query_error_path_emits_audit_event_with_error_field(
+    monkeypatch, tmp_path: Path
+) -> None:
+    from dashboard.admin import process_admin_query
+
+    monkeypatch.setenv("BICAMERAL_ENABLE_ADMIN_PANEL", "1")
+    writer = _FakeWriter()
+    client = _FakeClient(raise_on="BAD_SYNTAX")
+    ledger = _FakeLedger(client, writer=writer)
+
+    status, body = await process_admin_query(
+        payload_in={"sql": "BAD_SYNTAX !!", "mode": "read"},
+        origin="http://localhost:8080",
+        dashboard_port=8080,
+        ledger=ledger,
+        repo_path=tmp_path,
+    )
+    # The handler returns 200 + error field rather than 500 — the error
+    # belongs in the response body so the operator sees the SurrealDB
+    # error message in the UI.
+    assert status == 200
+    assert body["error"] is not None
+    assert "simulated failure" in body["error"]
+    # Audit event still emitted with the error captured
+    assert len(writer.events) == 1
+    assert writer.events[0][1]["error"] == body["error"]

--- a/tests/test_dashboard_admin_panel.py
+++ b/tests/test_dashboard_admin_panel.py
@@ -1,0 +1,172 @@
+"""Phase 3B — static-HTML pattern tests for the dashboard admin SurrealQL panel.
+
+Mirrors the harness from Phase 1 + Phase 2 dashboard tests: pure string
+assertions against assets/dashboard.html. The panel is off-by-default at
+the server level (env flag); these tests verify the UI two-step toggle +
+XSS discipline carried from prior phases.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+import pytest
+
+DASHBOARD_HTML = Path(__file__).resolve().parent.parent / "assets" / "dashboard.html"
+
+
+@pytest.fixture(scope="module")
+def html() -> str:
+    assert DASHBOARD_HTML.exists(), f"missing dashboard template at {DASHBOARD_HTML}"
+    return DASHBOARD_HTML.read_text(encoding="utf-8")
+
+
+def _extract_function_body(html: str, fn_name: str) -> str:
+    match = re.search(rf"function\s+{re.escape(fn_name)}\s*\([^)]*\)\s*\{{", html)
+    if not match:
+        raise AssertionError(f"function {fn_name} not found in dashboard.html")
+    start = match.end() - 1
+    depth = 0
+    for i in range(start, len(html)):
+        ch = html[i]
+        if ch == "{":
+            depth += 1
+        elif ch == "}":
+            depth -= 1
+            if depth == 0:
+                return html[start : i + 1]
+    return html[start : start + 4000]
+
+
+# ── Panel structure ───────────────────────────────────────────────────────
+
+
+def test_admin_panel_container_present_and_default_closed(html: str) -> None:
+    """The panel container exists with data-state='closed' as the initial
+    state, and a CSS rule keys visibility on the attribute."""
+    assert re.search(
+        r'<[^>]*id\s*=\s*"adm-panel"[^>]*data-state\s*=\s*"closed"',
+        html,
+    ), 'expected <... id="adm-panel" data-state="closed">'
+    assert re.search(
+        r'#adm-panel\[data-state\s*=\s*"open"\]\s*\{[^}]*'
+        r"(display\s*:\s*(block|flex|grid)|visibility\s*:\s*visible)",
+        html,
+        re.DOTALL,
+    ), 'expected #adm-panel[data-state="open"] visible CSS rule'
+
+
+def test_admin_panel_advanced_toggle_calls_toggleAdvancedPanel(html: str) -> None:
+    """The advanced toggle is wired to toggleAdvancedPanel()."""
+    assert "toggleAdvancedPanel" in html, "expected toggleAdvancedPanel function"
+    # The toggle UI element calls it
+    assert re.search(
+        r'onclick\s*=\s*"toggleAdvancedPanel\(\)"|onchange\s*=\s*"toggleAdvancedPanel\(\)"',
+        html,
+    ), "expected the advanced toggle to call toggleAdvancedPanel()"
+
+
+def test_admin_panel_query_textarea_and_execute_button(html: str) -> None:
+    assert re.search(r'<textarea[^>]*id\s*=\s*"adm-sql"', html), (
+        "expected <textarea id='adm-sql'> for the SurrealQL input"
+    )
+    assert re.search(
+        r'<button[^>]*onclick\s*=\s*"runAdminQuery\(\)"',
+        html,
+    ), "expected an Execute button bound to runAdminQuery()"
+
+
+def test_admin_panel_quickref_dropdown_with_starter_queries(html: str) -> None:
+    """A select#adm-quickref carries at least three starter queries from
+    the plan's curated list."""
+    assert re.search(r'<select[^>]*id\s*=\s*"adm-quickref"', html), (
+        "expected <select id='adm-quickref'> dropdown"
+    )
+    for needle in (
+        "SELECT * FROM decision",
+        "SELECT count() FROM decision",
+        "INFO FOR DB",
+    ):
+        assert needle in html, f"expected quickref to include {needle!r}"
+
+
+# ── Write-mode gating ─────────────────────────────────────────────────────
+
+
+def test_admin_panel_writes_toggle_default_off(html: str) -> None:
+    """The write-mode toggle starts disabled (operator must complete typed
+    confirmation to enable). Pins by asserting the global state variable
+    initializes to false in the JS."""
+    assert re.search(r"let\s+_writeModeEnabled\s*=\s*false", html), (
+        "expected _writeModeEnabled to initialize to false"
+    )
+
+
+def test_admin_panel_write_mode_requires_typed_confirmation(html: str) -> None:
+    """confirmWriteRisk() must check that an input value equals the literal
+    'I accept the risk' before flipping _writeModeEnabled to true."""
+    assert "confirmWriteRisk" in html, "expected confirmWriteRisk function"
+    body = _extract_function_body(html, "confirmWriteRisk")
+    # The magic string must appear as a literal in the comparison
+    assert "I accept the risk" in body, (
+        "confirmWriteRisk must check for the literal 'I accept the risk' phrase"
+    )
+    # And the body must set _writeModeEnabled = true under the comparison
+    assert "_writeModeEnabled" in body and "true" in body
+
+
+def test_admin_panel_warning_banner_keyed_on_write_mode(html: str) -> None:
+    """The warning banner CSS shows when write mode is active."""
+    assert "adm-write-warn" in html, "expected .adm-write-warn warning banner class"
+
+
+# ── runAdminQuery + result rendering ──────────────────────────────────────
+
+
+def test_admin_panel_runAdminQuery_posts_to_admin_endpoint(html: str) -> None:
+    body = _extract_function_body(html, "runAdminQuery")
+    assert "fetch(" in body, "runAdminQuery must use fetch()"
+    assert "'/admin/query'" in body or '"/admin/query"' in body, (
+        "runAdminQuery must POST to /admin/query"
+    )
+    assert "POST" in body, "runAdminQuery must use POST method"
+
+
+def test_admin_panel_runAdminQuery_includes_mode_based_on_write_toggle(
+    html: str,
+) -> None:
+    body = _extract_function_body(html, "runAdminQuery")
+    # The function must read _writeModeEnabled to pick mode
+    assert "_writeModeEnabled" in body, (
+        "runAdminQuery must consult _writeModeEnabled when choosing mode"
+    )
+
+
+def test_admin_panel_results_use_text_content_xss_canary(html: str) -> None:
+    """renderAdminResult writes rows via .textContent — never .innerHTML.
+    A row containing <script> must not be parsed as HTML."""
+    body = _extract_function_body(html, "renderAdminResult")
+    assert ".textContent" in body, (
+        "renderAdminResult must write rows via .textContent (XSS discipline)"
+    )
+    # And must NOT write user-controlled row data via .innerHTML
+    assert not re.search(
+        r"\.innerHTML\s*=\s*[^;]*\b(rows|row|JSON\.stringify)\b",
+        body,
+    ), "renderAdminResult must not write user-row data via .innerHTML"
+
+
+def test_admin_panel_results_render_mode_and_elapsed(html: str) -> None:
+    body = _extract_function_body(html, "renderAdminResult")
+    # The render function reads response.mode and response.elapsed_ms
+    assert ".mode" in body and ".elapsed_ms" in body, (
+        "renderAdminResult must surface response.mode and response.elapsed_ms"
+    )
+    # The DOM contains explicit slots for these
+    assert re.search(r'id\s*=\s*"adm-result-mode"', html), (
+        "expected <... id='adm-result-mode'> slot in the panel"
+    )
+    assert re.search(r'id\s*=\s*"adm-result-elapsed"', html), (
+        "expected <... id='adm-result-elapsed'> slot in the panel"
+    )


### PR DESCRIPTION
## Summary

Closes Phase 3 of #278. Stacks on #314.

Adds an off-by-default raw SurrealQL panel to the dashboard for operator debugging and emergency-correction tasks — the bottom of the dashboard-→-CLI-→-reset escape-hatch spectrum from v0 Productization §4.

## Defense in depth (defaults are safe)

1. Route gated on \`BICAMERAL_ENABLE_ADMIN_PANEL=1\`. Unset → 404 (the route is not even routable).
2. Strict same-origin check on Origin header. Missing or mismatched → 403. CORS allow-origin is suppressed on admin responses.
3. Read mode (default) wraps SQL in \`BEGIN/CANCEL TRANSACTION\` so even DELETE queries roll back. Response carries an explicit \`mode\` field so operators don't misread rolled-back row output.
4. Write mode requires a SECOND env flag (\`BICAMERAL_ENABLE_ADMIN_PANEL_WRITES=1\`) PLUS in-UI typed confirmation (\`I accept the risk\` verbatim) PLUS a non-empty signer. Empty signer → HTTP 400 before any DB call.
5. Every executed query (read or write, success or failure) emits one \`admin_query.executed\` event. Team mode → through the attached ledger writer; local mode → \`<repo>/.bicameral/events/_admin.jsonl\`. No unaudited admin-query path exists.

## UI

- "Advanced (raw SurrealQL panel)" checkbox at the bottom of the dashboard; the panel itself is \`data-state="closed"\` until toggled.
- Quickref dropdown with starter queries (SELECT * FROM decision, COUNT, INFO FOR DB, removed-decisions filter, etc.).
- Result block renders rows via \`JSON.stringify\` into a \`.textContent\`-only block (XSS canary pinned).
- Write-mode toggle opens a separate risk-confirmation modal that requires the typed phrase before flipping \`_writeModeEnabled = true\`.

Implementation lives in a new \`dashboard/admin.py\` module so the safety logic is unit-testable without spinning up the asyncio TCP server. \`dashboard/server.py\` is a thin HTTP wrapper.

## Test plan

- [x] \`python -m pytest tests/test_admin_surrealql_route.py -v\` — 14 tests (env-flag gating, origin lock, transaction wrap, audit event in both team and local modes, signer requirement for writes)
- [x] \`python -m pytest tests/test_dashboard_admin_panel.py -v\` — 11 tests (panel default state, toggle, write-mode typed confirmation, results render via .textContent)
- [x] Phase 1+2 regression — 50/50 pass

## Audit Pass 1 → Pass 2 resolutions

Initial audit VETOed on two findings, both resolved in this PR:

1. **A08 audit gap on local-mode writes** — fixed by writing to \`<repo>/.bicameral/events/_admin.jsonl\` when no team writer is attached. Test \`test_admin_query_emits_local_audit_file_when_no_team_writer\` pins it.
2. **Specification drift on signer** — write-mode queries with empty/whitespace signer now return HTTP 400. Test \`test_admin_write_rejects_empty_signer\` pins it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)