### PR TITLE
fix(ci): SHA-pin test-summary/action in preflight-eval workflow (#272 residual)

### DIFF
--- a/.github/workflows/preflight-eval.yml
+++ b/.github/workflows/preflight-eval.yml
@@ -95,7 +95,7 @@ jobs:
 
       - name: Surface results in step summary
         if: always()
-        uses: test-summary/action@v2
+        uses: test-summary/action@31493c76ec9e7aa675f1585d3ed6f1da69269a86  # v2.4 (#272 — match test-mcp-regression.yml pin)
         with:
           paths: "test-results/*.xml"
           show: fail, skip


### PR DESCRIPTION
## Summary

Closes #272 by SHA-pinning the last unpinned consumer of \`test-summary/action@v2\`. Aligns preflight-eval.yml with the pin landed for test-mcp-regression.yml in PR #273.

## Why this is the only residual

Three of the four #272 fixes already shipped on \`dev\`:

| Regression | Fixed in | Status |
|---|---|---|
| \`test-summary/action@v2\` mutable tag in \`test-mcp-regression.yml\` | #273 | SHA-pinned to 31493c76 (v2.4) ✓ |
| \`tests/eval_decision_relevance.py\` \`ungrounded_decisions\` AttributeError | #273 | renamed to \`pending_grounding_decisions\` ✓ |
| Flow 1 e2e expectation stale after #263 sync-skill auto-bind | #276 → #282 | asserter rewritten ("Per #272 Fix 3" in docstring) ✓ |
| \`test-summary/action@v2\` mutable tag in \`preflight-eval.yml\` | **this PR** | SHA-pinned to 31493c76 (v2.4) |

Same SHA used in both workflow files now — one grep-and-replace for any future bump.

## Test plan

- [x] \`git grep "test-summary/action" -- .github/workflows/\` — both consumers SHA-pinned, no stray \`@v2\`
- [ ] Next preflight-eval workflow run on \`dev\` resolves by SHA — confirms the pin took effect

## Per policy

Per \`docs/policies/install-trust-model.md\` (OWASP A06 supply-chain): no GitHub Action runs in our CI from a mutable tag.

🤖 Generated with [Claude Code](https://claude.com/claude-code)