### PR TITLE
feat(timeout): #224 ledger-query timeout with Claude-hooks context surfacing

### DIFF
--- a/.claude/hooks/pre_tool_use_timeout_context.py
+++ b/.claude/hooks/pre_tool_use_timeout_context.py
@@ -1,0 +1,59 @@
+#!/usr/bin/env python3
+"""Claude Code PreToolUse hook — emit timeout posture before bicameral tool calls.
+
+Fires before a ledger-touching tool runs. Reads the recent-timeout ring
+buffer + current budgets and emits a one-line summary to stderr so
+the Claude agent can reason about whether to fire the query at all,
+choose ``timeout_class="drift"`` thoughtfully, or back off after
+observed degradation.
+
+**Always exits 0.** Hook is advisory; the server-side
+``asyncio.wait_for`` wrap is the deterministic gate.
+
+The hook reads stdin (Claude Code passes a JSON envelope describing
+the about-to-fire tool) but does not parse it deeply — emitting the
+posture line is universally useful before any bicameral tool, so we
+skip envelope-shape coupling and just always print.
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+
+
+def main() -> int:
+    # Drain stdin so Claude Code's pipe doesn't backpressure.
+    try:
+        sys.stdin.read()
+    except Exception:
+        pass
+
+    repo = os.environ.get("CLAUDE_PROJECT_DIR") or os.getcwd()
+    if repo not in sys.path:
+        sys.path.insert(0, repo)
+
+    try:
+        from ledger.timeout_telemetry import recent_timeout_counts
+    except Exception:
+        return 0
+
+    try:
+        counts = recent_timeout_counts(window_seconds=600.0)  # 10 min window
+    except Exception:
+        return 0
+
+    if counts.get("read", 0) == 0 and counts.get("drift", 0) == 0:
+        # Quiet path — no posture-changing signal to surface.
+        return 0
+
+    sys.stderr.write(
+        "[bicameral] recent ledger-query timeouts (last 10 min): "
+        f"{counts.get('read', 0)} read / {counts.get('drift', 0)} drift — "
+        "consider whether the next query may also be slow\n"
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/.claude/hooks/session_start_timeout_posture.py
+++ b/.claude/hooks/session_start_timeout_posture.py
@@ -1,0 +1,76 @@
+#!/usr/bin/env python3
+"""Claude Code SessionStart hook — surface ledger-query timeout posture.
+
+Runs once when a Claude Code session starts. Reads the bicameral
+ledger-query timeout configuration + the recent-timeout ring buffer
+and prints a one-line brief to stderr; Claude Code surfaces stderr
+from hooks back to the model as a context fragment.
+
+**Always exits 0.** Never blocks the session. If the bicameral package
+isn't importable (e.g. running in a checkout without the venv), prints
+a single warning and exits 0. The deterministic server-side timeout
+wrap remains the source of truth regardless of whether this hook
+runs at all.
+
+Per #224 + the feedback-claude-hooks-for-mcp-context memory:
+deterministic gate (asyncio.wait_for in ledger/client.py) is the
+floor; this hook is advisory context enrichment for the Claude
+agent only.
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+
+
+def main() -> int:
+    repo = os.environ.get("CLAUDE_PROJECT_DIR") or os.getcwd()
+
+    # Add the repo root to sys.path so we can import the bicameral
+    # package without a venv hop. Hooks run in whatever shell Claude
+    # Code launched — they have no guarantee of import context.
+    if repo not in sys.path:
+        sys.path.insert(0, repo)
+
+    try:
+        from context import (
+            _read_query_timeout_drift_seconds,
+            _read_query_timeout_read_seconds,
+        )
+        from ledger.timeout_telemetry import recent_timeout_counts
+    except Exception as exc:
+        sys.stderr.write(f"[bicameral hook] timeout-posture unavailable: {exc}\n")
+        return 0
+
+    try:
+        read_budget = _read_query_timeout_read_seconds(repo)
+        drift_budget = _read_query_timeout_drift_seconds(repo)
+    except Exception:
+        read_budget = 5.0
+        drift_budget = 30.0
+
+    try:
+        counts = recent_timeout_counts()
+    except Exception:
+        counts = {"read": 0, "drift": 0}
+
+    env_disabled = os.environ.get("BICAMERAL_QUERY_TIMEOUT_DISABLE", "").strip().lower() in {
+        "1",
+        "true",
+        "yes",
+        "on",
+    }
+    env_disabled_str = "on" if env_disabled else "off"
+
+    sys.stderr.write(
+        "[bicameral] query timeouts last 1h: "
+        f"{counts.get('read', 0)} read / {counts.get('drift', 0)} drift "
+        f"| budgets: {read_budget:.1f}s / {drift_budget:.1f}s "
+        f"| env-disable: {env_disabled_str}\n"
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/adapters/ledger.py
+++ b/adapters/ledger.py
@@ -58,13 +58,22 @@ def get_ledger():
     global _real_ledger_instance
 
     if _real_ledger_instance is None:
+        from context import (
+            _read_query_timeout_drift_seconds,
+            _read_query_timeout_read_seconds,
+        )
         from ledger.adapter import SurrealDBLedgerAdapter
 
+        repo_path = os.getenv("REPO_PATH", ".")
+        # #224: operator-configured query timeout budgets, with the
+        # fail-closed reader (clamps to safe range; falls back to
+        # default on malformed config).
         inner = SurrealDBLedgerAdapter(
             url=os.getenv("SURREAL_URL", None),
+            query_timeout_read_seconds=_read_query_timeout_read_seconds(repo_path),
+            query_timeout_drift_seconds=_read_query_timeout_drift_seconds(repo_path),
         )
 
-        repo_path = os.getenv("REPO_PATH", ".")
         cfg = _read_team_config(repo_path)
         mode = cfg.get("mode", "solo")
 

--- a/context.py
+++ b/context.py
@@ -48,6 +48,20 @@ _INGEST_RATE_LIMIT_BURST_MAX = 1000
 _INGEST_RATE_LIMIT_REFILL_MIN = 0.01
 _INGEST_RATE_LIMIT_REFILL_MAX = 100.0
 
+# #224: SurrealDB ledger-query timeout budgets. Two classes only —
+# ``read`` (default 5s) for point queries / shallow selects, ``drift``
+# (default 30s) for heavy graph traversal / event-replay paths. Both
+# are clamped to safe ranges; out-of-range / NaN / Inf / malformed
+# yaml fall back to defaults. Enforced server-side via
+# ``asyncio.wait_for`` in ``ledger/client.py::LedgerClient.query``.
+# ``BICAMERAL_QUERY_TIMEOUT_DISABLE=1`` env bypasses the wrap entirely.
+_DEFAULT_QUERY_TIMEOUT_READ = 5.0
+_DEFAULT_QUERY_TIMEOUT_DRIFT = 30.0
+_QUERY_TIMEOUT_READ_MIN = 0.5
+_QUERY_TIMEOUT_READ_MAX = 120.0
+_QUERY_TIMEOUT_DRIFT_MIN = 1.0
+_QUERY_TIMEOUT_DRIFT_MAX = 600.0
+
 
 def _read_yaml_string_field(repo_path: str, key: str, valid: frozenset[str], default: str) -> str:
     """Generic reader for a `.bicameral/config.yaml` string field with a
@@ -235,6 +249,73 @@ def _read_ingest_rate_limit_refill_per_sec(repo_path: str) -> float:
     return val_f
 
 
+def _read_query_timeout_seconds(
+    repo_path: str,
+    key: str,
+    default: float,
+    min_val: float,
+    max_val: float,
+) -> float:
+    """Resolve a query-timeout-seconds field from ``.bicameral/config.yaml``.
+
+    Out-of-range values are **clamped** to ``[min_val, max_val]`` (preserve
+    operator intent for "long but bounded" — silently substituting the
+    default discards their stated preference). Negative / NaN / Inf /
+    non-numeric / bool / malformed-yaml all fall back to the documented
+    default (those aren't operator intent; they're config errors).
+    """
+    config_path = Path(repo_path) / ".bicameral" / "config.yaml"
+    if not config_path.exists():
+        return default
+    try:
+        import yaml
+
+        config = yaml.safe_load(config_path.read_text(encoding="utf-8")) or {}
+        val = config.get(key, default)
+    except Exception:
+        return default
+    if isinstance(val, bool) or not isinstance(val, (int, float)):
+        return default
+    val_f = float(val)
+    import math
+
+    if not math.isfinite(val_f):
+        return default
+    if val_f <= 0:
+        return default
+    # Clamp to the safe range — preserves operator intent vs. silently
+    # rewriting their value to the default.
+    if val_f < min_val:
+        return min_val
+    if val_f > max_val:
+        return max_val
+    return val_f
+
+
+def _read_query_timeout_read_seconds(repo_path: str) -> float:
+    """Resolve ``query_timeout_read_seconds`` (default 5.0). Clamped to
+    ``[_QUERY_TIMEOUT_READ_MIN, _QUERY_TIMEOUT_READ_MAX]``."""
+    return _read_query_timeout_seconds(
+        repo_path,
+        "query_timeout_read_seconds",
+        _DEFAULT_QUERY_TIMEOUT_READ,
+        _QUERY_TIMEOUT_READ_MIN,
+        _QUERY_TIMEOUT_READ_MAX,
+    )
+
+
+def _read_query_timeout_drift_seconds(repo_path: str) -> float:
+    """Resolve ``query_timeout_drift_seconds`` (default 30.0). Clamped to
+    ``[_QUERY_TIMEOUT_DRIFT_MIN, _QUERY_TIMEOUT_DRIFT_MAX]``."""
+    return _read_query_timeout_seconds(
+        repo_path,
+        "query_timeout_drift_seconds",
+        _DEFAULT_QUERY_TIMEOUT_DRIFT,
+        _QUERY_TIMEOUT_DRIFT_MIN,
+        _QUERY_TIMEOUT_DRIFT_MAX,
+    )
+
+
 def _read_guided_mode(repo_path: str) -> bool:
     """Resolve guided-mode flag for this MCP call.
 
@@ -369,6 +450,13 @@ class BicameralContext:
     # bypasses the gate entirely (local debugging knob).
     ingest_rate_limit_burst: int = _DEFAULT_INGEST_RATE_LIMIT_BURST
     ingest_rate_limit_refill_per_sec: float = _DEFAULT_INGEST_RATE_LIMIT_REFILL_PER_SEC
+    # #224: SurrealDB ledger-query timeout budgets in seconds. Two
+    # classes — ``read`` (5s) for point queries; ``drift`` (30s) for
+    # heavy graph traversal / event-replay paths. Enforced by
+    # ``ledger/client.py::LedgerClient.query`` via ``asyncio.wait_for``.
+    # ``BICAMERAL_QUERY_TIMEOUT_DISABLE=1`` env bypasses the wrap.
+    query_timeout_read_seconds: float = _DEFAULT_QUERY_TIMEOUT_READ
+    query_timeout_drift_seconds: float = _DEFAULT_QUERY_TIMEOUT_DRIFT
     # v0.4.8: mutable cache for within-call sync dedup. Frozen-dataclass-safe
     # because the reference stays pinned; only the dict's contents mutate.
     # Keys: ``last_sync_sha`` (str). Cleared by any handler that mutates
@@ -412,6 +500,8 @@ class BicameralContext:
         ingest_max_bytes = _read_ingest_max_bytes(repo_path)
         ingest_rate_limit_burst = _read_ingest_rate_limit_burst(repo_path)
         ingest_rate_limit_refill_per_sec = _read_ingest_rate_limit_refill_per_sec(repo_path)
+        query_timeout_read_seconds = _read_query_timeout_read_seconds(repo_path)
+        query_timeout_drift_seconds = _read_query_timeout_drift_seconds(repo_path)
         # #231: per-developer agent identity (salted email-hash); falls back
         # to _SESSION_ID UUID on git/salt failure.
         session_id = _resolve_agent_identity(repo_path)
@@ -433,6 +523,8 @@ class BicameralContext:
             ingest_max_bytes=ingest_max_bytes,
             ingest_rate_limit_burst=ingest_rate_limit_burst,
             ingest_rate_limit_refill_per_sec=ingest_rate_limit_refill_per_sec,
+            query_timeout_read_seconds=query_timeout_read_seconds,
+            query_timeout_drift_seconds=query_timeout_drift_seconds,
         )
         _emit_config_load_once(instance)
         return instance

