### PR TITLE
fix(setup): resolve hooks dir for submodule .git pointer

### DIFF
--- a/setup_wizard.py
+++ b/setup_wizard.py
@@ -225,6 +225,38 @@ def _find_git_root(start: Path) -> Path | None:
     return None
 
 
+def _resolve_git_hooks_dir(repo_path: Path) -> Path | None:
+    """Return the actual git hooks directory for ``repo_path``.
+
+    For a normal repo this is ``<root>/.git/hooks``. For a submodule or
+    linked worktree, ``.git`` is a *file* containing a ``gitdir:`` pointer
+    to the real git directory (e.g. ``<super>/.git/modules/<name>``); the
+    hooks live there, not under the submodule's working tree. The previous
+    implementation built ``<root>/.git/hooks`` unconditionally and crashed
+    with ``NotADirectoryError`` on submodule installs.
+    """
+    git_root = _find_git_root(repo_path)
+    if git_root is None:
+        return None
+    git_marker = git_root / ".git"
+    if git_marker.is_dir():
+        return git_marker / "hooks"
+    if git_marker.is_file():
+        try:
+            content = git_marker.read_text()
+        except OSError:
+            return None
+        for line in content.splitlines():
+            stripped = line.strip()
+            if stripped.startswith("gitdir:"):
+                gitdir_str = stripped.split(":", 1)[1].strip()
+                gitdir = Path(gitdir_str)
+                if not gitdir.is_absolute():
+                    gitdir = (git_root / gitdir).resolve()
+                return gitdir / "hooks"
+    return None
+
+
 def _detect_agents() -> list[str]:
     """Auto-detect which coding agents are available."""
     found = []
@@ -775,11 +807,11 @@ def _install_git_post_commit_hook(repo_path: Path) -> bool:
     Returns True if anything was written.
     """
     _verify_intended_writes("git:post-commit")
-    git_root = _find_git_root(repo_path)
-    if git_root is None:
+    hooks_dir = _resolve_git_hooks_dir(repo_path)
+    if hooks_dir is None:
         return False
 
-    hook_path = git_root / ".git" / "hooks" / "post-commit"
+    hook_path = hooks_dir / "post-commit"
     hook_path.parent.mkdir(parents=True, exist_ok=True)
 
     if hook_path.exists():
@@ -828,11 +860,11 @@ def _install_git_pre_push_hook(repo_path: Path) -> bool:
     Returns True if anything was written.
     """
     _verify_intended_writes("git:pre-push")
-    git_root = _find_git_root(repo_path)
-    if git_root is None:
+    hooks_dir = _resolve_git_hooks_dir(repo_path)
+    if hooks_dir is None:
         return False
 
-    hook_path = git_root / ".git" / "hooks" / "pre-push"
+    hook_path = hooks_dir / "pre-push"
     hook_path.parent.mkdir(parents=True, exist_ok=True)
 
     if hook_path.exists():

--- a/tests/test_setup_pre_push_hook.py
+++ b/tests/test_setup_pre_push_hook.py
@@ -90,3 +90,27 @@ def test_install_sets_executable_bit(tmp_path: Path) -> None:
     # Owner must have execute; world-readable acceptable
     assert mode & stat.S_IXUSR
     assert mode & stat.S_IRUSR
+
+
+def test_install_handles_submodule_gitdir_pointer(tmp_path: Path) -> None:
+    """Submodule layout — ``.git`` is a *file* containing ``gitdir: <path>``,
+    not a directory. The hooks live under the resolved gitdir, not under
+    a synthesized ``<repo>/.git/hooks``. Regression for the install
+    crashing with ``NotADirectoryError`` when run inside a submodule."""
+    superrepo = tmp_path / "super"
+    real_gitdir = superrepo / ".git" / "modules" / "sub"
+    real_gitdir.mkdir(parents=True)
+    (real_gitdir / "HEAD").write_text("ref: refs/heads/main\n")
+
+    submodule = superrepo / "sub"
+    submodule.mkdir()
+    # Relative pointer, mirroring how `git submodule add` writes it.
+    (submodule / ".git").write_text("gitdir: ../.git/modules/sub\n")
+
+    written = _install_git_pre_push_hook(submodule)
+    assert written is True
+
+    # Hook lives under the real gitdir — NOT under the submodule's .git file.
+    hook = real_gitdir / "hooks" / "pre-push"
+    assert hook.exists()
+    assert "bicameral" in hook.read_text()


### PR DESCRIPTION
## Summary
- Cherry-pick of `ddf3fd8` from `triage/may9-dogfood-fixes` — the only place the fix currently exists.
- `_install_git_post_commit_hook` and `_install_git_pre_push_hook` synthesized `<repo>/.git/hooks` unconditionally. In a submodule or linked-worktree layout, `.git` is a *file* containing `gitdir: …`, so `mkdir` crashes with `NotADirectoryError` and the wizard aborts mid-install.
- Adds `_resolve_git_hooks_dir()` that parses the `gitdir:` pointer and resolves it (absolute or relative-to-`.git`), routing both hook installers through it. Plain repos behave as before.
- Regression test in `tests/test_setup_pre_push_hook.py` constructs a realistic super-repo + submodule layout and asserts the pre-push hook lands under the real gitdir, not the submodule worktree.

## Linked issues
None — surfaced via dogfooding on `bicameral/pilot/mcp` (which is itself a submodule). Repro: `bicameral-mcp setup` inside any submodule worktree on `dev` HEAD.

## Plan / Audit / Seal
Plan: trivial; risk:L1 (single bugfix, scoped to two installer helpers, ≤70 LOC including test).

## Test plan
- [ ] `pytest tests/test_setup_pre_push_hook.py -q` (new regression case)
- [ ] regression: `pytest -q`
- [ ] manual: rerun `bicameral-mcp setup` inside `bicameral/pilot/mcp` (submodule) — wizard completes, hook lands under `<super>/.git/modules/pilot/mcp/hooks/`

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>