### PR TITLE
feat(pii-archive): #221 Phase A — PiiArchive primitive + schema slot (NOT closure)

### DIFF
--- a/docs/policies/gdpr-art-17-erasure-roadmap.md
+++ b/docs/policies/gdpr-art-17-erasure-roadmap.md
@@ -1,0 +1,130 @@
+# GDPR Art. 17 right-to-erasure — implementation roadmap
+
+**Status: Phase 1 of 3 shipped (2026-05-14). GDPR-01 audit gap remains OPEN until Phase 3 completes and backfill runs.**
+
+This document is the operator-facing roadmap for closing the
+**GDPR-01** audit gap identified in
+[`docs/research-brief-compliance-audit-2026-05-06.md`](../research-brief-compliance-audit-2026-05-06.md) § 2.1.
+It is **not** a closure claim — closure is recorded only when Phase 3
+ships and the migration backfill completes.
+
+## Operator directive
+
+> "Keep PII OUT of the ledger by ingress filtering + storage segregation,
+> NOT by tombstone/rehash mechanics on the append-only chain."
+> — operator memory `issue_221_design_directive`, 2026-05-13
+
+Of the three remediation options in [#221](https://github.com/BicameralAI/bicameral-mcp/issues/221):
+
+- **(i) Tombstone-and-rebuild** — rejected. Mutates the append-only chain.
+- **(ii) Crypto-shredding** — partial adoption (structural mechanism, no per-row key surface).
+- **(iii) Scope-out via ingress detect-and-refuse** — already partially in place via [#213](https://github.com/BicameralAI/bicameral-mcp/issues/213) (PHI/PAN detect-and-refuse). Used as defense-in-depth, not the load-bearing mechanism.
+
+The roadmap below implements a hybrid of (ii) and (iii): **storage
+segregation** carries the structural guarantee; **ingress filtering**
+is the first line of defense.
+
+## Phase 1 — foundation (this cycle, 2026-05-14)
+
+**Shipped:**
+
+- `pii_archive/` Python module — operator-erasable SQLite store at
+  `~/.bicameral/pii-archive.db` (env-override
+  `BICAMERAL_PII_ARCHIVE_PATH`).
+- `input_span.archive_key` additive schema field (default `''`).
+  Schema version bumped from 19 to 20.
+- Roadmap doc (this file) — declares Phase 1/2/3 scope and gap status.
+- 13 sociable tests against real SQLite + memory:// ledger.
+
+**Explicitly NOT shipped in Phase 1:**
+
+- No ingest wiring. The current `handlers/ingest.py` path is unchanged;
+  new rows still get `archive_key=''` and `input_span.text` populated
+  as before.
+- No read-path migration. Consumers of `input_span.text` continue to
+  read it directly.
+- No `bicameral-mcp erase-subject` CLI.
+- No migration backfill of legacy rows.
+
+**Gap-closure status after Phase 1**: GDPR-01 remains OPEN.
+
+## Phase 2 — ingest cutover (next cycle)
+
+**Will ship:**
+
+- Schema change: `input_span.text` becomes optional; new ASSERT
+  `archive_key != '' OR text != ''`; UNIQUE index swaps from
+  `(source_type, source_ref, text)` to a conditional UNIQUE on
+  `archive_key` where `archive_key != ''`.
+- `handlers/ingest.py` writes PII to the archive (sets `archive_key`)
+  and stores `''` in `input_span.text` for new rows.
+- Speakers and `source_ref` pseudonymization for new `decision` rows
+  (`decision.speakers` becomes a list of archive-keyed handles, not
+  raw names/emails).
+- Read-path migration: `ledger/queries.py` introduces
+  `_resolve_span_text(row, archive)` and all consumers route through
+  it. Empty-text-but-archive-key-set rows return archive content; legacy
+  rows fall back to `input_span.text`.
+- Cross-author replay sanitizer: `events/materializer.py` pushes peer
+  event text into the **local** archive before write, never inline-
+  persists peer PII into the structural ledger.
+- Governance gate (`governance-gates.yaml`) declared: the schema ASSERT
+  is the deterministic enforcement point.
+
+**Gap-closure status after Phase 2**: GDPR-01 still OPEN. New ingests
+are erasable in principle but the CLI surface hasn't shipped yet.
+
+## Phase 3 — operator-facing erasure (cycle after)
+
+**Will ship:**
+
+- `bicameral-mcp erase-subject` CLI subcommand:
+  - Predicates: `--speaker SUBSTRING | --source-ref SUBSTRING | --archive-key KEY`.
+  - Required `--reason "..."` flag for legitimate-interest documentation.
+  - Optional `--retain-with-reason "..."` flag for Art. 17(3)
+    legitimate-interest retention claims (audited but does not erase).
+  - Interactive `--yes` / `--confirm` to prevent accidental erasure.
+- Migration backfill: one-shot script that walks all `input_span` rows
+  with `archive_key=''`, copies `text` into the archive, and sets
+  `archive_key`. After backfill, every row in the ledger is reachable
+  by the CLI.
+- Audit-log emission: every erasure emits a
+  `GDPR_ERASURE` event with predicate-hash (not predicate),
+  count, reason, and operator-identity. The audit log is itself a
+  no-PII surface.
+- Operator-facing doc `docs/policies/gdpr-art-17-erasure.md` covering
+  the runbook for a Data Subject Access Request → erasure flow.
+
+**Gap-closure status after Phase 3**: GDPR-01 closed once backfill
+completes on the operator's specific ledger. Audit reviewers should
+verify the backfill ran by inspecting `audit_log` for the migration
+event.
+
+## What's deliberately out of scope of all three phases
+
+- **JSONL event-log erasure.** The per-author `.bicameral/events/<email>.jsonl`
+  files are a separate Art. 17 surface; operators handle them via filesystem
+  tooling (`rm`, redaction scripts) or via a future
+  `bicameral-mcp ledger-export --redact` pipeline. Tracked separately if
+  evidence shows demand.
+- **Per-row encryption (full crypto-shredding).** Option (ii) in #221's
+  full form requires per-row key management; the issue explicitly defers
+  this as out-of-scope-by-default. Future cycles may revisit if a customer
+  contract demands it.
+- **Ingress filter strengthening** for free-form PII (names/emails without
+  PHI/PAN labels). The existing `_check_sensitive` filter is best-effort;
+  storage segregation is the load-bearing guarantee. Strengthening the
+  filter is a separate cycle gated on evidence.
+- **`decision.description` and `decision.rationale` erasure.** These
+  fields hold *structural intent* (what was decided), not raw transcribed
+  source. The discipline is that operator-authored intent doesn't carry
+  PII; if it does, that's an operator-side hygiene issue, not a substrate
+  gap.
+
+## Refs
+
+- Audit gap: [`docs/research-brief-compliance-audit-2026-05-06.md`](../research-brief-compliance-audit-2026-05-06.md) § 2.1 (GDPR-01)
+- Issue: [#221](https://github.com/BicameralAI/bicameral-mcp/issues/221)
+- Doctrine: [#205](https://github.com/BicameralAI/bicameral-mcp/issues/205) (deterministic governance)
+- Related ingress filter: [#213](https://github.com/BicameralAI/bicameral-mcp/issues/213) (PHI/PAN detect-and-refuse)
+- Plan artifact (Phase A): `plan-221-gdpr-right-to-erasure.md` at repo root

--- a/ledger/schema.py
+++ b/ledger/schema.py
@@ -28,7 +28,7 @@ logger = logging.getLogger(__name__)
 #   - edges: yields(input_span→decision), binds_to(decision→code_region),
 #             locates(symbol→code_region)
 #   - removed: maps_to, implements
-SCHEMA_VERSION = 19
+SCHEMA_VERSION = 20
 
 # Maps schema version → minimum bicameral-mcp code version that understands it.
 # Used to produce actionable "upgrade your binary" messages.
@@ -106,6 +106,12 @@ _TABLES = [
     "DEFINE FIELD speakers       ON input_span TYPE array<string> DEFAULT []",
     "DEFINE FIELD meeting_date   ON input_span TYPE string DEFAULT ''",
     "DEFINE FIELD created_at     ON input_span TYPE datetime DEFAULT time::now()",
+    # #221 Phase A: additive slot for the PII archive key. Phase A ships
+    # the slot only; Phase B wires ingest to populate it and Phase B
+    # introduces the ASSERT enforcing archive_key != '' OR text != ''.
+    # For Phase A new rows continue to leave archive_key = '' (legacy
+    # fallback).
+    "DEFINE FIELD archive_key    ON input_span TYPE string DEFAULT ''",
     "DEFINE INDEX idx_input_span_ref   ON input_span FIELDS source_type, source_ref",
     # Dedup: same excerpt from same source is the same span
     "DEFINE INDEX idx_input_span_dedup ON input_span FIELDS source_type, source_ref, text UNIQUE",
@@ -1188,6 +1194,28 @@ async def _migrate_v18_to_v19(client: LedgerClient) -> None:
     )
 
 
+async def _migrate_v19_to_v20(client: LedgerClient) -> None:
+    """v19 → v20: Add ``input_span.archive_key`` field (#221 Phase A).
+
+    Phase A of GDPR Art. 17 right-to-erasure (#221). The new field is the
+    forthcoming reference into the operator-local PII archive
+    (``pii_archive/store.py``). This migration adds the field only; it
+    does NOT relax the existing ``input_span.text`` ASSERT or the
+    UNIQUE-on-text index. Those changes land in Phase B alongside the
+    ingest cutover.
+
+    Additive only — existing rows get ``archive_key = ''`` per the
+    DEFAULT, and the legacy read-path (preferring ``input_span.text``)
+    continues to function unchanged. Phase B introduces the schema
+    ASSERT that makes the PII archive the load-bearing store.
+    """
+    await _execute_define_idempotent(
+        client,
+        "DEFINE FIELD archive_key ON input_span TYPE string DEFAULT ''",
+    )
+    logger.info("[migration] v19 → v20: input_span.archive_key field added (#221 Phase A)")
+
+
 async def _write_wire_format_sentinel(
     client: LedgerClient,
 ) -> tuple[str | None, str | None, str]:
@@ -1268,6 +1296,7 @@ _MIGRATIONS: dict[int, ...] = {
     17: _migrate_v16_to_v17,
     18: _migrate_v17_to_v18,
     19: _migrate_v18_to_v19,
+    20: _migrate_v19_to_v20,
 }
 
 

--- a/pii_archive/__init__.py
+++ b/pii_archive/__init__.py
@@ -1,0 +1,16 @@
+"""PII archive — operator-erasable storage substrate for GDPR Art. 17 (#221).
+
+Phase A of #221: this module is the foundation. It is **not wired into
+the ingest path in this cycle**. See ``docs/policies/gdpr-art-17-erasure-roadmap.md``
+for the multi-cycle plan.
+"""
+
+from .contracts import ArchiveEntry, ErasePredicate, PiiArchiveError
+from .store import PiiArchive
+
+__all__ = [
+    "ArchiveEntry",
+    "ErasePredicate",
+    "PiiArchive",
+    "PiiArchiveError",
+]

--- a/pii_archive/contracts.py
+++ b/pii_archive/contracts.py
@@ -1,0 +1,46 @@
+"""Typed contracts for the PiiArchive primitive (#221 Phase A)."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+
+class PiiArchiveError(RuntimeError):
+    """Raised when the PII archive cannot be opened, initialized, or written.
+
+    Fail-fast: surfaced at the operator boundary, not silently swallowed.
+    Phase A's only discipline (per the plan's Security & Audit section).
+    """
+
+
+@dataclass(frozen=True)
+class ArchiveEntry:
+    """One PII span stored in the archive."""
+
+    key: str
+    text: str
+    speakers: list[str]
+    source_ref: str
+    meeting_date: str
+    decision_id: str | None
+    created_at: str  # ISO 8601 UTC
+
+
+@dataclass(frozen=True)
+class ErasePredicate:
+    """Selector for ``PiiArchive.erase_by_predicate``.
+
+    Exactly one of ``speaker_match`` (substring), ``source_ref_match``
+    (substring), or ``archive_key`` (exact) is honored per call. If more
+    than one is set, ``archive_key`` wins, then ``speaker_match``, then
+    ``source_ref_match`` — but callers should set only one for clarity.
+
+    Notably absent: ``text_match``. The discipline (per plan-221
+    F2 / decision-log): the predicate does NOT scan the ``text`` field
+    to find subjects, because that would mean reading PII to find which
+    PII to erase, defeating the segregation discipline.
+    """
+
+    speaker_match: str | None = None
+    source_ref_match: str | None = None
+    archive_key: str | None = None

--- a/pii_archive/store.py
+++ b/pii_archive/store.py
@@ -1,0 +1,219 @@
+"""SQLite-backed PiiArchive — operator-erasable PII storage substrate (#221 Phase A).
+
+This module is the **foundation** for GDPR Art. 17 right-to-erasure. It is
+**not wired into the ingest path in this cycle** — Phase B does that.
+Phase A ships only the primitive plus the additive ``input_span.archive_key``
+schema slot.
+
+Operational design:
+
+- Single SQLite file at ``~/.bicameral/pii-archive.db`` (or
+  ``BICAMERAL_PII_ARCHIVE_PATH`` env override). Operator-erasable by ``rm``.
+- ``put()`` is idempotent on dedup; same (text, source_ref, meeting_date)
+  always yields the same key (sha256-derived).
+- ``erase_by_predicate()`` runs inside a single ``BEGIN IMMEDIATE`` /
+  ``COMMIT`` transaction so mid-operation crash leaves the archive
+  coherent at the pre-crash state.
+- ``PiiArchiveError`` is raised fail-fast on unwritable backing store.
+
+This module **does not** auto-redact or auto-detect PII. It is the
+storage substrate; the upstream caller (Phase B's ingest wiring) is
+responsible for routing the right data into it.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import sqlite3
+from collections.abc import Iterator
+from datetime import UTC, datetime
+from pathlib import Path
+
+from .contracts import ArchiveEntry, ErasePredicate, PiiArchiveError
+
+_INIT_SQL = """
+CREATE TABLE IF NOT EXISTS pii_span (
+    key TEXT PRIMARY KEY,
+    text TEXT NOT NULL,
+    speakers TEXT NOT NULL,
+    source_ref TEXT NOT NULL DEFAULT '',
+    meeting_date TEXT NOT NULL DEFAULT '',
+    decision_id TEXT,
+    created_at TEXT NOT NULL
+);
+CREATE INDEX IF NOT EXISTS idx_pii_span_source_ref ON pii_span(source_ref);
+"""
+
+
+def _derive_key(text: str, source_ref: str, meeting_date: str) -> str:
+    """Deterministic content-addressable key.
+
+    Matches the dedup semantic of ``input_span``'s UNIQUE index
+    ``(source_type, source_ref, text)`` (with ``source_type`` and
+    ``meeting_date`` swapped — Phase B's wiring decides which composite
+    is canonical). Identical inputs yield identical keys across processes
+    and machines.
+    """
+    digest = hashlib.sha256()
+    digest.update(text.encode("utf-8"))
+    digest.update(b"\x00")
+    digest.update(source_ref.encode("utf-8"))
+    digest.update(b"\x00")
+    digest.update(meeting_date.encode("utf-8"))
+    return digest.hexdigest()
+
+
+class PiiArchive:
+    """Per-operator, operator-erasable PII storage substrate."""
+
+    def __init__(self, path: str | Path) -> None:
+        self.path = str(path)
+        try:
+            # ``:memory:`` and tmp paths both flow through here; the
+            # ``check_same_thread=False`` is safe because callers are
+            # responsible for serializing access (Phase B's ingest path
+            # is async-single-threaded; the CLI shipping in Phase C
+            # takes an exclusive transaction).
+            self._conn = sqlite3.connect(self.path, check_same_thread=False)
+            self._conn.executescript(_INIT_SQL)
+            self._commit()
+        except sqlite3.Error as exc:
+            raise PiiArchiveError(
+                f"PiiArchive could not open or initialize {self.path}: {exc}"
+            ) from exc
+
+    def _commit(self) -> None:
+        """Indirection over ``self._conn.commit()`` so the crash-injection
+        test can patch this method (sqlite3.Connection.commit is a
+        read-only C slot and resists ``patch.object``)."""
+        self._conn.commit()
+
+    def put(
+        self,
+        *,
+        text: str,
+        speakers: list[str],
+        source_ref: str = "",
+        meeting_date: str = "",
+        decision_id: str | None = None,
+    ) -> str:
+        """Insert a PII span and return its archive key.
+
+        Idempotent on dedup — calling with the same (text, source_ref,
+        meeting_date) returns the existing key without raising and
+        without modifying the existing row.
+        """
+        key = _derive_key(text, source_ref, meeting_date)
+        try:
+            self._conn.execute(
+                """
+                INSERT OR IGNORE INTO pii_span
+                    (key, text, speakers, source_ref, meeting_date,
+                     decision_id, created_at)
+                VALUES (?, ?, ?, ?, ?, ?, ?)
+                """,
+                (
+                    key,
+                    text,
+                    json.dumps(speakers),
+                    source_ref,
+                    meeting_date,
+                    decision_id,
+                    datetime.now(UTC).isoformat(),
+                ),
+            )
+            self._commit()
+        except sqlite3.Error as exc:
+            raise PiiArchiveError(f"PiiArchive.put failed for key {key[:16]}…: {exc}") from exc
+        return key
+
+    def get(self, key: str) -> ArchiveEntry | None:
+        """Return the entry for ``key``, or ``None`` if not present
+        (including post-erasure)."""
+        try:
+            row = self._conn.execute(
+                """
+                SELECT key, text, speakers, source_ref, meeting_date,
+                       decision_id, created_at
+                FROM pii_span WHERE key = ?
+                """,
+                (key,),
+            ).fetchone()
+        except sqlite3.Error as exc:
+            raise PiiArchiveError(f"PiiArchive.get failed: {exc}") from exc
+        if row is None:
+            return None
+        return ArchiveEntry(
+            key=row[0],
+            text=row[1],
+            speakers=json.loads(row[2]),
+            source_ref=row[3],
+            meeting_date=row[4],
+            decision_id=row[5],
+            created_at=row[6],
+        )
+
+    def erase_by_predicate(self, predicate: ErasePredicate) -> int:
+        """Erase matching rows inside a single transaction. Returns the
+        count of rows deleted.
+
+        Precedence when multiple predicate fields are set: ``archive_key``
+        wins, then ``speaker_match``, then ``source_ref_match``. Callers
+        should set exactly one for clarity.
+
+        Transactional: ``BEGIN IMMEDIATE`` + ``COMMIT``. Mid-operation
+        crash rolls back via SQLite atomicity.
+        """
+        if (
+            predicate.archive_key is None
+            and predicate.speaker_match is None
+            and predicate.source_ref_match is None
+        ):
+            return 0
+
+        try:
+            self._conn.execute("BEGIN IMMEDIATE")
+            if predicate.archive_key is not None:
+                cur = self._conn.execute(
+                    "DELETE FROM pii_span WHERE key = ?",
+                    (predicate.archive_key,),
+                )
+            elif predicate.speaker_match is not None:
+                # JSON-substring match — sqlite has no native JSON-array
+                # contains, but the stored value is a JSON array of strings,
+                # so substring works for non-pathological speaker names.
+                cur = self._conn.execute(
+                    "DELETE FROM pii_span WHERE speakers LIKE ?",
+                    (f"%{predicate.speaker_match}%",),
+                )
+            else:
+                assert predicate.source_ref_match is not None
+                cur = self._conn.execute(
+                    "DELETE FROM pii_span WHERE source_ref LIKE ?",
+                    (f"%{predicate.source_ref_match}%",),
+                )
+            count = cur.rowcount
+            self._commit()
+            return count
+        except sqlite3.Error as exc:
+            # Rollback is implicit on connection error; explicit safety.
+            try:
+                self._conn.rollback()
+            except sqlite3.Error:
+                pass
+            raise PiiArchiveError(f"PiiArchive.erase_by_predicate failed: {exc}") from exc
+
+    def iter_keys(self) -> Iterator[str]:
+        """Yield every archive key currently stored. Useful for migration
+        tooling and operator-side inventory."""
+        try:
+            for row in self._conn.execute("SELECT key FROM pii_span"):
+                yield row[0]
+        except sqlite3.Error as exc:
+            raise PiiArchiveError(f"PiiArchive.iter_keys failed: {exc}") from exc
+
+    def close(self) -> None:
+        if self._conn is not None:
+            self._conn.close()
+            self._conn = None  # type: ignore[assignment]

--- a/tests/test_pii_archive_schema_migration.py
+++ b/tests/test_pii_archive_schema_migration.py
@@ -1,0 +1,130 @@
+"""#221 Phase A — schema migration regression tests.
+
+Verify the additive ``input_span.archive_key`` field migration (v19→v20)
+is non-destructive and doesn't break the existing ledger surface.
+
+Sociable per CLAUDE.md: real ``LedgerClient`` over ``memory://``,
+real ``init_schema`` + ``migrate`` flow.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from ledger.client import LedgerClient
+from ledger.schema import SCHEMA_VERSION, init_schema, migrate
+
+
+@pytest.mark.asyncio
+async def test_schema_version_is_at_least_20_after_migration() -> None:
+    """v19→v20 lifts SCHEMA_VERSION; init_schema + migrate must reach it."""
+    client = LedgerClient(url="memory://")
+    await client.connect()
+    try:
+        await init_schema(client)
+        await migrate(client)
+        rows = await client.query("SELECT version FROM schema_meta LIMIT 1")
+        assert rows
+        assert rows[0]["version"] >= 20
+        assert SCHEMA_VERSION >= 20
+    finally:
+        await client.close()
+
+
+@pytest.mark.asyncio
+async def test_input_span_accepts_archive_key_field_after_migration() -> None:
+    """Confirm the additive field is queryable after migration.
+
+    Insert an input_span row with archive_key set; read it back; assert
+    the value round-trips. Verifies the field exists and is writeable.
+    """
+    client = LedgerClient(url="memory://")
+    await client.connect()
+    try:
+        await init_schema(client)
+        await migrate(client)
+        await client.execute(
+            """
+            CREATE input_span SET
+                text = 'sample verbatim',
+                source_type = 'manual',
+                source_ref = 'test-ref',
+                speakers = ['someone@example.com'],
+                meeting_date = '2026-05-14',
+                archive_key = 'abcdef0123456789'
+            """
+        )
+        rows = await client.query(
+            "SELECT archive_key, text FROM input_span WHERE source_ref = 'test-ref'"
+        )
+        assert rows
+        assert rows[0]["archive_key"] == "abcdef0123456789"
+        assert rows[0]["text"] == "sample verbatim"
+    finally:
+        await client.close()
+
+
+@pytest.mark.asyncio
+async def test_legacy_input_span_rows_get_empty_archive_key_default() -> None:
+    """Legacy ingest path (no archive_key in CREATE) → defaults to ''.
+
+    This is the load-bearing Phase A contract: rows ingested via the
+    current (Phase A) code path will have archive_key='' and the
+    read-path falls back to input_span.text. Phase B's ingest cutover
+    flips this default by injecting archive_key at write time.
+    """
+    client = LedgerClient(url="memory://")
+    await client.connect()
+    try:
+        await init_schema(client)
+        await migrate(client)
+        # Insert WITHOUT archive_key — the DEFAULT '' must kick in.
+        await client.execute(
+            """
+            CREATE input_span SET
+                text = 'legacy span without archive key',
+                source_type = 'manual',
+                source_ref = 'legacy-ref',
+                speakers = []
+            """
+        )
+        rows = await client.query(
+            "SELECT archive_key FROM input_span WHERE source_ref = 'legacy-ref'"
+        )
+        assert rows
+        # DEFAULT '' must be applied
+        assert rows[0]["archive_key"] == ""
+
+    finally:
+        await client.close()
+
+
+@pytest.mark.asyncio
+async def test_existing_input_span_assert_text_not_relaxed() -> None:
+    """Phase A does NOT relax the input_span.text ASSERT.
+
+    Pin the non-relaxation: inserting a row with empty text must still
+    fail. Phase B is the cycle that introduces ASSERT
+    ``archive_key != '' OR text != ''`` and relaxes the current
+    ``string::len > 0`` ASSERT on text. This test confirms Phase A
+    has NOT moved that goalpost.
+    """
+    from ledger.client import LedgerError
+
+    client = LedgerClient(url="memory://")
+    await client.connect()
+    try:
+        await init_schema(client)
+        await migrate(client)
+        with pytest.raises((LedgerError, Exception)):  # SurrealDB will reject
+            await client.execute(
+                """
+                CREATE input_span SET
+                    text = '',
+                    source_type = 'manual',
+                    source_ref = 'reject-me',
+                    speakers = []
+                """
+            )
+    finally:
+        await client.close()

--- a/tests/test_pii_archive_unit.py
+++ b/tests/test_pii_archive_unit.py
@@ -1,0 +1,233 @@
+"""#221 Phase A — sociable unit tests for the PiiArchive primitive.
+
+Sociable per CLAUDE.md: real SQLite in-memory + tmp_path. The only
+non-real seam is ``monkeypatch.setattr`` for the crash-injection test,
+which is a narrow seam for an otherwise unreachable failure mode
+(CLAUDE.md rule 4 allowance).
+"""
+
+from __future__ import annotations
+
+import sqlite3
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from pii_archive import (
+    ArchiveEntry,
+    ErasePredicate,
+    PiiArchive,
+    PiiArchiveError,
+)
+
+
+def _archive(path: str = ":memory:") -> PiiArchive:
+    return PiiArchive(path)
+
+
+def _put_sample(archive: PiiArchive, **kwargs) -> str:
+    defaults = {
+        "text": "Alice said we should ratify the auth proposal",
+        "speakers": ["alice@example.com"],
+        "source_ref": "meeting-2026-05-14",
+        "meeting_date": "2026-05-14",
+        "decision_id": None,
+    }
+    defaults.update(kwargs)
+    return archive.put(**defaults)
+
+
+# ── determinism + dedup ─────────────────────────────────────────────
+
+
+def test_put_returns_deterministic_key() -> None:
+    """Same (text, source_ref, meeting_date) → same key across calls."""
+    a = _archive()
+    k1 = _put_sample(a)
+    k2 = _put_sample(a)
+    assert k1 == k2
+
+
+def test_put_with_distinct_inputs_returns_distinct_keys() -> None:
+    a = _archive()
+    k1 = _put_sample(a, text="text one")
+    k2 = _put_sample(a, text="text two")
+    k3 = _put_sample(a, text="text one", meeting_date="2026-05-15")
+    assert len({k1, k2, k3}) == 3
+
+
+def test_put_is_idempotent_on_dedup() -> None:
+    """Calling put twice with same payload returns same key; row count is 1."""
+    a = _archive()
+    k = _put_sample(a)
+    assert k == _put_sample(a)
+    # Verify only one row exists for this key
+    keys = list(a.iter_keys())
+    assert keys == [k]
+
+
+# ── get round-trip ──────────────────────────────────────────────────
+
+
+def test_get_round_trip() -> None:
+    a = _archive()
+    k = _put_sample(a)
+    entry = a.get(k)
+    assert entry is not None
+    assert isinstance(entry, ArchiveEntry)
+    assert entry.key == k
+    assert entry.text == "Alice said we should ratify the auth proposal"
+    assert entry.speakers == ["alice@example.com"]
+    assert entry.source_ref == "meeting-2026-05-14"
+    assert entry.meeting_date == "2026-05-14"
+
+
+def test_get_missing_key_returns_none() -> None:
+    a = _archive()
+    assert a.get("0" * 64) is None
+
+
+# ── erase by predicate ──────────────────────────────────────────────
+
+
+def test_erase_by_speaker_substring() -> None:
+    a = _archive()
+    _put_sample(a, text="alice says X", speakers=["alice@example.com"])
+    _put_sample(a, text="bob says Y", speakers=["bob@example.com"])
+    _put_sample(a, text="alice says Z", speakers=["alice@example.com"])
+    count = a.erase_by_predicate(ErasePredicate(speaker_match="alice@"))
+    assert count == 2
+    # Non-matching survivor
+    remaining = list(a.iter_keys())
+    assert len(remaining) == 1
+    survivor = a.get(remaining[0])
+    assert survivor is not None
+    assert survivor.speakers == ["bob@example.com"]
+
+
+def test_erase_by_source_ref_substring() -> None:
+    a = _archive()
+    _put_sample(a, text="t1", source_ref="meeting-2026-05-14")
+    _put_sample(a, text="t2", source_ref="meeting-2026-05-15")
+    _put_sample(a, text="t3", source_ref="slack-thread-abc")
+    count = a.erase_by_predicate(ErasePredicate(source_ref_match="meeting-"))
+    assert count == 2
+    remaining = list(a.iter_keys())
+    assert len(remaining) == 1
+    survivor = a.get(remaining[0])
+    assert survivor is not None
+    assert survivor.source_ref == "slack-thread-abc"
+
+
+def test_erase_by_archive_key_exact() -> None:
+    a = _archive()
+    k1 = _put_sample(a, text="t1")
+    k2 = _put_sample(a, text="t2")
+    count = a.erase_by_predicate(ErasePredicate(archive_key=k1))
+    assert count == 1
+    assert a.get(k1) is None
+    assert a.get(k2) is not None
+
+
+def test_erase_predicate_no_match_returns_zero() -> None:
+    a = _archive()
+    _put_sample(a, text="t1")
+    count = a.erase_by_predicate(ErasePredicate(speaker_match="not-a-real-handle"))
+    assert count == 0
+    assert len(list(a.iter_keys())) == 1
+
+
+def test_erase_predicate_empty_returns_zero() -> None:
+    """Empty predicate (no fields set) is a noop, returns 0."""
+    a = _archive()
+    _put_sample(a)
+    count = a.erase_by_predicate(ErasePredicate())
+    assert count == 0
+    assert len(list(a.iter_keys())) == 1
+
+
+# ── transactional crash safety ───────────────────────────────────────
+
+
+def test_erase_transactional_on_crash(tmp_path: Path) -> None:
+    """Mid-erasure crash leaves the archive coherent at pre-crash state.
+
+    Narrow seam: patch ``commit`` to raise so the DELETE statement runs
+    inside the txn but the commit fails. Per SQLite atomicity, the
+    rollback discards the deletion. Verifies the fail-closed promise
+    of the plan's Phase A discipline #1.
+    """
+    db = tmp_path / "archive.db"
+    a = PiiArchive(db)
+    k = _put_sample(a, text="surviving content")
+    a.close()
+
+    # Reopen and inject the crash. We patch ``PiiArchive._commit`` rather
+    # than the underlying ``sqlite3.Connection.commit`` because the
+    # connection's commit slot is a read-only C attribute resistant to
+    # ``patch.object``. ``_commit`` exists exactly to make this seam
+    # patchable for the fail-closed test (see CLAUDE.md "narrow seam"
+    # rule 4).
+    a2 = PiiArchive(db)
+
+    def _raise(*_a, **_kw):
+        raise sqlite3.OperationalError("simulated mid-txn failure")
+
+    with patch.object(a2, "_commit", side_effect=_raise):
+        with pytest.raises(PiiArchiveError):
+            a2.erase_by_predicate(ErasePredicate(archive_key=k))
+
+    a2.close()
+
+    # Reopen fresh: row must still be there.
+    a3 = PiiArchive(db)
+    entry = a3.get(k)
+    assert entry is not None, "Row was deleted despite simulated commit failure"
+    assert entry.text == "surviving content"
+    a3.close()
+
+
+# ── unwritable backing store ────────────────────────────────────────
+
+
+def test_archive_unwritable_raises_pii_archive_error(tmp_path: Path) -> None:
+    """Unwritable path → fail-fast at constructor, not silent allow."""
+    # Point at a path inside a file (not a directory) — SQLite will reject.
+    blocker = tmp_path / "not-a-dir"
+    blocker.write_text("blocker", encoding="utf-8")
+    bad_path = blocker / "archive.db"
+
+    with pytest.raises(PiiArchiveError) as excinfo:
+        PiiArchive(bad_path)
+    assert "could not open" in str(excinfo.value).lower()
+
+
+# ── iter_keys ───────────────────────────────────────────────────────
+
+
+def test_iter_keys_yields_every_stored_key() -> None:
+    a = _archive()
+    k1 = _put_sample(a, text="t1")
+    k2 = _put_sample(a, text="t2")
+    k3 = _put_sample(a, text="t3")
+    assert set(a.iter_keys()) == {k1, k2, k3}
+
+
+def test_iter_keys_empty_when_nothing_stored() -> None:
+    a = _archive()
+    assert list(a.iter_keys()) == []
+
+
+# ── close ───────────────────────────────────────────────────────────
+
+
+def test_close_releases_connection(tmp_path: Path) -> None:
+    db = tmp_path / "archive.db"
+    a = PiiArchive(db)
+    _put_sample(a)
+    a.close()
+    # Reopen succeeds (file is not locked).
+    a2 = PiiArchive(db)
+    assert len(list(a2.iter_keys())) == 1
+    a2.close()


### PR DESCRIPTION
## Status

**Phase 1 of 3. GDPR-01 audit gap remains OPEN.** This PR ships the foundation only. Phase B (ingest cutover + speakers pseudonymization + cross-author replay sanitizer + schema ASSERT) and Phase C (erase-subject CLI + migration backfill + audit-log GDPR_ERASURE event) are tracked as follow-up cycles.

## Operator directive

Per the `issue_221_design_directive` memory:

> Keep PII OUT of the ledger by ingress filtering + storage segregation, NOT by tombstone/rehash mechanics on the append-only chain.

Of BicameralAI/bicameral-daemon#23's three remediation paths: (i) tombstone-and-rebuild rejected; (ii) crypto-shredding partially adopted (structural mechanism, no per-row key surface); (iii) ingress scope-out remains as defense-in-depth via BicameralAI/bicameral-mcp#213. **Storage segregation is the load-bearing mechanism.**

## Audit trail

- **Round 1**: qor-judge **VETO** with 6 findings (security-stub on dual-write retention; no PII coverage on `decision.speakers`/`source_ref`; governance gate not a real wrapper; backfill defer; cross-author re-contamination; phase-per-cycle violation).
- **Revision 2**: scope drastically reduced to Phase A only. F1/F2/F3/F4/F5 recorded as load-bearing constraints for Phase B/C plans.
- **Round 2**: qor-judge **PASS at L2**.

## What ships

- ``pii_archive/`` Python module (SQLite-backed, operator-erasable):
  - `PiiArchive` with `put`/`get`/`erase_by_predicate`/`iter_keys`/`close`
  - Content-addressable keys (sha256 of text + source_ref + meeting_date)
  - Transactional erasure via ``BEGIN IMMEDIATE`` + ``COMMIT`` (mid-op crash rolls back)
  - Fail-fast ``PiiArchiveError`` on unwritable backing store
- ``input_span.archive_key`` additive schema field (``SCHEMA_VERSION`` 19 → 20)
  - **No ASSERT changes; no UNIQUE-index changes.** ``input_span.text`` stays required. Phase B's cutover relaxes both.
- ``docs/policies/gdpr-art-17-erasure-roadmap.md`` — operator-facing roadmap declaring Phase 1/2/3 scope; explicitly states GDPR-01 remains OPEN.

## What does NOT ship (deferred to Phase B/C with explicit non-claim)

- No ``handlers/ingest.py`` wiring. New rows still get ``archive_key=''``.
- No read-path migration; consumers continue reading ``input_span.text``.
- No ``bicameral-mcp erase-subject`` CLI.
- No migration backfill of legacy rows.
- No ``governance-gates.yaml`` entry yet — the deterministic gate is the schema ASSERT in Phase B; declaring a gate pointing at unwired code would invert BicameralAI/bicameral-daemon#34 doctrine. Mirrors the BicameralAI/bicameral-daemon#9 Track 1 precedent.

## Test plan

- [x] ``tests/test_pii_archive_unit.py`` — 15 sociable tests against real SQLite (determinism, dedup, get round-trip, erase by speaker/source_ref/archive_key, no-match zero count, empty-predicate noop, transactional crash safety, unwritable backing store fail-fast, iter_keys, close lifecycle)
- [x] ``tests/test_pii_archive_schema_migration.py`` — 4 regression tests (version reaches 20, ``archive_key`` field writable, legacy rows get DEFAULT ``''``, ``input_span.text`` ASSERT not relaxed in Phase A)
- [x] ``tests/test_phase2_ledger.py`` — 15 existing tests still pass (no ledger surface regression)
- [x] ``ruff format`` + ``ruff check`` clean on all 7 modified/new files

## Plan

- ``plan-221-gdpr-right-to-erasure.md`` (revision 2; qor-judge PASS at L2)

## Review Boundary

This is the explicit-authorization push + merge of locally-committed work. Per the persistent Review Boundary, neither this PR nor the underlying commit was created without operator authorization.

🤖 Generated with [Claude Code](https://claude.com/claude-code)