--- a/contracts.py
+++ b/contracts.py
@@ -721,6 +721,16 @@ class PreflightResponse(BaseModel):
     # csv list excludes "preflight"; legacy BICAMERAL_PREFLIGHT_TELEMETRY=1 still
     # honored via the #192 deprecation overlay).
     preflight_id: str | None = None
+    # #224 Phase C-pre — count of ledger-query timeout events recorded in
+    # the last 1 hour, per ``timeout_class``. Populated from the
+    # process-local ring buffer in ``ledger/timeout_telemetry.py`` so
+    # the Claude Code ``PreToolUse`` / ``SessionStart`` hooks can surface
+    # current timeout posture to the model without a SurrealDB roundtrip.
+    # Shape: ``{"read": int, "drift": int}``. Defaults to all-zero so
+    # older response consumers ignore the field cleanly. Reset on
+    # process restart (per-session granularity is correct for the
+    # session-start hook surfacing).
+    recent_timeout_count: dict[str, int] = Field(default_factory=lambda: {"read": 0, "drift": 0})
 
 
 # ── Tool 10: /bicameral_judge_gaps ───────────────────────────────────

--- a/docs/policies/claude-hooks-mcp-integration.md
+++ b/docs/policies/claude-hooks-mcp-integration.md
@@ -1,0 +1,124 @@
+# Claude Code hooks → bicameral MCP context integration (#224 Phase C-pre)
+
+When the agent on the other end of the MCP transport is **Claude Code**,
+we leverage Claude Code hooks (``PreToolUse``, ``SessionStart``) to
+fetch *relative context* from the bicameral MCP at gate-time and
+surface it to the model.
+
+This is **additive** over the deterministic server-side gates
+documented elsewhere. It is not a substitute. Per the #205
+doctrine, governance is enforced by deterministic code; the hooks
+add context, not authority.
+
+## Hooks in this repo
+
+| Hook | Fires | Effect |
+|---|---|---|
+| ``.claude/hooks/session_start_timeout_posture.py`` | Once per Claude Code session | Prints a one-line brief to stderr summarizing current ledger-query timeout config + recent timeout-event counts |
+| ``.claude/hooks/pre_tool_use_timeout_context.py`` | Before bicameral tool calls (configure via ``.claude/settings.json``) | Prints a warning to stderr only when the ring buffer shows recent (<10 min) timeouts, so the model has evidence to back off or pick ``timeout_class="drift"`` |
+
+Both hooks **always exit 0**. They never block tool execution.
+``stderr`` is the surfacing channel because Claude Code routes hook
+stderr back to the model as a context fragment.
+
+## Wiring the hooks
+
+Edit ``.claude/settings.json`` to register the hooks. Example shape
+(operator-specific; not committed by default):
+
+```json
+{
+  "hooks": {
+    "SessionStart": [
+      {
+        "matcher": "",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "python .claude/hooks/session_start_timeout_posture.py"
+          }
+        ]
+      }
+    ],
+    "PreToolUse": [
+      {
+        "matcher": "mcp__bicameral__bicameral_.*",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "python .claude/hooks/pre_tool_use_timeout_context.py"
+          }
+        ]
+      }
+    ]
+  }
+}
+```
+
+## Design constraints
+
+1. **Exit 0 unconditionally.** A hook crash must never block the
+   session or the tool call. Each script wraps every external
+   call in ``try / except``.
+2. **Quiet when there's nothing to say.** The pre-tool-use hook
+   only emits when recent timeouts exist. A clean session prints
+   nothing — no model-context noise.
+3. **No PII / secret routing.** The brief emits counts + numeric
+   budgets + the env-disable boolean. No SQL fragments, no
+   decision IDs, no operator email — the hook is observability,
+   not exfiltration.
+4. **MCP unreachable → graceful degradation.** If the bicameral
+   package isn't importable from where the hook runs, the
+   session-start hook prints a single warning and exits 0. The
+   pre-tool-use hook exits 0 silently.
+5. **Cross-platform.** Hooks are Python scripts because the
+   bicameral operator base spans Windows and POSIX. ``python``
+   on PATH is the only requirement.
+
+## Wire format with the MCP
+
+The hooks read two surfaces:
+
+1. **Local config** via ``context._read_query_timeout_*_seconds`` —
+   so the brief always shows the actually-resolved budget after
+   fail-closed parsing, not the unverified raw config value.
+2. **In-process ring buffer** via
+   ``ledger.timeout_telemetry.recent_timeout_counts`` — counts of
+   ``LedgerTimeoutError`` events emitted in the configured window.
+
+The buffer is **process-local**. Each Claude Code session running
+in the bicameral checkout sees its own process; restarting the
+MCP server resets the buffer. This matches the session-start
+surfacing semantic — operators want "what's happened in this
+session" not "what's happened in history."
+
+The same ring-buffer state is also surfaced via the
+``bicameral_preflight`` MCP response (``recent_timeout_count`` field).
+That's the *other* path the hook architecture supports: a future
+hook variant could call into the MCP transport directly rather
+than importing the Python package, useful for clients running the
+MCP over network. The current scripts use the local import path
+because it's simpler and the operator install is local-only.
+
+## Adding a new hook for a different gate
+
+When adding a new gate elsewhere in the codebase (rate-limit,
+fail-closed config, schema check), follow this pattern:
+
+1. **Implement the deterministic server-side gate first.** That
+   is the floor. The hook is additive.
+2. **Add the ring-buffer / counter surface** alongside the gate
+   so the hook has data to fetch.
+3. **Register the gate** in ``governance-gates.yaml``.
+4. **Add a Python hook script** at ``.claude/hooks/<gate>_*.py``
+   that reads the surface and emits stderr context. Exit 0 always.
+5. **Document the wiring** in this file under a new section so
+   operators can register the hook in ``.claude/settings.json``
+   if they want it.
+6. **Test the hook script as a subprocess** in
+   ``tests/test_claude_hooks_*.py`` — sociable, real script,
+   real env, real buffer state.
+
+Per the
+[feedback-claude-hooks-for-mcp-context memory](../../memory/feedback_claude_hooks_for_mcp_context.md),
+this is the default pattern for new gates in this codebase.

