### PR TITLE
doctrine(governance): #205 Phase 1 — deterministic governance doctrine + skill lint

### DIFF
--- a/docs/governance/compliance-stance-matrix.md
+++ b/docs/governance/compliance-stance-matrix.md
@@ -1,0 +1,42 @@
+# Compliance Stance Matrix (#205)
+
+Project-wide stance on every privacy / security / compliance standard that could plausibly apply to bicameral-mcp's footprint. For each row: **Standard**, **Applies?**, **Project stance**, **Gate** that enforces the stance.
+
+A "we don't process X" stance is fine if a deterministic gate enforces it. See `docs/governance/doctrine-deterministic-governance.md` for the rule: skill-text instructions are suggestive but never qualify as governance.
+
+This matrix is reviewed annually; the cadence is wired into `/qor-compliance-review` (deferred to #205 Phase 4).
+
+## Matrix
+
+| Standard | Applies? | Project stance | Gate |
+|---|---|---|---|
+| **GDPR** (EU 2016/679) | Yes (any EU end user or operator) | Process minimum personal data. Operator's git email is the only PII routinely persisted; `signer_email_fallback` policy lets the operator opt to local-part-only or full-redact. Right-to-erasure via ingest filtering + storage segregation, NOT tombstone/rehash on the append-only chain. | `context.py:_resolve_signer_email()` env-driven mode; `handlers/ingest.py` PII detect-and-refuse; #221 (deferred) for full erasure procedure |
+| **CCPA / CPRA** (California) | Yes (any California end user) | Same data-minimization commitments as GDPR. No selling of personal data; no behavioral advertising. | Inherits GDPR gates above |
+| **SOC 2 Type I → Type II** | Target (B2B sales gate) | Pursuing Type I evidence collection in 2026; Type II ramp after first Type I report. Five trust principles: security, availability, processing integrity, confidentiality, privacy. | Multi-issue track — see `#215` (transport trust boundary), `#292` (supply-chain sigstore), `#227` (structured audit log) |
+| **NIST CSF 2.0** | Yes (overall alignment) | Align with the six CSF functions: Govern, Identify, Protect, Detect, Respond, Recover. Govern function tracked in `/qor-` skills + this doctrine. | This doctrine + audit gates |
+| **NIST AI RMF (AI 100-1)** | Yes (we ship an LLM-tool surface) | Already partially referenced in `qor/references/doctrine-ai-rmf.md` (qor-logic package). MAP / MEASURE / MANAGE / GOVERN functions: `/qor-audit` runs plan-time MAP; runtime MEASURE deferred to follow-up | `/qor-audit` Step 1c (impact assessment) + `governance` plan field |
+| **NIST SSDF (SP 800-218)** | Yes (we ship developer tooling) | Secure SDLC alignment: protect software, produce well-secured software, respond to vulnerabilities. | `/qor-audit` Step 3 OWASP pass; supply-chain via #292 |
+| **FIPS 140-3** | Partial (cryptographic surfaces only) | Ledger Merkle hashing uses SHA-256 (FIPS-approved). Sigstore signing uses Ed25519 (Suite B). No other cryptographic operations. | `ledger/adapter.py` SHA-256 declaration; `release/manifest_verify.py` sigstore verification |
+| **OWASP Top 10 (2021/2025)** | Yes | A01 Broken Access Control (admin panel env flag + origin lock); A03 Injection (SQL via parameterized queries, no shell exec); A04 Insecure Design (audit gates, confirm-first destructive ops); A05 Misconfig (defaults safe); A06 Vulnerable Components (SHA-pin GitHub actions per #272); A08 Software Integrity (sigstore-signed manifests). | `/qor-audit` Step 3; #272 (action pinning); #292 (sigstore) |
+| **OWASP LLM Top 10** | Yes (we ship an LLM-tool surface) | LLM01 Prompt Injection (ingest canary scanner #212; brief renderer fence-isolation #278 Phase 1); LLM02 Insecure Output Handling (escape user-supplied text in dashboard via `.textContent`); LLM06 Sensitive Info Disclosure (PII/PHI/PAN detect-and-refuse #213); LLM10 Model DoS (rate limit on ingest). | `handlers/ingest.py` canary + sensitive-pattern detectors; #278 fence isolation; ingest rate limit |
+| **OWASP ASVS Level 2** | Target (production deployment minimum) | Verification requirements for the dashboard HTTP surface, ingest path, ledger queries. Pursuit deferred to a focused cycle; intermediate gains land via OWASP Top 10 + LLM Top 10 work. | Future cycle |
+| **EU AI Act** | Partial — limited-risk classification likely | The bicameral-mcp surface is an AI-orchestration tool; we are NOT a high-risk system per Annex III. Customer's downstream use may be high-risk; `/qor-plan`'s `high_risk_target` flag declares per-plan. | `qor/references/doctrine-eu-ai-act.md` (qor-logic package); `/qor-plan` Step 1c |
+| **HIPAA** | **No** | bicameral-mcp does NOT process Protected Health Information. Ingest pipeline refuses payloads matching PHI patterns (medical record numbers, common PHI field names). Operators must not ingest clinical content; use HIPAA-compliant tooling for medical data. | `handlers/sensitive_patterns.py` PHI patterns; `_IngestRefused` with `sensitive_data:phi` reason |
+| **PCI DSS** | **No** | bicameral-mcp does NOT process cardholder data. Ingest pipeline refuses Luhn-valid 13-19 digit sequences not preceded by ID-class labels. Operators must use PCI-compliant systems for cardholder data. | `handlers/sensitive_patterns.py` PAN patterns; `_IngestRefused` with `sensitive_data:pan` reason |
+| **ISO 27001 / 27701** | Future (enterprise sales gate) | Long-tail enterprise readiness; track as future work. Aspects already covered by SOC 2 work overlap heavily. | Future cycle |
+| **Illinois BIPA** | Minimal exposure | We don't process biometric data. Operators must not ingest biometric identifiers. | Inherits PII detect-and-refuse |
+| **Texas CUPRA / state-specific** | Minimal exposure | Aligned with GDPR/CCPA stance; revisit if specific obligations land. | Inherits GDPR gates |
+
+## How to add a new standard
+
+1. Add a row to this matrix with the four columns filled.
+2. If "Applies? = Yes" and there's a "we don't process X" stance, the **Gate** column MUST point to deterministic enforcement (e.g., a detect-and-refuse pattern in `handlers/`). Skill-text-only enforcement is NOT acceptable per `docs/governance/doctrine-deterministic-governance.md`.
+3. If "Applies? = Yes" and we do process X, document the data minimization or scope-reduction gate(s).
+4. Update `governance-gates.yaml` if the new row introduces a new gate kind.
+5. File specific compliance work (Type II evidence, DPIA, etc.) as separate issues that reference this matrix.
+
+## Audit history
+
+| Date | Reviewer | Notes |
+|---|---|---|
+| 2026-05-14 | initial author (Knapp-Kevin, AI-assisted) | First draft. Issue #205 Phase 1. |

--- a/docs/governance/doctrine-deterministic-governance.md
+++ b/docs/governance/doctrine-deterministic-governance.md
@@ -1,0 +1,82 @@
+# Doctrine: Deterministic Governance Boundaries (#205)
+
+## The hard rule
+
+> **Prompt/skill-level instruction is suggestive but never qualifies as governance. Governance requires deterministic gates.**
+
+This applies to every privacy / security / compliance default in the bicameral-mcp surface. Skill text in `skills/**/SKILL.md` is *orchestration glue* — it tells the agent **how** to use the tools we ship. It is **never the only gate** that enforces a default behavior the project commits to.
+
+## Why this matters
+
+Several recently-shipped skills implement privacy / security defaults via SKILL.md instructions to the agent — *"extract only the keys, by default"*, *"redact branch names"*, *"never include verbatim ledger entries"*. A `AskUserQuestion` toggle is a deterministic gate (the user's answer becomes a boolean the handler reads). But the *default behavior* depends on the agent following the markdown faithfully. A jailbroken agent, a model regression, or a prompt-injection upstream can bypass instruction-only defaults silently. The leak surface is invisible until a downstream incident.
+
+For bicameral-mcp to support customers in regulated environments — any team using the team-server JSONL substrate over git, any ingest of compliance-sensitive transcripts/PRDs/Slack threads — the privacy and security defaults need to be enforced **at server-side and config-load boundaries**, not at agent-instruction time.
+
+## Suggestive vs governance
+
+| Class | Property | Example | Sufficient for governance? |
+|---|---|---|---|
+| **Suggestive** | The agent CHOOSES whether to comply | SKILL.md: *"By default, redact branch names from output."* — agent may or may not follow | ❌ No |
+| **Governance** | The system ENFORCES regardless of agent compliance | `handlers/ingest.py:_filter_redacted_branches()` strips branch names BEFORE the payload reaches the model | ✅ Yes |
+
+The suggestive instruction can still exist — it's useful agent-side guidance for graceful degradation, observability, and consistent UX. But it cannot be the *only* enforcement mechanism for a privacy or security commitment.
+
+## Worked examples
+
+### ✅ Good: env-flag gate
+
+`dashboard/admin.py::admin_route_enabled()` reads `BICAMERAL_ENABLE_ADMIN_PANEL` from the environment. Without the flag set, the route returns 404 — regardless of what skill text says or what the agent attempts. The skill at `skills/admin-surrealql/SKILL.md` describes the flag, but the gate is the env check on the server.
+
+### ✅ Good: API-key indirection in config
+
+`events/sources/granola.py::_build_default_client()` reads the API key from `os.environ[<api_key_env>]` based on the config's `api_key_env` field. The config holds the env-var *name*, not the secret. This is a deterministic gate: even if the skill said "feel free to inline the key in config", the handler still reads from env.
+
+### ✅ Good: ingest filter
+
+`handlers/ingest.py` runs sensitive-data detection against every ingest payload. The skill `skills/bicameral-ingest/SKILL.md` advises the agent on how to avoid triggering refusals, but the refusal itself is server-side: PII/secret/PHI/PAN patterns return `_IngestRefused` regardless of what the agent thinks should happen.
+
+### ❌ Bad: SKILL.md-only default
+
+A hypothetical `skills/bicameral-foo/SKILL.md` says:
+
+> By default, the `foo` tool extracts only the public keys and discards values.
+
+…with no `handlers/foo.py` filter performing the extraction. The agent receives the full payload + the instruction to "extract only keys". A jailbroken agent that ignores the instruction leaks values. Not governance.
+
+The fix: the server-side filter strips values before constructing the agent-visible payload. The skill text then describes the contract, but the gate is the filter.
+
+## The `governance-gates.yaml` registry
+
+This file at the repo root declares the project's deterministic gates so the lint at `scripts/lint_skill_governance.py` can match SKILL.md text against registered gates.
+
+Schema (minimal Phase 1 shape):
+
+```yaml
+gates:
+  - skill: bicameral-ingest          # skill folder name under skills/
+    instruction_pattern: "extract only the keys"
+    backing_gate: handlers/ingest.py::_extract_keys_only
+    gate_kind: server                # one of: env | config | server | schema
+```
+
+Future phases of #205 may extend this with severity, evidence path, last-verified date, etc. Phase 1 ships the minimal shape so the lint has something to match against.
+
+## What the lint enforces
+
+`scripts/lint_skill_governance.py` scans `skills/**/SKILL.md` for instruction patterns that claim a default behavior (`"by default"`, `"redact"`, `"extract only"`, etc.). For each matched claim, it checks `governance-gates.yaml` for a corresponding entry. Findings — claims without a registered backing gate — are reported as advisory in Phase 1.
+
+Phase 4 of #205 will wire the lint into CI as a hard gate. Until then, the lint runs locally + can be invoked manually; reviewers should consult its output on PRs that add new default claims.
+
+## What this doctrine does NOT change
+
+- **Skill text is still required.** Removing all SKILL.md guidance is not the fix; agents need orchestration help to use tools well. The fix is ensuring every claimed default has a backing gate.
+- **Existing skills are not retroactively broken.** Phase 3 of #205 (a future cycle) sweeps existing skills against the new lint and files per-skill remediation issues. Phase 1 does not block CI on legacy findings.
+- **Suggestive instructions don't go away.** UX improvement guidance, formatting conventions, "how the agent should phrase X" — all suggestive, all still belong in SKILL.md. The doctrine narrows to *privacy / security / compliance defaults*: those need gates.
+
+## References
+
+- `docs/governance/compliance-stance-matrix.md` — the project's stance on every applicable standard.
+- `scripts/lint_skill_governance.py` — the static lint.
+- `governance-gates.yaml` — the registry the lint reads.
+- Issue #205 — the originating doctrine + roadmap to CI enforcement.
+- `docs/policies/install-trust-model.md` — example of a related deterministic gate pattern (action SHA-pinning).

--- a/governance-gates.yaml
+++ b/governance-gates.yaml
@@ -1,0 +1,22 @@
+# governance-gates.yaml — registry of deterministic gates backing the
+# privacy / security / compliance defaults claimed in skills/**/SKILL.md.
+#
+# Read by scripts/lint_skill_governance.py. Each entry declares one
+# SKILL.md instruction pattern and the deterministic gate that enforces
+# the corresponding default at runtime / config-load / server-side.
+#
+# Schema (Phase 1 minimal — see docs/governance/doctrine-deterministic-governance.md):
+#   gates:
+#     - skill: <skill-folder-name-under-skills/>
+#       instruction_pattern: <substring of the SKILL.md sentence claiming a default>
+#       backing_gate: <file:path::function or descriptive identifier>
+#       gate_kind: <one of: env | config | server | schema>
+#
+# Phase 1 starts empty; per the doctrine, skills with default claims will
+# light up as advisory lint findings until either (a) the SKILL.md text is
+# revised to drop the claim, or (b) a gate entry is added here pointing to
+# the deterministic enforcement code. Phase 3 of #205 is the retroactive
+# sweep that lands real entries; Phase 4 wires the lint into CI as a hard
+# gate.
+
+gates: []

--- a/scripts/lint_skill_governance.py
+++ b/scripts/lint_skill_governance.py
@@ -1,0 +1,218 @@
+"""scripts/lint_skill_governance.py — static lint for skill governance (#205 Phase 1).
+
+Scans every ``skills/<name>/SKILL.md`` for sentence-level patterns that
+claim a default privacy / security behavior (``"by default"``,
+``"redacted by default"``, ``"extract only"``, etc.). For each matched
+claim, checks ``governance-gates.yaml`` for a corresponding registered
+gate entry. Findings — claims without a registered backing gate — are
+reported as advisory in Phase 1.
+
+Phase 1 contract: the lint exits 1 if findings are present (so a future
+CI workflow can opt to enforce); but is NOT wired into CI yet (that's
+Phase 4 of #205). Operators invoke it locally:
+
+    python scripts/lint_skill_governance.py --skill-dir skills/ \\
+        --registry governance-gates.yaml
+
+See ``docs/governance/doctrine-deterministic-governance.md`` for the rule
+this lint enforces.
+"""
+
+from __future__ import annotations
+
+import argparse
+import re
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+
+import yaml
+
+# Sentence-level patterns that signal a default behavior claim. Case-
+# insensitive, line-based scan. Extend this list as new patterns surface
+# during the retroactive sweep (#205 Phase 3).
+_DEFAULT_CLAIM_PATTERNS: list[re.Pattern[str]] = [
+    re.compile(r"\bby\s+default\b[^.\n]*", re.IGNORECASE),
+    re.compile(r"\bredact(?:ed)?\s+by\s+default\b[^.\n]*", re.IGNORECASE),
+    re.compile(r"\bextract(?:s|ed)?\s+only\b[^.\n]*", re.IGNORECASE),
+    re.compile(r"\bnever\s+include\b[^.\n]*", re.IGNORECASE),
+    re.compile(r"\bdefault(?:s|ed)?\s+to\b[^.\n]*", re.IGNORECASE),
+]
+
+
+@dataclass(frozen=True)
+class Finding:
+    """One unregistered default-claim in a SKILL.md."""
+
+    skill: str  # folder name (e.g. "bicameral-ingest")
+    line: int  # 1-indexed line number in the SKILL.md
+    claim: str  # the matched sentence/phrase, stripped
+    suggestion: str  # operator-facing remediation hint
+
+
+def main(argv: list[str] | None = None) -> int:
+    """Argparse entry. Returns 0 if no findings; 1 otherwise."""
+    parser = argparse.ArgumentParser(
+        description="Lint SKILL.md files for default-behavior claims that "
+        "lack a registered deterministic gate (#205 Phase 1).",
+    )
+    parser.add_argument(
+        "--skill-dir",
+        type=Path,
+        default=Path("skills"),
+        help="Root of the skill tree (default: skills/).",
+    )
+    parser.add_argument(
+        "--registry",
+        type=Path,
+        default=Path("governance-gates.yaml"),
+        help="Path to the governance-gates registry (default: governance-gates.yaml).",
+    )
+    parser.add_argument(
+        "--json",
+        action="store_true",
+        help="Emit JSON instead of a markdown report.",
+    )
+    args = parser.parse_args(argv)
+
+    registry = _load_registry(args.registry)
+    findings = _scan_skill_tree(args.skill_dir, registry)
+
+    if args.json:
+        import json as _json
+
+        report = [
+            {
+                "skill": f.skill,
+                "line": f.line,
+                "claim": f.claim,
+                "suggestion": f.suggestion,
+            }
+            for f in findings
+        ]
+        print(_json.dumps(report, indent=2))
+    else:
+        print(format_report(findings))
+
+    return 0 if not findings else 1
+
+
+def _load_registry(path: Path) -> dict[str, list[dict]]:
+    """Load governance-gates.yaml via ``yaml.safe_load``.
+
+    SafeLoader required (per OWASP A08 + `context.py:63` precedent — never
+    use ``yaml.load`` on operator-authored config).
+    Returns ``{skill_name: [gate_entry, ...]}``; absent file → empty.
+    """
+    if not path.exists():
+        return {}
+    raw = yaml.safe_load(path.read_text(encoding="utf-8")) or {}
+    gates: dict[str, list[dict]] = {}
+    for entry in raw.get("gates") or []:
+        if not isinstance(entry, dict):
+            continue
+        skill = str(entry.get("skill") or "").strip()
+        if not skill:
+            continue
+        gates.setdefault(skill, []).append(entry)
+    return gates
+
+
+def _scan_skill_tree(
+    skill_dir: Path,
+    registry: dict[str, list[dict]],
+) -> list[Finding]:
+    """Walk every SKILL.md under ``skill_dir`` and accumulate findings."""
+    findings: list[Finding] = []
+    if not skill_dir.exists():
+        return findings
+    for skill_path in sorted(skill_dir.iterdir()):
+        if not skill_path.is_dir():
+            continue
+        md_path = skill_path / "SKILL.md"
+        if not md_path.exists():
+            continue
+        findings.extend(_lint_skill(md_path, registry.get(skill_path.name, [])))
+    return findings
+
+
+def _lint_skill(skill_md: Path, gates: list[dict]) -> list[Finding]:
+    """Lint one SKILL.md against its registered gates."""
+    text = skill_md.read_text(encoding="utf-8")
+    skill_name = skill_md.parent.name
+    findings: list[Finding] = []
+    for line_no, claim in _extract_default_claims(text):
+        if _match_registered_gate(claim, gates) is not None:
+            continue
+        findings.append(
+            Finding(
+                skill=skill_name,
+                line=line_no,
+                claim=claim.strip(),
+                suggestion=(
+                    f"Either revise the SKILL.md text to drop the default "
+                    f"claim, or add a gate entry under skill: {skill_name} in "
+                    f"governance-gates.yaml pointing to the deterministic "
+                    f"enforcement code."
+                ),
+            )
+        )
+    return findings
+
+
+def _extract_default_claims(text: str) -> list[tuple[int, str]]:
+    """Return (line_number, matched_sentence) tuples for every default-claim
+    pattern hit in the text. 1-indexed line numbers."""
+    out: list[tuple[int, str]] = []
+    for line_no, line in enumerate(text.splitlines(), start=1):
+        for pattern in _DEFAULT_CLAIM_PATTERNS:
+            for match in pattern.finditer(line):
+                out.append((line_no, match.group(0)))
+    return out
+
+
+def _match_registered_gate(claim: str, gates: list[dict]) -> dict | None:
+    """For each gate entry, fuzzy-match its ``instruction_pattern`` field
+    against ``claim`` (substring match, case-insensitive). Returns the
+    first matching gate or ``None``."""
+    claim_lower = claim.lower()
+    for gate in gates:
+        pattern = str(gate.get("instruction_pattern") or "").strip().lower()
+        if pattern and pattern in claim_lower:
+            return gate
+    return None
+
+
+def format_report(findings: list[Finding]) -> str:
+    """Render findings as a markdown report. Empty input → friendly OK message."""
+    if not findings:
+        return "✅ governance-gates lint: no unregistered default claims found.\n"
+    grouped: dict[str, list[Finding]] = {}
+    for f in findings:
+        grouped.setdefault(f.skill, []).append(f)
+    lines: list[str] = [
+        f"# Governance-gates lint — {len(findings)} finding(s)",
+        "",
+        "Per `docs/governance/doctrine-deterministic-governance.md`: "
+        "skill-text claims of default behavior must have a deterministic "
+        "backing gate registered in `governance-gates.yaml`.",
+        "",
+    ]
+    for skill in sorted(grouped):
+        lines.append(f"## `{skill}`")
+        lines.append("")
+        lines.append("| Line | Claim | Suggestion |")
+        lines.append("|---|---|---|")
+        for f in grouped[skill]:
+            claim_short = f.claim if len(f.claim) <= 80 else f.claim[:77] + "…"
+            # Escape pipe-chars in the suggestion so they don't break the
+            # markdown table column boundary. Done outside the f-string to
+            # satisfy py3.11 (no backslashes inside f-string expressions).
+            suggestion_escaped = f.suggestion.replace("|", "\\|")
+            lines.append(f"| {f.line} | `{claim_short}` | {suggestion_escaped} |")
+        lines.append("")
+    return "\n".join(lines) + "\n"
+
+
+if __name__ == "__main__":  # pragma: no cover
+    sys.exit(main())

--- a/tests/fixtures/skill_lint/clean_skill/SKILL.md
+++ b/tests/fixtures/skill_lint/clean_skill/SKILL.md
@@ -1,0 +1,27 @@
+---
+name: clean-skill-fixture
+description: Skill fixture with NO default-behavior claims (lint should report zero findings).
+---
+
+# Clean skill fixture
+
+This skill describes a tool. It tells the agent how to call the tool.
+It explains when to use the tool and when to skip it.
+
+## When to use
+
+- When the operator asks for X.
+- When the upstream context provides Y.
+
+## When NOT to use
+
+- When the operator has not authorized the action.
+- When the tool's output would be misleading.
+
+## Format
+
+```json
+{"name": "tool", "arguments": {"x": "..."}}
+```
+
+No default claims; no privacy / security defaults stated; lint passes.

--- a/tests/fixtures/skill_lint/flagged_skill/SKILL.md
+++ b/tests/fixtures/skill_lint/flagged_skill/SKILL.md
@@ -1,0 +1,22 @@
+---
+name: flagged-skill-fixture
+description: Skill fixture WITH unregistered default-behavior claim (lint should flag).
+---
+
+# Flagged skill fixture
+
+This skill claims a privacy default in skill text without a backing gate.
+
+## Behavior
+
+By default, the agent extracts only the public keys and discards values.
+Branch names are redacted by default.
+
+## When to use
+
+Whenever the operator passes in a config payload.
+
+## Note
+
+The above default claims have no backing gate in this fixture's
+imaginary handler. A linter scan should produce findings.

--- a/tests/fixtures/skill_lint/registered_skill/SKILL.md
+++ b/tests/fixtures/skill_lint/registered_skill/SKILL.md
@@ -1,0 +1,15 @@
+---
+name: registered-skill-fixture
+description: Skill fixture with default-behavior claim that IS backed by a registered gate.
+---
+
+# Registered skill fixture
+
+By default, the agent extracts only the public keys and discards values.
+
+## Backing gate
+
+See the per-test registry passed to the lint: the gate entry for this
+skill points to `handlers/fixture.py::_extract_keys_only`. The lint
+should match the SKILL.md text against the registered pattern and NOT
+emit a finding.

--- a/tests/test_skill_governance_lint.py
+++ b/tests/test_skill_governance_lint.py
@@ -1,0 +1,282 @@
+"""Unit tests for scripts/lint_skill_governance.py — #205 Phase 1.
+
+Sociable per CLAUDE.md: the lint is exercised through its real module
+surface, against real fixture SKILL.md files at
+``tests/fixtures/skill_lint/``. No mocked file IO; no monkey-patched
+parsers.
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+import pytest
+import yaml
+
+# Make ``scripts/`` importable for the test runner.
+_REPO_ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(_REPO_ROOT / "scripts"))
+
+import lint_skill_governance as lint  # noqa: E402
+
+FIXTURES = _REPO_ROOT / "tests" / "fixtures" / "skill_lint"
+
+
+# ── _extract_default_claims ───────────────────────────────────────────────
+
+
+def test_extract_default_claims_finds_by_default_pattern() -> None:
+    text = "By default, the agent extracts only keys."
+    claims = lint._extract_default_claims(text)
+    assert len(claims) >= 1
+    assert any("by default" in c.lower() for _, c in claims)
+
+
+def test_extract_default_claims_case_insensitive() -> None:
+    text = "BY DEFAULT, x is redacted."
+    claims = lint._extract_default_claims(text)
+    assert len(claims) >= 1
+    assert "BY DEFAULT" in claims[0][1].upper()
+
+
+def test_extract_default_claims_ignores_unrelated_text() -> None:
+    """Plain mention of the word 'default' without a claim should not fire.
+
+    The patterns key on \"by default\" / \"defaults to\" / \"extract only\" / etc.,
+    not on the bare word 'default'."""
+    text = "The default port is 8080. The system is robust."
+    claims = lint._extract_default_claims(text)
+    # No "by default" / "default to" / "extract only" / "redact" / "never include"
+    assert claims == []
+
+
+def test_extract_default_claims_finds_redact_pattern() -> None:
+    text = "Branch names are redacted by default."
+    claims = lint._extract_default_claims(text)
+    assert len(claims) >= 1
+
+
+def test_extract_default_claims_finds_extract_only_pattern() -> None:
+    text = "The handler extracts only the keys."
+    claims = lint._extract_default_claims(text)
+    assert any("extract" in c.lower() and "only" in c.lower() for _, c in claims)
+
+
+def test_extract_default_claims_reports_1_indexed_line_numbers() -> None:
+    text = "\nLine 2 has no claim.\nBy default, line 3 has a claim.\n"
+    claims = lint._extract_default_claims(text)
+    assert len(claims) == 1
+    line_no, _ = claims[0]
+    assert line_no == 3
+
+
+# ── _match_registered_gate ────────────────────────────────────────────────
+
+
+def test_match_registered_gate_finds_exact_substring() -> None:
+    """Registry patterns are matched as case-insensitive substrings, so
+    the registered ``instruction_pattern`` must appear verbatim in the
+    claim text. Operators choose patterns that hit common variations of
+    the SKILL.md text — typically the noun phrase rather than the verb
+    form, which is more stable across rewrites."""
+    gate = {
+        "skill": "fixture",
+        "instruction_pattern": "only the keys",  # noun phrase, substring of claim
+        "backing_gate": "handlers/fixture.py::_extract_keys_only",
+        "gate_kind": "server",
+    }
+    claim = "By default, the agent extracts only the keys and discards values."
+    assert lint._match_registered_gate(claim, [gate]) is gate
+
+
+def test_match_registered_gate_case_insensitive() -> None:
+    gate = {
+        "instruction_pattern": "REDACTED BY DEFAULT",
+    }
+    claim = "Branch names are redacted by default."
+    assert lint._match_registered_gate(claim, [gate]) is gate
+
+
+def test_match_registered_gate_returns_none_for_unregistered() -> None:
+    gate = {"instruction_pattern": "something else entirely"}
+    claim = "By default, the agent extracts only the keys."
+    assert lint._match_registered_gate(claim, [gate]) is None
+
+
+def test_match_registered_gate_returns_none_for_empty_pattern() -> None:
+    """An empty/missing pattern field must not silently match every claim."""
+    gate = {"instruction_pattern": ""}
+    claim = "By default, x is y."
+    assert lint._match_registered_gate(claim, [gate]) is None
+
+
+# ── _lint_skill against fixtures ──────────────────────────────────────────
+
+
+def test_lint_skill_clean_fixture_produces_no_findings() -> None:
+    findings = lint._lint_skill(FIXTURES / "clean_skill" / "SKILL.md", [])
+    assert findings == []
+
+
+def test_lint_skill_flagged_fixture_produces_findings() -> None:
+    findings = lint._lint_skill(FIXTURES / "flagged_skill" / "SKILL.md", [])
+    assert len(findings) >= 2
+    skills = {f.skill for f in findings}
+    assert skills == {"flagged_skill"}
+
+
+def test_lint_skill_registered_fixture_with_matching_gate_is_clean() -> None:
+    """When the registry has a gate matching the SKILL.md's default claim,
+    the lint emits no finding for that claim."""
+    gate = {
+        "skill": "registered_skill",
+        "instruction_pattern": "extracts only the public keys",
+        "backing_gate": "handlers/fixture.py::_extract_keys_only",
+        "gate_kind": "server",
+    }
+    findings = lint._lint_skill(FIXTURES / "registered_skill" / "SKILL.md", [gate])
+    assert findings == []
+
+
+def test_lint_skill_registered_fixture_without_matching_gate_still_flags() -> None:
+    """Negative case: registered_skill's SKILL.md WITHOUT the matching gate
+    in the registry — lint flags it."""
+    findings = lint._lint_skill(FIXTURES / "registered_skill" / "SKILL.md", [])
+    assert len(findings) >= 1
+
+
+# ── _load_registry ────────────────────────────────────────────────────────
+
+
+def test_load_registry_returns_empty_for_missing_file(tmp_path: Path) -> None:
+    missing = tmp_path / "absent.yaml"
+    assert lint._load_registry(missing) == {}
+
+
+def test_load_registry_groups_entries_by_skill(tmp_path: Path) -> None:
+    yaml_path = tmp_path / "gates.yaml"
+    yaml_path.write_text(
+        yaml.safe_dump(
+            {
+                "gates": [
+                    {
+                        "skill": "skill-a",
+                        "instruction_pattern": "p1",
+                        "backing_gate": "h.py::f",
+                        "gate_kind": "server",
+                    },
+                    {
+                        "skill": "skill-a",
+                        "instruction_pattern": "p2",
+                        "backing_gate": "h.py::g",
+                        "gate_kind": "server",
+                    },
+                    {
+                        "skill": "skill-b",
+                        "instruction_pattern": "p3",
+                        "backing_gate": "h.py::h",
+                        "gate_kind": "env",
+                    },
+                ]
+            }
+        )
+    )
+    reg = lint._load_registry(yaml_path)
+    assert set(reg.keys()) == {"skill-a", "skill-b"}
+    assert len(reg["skill-a"]) == 2
+    assert len(reg["skill-b"]) == 1
+
+
+def test_load_registry_uses_safe_load_for_owasp_a08(tmp_path: Path) -> None:
+    """The lint must use yaml.safe_load — feeding a Python-object-tag YAML
+    would otherwise execute arbitrary code. SafeLoader rejects such tags
+    by raising ConstructorError; the lint either propagates or filters
+    to empty. Either way, no arbitrary code executes."""
+    yaml_path = tmp_path / "evil.yaml"
+    # !!python/object/apply tags would deserialize-and-call under
+    # yaml.load() (unsafe). yaml.safe_load() rejects them.
+    yaml_path.write_text(
+        "gates:\n"
+        "  - skill: x\n"
+        "    instruction_pattern: !!python/object/apply:os.system ['echo p0wned']\n"
+        "    backing_gate: y\n"
+        "    gate_kind: env\n"
+    )
+    with pytest.raises(yaml.YAMLError):
+        lint._load_registry(yaml_path)
+
+
+# ── main() integration ───────────────────────────────────────────────────
+
+
+def test_main_exits_0_when_skill_dir_has_no_skills(tmp_path: Path) -> None:
+    """Empty skill dir → no SKILL.md files → no findings → exit 0."""
+    empty_skills = tmp_path / "skills"
+    empty_skills.mkdir()
+    empty_registry = tmp_path / "gates.yaml"
+    empty_registry.write_text("gates: []\n")
+    rc = lint.main(["--skill-dir", str(empty_skills), "--registry", str(empty_registry)])
+    assert rc == 0
+
+
+def test_main_exits_1_when_findings_present_in_flagged_fixture(tmp_path: Path, capsys) -> None:
+    """Wire main() against the flagged fixture; expect exit 1 + report."""
+    # Build a tmp skill tree containing just the flagged fixture, copied.
+    skills = tmp_path / "skills"
+    skills.mkdir()
+    target = skills / "flagged_skill"
+    target.mkdir()
+    src = FIXTURES / "flagged_skill" / "SKILL.md"
+    (target / "SKILL.md").write_text(src.read_text(encoding="utf-8"), encoding="utf-8")
+    reg = tmp_path / "gates.yaml"
+    reg.write_text("gates: []\n")
+    rc = lint.main(["--skill-dir", str(skills), "--registry", str(reg)])
+    assert rc == 1
+    captured = capsys.readouterr()
+    assert "flagged_skill" in captured.out
+
+
+def test_main_json_mode_emits_valid_json(tmp_path: Path, capsys) -> None:
+    skills = tmp_path / "skills"
+    skills.mkdir()
+    target = skills / "flagged_skill"
+    target.mkdir()
+    (target / "SKILL.md").write_text(
+        (FIXTURES / "flagged_skill" / "SKILL.md").read_text(encoding="utf-8"),
+        encoding="utf-8",
+    )
+    reg = tmp_path / "gates.yaml"
+    reg.write_text("gates: []\n")
+    rc = lint.main(["--skill-dir", str(skills), "--registry", str(reg), "--json"])
+    assert rc == 1
+    captured = capsys.readouterr()
+    decoded = json.loads(captured.out)
+    assert isinstance(decoded, list)
+    assert len(decoded) >= 2
+    for f in decoded:
+        assert {"skill", "line", "claim", "suggestion"} <= set(f.keys())
+
+
+# ── format_report ────────────────────────────────────────────────────────
+
+
+def test_format_report_returns_friendly_ok_on_empty() -> None:
+    report = lint.format_report([])
+    assert "no unregistered default claims found" in report
+
+
+def test_format_report_renders_markdown_table_for_findings() -> None:
+    finding = lint.Finding(
+        skill="x",
+        line=42,
+        claim="By default, x is y.",
+        suggestion="Add a gate entry.",
+    )
+    report = lint.format_report([finding])
+    assert "# Governance-gates lint" in report
+    assert "## `x`" in report
+    assert "42" in report
+    assert "By default, x is y." in report
+    assert "Add a gate entry" in report


### PR DESCRIPTION
## Summary

Phase 1 of BicameralAI/bicameral-daemon#34. Establishes the hard rule that prompt/skill-level instruction is SUGGESTIVE but never qualifies as governance — governance requires deterministic gates (server-side filters, env flags, config-load enforcement).

## Three deliverables

| Path | Purpose |
|---|---|
| \`docs/governance/doctrine-deterministic-governance.md\` | The hard rule, suggestive-vs-governance worked examples with file:line citations to existing good gates (\`dashboard/admin.py\` env flag, \`events/sources/granola.py\` api-key indirection, \`handlers/ingest.py\` detect-and-refuse), the \`governance-gates.yaml\` registry shape. |
| \`docs/governance/compliance-stance-matrix.md\` | One-page table covering GDPR, CCPA/CPRA, SOC 2, NIST CSF / AI RMF / SSDF / FIPS, OWASP Top 10 / LLM Top 10 / ASVS, EU AI Act, HIPAA, PCI DSS, ISO 27001/27701, state-specific privacy laws. Each row: Applies? / Project stance / Gate. |
| \`scripts/lint_skill_governance.py\` | Static lint over \`skills/**/SKILL.md\` for default-claim patterns checked against \`governance-gates.yaml\`. \`yaml.safe_load\` (OWASP A08); exit 1 on findings; markdown + \`--json\` modes. **Advisory in Phase 1** — Phase 4 of BicameralAI/bicameral-daemon#34 wires it as a hard CI gate. |

Plus:

- \`governance-gates.yaml\` — empty registry with schema-documenting header.
- \`tests/fixtures/skill_lint/\` — clean / flagged / registered fixture SKILL.md files.
- \`tests/test_skill_governance_lint.py\` — 22 sociable tests covering pattern extraction, registry loading, fixture-driven lint runs, JSON mode, and an OWASP A08 \`!!python/object/apply\` canary.

## Phase scope (per project phase-per-cycle convention)

This PR ships **Phase 1 only**:
- [x] Doctrine document
- [x] Compliance stance matrix
- [x] Skill-governance lint + tests

Deferred to subsequent cycles:
- Phase 2 (audit-gate integration into \`/qor-audit\`)
- Phase 3 (retroactive sweep of existing skills)
- Phase 4 (CI enforcement via \`.github/workflows/skill-governance-lint.yml\`)

## Path deviation from issue body

The issue references \`qor/references/doctrine-deterministic-governance.md\` and \`qor/references/compliance-stance-matrix.md\`. The \`qor/\` directory does NOT exist in this repo — those references in issue text are to the operator's installed \`qor-logic\` skill package alongside \`qor/references/doctrine-ai-rmf.md\` etc.

This repo's convention is \`docs/policies/\` (\`install-trust-model.md\`, \`sources-config.md\`) and \`docs/governance/\` (\`semantic-drift-governance.md\` referenced in BicameralAI/bicameral-mcp#275). Plan uses \`docs/governance/\` for both deliverables. Documented in plan Open Question 1.

## Test plan

- [x] \`python -m pytest tests/test_skill_governance_lint.py -v\` — 22 tests
- [x] \`python scripts/lint_skill_governance.py --skill-dir skills/ --registry governance-gates.yaml\` — manual run against live skill tree (expected to produce many advisory findings; empty registry by design)

## Sociable testing

22/22 tests use real fixture files at \`tests/fixtures/skill_lint/\` and exercise the lint module through its public surface. No mocks, no monkey-patches. The OWASP A08 \`safe_load\` canary test feeds an \`!!python/object/apply:os.system\` tag and asserts \`yaml.YAMLError\` is raised rather than \`os.system\` being called.

🤖 Generated with [Claude Code](https://claude.com/claude-code)