### PR TITLE
[#278 Phase 4] Design-partner dogfood instrumentation + plan

### DIFF
--- a/dashboard/admin.py
+++ b/dashboard/admin.py
@@ -195,14 +195,18 @@ async def process_admin_query(
     elapsed_ms = (time.perf_counter() - started) * 1000.0
 
     # Emit one audit event — success or failure, both modes.
-    audit_payload = {
-        "sql": sql,
-        "mode": response_mode,
-        "elapsed_ms": elapsed_ms,
-        "error": error,
-        "signer": signer,
-        "ts": datetime.now(UTC).isoformat(),
-    }
+    from events.dogfood import maybe_dogfood_label
+
+    audit_payload = maybe_dogfood_label(
+        {
+            "sql": sql,
+            "mode": response_mode,
+            "elapsed_ms": elapsed_ms,
+            "error": error,
+            "signer": signer,
+            "ts": datetime.now(UTC).isoformat(),
+        }
+    )
     _emit_admin_event(ledger, audit_payload, repo_path)
 
     body = {

--- a/docs/v0-productization-design-partner-dogfood.md
+++ b/docs/v0-productization-design-partner-dogfood.md
@@ -1,0 +1,121 @@
+# v0 Productization — Design Partner Dogfood (#278 Phase 4)
+
+This is the validation milestone for #278. Phases 1–3 shipped the source
+view, remove flows, and raw SurrealQL admin panel; Phase 4 is about
+proving those features work in the hands of real users.
+
+## Goal
+
+Validate that the dashboard surfaces from Phases 1–3 enable the two
+success scenarios from v0 Productization §4 without operator escalation.
+
+## Success criteria (from #278)
+
+1. **A PM finds a wrong decision and removes it via the dashboard, without
+   escalating to the operator.** The PM:
+   - sees the wrong decision in the dashboard's decision list,
+   - opens the source view to verify what the ingest captured,
+   - clicks "remove" on the decision,
+   - completes the confirmation modal (reason + signer),
+   - copies the surfaced `bicameral.remove_decision` MCP call into their
+     bicameral-connected agent,
+   - sees the decision render as `signoff.state="removed"` on the next
+     SSE update — all without asking the operator to run anything from
+     a terminal.
+
+2. **An operator runs a SurrealQL query to investigate a stale ledger
+   entry without leaving the dashboard.** The operator:
+   - has started the MCP server with `BICAMERAL_ENABLE_ADMIN_PANEL=1`,
+   - opens the dashboard, toggles "Advanced (raw SurrealQL panel)",
+   - picks a starter query from the quickref or types their own,
+   - executes in read mode, inspects the result rows,
+   - never opens a separate terminal or `surreal sql` session.
+
+## Counting
+
+To slice the event log by design partner, start the MCP server with:
+
+```bash
+BICAMERAL_DOGFOOD_LABEL=partner-acme BICAMERAL_ENABLE_ADMIN_PANEL=1 \
+  python -m bicameral_mcp
+```
+
+Every event emitted by the Phase 1–3 surfaces gains a `dogfood_label`
+field with the env value. Count hits via `jq`:
+
+```bash
+# Scenario 1 — PM removes a wrong decision via dashboard
+jq -c 'select(.event_type=="decision_removed.completed" and .payload.dogfood_label=="partner-acme")' \
+  .bicameral/events/*.jsonl | wc -l
+
+# Scenario 2 — operator runs SurrealQL from the dashboard
+jq -c 'select(.event_type=="admin_query.executed" and .payload.dogfood_label=="partner-acme")' \
+  .bicameral/events/*.jsonl .bicameral/events/_admin.jsonl 2>/dev/null | wc -l
+```
+
+The `_admin.jsonl` path captures admin queries in local-only mode (no
+team adapter writer attached); the per-author `.jsonl` files capture
+team-mode events. Reading both covers both deployment shapes.
+
+## Threshold
+
+At minimum, **one matching event for each scenario** from the design
+partner's session within a 2-week dogfood window. Higher bars (multiple
+PMs, multiple orgs, multiple sessions) are operator-tunable depending on
+what you want to learn.
+
+## What we expect to learn
+
+- **Friction shape.** Is the typed "I accept the risk" confirmation in
+  the admin panel right-sized for "I'm investigating" vs. "I'm about to
+  break something"? If operators bounce off it, the friction is
+  miscalibrated.
+- **Removal triggers.** Do PMs reach for "remove decision" or "remove
+  source"? The cascading remove_source is more powerful but harder to
+  preview; if PMs default to remove_decision and forget remove_source
+  exists, the dashboard should surface the source-grouped removal path
+  more obviously.
+- **Source-view utility.** Phase 1's source view renders the ingested
+  excerpt with side-by-side decision linkage. If PMs don't open it
+  before removing, the source view's role is wrong — maybe it should
+  open automatically when a decision row is expanded.
+- **Confirm-first vs. confirm-typed.** `remove_decision` and the admin
+  panel use different confirmation shapes (single-step + reason vs.
+  typed phrase). Dogfood reveals whether the difference is intentional
+  or arbitrary.
+- **Audit-log readability.** Operators who try to inspect their own
+  dogfood metrics via `jq` are also testing whether the event-log shape
+  is something humans can read. If the JSON shape requires too much
+  munging, that's signal for a future "events viewer" surface.
+
+## Rollback plan
+
+If dogfood reveals a serious flaw in Phases 1–3, the operator can:
+
+1. **Disable the admin panel** by removing `BICAMERAL_ENABLE_ADMIN_PANEL`
+   from the server env and restarting. The route returns 404; the panel
+   in the dashboard stays hidden because the UI side reads from the
+   server route. No code change required.
+2. **Soft-disable remove flows in the dashboard** by adding a CSS rule
+   that hides `.rm-dec-btn` and `.rm-src-btn`. A 5-minute change; the
+   backend tools remain reachable via MCP for power users.
+3. **Revert by commit.** Phases 1–3 are stacked commits with no
+   dependencies on subsequent v0 work (cross-checked against the
+   integration map in `docs/CONCEPT.md`). `git revert <commit>` per
+   phase is clean.
+
+If the dogfood metric for scenario 1 is zero after a week, that's signal
+to talk to the design partner about WHY they didn't use the dashboard
+remove flow — the answer might be a docs gap, an onboarding gap, or a
+genuine design defect. Don't assume a metric of zero means failure
+until you have a conversation.
+
+## Out of scope for Phase 4
+
+- Reporting / aggregation UI for dogfood metrics. Operators count via
+  `jq`; a reporting dashboard is a follow-up if dogfood produces enough
+  signal to justify it.
+- Pre-defined "test scripts" the design partner follows. Canned scripts
+  defeat dogfood's purpose — we want to see what users actually do.
+- Auto-collection of partner credentials or sessions. The label is
+  operator-supplied at server start; no PII collection.

--- a/events/dogfood.py
+++ b/events/dogfood.py
@@ -1,0 +1,35 @@
+"""Optional dogfood label propagation for event payloads (#278 Phase 4).
+
+When ``BICAMERAL_DOGFOOD_LABEL`` is set to a non-empty value at MCP server
+start, every event emitted by the Phase 1–3 surfaces
+(``decision_removed.completed``, ``source_removed.completed``,
+``admin_query.executed``) carries an extra ``dogfood_label`` field with
+that value. Operators slice the event log by label to count whether the
+design-partner success criteria from #278 Phase 4 were met:
+
+  - "A PM finds a wrong decision and removes it via the dashboard,
+     without escalating to the operator."
+  - "An operator runs a SurrealQL query to investigate a stale ledger
+     entry without leaving the dashboard."
+
+The label is purely additive and opt-in. The env unset / empty produces
+no field, preserving the pre-Phase-4 payload shape exactly.
+"""
+
+from __future__ import annotations
+
+import os
+from typing import Any
+
+
+def maybe_dogfood_label(payload: dict[str, Any]) -> dict[str, Any]:
+    """Add ``dogfood_label`` to ``payload`` iff
+    ``BICAMERAL_DOGFOOD_LABEL`` is set to a non-empty value.
+
+    Mutates and returns the same dict. Empty-string env values are
+    treated as unset (noise, not signal — the env var is opt-in).
+    """
+    label = (os.environ.get("BICAMERAL_DOGFOOD_LABEL") or "").strip()
+    if label:
+        payload["dogfood_label"] = label
+    return payload

--- a/handlers/remove_decision.py
+++ b/handlers/remove_decision.py
@@ -111,13 +111,15 @@ async def handle_remove_decision(
     # is satisfied by the ledger row's signoff history itself.
     writer = getattr(ledger, "_writer", None)
     if writer is not None:
-        writer.write(
-            "decision_removed.completed",
+        from events.dogfood import maybe_dogfood_label
+
+        payload = maybe_dogfood_label(
             {
                 "decision_id": decision_id,
                 "signoff": signoff,
-            },
+            }
         )
+        writer.write("decision_removed.completed", payload)
 
     logger.info(
         "[remove_decision] decision=%s signer=%s previous_state=%s projected_status=%s",

--- a/handlers/remove_source.py
+++ b/handlers/remove_source.py
@@ -108,8 +108,9 @@ async def handle_remove_source(
     writer = getattr(ledger, "_writer", None)
     event_logged = False
     if writer is not None:
-        writer.write(
-            "source_removed.completed",
+        from events.dogfood import maybe_dogfood_label
+
+        payload = maybe_dogfood_label(
             {
                 "span_id": span_id,
                 "input_span_content": span_content,
@@ -117,8 +118,9 @@ async def handle_remove_source(
                 "signer": signer,
                 "reason": reason,
                 "removed_at": datetime.now(UTC).isoformat(),
-            },
+            }
         )
+        writer.write("source_removed.completed", payload)
         event_logged = True
 
     logger.info(

--- a/tests/test_dogfood_label_propagation.py
+++ b/tests/test_dogfood_label_propagation.py
@@ -1,0 +1,282 @@
+"""Phase 4 — dogfood label propagation tests.
+
+Pins:
+  1. The `dogfood_label` field is OMITTED from event payloads when
+     BICAMERAL_DOGFOOD_LABEL is unset.
+  2. The field is OMITTED when the env var is set to an empty string
+     (empty-string env is treated as noise, not signal).
+  3. The field is PRESENT and matches the env value for all three
+     Phase 1–3 emitter sites: remove_decision, remove_source,
+     admin_query (both team-mode and local-mode paths).
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+pytestmark = pytest.mark.asyncio
+
+
+# ── pure helper unit tests ────────────────────────────────────────────────
+
+
+def test_maybe_dogfood_label_omits_when_env_unset(monkeypatch) -> None:
+    from events.dogfood import maybe_dogfood_label
+
+    monkeypatch.delenv("BICAMERAL_DOGFOOD_LABEL", raising=False)
+    out = maybe_dogfood_label({"a": 1})
+    assert "dogfood_label" not in out
+
+
+def test_maybe_dogfood_label_omits_when_env_empty(monkeypatch) -> None:
+    """Empty-string env values are noise, not signal — handler must not
+    add the field. Pinned because operators sometimes accidentally set
+    env vars to empty when they meant to unset them."""
+    from events.dogfood import maybe_dogfood_label
+
+    monkeypatch.setenv("BICAMERAL_DOGFOOD_LABEL", "")
+    out = maybe_dogfood_label({"a": 1})
+    assert "dogfood_label" not in out
+
+
+def test_maybe_dogfood_label_omits_when_env_whitespace(monkeypatch) -> None:
+    from events.dogfood import maybe_dogfood_label
+
+    monkeypatch.setenv("BICAMERAL_DOGFOOD_LABEL", "   \t\n")
+    out = maybe_dogfood_label({"a": 1})
+    assert "dogfood_label" not in out
+
+
+def test_maybe_dogfood_label_adds_when_env_set(monkeypatch) -> None:
+    from events.dogfood import maybe_dogfood_label
+
+    monkeypatch.setenv("BICAMERAL_DOGFOOD_LABEL", "partner-acme")
+    out = maybe_dogfood_label({"a": 1})
+    assert out["dogfood_label"] == "partner-acme"
+    assert out["a"] == 1  # original fields preserved
+
+
+# ── reuse the Phase 2 fake-ledger pattern for handler emitter tests ───────
+
+
+class _FakeClient:
+    def __init__(
+        self,
+        decisions: dict | None = None,
+        spans: dict | None = None,
+        edges: list | None = None,
+        response_rows=None,
+    ) -> None:
+        self._decisions = decisions or {}
+        self._spans = spans or {}
+        self._edges = list(edges or [])
+        self._rows = response_rows or []
+        self.queries: list[str] = []
+
+    async def query(self, sql: str, params=None):
+        self.queries.append(sql)
+        sql_l = sql.lower()
+        # decision_exists
+        if "select id from decision:" in sql_l and "limit 1" in sql_l:
+            did = sql.split("FROM ", 1)[1].split(" ", 1)[0]
+            return [{"id": did}] if did in self._decisions else []
+        # input_span_exists
+        if "select id from input_span:" in sql_l and "limit 1" in sql_l:
+            sid = sql.split("FROM ", 1)[1].split(" ", 1)[0]
+            return [{"id": sid}] if sid in self._spans else []
+        # span row
+        if sql_l.startswith("select text, source_ref, source_type"):
+            sid = sql.split("FROM ", 1)[1].split(" ", 1)[0]
+            row = self._spans.get(sid)
+            return [row] if row else []
+        # span->decisions
+        if "<-yields<-input_span contains" in sql_l:
+            sid = sql.split("CONTAINS ", 1)[1].strip()
+            return [{"decision_id": d} for (s, d) in self._edges if s == sid]
+        # signoff read
+        if "select signoff from decision:" in sql_l:
+            did = sql.split("FROM ", 1)[1].split(" ", 1)[0]
+            return [{"signoff": self._decisions.get(did, {}).get("signoff")}]
+        # UPDATE
+        if "update decision:" in sql_l and "set signoff" in sql_l:
+            did = sql.split("UPDATE ", 1)[1].split(" SET")[0].strip()
+            row = self._decisions.setdefault(did, {})
+            row["signoff"] = params["signoff"]
+            return [row]
+        # DELETE yields/span
+        if sql_l.startswith("delete yields"):
+            sid = sql.rsplit("=", 1)[1].strip()
+            self._edges = [(s, d) for (s, d) in self._edges if s != sid]
+            return []
+        if sql_l.startswith("delete input_span:"):
+            sid = sql.split("DELETE ", 1)[1].strip()
+            self._spans.pop(sid, None)
+            return []
+        return list(self._rows)
+
+
+class _FakeLedger:
+    def __init__(self, client, writer=None) -> None:
+        self._inner = self
+        self._client = client
+        if writer is not None:
+            self._writer = writer
+
+    async def connect(self) -> None:
+        return None
+
+
+class _FakeWriter:
+    def __init__(self) -> None:
+        self.events: list[tuple[str, dict]] = []
+
+    def write(self, event_type: str, payload: dict):
+        self.events.append((event_type, payload))
+
+
+class _FakeCtx:
+    def __init__(self, ledger, session_id="s", sha="d") -> None:
+        self.ledger = ledger
+        self.session_id = session_id
+        self.authoritative_sha = sha
+
+
+@pytest.fixture(autouse=True)
+def _stub_queries(monkeypatch):
+    """Stub status-projection helpers so handler tests don't need full schema."""
+
+    async def _decision_exists(client, did):
+        return did in client._decisions
+
+    async def _project(client, did):
+        return "ungrounded"
+
+    async def _update(client, did, status):
+        return None
+
+    monkeypatch.setattr("handlers.remove_decision.decision_exists", _decision_exists)
+    monkeypatch.setattr("handlers.remove_decision.project_decision_status", _project)
+    monkeypatch.setattr("handlers.remove_decision.update_decision_status", _update)
+    monkeypatch.setattr("handlers.remove_source.project_decision_status", _project)
+    monkeypatch.setattr("handlers.remove_source.update_decision_status", _update)
+
+
+# ── remove_decision emitter ───────────────────────────────────────────────
+
+
+async def test_remove_decision_event_omits_dogfood_label_by_default(
+    monkeypatch,
+) -> None:
+    from handlers.remove_decision import handle_remove_decision
+
+    monkeypatch.delenv("BICAMERAL_DOGFOOD_LABEL", raising=False)
+    writer = _FakeWriter()
+    ledger = _FakeLedger(
+        _FakeClient(decisions={"decision:abc": {"signoff": {"state": "ratified"}}}),
+        writer=writer,
+    )
+    await handle_remove_decision(
+        _FakeCtx(ledger), decision_id="decision:abc", signer="x", reason="r"
+    )
+    assert len(writer.events) == 1
+    _, payload = writer.events[0]
+    assert "dogfood_label" not in payload
+
+
+async def test_remove_decision_event_includes_dogfood_label_when_env_set(
+    monkeypatch,
+) -> None:
+    from handlers.remove_decision import handle_remove_decision
+
+    monkeypatch.setenv("BICAMERAL_DOGFOOD_LABEL", "partner-acme")
+    writer = _FakeWriter()
+    ledger = _FakeLedger(
+        _FakeClient(decisions={"decision:abc": {"signoff": {"state": "ratified"}}}),
+        writer=writer,
+    )
+    await handle_remove_decision(
+        _FakeCtx(ledger), decision_id="decision:abc", signer="x", reason="r"
+    )
+    _, payload = writer.events[0]
+    assert payload["dogfood_label"] == "partner-acme"
+
+
+# ── remove_source emitter ─────────────────────────────────────────────────
+
+
+async def test_remove_source_event_includes_dogfood_label_when_env_set(
+    monkeypatch,
+) -> None:
+    from handlers.remove_source import handle_remove_source
+
+    monkeypatch.setenv("BICAMERAL_DOGFOOD_LABEL", "partner-acme")
+    span_id = "input_span:s1"
+    spans = {
+        span_id: {
+            "text": "t",
+            "source_ref": "r",
+            "source_type": "manual",
+            "meeting_date": "",
+            "speakers": [],
+            "created_at": "",
+        }
+    }
+    decisions = {"decision:d1": {"signoff": {"state": "ratified"}}}
+    edges = [(span_id, "decision:d1")]
+    writer = _FakeWriter()
+    ledger = _FakeLedger(_FakeClient(decisions=decisions, spans=spans, edges=edges), writer=writer)
+
+    await handle_remove_source(
+        _FakeCtx(ledger), span_id=span_id, signer="x", reason="r", confirm=True
+    )
+    assert len(writer.events) == 1
+    _, payload = writer.events[0]
+    assert payload["dogfood_label"] == "partner-acme"
+
+
+# ── admin_query emitter (team mode + local mode) ──────────────────────────
+
+
+async def test_admin_query_event_includes_dogfood_label_when_env_set_team_mode(
+    monkeypatch, tmp_path: Path
+) -> None:
+    from dashboard.admin import process_admin_query
+
+    monkeypatch.setenv("BICAMERAL_ENABLE_ADMIN_PANEL", "1")
+    monkeypatch.setenv("BICAMERAL_DOGFOOD_LABEL", "partner-acme")
+    writer = _FakeWriter()
+    ledger = _FakeLedger(_FakeClient(response_rows=[{"x": 1}]), writer=writer)
+    await process_admin_query(
+        payload_in={"sql": "SELECT 1", "mode": "read"},
+        origin="http://localhost:8080",
+        dashboard_port=8080,
+        ledger=ledger,
+        repo_path=tmp_path,
+    )
+    assert len(writer.events) == 1
+    _, payload = writer.events[0]
+    assert payload["dogfood_label"] == "partner-acme"
+
+
+async def test_admin_query_event_includes_dogfood_label_when_env_set_local_mode(
+    monkeypatch, tmp_path: Path
+) -> None:
+    from dashboard.admin import process_admin_query
+
+    monkeypatch.setenv("BICAMERAL_ENABLE_ADMIN_PANEL", "1")
+    monkeypatch.setenv("BICAMERAL_DOGFOOD_LABEL", "partner-acme")
+    ledger = _FakeLedger(_FakeClient(response_rows=[{"x": 1}]))  # no writer
+    await process_admin_query(
+        payload_in={"sql": "SELECT 1", "mode": "read"},
+        origin="http://localhost:8080",
+        dashboard_port=8080,
+        ledger=ledger,
+        repo_path=tmp_path,
+    )
+    audit_path = tmp_path / ".bicameral" / "events" / "_admin.jsonl"
+    line = audit_path.read_text(encoding="utf-8").strip().split("\n")[0]
+    decoded = json.loads(line)
+    assert decoded["payload"]["dogfood_label"] == "partner-acme"


### PR DESCRIPTION
## Summary

Closes #278. Stacks on #315.

Phase 4 is the validation milestone for the work shipped in Phases 1–3, not a new user-facing feature. The deliverables are (a) a documented dogfood plan with explicit success criteria, and (b) an opt-in event-tagging mechanism that lets the operator slice their event log to count whether the success criteria were met.

## Success criteria (from #278)

1. A PM finds a wrong decision and removes it via the dashboard, without escalating to the operator.
2. An operator runs a SurrealQL query to investigate a stale ledger entry without leaving the dashboard.

Both are validated by counting Phase 1–3 event types (\`decision_removed.completed\`, \`admin_query.executed\`) filtered by a new optional \`dogfood_label\` payload field.

## Instrumentation

- \`events/dogfood.py\` — pure helper \`maybe_dogfood_label(payload)\` reads \`BICAMERAL_DOGFOOD_LABEL\` from env and augments the payload iff the value is non-empty (whitespace counts as empty).
- Wired into three emitter sites: \`handlers/remove_decision.py\`, \`handlers/remove_source.py\`, \`dashboard/admin.py\` (both team-mode and local-mode paths).

The label is purely additive — empty/unset \`BICAMERAL_DOGFOOD_LABEL\` produces no payload change, preserving the pre-Phase-4 event shape exactly. \`EventEnvelope.payload\` is \`dict[str,Any]\` so \`EventMaterializer\` replay is unaffected.

## Docs

\`docs/v0-productization-design-partner-dogfood.md\` — the operator's plan: goal, success criteria, counting recipe (\`jq\` one-liners), the 1-event/scenario threshold for the 2-week dogfood window, what we expect to learn, and the rollback plan if dogfood reveals a serious Phase 1–3 flaw.

## Test plan

- [x] \`python -m pytest tests/test_dogfood_label_propagation.py -v\` — 9 tests covering omitted-by-default, omitted-on-empty, omitted-on-whitespace, present-when-set across all three emitter sites.
- [x] Phase 1+2+3 regression — 75/75 pass.
- [x] Full sweep — 84/84 pass.

## Usage

Start the MCP server with:

\`\`\`bash
BICAMERAL_DOGFOOD_LABEL=partner-acme BICAMERAL_ENABLE_ADMIN_PANEL=1 \
  python -m bicameral_mcp
\`\`\`

Count hits via:

\`\`\`bash
jq -c 'select(.event_type==\"decision_removed.completed\" and .payload.dogfood_label==\"partner-acme\")' \
  .bicameral/events/*.jsonl | wc -l
\`\`\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)