--- a/docs/policies/query-timeouts.md
+++ b/docs/policies/query-timeouts.md
@@ -1,0 +1,130 @@
+# Ledger query timeouts (#224)
+
+Every ledger query is bounded by a wallclock timeout. Queries that
+exceed their budget raise ``LedgerTimeoutError`` (a subclass of
+``LedgerError``) rather than hanging the agent indefinitely.
+
+## Default budgets
+
+| Class | Default | Range (clamped) | Where it's used |
+|---|---|---|---|
+| ``read`` | 5.0 s | 0.5 – 120 s | Point queries, shallow SELECTs (the default for every ledger call) |
+| ``drift`` | 30.0 s | 1 – 600 s | Heavy graph-traversal queries (currently: ``handlers/history.py::_fetch_all_decisions_enriched``) |
+
+The two classes are deliberate — see [the audit decision below](#why-only-two-classes).
+
+## Configuration
+
+Set under ``.bicameral/config.yaml`` (operator-supplied, project-local):
+
+```yaml
+query_timeout_read_seconds: 5
+query_timeout_drift_seconds: 30
+```
+
+### Fail-closed behavior
+
+Bad config never produces an unbounded query.
+
+| Config value | Resolved budget |
+|---|---|
+| Missing key | Default |
+| ``"fast"`` / any string | Default |
+| ``True`` / ``False`` | Default |
+| ``-1``, ``0``, NaN, Inf | Default |
+| ``0.01`` (below min) | Clamped to MIN |
+| ``9999`` (above max) | Clamped to MAX |
+| Valid numeric in range | Used as-is |
+
+Out-of-range values are **clamped** rather than substituted with the default so
+operator intent ("I want a long-but-bounded budget") is preserved. Truly
+malformed values (NaN, negative, non-numeric) fall back to the documented default —
+those aren't operator intent; they're config errors.
+
+## Env override (debugging)
+
+Set ``BICAMERAL_QUERY_TIMEOUT_DISABLE=1`` to skip the wrap entirely.
+Use for:
+
+- Intentional data export / recovery operations that legitimately run long.
+- Local debugging when a slow query is what you're trying to understand.
+
+The flag matches the precedent set by ``BICAMERAL_INGEST_RATE_LIMIT_DISABLE``.
+It is **read fresh on every query**, so test fixtures can toggle it via
+``monkeypatch.setenv`` without restarting the process.
+
+## Error shape
+
+When a query exceeds its budget, ``LedgerTimeoutError`` carries:
+
+| Attribute | Description |
+|---|---|
+| ``sql_prefix`` | First 200 chars of the SQL (truncated for log safety) |
+| ``timeout_class`` | ``"read"`` or ``"drift"`` |
+| ``elapsed_seconds`` | Actual wallclock at the point of cancellation |
+| ``budget_seconds`` | Configured budget that was exceeded |
+
+Existing ``except LedgerError`` handlers catch this transparently —
+``LedgerTimeoutError`` is a subclass. Code that needs to distinguish
+timeout from other ledger errors can match the subclass directly.
+
+## Telemetry
+
+Each timeout fire appends one entry to a process-local ring buffer in
+``ledger/timeout_telemetry.py``:
+
+- Capacity: 1000 entries (older drop automatically).
+- Surfaced via the ``recent_timeout_count`` field on
+  ``PreflightResponse`` so a Claude Code hook can read the recent
+  count without a SurrealDB roundtrip.
+- Reset on process restart — per-session granularity matches the
+  session-start hook surfacing.
+
+To completely disable telemetry, set ``BICAMERAL_TELEMETRY`` to a CSV
+that excludes the relevant scope. The ring buffer itself has no PII;
+``sql_prefix`` is capped at 200 chars but a sufficiently long table
+name + WHERE clause could leak a column name or ID prefix. Trade off
+observability vs. zero-info-leak by disabling the scope.
+
+## Why only two classes
+
+The initial design considered per-call override knobs and a third
+"slow-but-legitimate" class. We deferred both:
+
+- **Per-call override knob.** Adding a third public parameter to
+  ``LedgerClient.query`` for an unmeasured need is YAGNI. If
+  ``drift`` (30s) proves insufficient, a future cycle adds a
+  ``timeout_seconds: float | None = None`` kwarg that bypasses the
+  class lookup — forward-compat preserved.
+- **Third class.** The drift-class call site is currently a single
+  one — the enriched-fetch full-tree query in
+  ``handlers/history.py``. The other workflows that initially
+  looked drift-shaped (preflight, sync_middleware, link_commit)
+  turned out to chain many individually-fast queries; each
+  individual query stays inside ``read`` budget. Adding a third
+  class without a concrete site needing it would be premature.
+
+## Deterministic gate vs. agent hooks (#205 doctrine)
+
+The ``asyncio.wait_for`` wrap in
+``ledger/client.py::LedgerClient._run_with_timeout`` is the
+**deterministic server-side gate**. It fires identically regardless
+of which MCP client is on the other end — generic MCP clients,
+custom integrations, Claude Code. That gate is the truth.
+
+For **Claude-as-agent specifically**, the timeout posture is
+surfaced via Claude Code hooks in ``.claude/hooks/`` that read the
+ring buffer + config and emit context to stderr where Claude Code
+routes it back to the model. The hooks are **advisory only** —
+they exit 0 always, never block, and the deterministic wrap still
+fires whether they ran or not. See
+[claude-hooks-mcp-integration.md](claude-hooks-mcp-integration.md)
+for the hook design.
+
+## Governance
+
+The wrap is registered in ``governance-gates.yaml`` as the backing
+gate for any SKILL.md text that claims a "queries time out" default.
+The skill-governance lint will fail to find a backing gate for that
+claim only if the gate entry is removed; the wrap itself is
+unconditional.

--- a/governance-gates.yaml
+++ b/governance-gates.yaml
@@ -19,4 +19,14 @@
 # sweep that lands real entries; Phase 4 wires the lint into CI as a hard
 # gate.
 
-gates: []
+gates:
+  # #224: deterministic server-side timeout on every ledger query.
+  # Enforces the "queries time out after configured budget" claim
+  # uniformly for all MCP clients (not just Claude — the wrap is
+  # client-agnostic). Operator config can adjust budgets; the wrap
+  # itself is unconditional unless BICAMERAL_QUERY_TIMEOUT_DISABLE=1.
+  - skill: "*"
+    instruction_pattern: "queries time out"
+    backing_gate: ledger/client.py::LedgerClient._run_with_timeout::asyncio.wait_for
+    gate_kind: server
+

--- a/handlers/history.py
+++ b/handlers/history.py
@@ -218,6 +218,9 @@ async def _fetch_all_decisions_enriched(ledger) -> list[dict]:
             FROM decision
             ORDER BY created_at ASC
             """,
+            # #224: full-tree enriched query with graph traversal on
+            # every decision row. Heavy traversal path → drift budget.
+            timeout_class="drift",
         )
     except Exception as exc:
         logger.warning("[history] enriched query failed, falling back: %s", exc)

--- a/handlers/preflight.py
+++ b/handlers/preflight.py
@@ -749,6 +749,17 @@ async def handle_preflight(
     fired = bool(region_matches or unresolved_collisions or context_pending_ready or guided_mode)
     action_hints = generate_hints_from_findings([], drift_candidates, [], guided_mode)
 
+    # #224 Phase C-pre: surface recent timeout counts so a Claude
+    # PreToolUse / SessionStart hook can read current gate posture
+    # without a separate MCP roundtrip. Defaults to {"read": 0, "drift": 0}
+    # if the telemetry buffer is unavailable.
+    try:
+        from ledger.timeout_telemetry import recent_timeout_counts
+
+        recent_timeouts = recent_timeout_counts()
+    except Exception:
+        recent_timeouts = {"read": 0, "drift": 0}
+
     response = PreflightResponse(
         topic=topic,
         fired=fired,
@@ -765,6 +776,7 @@ async def handle_preflight(
         sync_metrics=sync_metrics,
         product_stage=_PRODUCT_STAGE_MSG if _should_show_product_stage() else None,
         preflight_id=pid,
+        recent_timeout_count=recent_timeouts,
     )
 
     # #65 — capture-loop event. surfaced_ids is the union of decision_ids the

--- a/ledger/adapter.py
+++ b/ledger/adapter.py
@@ -156,9 +156,21 @@ class SurrealDBLedgerAdapter:
         url: str | None = None,
         ns: str = "bicameral",
         db: str = "ledger",
+        *,
+        query_timeout_read_seconds: float | None = None,
+        query_timeout_drift_seconds: float | None = None,
     ) -> None:
         self._url = url or os.getenv("SURREAL_URL", _default_db_url())
-        self._client = LedgerClient(url=self._url, ns=ns, db=db)
+        # #224: timeout budgets are forwarded into LedgerClient. None →
+        # LedgerClient module defaults (5s read / 30s drift); callers
+        # that wire operator config through get_ledger() pass concrete
+        # floats.
+        client_kwargs: dict = {"url": self._url, "ns": ns, "db": db}
+        if query_timeout_read_seconds is not None:
+            client_kwargs["query_timeout_read_seconds"] = query_timeout_read_seconds
+        if query_timeout_drift_seconds is not None:
+            client_kwargs["query_timeout_drift_seconds"] = query_timeout_drift_seconds
+        self._client = LedgerClient(**client_kwargs)
         self._connected = False
         self._pending_destructive: DestructiveMigrationRequired | None = None
 

--- a/ledger/client.py
+++ b/ledger/client.py
@@ -7,9 +7,12 @@ back a plain list of dicts — no SDK types leak through.
 
 from __future__ import annotations
 
+import asyncio
 import logging
+import os
 import re
-from typing import Any
+import time
+from typing import Any, Literal
 
 from surrealdb import AsyncSurreal, RecordID
 
@@ -19,6 +22,29 @@ except ImportError:
     SurrealError = Exception  # type: ignore[assignment,misc]
 
 logger = logging.getLogger(__name__)
+
+# #224: per-query wallclock timeout budgets. Defaults match
+# ``context.py::_DEFAULT_QUERY_TIMEOUT_{READ,DRIFT}`` so a
+# bare ``LedgerClient(url)`` constructed in tests / adapters gets
+# safe defaults without requiring a ``BicameralContext`` injection.
+# Operator-configured values flow through
+# ``BicameralContext.query_timeout_{read,drift}_seconds`` → the
+# adapter passes them to ``LedgerClient.__init__``.
+_DEFAULT_QUERY_TIMEOUT_READ_SECONDS = 5.0
+_DEFAULT_QUERY_TIMEOUT_DRIFT_SECONDS = 30.0
+
+# #224: env-override for the timeout wrap. Mirror the
+# ``BICAMERAL_INGEST_RATE_LIMIT_DISABLE`` precedent at
+# ``handlers/ingest.py:368``. Use cases: data export, recovery,
+# intentionally long-running operator query.
+_QUERY_TIMEOUT_DISABLE_ENV = "BICAMERAL_QUERY_TIMEOUT_DISABLE"
+_TRUTHY = frozenset({"1", "true", "yes", "on"})
+
+
+def _query_timeout_disabled() -> bool:
+    """Read the env-override fresh on every call so test fixtures
+    can toggle it without restarting the module."""
+    return os.getenv(_QUERY_TIMEOUT_DISABLE_ENV, "").strip().lower() in _TRUTHY
 
 
 # Windows-drive-letter detector at the start of an embedded URL path.
@@ -89,6 +115,40 @@ class LedgerError(RuntimeError):
     """
 
 
+class LedgerTimeoutError(LedgerError):
+    """Raised when a ledger query exceeds its wallclock timeout budget.
+
+    Carries the timeout class, elapsed seconds, configured budget,
+    and a 200-char SQL prefix for operator triage. Subclass of
+    ``LedgerError`` so existing ``except LedgerError`` handler blocks
+    catch it by default; callers that need to distinguish a timeout
+    from other ledger errors can match on ``LedgerTimeoutError``.
+
+    The wrap that produces this is the deterministic server-side gate
+    for #224 — it fires identically regardless of which MCP client is
+    on the other end of the transport. Per #205 doctrine, governance
+    is enforced here, not in skill text.
+    """
+
+    def __init__(
+        self,
+        *,
+        sql_prefix: str,
+        timeout_class: str,
+        elapsed_seconds: float,
+        budget_seconds: float,
+    ) -> None:
+        self.sql_prefix = sql_prefix
+        self.timeout_class = timeout_class
+        self.elapsed_seconds = elapsed_seconds
+        self.budget_seconds = budget_seconds
+        super().__init__(
+            f"Ledger query exceeded {timeout_class} timeout "
+            f"({elapsed_seconds:.2f}s > {budget_seconds:.1f}s budget): "
+            f"{sql_prefix}"
+        )
+
+
 def _normalize(value: Any) -> Any:
     """Recursively convert SDK types to plain Python objects."""
     if isinstance(value, RecordID):
@@ -121,6 +181,9 @@ class LedgerClient:
         db: str = "ledger",
         username: str = "root",
         password: str = "root",
+        *,
+        query_timeout_read_seconds: float = _DEFAULT_QUERY_TIMEOUT_READ_SECONDS,
+        query_timeout_drift_seconds: float = _DEFAULT_QUERY_TIMEOUT_DRIFT_SECONDS,
     ) -> None:
         # Normalize embedded Windows paths so the SurrealDB SDK's internal
         # urllib.parse.urlparse() doesn't choke on the drive-letter colon.
@@ -131,6 +194,8 @@ class LedgerClient:
         self._username = username
         self._password = password
         self._db: Any = None
+        self._timeout_read = query_timeout_read_seconds
+        self._timeout_drift = query_timeout_drift_seconds
 
     async def connect(self) -> None:
         self._db = AsyncSurreal(self.url)
@@ -147,7 +212,47 @@ class LedgerClient:
             await self._db.close()
             self._db = None
 
-    async def query(self, sql: str, vars: dict | None = None) -> list[dict]:
+    def _budget_for(self, timeout_class: Literal["read", "drift"]) -> float:
+        return self._timeout_drift if timeout_class == "drift" else self._timeout_read
+
+    async def _run_with_timeout(
+        self,
+        sql: str,
+        vars: dict | None,
+        timeout_class: Literal["read", "drift"],
+    ) -> Any:
+        """Execute the underlying SDK query under the configured timeout
+        wallclock. ``BICAMERAL_QUERY_TIMEOUT_DISABLE=1`` bypasses the
+        wrap (debugging knob for intentionally long-running queries).
+        """
+        if _query_timeout_disabled():
+            return await self._db.query(sql, vars)
+        budget = self._budget_for(timeout_class)
+        started = time.perf_counter()
+        try:
+            return await asyncio.wait_for(self._db.query(sql, vars), timeout=budget)
+        except TimeoutError:
+            elapsed = time.perf_counter() - started
+            _emit_timeout_telemetry(
+                sql=sql,
+                timeout_class=timeout_class,
+                elapsed_seconds=elapsed,
+                budget_seconds=budget,
+            )
+            raise LedgerTimeoutError(
+                sql_prefix=sql[:200],
+                timeout_class=timeout_class,
+                elapsed_seconds=elapsed,
+                budget_seconds=budget,
+            ) from None
+
+    async def query(
+        self,
+        sql: str,
+        vars: dict | None = None,
+        *,
+        timeout_class: Literal["read", "drift"] = "read",
+    ) -> list[dict]:
         """Run a SurrealQL statement and return a list of normalized dicts.
 
         Raises:
@@ -155,18 +260,28 @@ class LedgerClient:
                 error string instead of rows). Common causes: malformed
                 SurrealQL, permission failures, ASSERT violations on the
                 underlying SELECT.
+            LedgerTimeoutError: when the query exceeds the configured
+                wallclock budget for its ``timeout_class`` (default
+                ``"read"`` = 5s; pass ``timeout_class="drift"`` for
+                heavy traversal / replay paths = 30s default). #224.
         """
         if self._db is None:
             raise RuntimeError("LedgerClient not connected — call await client.connect() first")
         try:
-            result = await self._db.query(sql, vars)
+            result = await self._run_with_timeout(sql, vars, timeout_class)
         except SurrealError as exc:
             raise LedgerError(f"SurrealDB rejected query: {exc}\nSQL: {sql[:300]}") from exc
         if isinstance(result, str):
             raise LedgerError(f"SurrealDB rejected query: {result}\nSQL: {sql[:300]}")
         return _normalize(result) if isinstance(result, list) else []
 
-    async def execute(self, sql: str, vars: dict | None = None) -> None:
+    async def execute(
+        self,
+        sql: str,
+        vars: dict | None = None,
+        *,
+        timeout_class: Literal["read", "drift"] = "read",
+    ) -> None:
         """Run a SurrealQL statement, discarding the result (DDL / DML).
 
         Raises:
@@ -174,19 +289,53 @@ class LedgerClient:
                 the class of silent-failure bugs where a UNIQUE violation
                 or ASSERT failure gets returned as an error string and
                 the caller proceeds believing the write succeeded.
+            LedgerTimeoutError: when the statement exceeds the configured
+                wallclock budget. See ``query`` for details.
         """
         if self._db is None:
             raise RuntimeError("LedgerClient not connected")
         try:
-            result = await self._db.query(sql, vars)
+            result = await self._run_with_timeout(sql, vars, timeout_class)
         except SurrealError as exc:
             raise LedgerError(f"SurrealDB rejected statement: {exc}\nSQL: {sql[:300]}") from exc
         if isinstance(result, str):
             raise LedgerError(f"SurrealDB rejected statement: {result}\nSQL: {sql[:300]}")
 
-    async def execute_many(self, statements: list[str]) -> None:
+    async def execute_many(
+        self,
+        statements: list[str],
+        *,
+        timeout_class: Literal["read", "drift"] = "read",
+    ) -> None:
         """Run multiple DDL/DML statements in sequence (one at a time)."""
         for stmt in statements:
             stmt = stmt.strip()
             if stmt:
-                await self.execute(stmt)
+                await self.execute(stmt, timeout_class=timeout_class)
+
+
+def _emit_timeout_telemetry(
+    *,
+    sql: str,
+    timeout_class: str,
+    elapsed_seconds: float,
+    budget_seconds: float,
+) -> None:
+    """Forward a timeout event to the ring-buffer + audit-log telemetry
+    layer. Imported lazily so a ``LedgerClient`` constructed before
+    ``ledger.timeout_telemetry`` is importable (e.g. early in module
+    import) still raises a useful timeout, just without the recorded
+    event. Phase C-pre wires up the ring buffer; Phase C wires up
+    the audit-log emit.
+    """
+    try:
+        from ledger.timeout_telemetry import record_timeout
+
+        record_timeout(
+            sql_prefix=sql[:200],
+            timeout_class=timeout_class,
+            elapsed_seconds=elapsed_seconds,
+            budget_seconds=budget_seconds,
+        )
+    except Exception:  # noqa: BLE001 — telemetry must never break a query
+        pass

--- a/ledger/timeout_telemetry.py
+++ b/ledger/timeout_telemetry.py
@@ -1,0 +1,90 @@
+"""In-memory ring buffer + counters for ledger-query timeout events (#224).
+
+Two responsibilities:
+
+1. **Ring buffer** — last 1000 timeout records, used by the
+   ``bicameral_preflight`` response (``recent_timeout_count``) so a
+   Claude Code ``SessionStart`` / ``PreToolUse`` hook can fetch
+   gate-time context for the model without round-tripping SurrealDB.
+
+2. **Counter snapshot** — per-timeout-class count of events fired in
+   the last 1 hour. Same backing store; surfaced via
+   ``recent_timeout_counts(window_seconds=3600)``.
+
+Scope is **process-local** and **in-memory only** by design:
+
+- Same granularity as the session-start hook (a fresh process = a
+  fresh count, which is what a session-start surfacing wants).
+- Zero SurrealDB roundtrip for the dashboard / preflight read path.
+- Trivial to reason about for tests (``clear_for_testing()``).
+
+Phase C wires the audit-log emit alongside this buffer.
+"""
+
+from __future__ import annotations
+
+import threading
+import time
+from collections import deque
+from dataclasses import dataclass
+
+_BUFFER_CAP = 1000
+
+
+@dataclass(frozen=True)
+class TimeoutEvent:
+    sql_prefix: str
+    timeout_class: str
+    elapsed_seconds: float
+    budget_seconds: float
+    recorded_at: float  # time.time() unix seconds
+
+
+_buffer: deque[TimeoutEvent] = deque(maxlen=_BUFFER_CAP)
+_lock = threading.Lock()
+
+
+def record_timeout(
+    *,
+    sql_prefix: str,
+    timeout_class: str,
+    elapsed_seconds: float,
+    budget_seconds: float,
+) -> None:
+    """Append a timeout event to the ring buffer. Thread-safe; bounded
+    at ``_BUFFER_CAP`` (older entries automatically dropped by deque)."""
+    event = TimeoutEvent(
+        sql_prefix=sql_prefix[:200],
+        timeout_class=timeout_class,
+        elapsed_seconds=elapsed_seconds,
+        budget_seconds=budget_seconds,
+        recorded_at=time.time(),
+    )
+    with _lock:
+        _buffer.append(event)
+
+
+def recent_timeout_counts(window_seconds: float = 3600.0) -> dict[str, int]:
+    """Return per-class counts of timeout events recorded in the last
+    ``window_seconds`` (default 1 hour). Classes always present in the
+    result so hook scripts can rely on the shape: at minimum returns
+    ``{"read": 0, "drift": 0}``."""
+    cutoff = time.time() - window_seconds
+    counts: dict[str, int] = {"read": 0, "drift": 0}
+    with _lock:
+        for event in _buffer:
+            if event.recorded_at < cutoff:
+                continue
+            counts[event.timeout_class] = counts.get(event.timeout_class, 0) + 1
+    return counts
+
+
+def buffer_size() -> int:
+    with _lock:
+        return len(_buffer)
+
+
+def clear_for_testing() -> None:
+    """Reset the buffer. Test-only; never call from production code."""
+    with _lock:
+        _buffer.clear()

--- a/tests/test_claude_hooks_timeout_context.py
+++ b/tests/test_claude_hooks_timeout_context.py
@@ -1,0 +1,194 @@
+"""#224 Phase C-pre tests for the Claude Code hook scripts.
+
+Sociable per CLAUDE.md: invokes the real hook script as a subprocess
+against a real bicameral checkout (the test's repo), real
+``ledger.timeout_telemetry`` ring buffer state. The only seam is
+``CLAUDE_PROJECT_DIR`` (env), which the harness uses to point the
+hook at this repo's root.
+
+These tests pin three contracts:
+
+1. The session-start hook always exits 0 and emits a parseable
+   one-line brief to stderr.
+2. The pre-tool-use hook always exits 0 and emits a warning to
+   stderr only when recent timeouts exist.
+3. ``PreflightResponse.recent_timeout_count`` is shaped as
+   ``{"read": int, "drift": int}`` so the hook + MCP both see the
+   same default value when nothing has timed out.
+"""
+
+from __future__ import annotations
+
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+from ledger import timeout_telemetry
+
+_REPO_ROOT = Path(__file__).resolve().parent.parent
+_HOOKS_DIR = _REPO_ROOT / ".claude" / "hooks"
+
+
+@pytest.fixture(autouse=True)
+def _clear_buffer():
+    timeout_telemetry.clear_for_testing()
+    yield
+    timeout_telemetry.clear_for_testing()
+
+
+def _run_hook(script: str, *, stdin: str = "") -> subprocess.CompletedProcess:
+    env = os.environ.copy()
+    env["CLAUDE_PROJECT_DIR"] = str(_REPO_ROOT)
+    return subprocess.run(
+        [sys.executable, str(_HOOKS_DIR / script)],
+        capture_output=True,
+        text=True,
+        env=env,
+        input=stdin,
+        timeout=15,
+    )
+
+
+def test_session_start_hook_exits_zero_with_no_timeouts() -> None:
+    result = _run_hook("session_start_timeout_posture.py")
+    assert result.returncode == 0
+    assert "[bicameral] query timeouts last 1h:" in result.stderr
+    assert "0 read / 0 drift" in result.stderr
+    assert "budgets:" in result.stderr
+
+
+def test_session_start_hook_includes_env_disable_state(monkeypatch) -> None:
+    """The brief surfaces whether BICAMERAL_QUERY_TIMEOUT_DISABLE is on."""
+    env = os.environ.copy()
+    env["CLAUDE_PROJECT_DIR"] = str(_REPO_ROOT)
+    env["BICAMERAL_QUERY_TIMEOUT_DISABLE"] = "1"
+    result = subprocess.run(
+        [sys.executable, str(_HOOKS_DIR / "session_start_timeout_posture.py")],
+        capture_output=True,
+        text=True,
+        env=env,
+        timeout=15,
+    )
+    assert result.returncode == 0
+    assert "env-disable: on" in result.stderr
+
+
+def test_session_start_hook_reflects_recent_timeouts() -> None:
+    """If the ring buffer has events, the count appears in the brief."""
+    timeout_telemetry.record_timeout(
+        sql_prefix="SELECT 1",
+        timeout_class="read",
+        elapsed_seconds=6.0,
+        budget_seconds=5.0,
+    )
+    timeout_telemetry.record_timeout(
+        sql_prefix="SELECT 2",
+        timeout_class="drift",
+        elapsed_seconds=35.0,
+        budget_seconds=30.0,
+    )
+    # The hook runs in a subprocess — it sees a fresh, empty ring
+    # buffer in that subprocess. So this test verifies the in-process
+    # buffer state directly. The subprocess-side coverage is the
+    # exit-0 + brief-shape test above.
+    counts = timeout_telemetry.recent_timeout_counts()
+    assert counts == {"read": 1, "drift": 1}
+
+
+def test_pre_tool_use_hook_exits_zero_with_no_timeouts() -> None:
+    """No-timeout path: hook is quiet (exit 0, empty stderr posture line)."""
+    result = _run_hook("pre_tool_use_timeout_context.py", stdin="{}")
+    assert result.returncode == 0
+    # Quiet path — should not emit the "recent ledger-query timeouts" line.
+    assert "recent ledger-query timeouts" not in result.stderr
+
+
+def test_pre_tool_use_hook_drains_stdin() -> None:
+    """Even with a large JSON envelope on stdin, hook completes promptly."""
+    big_payload = '{"tool": "bicameral_search", "args": ' + ('"x" * 10000') + "}"
+    result = _run_hook("pre_tool_use_timeout_context.py", stdin=big_payload)
+    assert result.returncode == 0
+
+
+def test_session_start_hook_handles_missing_bicameral_import(tmp_path) -> None:
+    """Run the hook with CLAUDE_PROJECT_DIR pointing at an empty dir.
+    It should exit 0 and emit a single warning to stderr, not crash."""
+    env = os.environ.copy()
+    env["CLAUDE_PROJECT_DIR"] = str(tmp_path)
+    # Also strip PYTHONPATH so it can't find bicameral via the parent env.
+    env.pop("PYTHONPATH", None)
+    result = subprocess.run(
+        [sys.executable, str(_HOOKS_DIR / "session_start_timeout_posture.py")],
+        capture_output=True,
+        text=True,
+        env=env,
+        cwd=str(tmp_path),
+        timeout=15,
+    )
+    # Exit 0 — graceful degradation.
+    assert result.returncode == 0
+
+
+def test_preflight_response_includes_recent_timeout_count_field() -> None:
+    """Schema check — the new additive field is present with the
+    documented default shape, so older response consumers can ignore
+    it and hooks can rely on a stable key structure."""
+    from contracts import PreflightResponse
+
+    resp = PreflightResponse(topic="t", fired=False, reason="no_matches", guided_mode=False)
+    assert resp.recent_timeout_count == {"read": 0, "drift": 0}
+
+    resp2 = PreflightResponse(
+        topic="t",
+        fired=False,
+        reason="no_matches",
+        guided_mode=False,
+        recent_timeout_count={"read": 7, "drift": 1},
+    )
+    assert resp2.recent_timeout_count == {"read": 7, "drift": 1}
+
+
+# ── ring-buffer cap ────────────────────────────────────────────────
+
+
+def test_timeout_telemetry_ring_buffer_caps_at_1000() -> None:
+    """Per Phase C-pre design — buffer is bounded so a runaway timeout
+    storm doesn't unbounded-grow process memory."""
+    for i in range(1500):
+        timeout_telemetry.record_timeout(
+            sql_prefix=f"SELECT {i}",
+            timeout_class="read",
+            elapsed_seconds=6.0,
+            budget_seconds=5.0,
+        )
+    assert timeout_telemetry.buffer_size() == 1000
+
+
+def test_recent_timeout_counts_respects_window() -> None:
+    """An entry older than the configured window must not appear in
+    the per-class count."""
+    import time as _time
+    from unittest.mock import patch
+
+    # Inject a record with a recorded_at well in the past.
+    fake_old = _time.time() - 10_000
+    event = timeout_telemetry.TimeoutEvent(
+        sql_prefix="old",
+        timeout_class="read",
+        elapsed_seconds=10.0,
+        budget_seconds=5.0,
+        recorded_at=fake_old,
+    )
+    timeout_telemetry._buffer.append(event)
+    # A fresh recent event.
+    timeout_telemetry.record_timeout(
+        sql_prefix="fresh",
+        timeout_class="read",
+        elapsed_seconds=6.0,
+        budget_seconds=5.0,
+    )
+    counts = timeout_telemetry.recent_timeout_counts(window_seconds=3600.0)
+    assert counts["read"] == 1  # the old entry filtered out

--- a/tests/test_query_timeout_handler_routing.py
+++ b/tests/test_query_timeout_handler_routing.py
@@ -1,0 +1,132 @@
+"""#224 handler-routing tests — pin which call sites take the drift
+budget vs. the default read budget.
+
+Static-grep shape against handler source rather than behavioral
+spin-up: the cost of forcing a real slow query to verify class
+selection is high relative to the static-guarantee value. This file
+catches the regression class "annotation was removed during a
+refactor" cheaply.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+import pytest
+
+_REPO_ROOT = Path(__file__).resolve().parent.parent
+_HANDLERS_DIR = _REPO_ROOT / "handlers"
+
+
+def _read(path: Path) -> str:
+    return path.read_text(encoding="utf-8")
+
+
+# ── Drift-class sites (declared in plan-224 Phase B) ─────────────────
+
+
+def test_history_enriched_fetch_uses_drift_class() -> None:
+    """`_fetch_all_decisions_enriched` runs a single graph-traversal
+    query across every decision row — the only handler-level call
+    site declared as drift-class in Phase B."""
+    src = _read(_HANDLERS_DIR / "history.py")
+    # The annotation must appear after the enriched SELECT body.
+    enriched_idx = src.find("<-yields<-input_span")
+    assert enriched_idx >= 0, "enriched SELECT missing — refactor?"
+    # The drift-class annotation appears somewhere after this point
+    # and before the next def.
+    next_def = src.find("\nasync def ", enriched_idx)
+    if next_def < 0:
+        next_def = len(src)
+    enriched_block = src[enriched_idx:next_def]
+    assert 'timeout_class="drift"' in enriched_block, (
+        'history.py enriched-fetch call no longer carries timeout_class="drift" — #224 regression'
+    )
+
+
+# ── Read-class sites (default; must NOT carry drift annotation) ─────
+
+
+_READ_CLASS_HANDLERS = [
+    "ratify.py",
+    "remove_decision.py",
+    "remove_source.py",
+    "reset.py",
+    "resolve_collision.py",
+    "usage_summary.py",
+    "decision_status.py",
+    "search_decisions.py",
+    "ingest.py",
+]
+
+
+@pytest.mark.parametrize("handler_name", _READ_CLASS_HANDLERS)
+def test_read_class_handlers_do_not_carry_drift_annotation(handler_name: str) -> None:
+    """Phase B keeps read-class handlers on the 5s default. If any of
+    them sprout a `timeout_class="drift"` annotation, the plan needs
+    to be revisited (either narrow scope, or update this test)."""
+    path = _HANDLERS_DIR / handler_name
+    if not path.exists():
+        pytest.skip(f"handler {handler_name} not present in this checkout")
+    src = _read(path)
+    assert 'timeout_class="drift"' not in src, (
+        f"{handler_name} acquired a drift annotation outside the "
+        "Phase B scope — update plan-224 and this test if intentional"
+    )
+
+
+# ── Audit-tier guard: only the declared site uses drift across all handlers ─
+
+
+def test_exactly_one_handler_call_site_uses_drift_class() -> None:
+    """Sanity check: the entire `handlers/` directory should carry
+    exactly one `timeout_class="drift"` annotation today (history's
+    enriched fetch). Drives reviewers to update plan-224 + this
+    test together when adding new drift sites."""
+    drift_uses = []
+    for path in _HANDLERS_DIR.glob("*.py"):
+        for i, line in enumerate(_read(path).splitlines(), start=1):
+            if 'timeout_class="drift"' in line:
+                drift_uses.append((path.name, i))
+    assert len(drift_uses) == 1, f"expected exactly one handler drift annotation, got {drift_uses}"
+    assert drift_uses[0][0] == "history.py", drift_uses
+
+
+# ── governance-gates.yaml: #224 entry present ─────────────────────────
+
+
+def test_governance_gates_contains_query_timeout_entry() -> None:
+    """Per Discipline #2 of plan-224, the deterministic gate must be
+    declared in `governance-gates.yaml` so the skill-governance lint
+    sees the backing-gate link."""
+    gates_yaml = _REPO_ROOT / "governance-gates.yaml"
+    src = _read(gates_yaml)
+    assert "ledger/client.py::LedgerClient._run_with_timeout::asyncio.wait_for" in src, (
+        "#224 gate entry missing from governance-gates.yaml"
+    )
+    # And the instruction pattern is present so the lint can match.
+    assert "queries time out" in src
+
+
+# ── Module-level signature pin: timeout_class is a typed kwarg ────────
+
+
+def test_ledger_client_query_exposes_timeout_class_kwarg() -> None:
+    """If the kwarg name changes, all handler annotations break
+    silently. Pin the signature shape here so a rename caught
+    during refactor surfaces as a single failing test."""
+    src = _read(_REPO_ROOT / "ledger" / "client.py")
+    # The Literal type must be present in the signature.
+    pattern = re.compile(
+        r'async def query\(.*?timeout_class:\s*Literal\["read",\s*"drift"\]',
+        re.DOTALL,
+    )
+    assert pattern.search(src), (
+        'LedgerClient.query signature no longer exposes timeout_class: Literal["read", "drift"]'
+    )
+    pattern_exec = re.compile(
+        r'async def execute\(.*?timeout_class:\s*Literal\["read",\s*"drift"\]',
+        re.DOTALL,
+    )
+    assert pattern_exec.search(src), "LedgerClient.execute signature lost its timeout_class kwarg"

--- a/tests/test_query_timeout_unit.py
+++ b/tests/test_query_timeout_unit.py
@@ -1,0 +1,368 @@
+"""#224 unit tests for ledger query timeout wrap and fail-closed config.
+
+Sociable per CLAUDE.md: instantiates real ``LedgerClient`` over
+``memory://``, real ``BicameralContext`` via direct construction, and
+runs the real ``asyncio.wait_for`` wrap. Narrow seam: patches
+``self._db.query`` with an ``asyncio.sleep`` coroutine to force a slow
+query (we cannot naturally make SurrealDB embedded slow). The patch
+is at the SDK boundary — the wrap and error-shape logic under test
+run unmodified.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import math
+import os
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+import yaml
+
+from context import (
+    _DEFAULT_QUERY_TIMEOUT_DRIFT,
+    _DEFAULT_QUERY_TIMEOUT_READ,
+    _QUERY_TIMEOUT_DRIFT_MAX,
+    _QUERY_TIMEOUT_DRIFT_MIN,
+    _QUERY_TIMEOUT_READ_MAX,
+    _QUERY_TIMEOUT_READ_MIN,
+    _read_query_timeout_drift_seconds,
+    _read_query_timeout_read_seconds,
+)
+from ledger import timeout_telemetry
+from ledger.client import (
+    LedgerClient,
+    LedgerError,
+    LedgerTimeoutError,
+)
+
+# ── fixtures ──────────────────────────────────────────────────────────
+
+
+@pytest.fixture(autouse=True)
+def _clear_telemetry_buffer():
+    """Each test starts with an empty ring buffer."""
+    timeout_telemetry.clear_for_testing()
+    yield
+    timeout_telemetry.clear_for_testing()
+
+
+@pytest.fixture(autouse=True)
+def _clear_timeout_disable_env(monkeypatch):
+    """Default: timeout enabled. Tests that exercise the env-disable
+    bypass set it explicitly."""
+    monkeypatch.delenv("BICAMERAL_QUERY_TIMEOUT_DISABLE", raising=False)
+
+
+async def _connected_client(
+    *,
+    read_seconds: float = 0.2,
+    drift_seconds: float = 0.5,
+) -> LedgerClient:
+    client = LedgerClient(
+        url="memory://",
+        query_timeout_read_seconds=read_seconds,
+        query_timeout_drift_seconds=drift_seconds,
+    )
+    await client.connect()
+    return client
+
+
+def _write_config(repo: Path, payload: dict) -> None:
+    cfg = repo / ".bicameral" / "config.yaml"
+    cfg.parent.mkdir(parents=True, exist_ok=True)
+    cfg.write_text(yaml.safe_dump(payload), encoding="utf-8")
+
+
+# ── ledger/client.py: wrap behavior ──────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_query_under_budget_succeeds_unchanged() -> None:
+    """A fast query goes through the wrap and returns rows unchanged."""
+    client = await _connected_client(read_seconds=2.0)
+    try:
+        # Real SurrealDB embedded; INFO FOR DB is fast and harmless.
+        rows = await client.query("SELECT * FROM bicameral_schema_version")
+        # Result shape: a list (empty or populated). The wrap should
+        # not have altered it.
+        assert isinstance(rows, list)
+    finally:
+        await client.close()
+
+
+@pytest.mark.asyncio
+async def test_query_over_read_budget_raises_ledger_timeout_error() -> None:
+    """A query that exceeds the read budget raises LedgerTimeoutError
+    with all four attributes populated and the SQL prefix preserved."""
+    client = await _connected_client(read_seconds=0.1)
+    sql = "SELECT * FROM intent"
+
+    async def _slow_query(_sql, _vars):
+        await asyncio.sleep(0.5)
+        return []
+
+    try:
+        with patch.object(client._db, "query", side_effect=_slow_query):
+            with pytest.raises(LedgerTimeoutError) as excinfo:
+                await client.query(sql)
+        err = excinfo.value
+        assert err.timeout_class == "read"
+        assert err.budget_seconds == pytest.approx(0.1)
+        assert err.elapsed_seconds >= 0.1
+        assert err.sql_prefix == sql
+        # Subclass of LedgerError so existing catch blocks work.
+        assert isinstance(err, LedgerError)
+    finally:
+        await client.close()
+
+
+@pytest.mark.asyncio
+async def test_query_drift_class_uses_drift_budget() -> None:
+    """timeout_class='drift' uses the drift budget, not the read one."""
+    client = await _connected_client(read_seconds=0.1, drift_seconds=1.0)
+
+    async def _slow_query(_sql, _vars):
+        await asyncio.sleep(0.3)
+        return []
+
+    try:
+        with patch.object(client._db, "query", side_effect=_slow_query):
+            # Under read budget → would timeout. Under drift budget → succeeds.
+            result = await client.query("SELECT * FROM intent", timeout_class="drift")
+            assert result == []
+    finally:
+        await client.close()
+
+
+@pytest.mark.asyncio
+async def test_query_drift_over_drift_budget_still_raises() -> None:
+    """drift budget is itself bounded — exceeding it still raises."""
+    client = await _connected_client(drift_seconds=0.1)
+
+    async def _slow_query(_sql, _vars):
+        await asyncio.sleep(0.4)
+        return []
+
+    try:
+        with patch.object(client._db, "query", side_effect=_slow_query):
+            with pytest.raises(LedgerTimeoutError) as excinfo:
+                await client.query("SELECT * FROM intent", timeout_class="drift")
+        assert excinfo.value.timeout_class == "drift"
+        assert excinfo.value.budget_seconds == pytest.approx(0.1)
+    finally:
+        await client.close()
+
+
+@pytest.mark.asyncio
+async def test_query_timeout_disable_env_skips_wait_for(monkeypatch) -> None:
+    """BICAMERAL_QUERY_TIMEOUT_DISABLE=1 → wrap is bypassed, slow query
+    completes without raising LedgerTimeoutError."""
+    monkeypatch.setenv("BICAMERAL_QUERY_TIMEOUT_DISABLE", "1")
+    client = await _connected_client(read_seconds=0.05)
+
+    async def _slow_query(_sql, _vars):
+        await asyncio.sleep(0.2)
+        return []
+
+    try:
+        with patch.object(client._db, "query", side_effect=_slow_query):
+            result = await client.query("SELECT * FROM intent")
+            assert result == []
+    finally:
+        await client.close()
+
+
+@pytest.mark.asyncio
+async def test_execute_method_also_timeout_wrapped() -> None:
+    """execute() must surface LedgerTimeoutError the same way query() does."""
+    client = await _connected_client(read_seconds=0.1)
+
+    async def _slow_query(_sql, _vars):
+        await asyncio.sleep(0.3)
+        return []
+
+    try:
+        with patch.object(client._db, "query", side_effect=_slow_query):
+            with pytest.raises(LedgerTimeoutError) as excinfo:
+                await client.execute("CREATE foo SET bar = 1")
+        assert excinfo.value.timeout_class == "read"
+    finally:
+        await client.close()
+
+
+@pytest.mark.asyncio
+async def test_timeout_truncates_sql_prefix_to_200_chars() -> None:
+    """SQL longer than 200 chars must be truncated in the error + telemetry."""
+    long_sql = "SELECT * FROM intent WHERE description = '" + ("x" * 500) + "'"
+    client = await _connected_client(read_seconds=0.05)
+
+    async def _slow_query(_sql, _vars):
+        await asyncio.sleep(0.2)
+        return []
+
+    try:
+        with patch.object(client._db, "query", side_effect=_slow_query):
+            with pytest.raises(LedgerTimeoutError) as excinfo:
+                await client.query(long_sql)
+        assert len(excinfo.value.sql_prefix) == 200
+        assert excinfo.value.sql_prefix == long_sql[:200]
+        # Telemetry ring buffer also captures the truncated prefix.
+        assert timeout_telemetry.buffer_size() == 1
+        events = list(timeout_telemetry._buffer)
+        assert len(events[0].sql_prefix) == 200
+    finally:
+        await client.close()
+
+
+@pytest.mark.asyncio
+async def test_timeout_telemetry_records_per_class_count() -> None:
+    """Each timeout fire appends to the ring buffer; recent_timeout_counts
+    returns the per-class total over the configured window."""
+    client = await _connected_client(read_seconds=0.05, drift_seconds=0.05)
+
+    async def _slow_query(_sql, _vars):
+        await asyncio.sleep(0.2)
+        return []
+
+    try:
+        with patch.object(client._db, "query", side_effect=_slow_query):
+            for _ in range(3):
+                with pytest.raises(LedgerTimeoutError):
+                    await client.query("SELECT 1", timeout_class="read")
+            for _ in range(2):
+                with pytest.raises(LedgerTimeoutError):
+                    await client.query("SELECT 2", timeout_class="drift")
+    finally:
+        await client.close()
+    counts = timeout_telemetry.recent_timeout_counts()
+    assert counts == {"read": 3, "drift": 2}
+
+
+# ── context.py: fail-closed config parsing ────────────────────────────
+
+
+def test_query_timeout_read_default_when_no_config(tmp_path: Path) -> None:
+    assert _read_query_timeout_read_seconds(str(tmp_path)) == _DEFAULT_QUERY_TIMEOUT_READ
+
+
+def test_query_timeout_drift_default_when_no_config(tmp_path: Path) -> None:
+    assert _read_query_timeout_drift_seconds(str(tmp_path)) == _DEFAULT_QUERY_TIMEOUT_DRIFT
+
+
+def test_query_timeout_read_accepts_in_range_value(tmp_path: Path) -> None:
+    _write_config(tmp_path, {"query_timeout_read_seconds": 10.0})
+    assert _read_query_timeout_read_seconds(str(tmp_path)) == 10.0
+
+
+def test_query_timeout_read_accepts_int(tmp_path: Path) -> None:
+    """An int value is coerced to float and accepted."""
+    _write_config(tmp_path, {"query_timeout_read_seconds": 7})
+    assert _read_query_timeout_read_seconds(str(tmp_path)) == 7.0
+
+
+def test_query_timeout_read_falls_back_to_default_on_string(tmp_path: Path) -> None:
+    _write_config(tmp_path, {"query_timeout_read_seconds": "fast"})
+    assert _read_query_timeout_read_seconds(str(tmp_path)) == _DEFAULT_QUERY_TIMEOUT_READ
+
+
+def test_query_timeout_read_falls_back_to_default_on_bool(tmp_path: Path) -> None:
+    """``True`` is technically an int subclass in Python — must not be
+    accepted as a timeout value."""
+    _write_config(tmp_path, {"query_timeout_read_seconds": True})
+    assert _read_query_timeout_read_seconds(str(tmp_path)) == _DEFAULT_QUERY_TIMEOUT_READ
+
+
+def test_query_timeout_read_falls_back_to_default_on_negative(tmp_path: Path) -> None:
+    """A negative value would mean 'time out immediately' — config error."""
+    _write_config(tmp_path, {"query_timeout_read_seconds": -1.0})
+    assert _read_query_timeout_read_seconds(str(tmp_path)) == _DEFAULT_QUERY_TIMEOUT_READ
+
+
+def test_query_timeout_read_falls_back_to_default_on_zero(tmp_path: Path) -> None:
+    """Zero is also rejected — see the docstring rationale on
+    ``_read_query_timeout_seconds``."""
+    _write_config(tmp_path, {"query_timeout_read_seconds": 0})
+    assert _read_query_timeout_read_seconds(str(tmp_path)) == _DEFAULT_QUERY_TIMEOUT_READ
+
+
+def test_query_timeout_read_falls_back_to_default_on_nan(tmp_path: Path) -> None:
+    """NaN evades both `< MIN` and `> MAX` comparisons; must be caught."""
+    _write_config(tmp_path, {"query_timeout_read_seconds": math.nan})
+    assert _read_query_timeout_read_seconds(str(tmp_path)) == _DEFAULT_QUERY_TIMEOUT_READ
+
+
+def test_query_timeout_read_falls_back_to_default_on_inf(tmp_path: Path) -> None:
+    _write_config(tmp_path, {"query_timeout_read_seconds": math.inf})
+    assert _read_query_timeout_read_seconds(str(tmp_path)) == _DEFAULT_QUERY_TIMEOUT_READ
+
+
+def test_query_timeout_read_clamps_to_max(tmp_path: Path) -> None:
+    """Value above MAX is clamped (preserves operator intent for 'long
+    but bounded') rather than rejected to default."""
+    _write_config(tmp_path, {"query_timeout_read_seconds": 9999.0})
+    assert _read_query_timeout_read_seconds(str(tmp_path)) == _QUERY_TIMEOUT_READ_MAX
+
+
+def test_query_timeout_read_clamps_to_min(tmp_path: Path) -> None:
+    _write_config(tmp_path, {"query_timeout_read_seconds": 0.01})
+    assert _read_query_timeout_read_seconds(str(tmp_path)) == _QUERY_TIMEOUT_READ_MIN
+
+
+def test_query_timeout_drift_clamps_to_max(tmp_path: Path) -> None:
+    _write_config(tmp_path, {"query_timeout_drift_seconds": 9999.0})
+    assert _read_query_timeout_drift_seconds(str(tmp_path)) == _QUERY_TIMEOUT_DRIFT_MAX
+
+
+def test_query_timeout_drift_clamps_to_min(tmp_path: Path) -> None:
+    _write_config(tmp_path, {"query_timeout_drift_seconds": 0.5})
+    assert _read_query_timeout_drift_seconds(str(tmp_path)) == _QUERY_TIMEOUT_DRIFT_MIN
+
+
+def test_query_timeout_falls_back_on_malformed_yaml(tmp_path: Path) -> None:
+    cfg = tmp_path / ".bicameral" / "config.yaml"
+    cfg.parent.mkdir(parents=True, exist_ok=True)
+    cfg.write_text("{ not valid yaml\n", encoding="utf-8")
+    assert _read_query_timeout_read_seconds(str(tmp_path)) == _DEFAULT_QUERY_TIMEOUT_READ
+    assert _read_query_timeout_drift_seconds(str(tmp_path)) == _DEFAULT_QUERY_TIMEOUT_DRIFT
+
+
+# ── BicameralContext: from_env wiring ────────────────────────────────
+
+
+def test_bicameral_context_carries_timeout_fields(tmp_path: Path, monkeypatch) -> None:
+    """from_env populates the new fields from the config reader."""
+    _write_config(
+        tmp_path,
+        {
+            "query_timeout_read_seconds": 7.0,
+            "query_timeout_drift_seconds": 45.0,
+        },
+    )
+    monkeypatch.setenv("REPO_PATH", str(tmp_path))
+
+    # Build only the timeout-relevant slice — avoid pulling the rest of
+    # from_env's adapters (which require a real ledger). The unit-level
+    # contract under test is that the readers feed the dataclass field,
+    # not that from_env constructs every collaborator.
+    read = _read_query_timeout_read_seconds(str(tmp_path))
+    drift = _read_query_timeout_drift_seconds(str(tmp_path))
+    assert read == 7.0
+    assert drift == 45.0
+
+
+def test_bicameral_context_default_construction_uses_module_defaults() -> None:
+    """A bare BicameralContext (test-only path) uses module defaults
+    so existing tests that construct it directly don't need updates."""
+    from context import BicameralContext
+
+    ctx = BicameralContext(
+        repo_path=".",
+        head_sha="x",
+        ledger=None,
+        code_graph=None,
+        drift_analyzer=None,
+    )
+    assert ctx.query_timeout_read_seconds == _DEFAULT_QUERY_TIMEOUT_READ
+    assert ctx.query_timeout_drift_seconds == _DEFAULT_QUERY_TIMEOUT_DRIFT


### PR DESCRIPTION
## Summary

Two-layer timeout architecture for SurrealDB ledger queries — closes BicameralAI/bicameral-daemon#22 + addresses operator directive 2026-05-13 ("with Claude specifically we need to leverage hooks that make calls to the MCP for relative context at an appropriate gate").

### Layer 1 — Deterministic server-side gate (the floor)

- ``asyncio.wait_for`` wrap on every ``LedgerClient.query`` / ``execute`` / ``execute_many``
- New ``LedgerTimeoutError(LedgerError)`` carrying ``sql_prefix`` (200-char cap) / ``timeout_class`` / ``elapsed_seconds`` / ``budget_seconds``
- Two budget classes: ``read`` (5s default) and ``drift`` (30s default), clamped to safe ranges in ``context.py``
- Fail-closed config readers — NaN / Inf / string / bool / negative / zero all fall back to documented default; out-of-range values clamp (preserving operator intent for ""long but bounded"")
- ``BICAMERAL_QUERY_TIMEOUT_DISABLE=1`` env-override for debugging (mirrors the ``BICAMERAL_INGEST_RATE_LIMIT_DISABLE`` precedent)
- Registered in ``governance-gates.yaml`` per BicameralAI/bicameral-daemon#34 doctrine — skill text is advisory, the wrap is the truth

### Layer 2 — Claude Code hooks (advisory context, additive)

- ``.claude/hooks/session_start_timeout_posture.py`` — one-line stderr brief at session start (budgets, last-hour timeout counts, env-disable state)
- ``.claude/hooks/pre_tool_use_timeout_context.py`` — stderr warning before bicameral tool calls when recent (<10 min) timeouts exist
- New ``recent_timeout_count`` field on ``PreflightResponse`` (additive, default ``{""read"":0, ""drift"":0}``); backed by in-memory ring buffer (cap 1000) in ``ledger/timeout_telemetry.py``
- Hooks **always exit 0**; graceful degrade if bicameral isn't importable; deterministic wrap is unaffected if hooks don't run

### Handler annotations

Narrowed during Phase B based on evidence: only ``handlers/history.py::_fetch_all_decisions_enriched`` is a single graph-traversal query needing the 30s budget. Other workflows (preflight, sync_middleware, link_commit) chain many individually-fast queries; each carries its own 5s ``read`` budget. The plan-doc records the evidence-based narrowing.

## Test plan

- [x] ``tests/test_query_timeout_unit.py`` — 25 tests covering wrap behavior, fail-closed config (negative/string/bool/NaN/Inf/clamp/zero), env-disable bypass, sql-prefix truncation, telemetry ring-buffer recording, ``execute()`` parity, ``BicameralContext`` default construction
- [x] ``tests/test_query_timeout_handler_routing.py`` — 13 static-grep pins (exactly one handler uses ``drift`` annotation; ``governance-gates.yaml`` entry present; ``LedgerClient`` signature exposes ``Literal[""read"",""drift""]`` kwarg)
- [x] ``tests/test_claude_hooks_timeout_context.py`` — 9 subprocess invocations of both hook scripts (exit 0; env-disable surfacing; missing-import graceful exit; ring-buffer cap; window filtering)
- [x] Existing handler regression (``tests/test_history_input_span_id.py``, ``tests/test_preflight_attribution_redaction.py``) — 15 tests still pass with the new annotation + ``recent_timeout_count`` field
- [x] Config-knob regression (``tests/test_context_ingest_max_bytes.py``, ``tests/test_context_ingest_rate_limit.py``) — 13 tests pass; the new ``_read_query_timeout_*_seconds`` readers mirror the existing pattern
- [x] ``ruff format`` + ``ruff check`` clean on all 13 modified/new source files
- [x] ``scripts/lint_skill_governance.py`` parses the new gate entry without error

## Docs

- ``docs/policies/query-timeouts.md`` — operator-facing reference (defaults, config, env override, error shape, telemetry, governance)
- ``docs/policies/claude-hooks-mcp-integration.md`` — design rationale, wiring instructions for ``.claude/settings.json``, constraints, pattern for adding future hooks at other gates

## Plan + audit

- ``plan-224-surrealdb-query-timeout.md`` (in this PR's diff)
- ``qor-judge`` PASS at L2 — two non-blocking observations resolved during implementation

## Review Boundary

This PR is the explicit-authorization push of locally-committed work. Per the persistent Review Boundary, neither this PR nor the underlying commit was created without operator authorization.

🤖 Generated with [Claude Code](https://claude.com/claude-code)