### PR TITLE
ci(perf): #357 sub-task 2 — file-backed SurrealKV perf gate

### DIFF
--- a/.github/workflows/perf-gate.yml
+++ b/.github/workflows/perf-gate.yml
@@ -1,0 +1,70 @@
+name: Perf Gate
+
+# Runs the file-backed SurrealKV performance suite on every PR targeting
+# main/dev. The pre-#357 perf claims (#311 "8ms p50 at N=1000", #312
+# "sub-3ms p95 at N=500") were all measured locally on memory:// — a
+# CPU-cache benchmark, not a storage benchmark. This workflow closes
+# that gap.
+#
+# See tests/perf/test_ledger_revision_perf.py for the test logic and
+# threshold rationale.
+
+on:
+  pull_request:
+    branches: [main, dev]
+  # Allow manual runs so the baseline can be captured / re-measured
+  # without opening a PR.
+  workflow_dispatch:
+
+env:
+  PYTHON_VERSION: '3.11'
+
+jobs:
+  perf-gate:
+    name: Perf gate (file-backed SurrealKV)
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: ${{ env.PYTHON_VERSION }}
+          cache: 'pip'
+
+      - name: Install dependencies
+        run: pip install -e ".[test]"
+
+      - name: Run perf gate (file-backed SurrealKV)
+        env:
+          PERF_RESULTS_DIR: ${{ github.workspace }}/perf-results
+        run: |
+          mkdir -p "$PERF_RESULTS_DIR"
+          # -m perf overrides the addopts "-m not perf" in pytest.ini.
+          # Verbose output so the p50/p95/p99 numbers land in the run log.
+          python -m pytest tests/perf/ -m perf -v --tb=short
+
+      - name: Upload perf result artifacts
+        if: always()  # capture even on failure for forensics
+        uses: actions/upload-artifact@v4
+        with:
+          name: perf-results-${{ github.run_id }}
+          path: perf-results/
+          retention-days: 30
+
+      - name: Summarize results
+        if: success()
+        run: |
+          echo "## Perf gate — file-backed SurrealKV" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "| N decisions | p50 ms | p95 ms | p99 ms | mean ms |" >> $GITHUB_STEP_SUMMARY
+          echo "|---|---|---|---|---|" >> $GITHUB_STEP_SUMMARY
+          for f in perf-results/get_ledger_revision_n*.json; do
+            n=$(python -c "import json; print(json.load(open('$f'))['n_decisions'])")
+            p50=$(python -c "import json; print(json.load(open('$f'))['p50_ms'])")
+            p95=$(python -c "import json; print(json.load(open('$f'))['p95_ms'])")
+            p99=$(python -c "import json; print(json.load(open('$f'))['p99_ms'])")
+            mean=$(python -c "import json; print(json.load(open('$f'))['mean_ms'])")
+            echo "| $n | $p50 | $p95 | $p99 | $mean |" >> $GITHUB_STEP_SUMMARY
+          done

--- a/.gitignore
+++ b/.gitignore
@@ -37,3 +37,4 @@ docs/demos/**/*.mp4
 # during a feature; once merged, the PR description + CHANGELOG carry the
 # durable record.
 plan-*.md
+perf-results/

--- a/ledger/queries.py
+++ b/ledger/queries.py
@@ -1142,7 +1142,16 @@ async def get_ledger_revision(client: LedgerClient) -> str | None:
     bicameral_meta LIMIT 1``. The counter is auto-bumped on every
     decision CREATE/UPDATE by the ``decision_revision_bump`` DEFINE
     EVENT (see ``ledger/schema.py::_BICAMERAL_META``). Constant-time
-    read, deterministic, ~0.4ms p95 at any ledger size.
+    read, deterministic.
+
+    SLO: p95 < 5ms on file-backed SurrealKV, constant-time wrt N.
+    Gated by ``tests/perf/test_ledger_revision_perf.py`` running in
+    ``.github/workflows/perf-gate.yml`` (#357 sub-task 2). The pre-#357
+    docstring claimed "~0.4ms p95 at any ledger size" but was measured
+    on ``memory://`` — a CPU-cache benchmark, not a storage benchmark.
+    Local file-backed measurements land at p95~0.15-0.20ms; the 5ms SLO
+    leaves CI-runner-noise headroom and will tighten once the gate has
+    landed enough green runs to learn the actual baseline.
 
     History — what this replaces:
       - v18 draft: ``math::max(coalesce(updated_at, created_at))`` —

--- a/pytest.ini
+++ b/pytest.ini
@@ -7,3 +7,5 @@ markers =
     phase1: requires RealCodeLocatorAdapter (fails until Phase 1 complete)
     phase2: requires SurrealDBLedgerAdapter + running SurrealDB (fails until Phase 2 complete)
     phase3: requires both Phase 1 + Phase 2 complete
+    perf: file-backed SurrealKV performance test — slow, excluded from default run; gated by .github/workflows/perf-gate.yml
+addopts = -m "not perf"

--- a/tests/perf/conftest.py
+++ b/tests/perf/conftest.py
@@ -1,0 +1,40 @@
+"""Shared fixtures for `tests/perf/` — file-backed SurrealKV perf tests (#357 sub-task 2).
+
+These tests run against a real on-disk SurrealKV instance, not `memory://`.
+Devin's #357 critique flagged that every perf claim shipped to dev came
+from `memory://` (a CPU-cache benchmark, not a storage benchmark); this
+fixture closes that gap.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from ledger.client import LedgerClient
+from ledger.schema import init_schema, migrate
+
+_NS_COUNTER = 0
+
+
+@pytest.fixture
+async def surrealkv_client(tmp_path):
+    """Build a fresh on-disk SurrealKV ledger with schema migrated.
+
+    Yields a connected `LedgerClient`. Backing file lives under pytest's
+    `tmp_path` so the OS cleans up automatically when the test finishes.
+    Each test gets a unique namespace to prevent any cross-test bleeding
+    if the same process re-enters the fixture.
+    """
+    global _NS_COUNTER
+    _NS_COUNTER += 1
+
+    db_path = tmp_path / "perf.db"
+    url = f"surrealkv://{db_path}"
+    client = LedgerClient(url=url, ns=f"perf_{_NS_COUNTER}", db="ledger_perf")
+    await client.connect()
+    await init_schema(client)
+    await migrate(client, allow_destructive=True)
+    try:
+        yield client
+    finally:
+        await client.close()

--- a/tests/perf/test_ledger_revision_perf.py
+++ b/tests/perf/test_ledger_revision_perf.py
@@ -108,7 +108,9 @@ async def test_get_ledger_revision_p95_under_threshold(surrealkv_client, n_decis
         "p95_threshold_ms": P95_THRESHOLD_MS,
     }
     RESULTS_DIR.mkdir(parents=True, exist_ok=True)
-    (RESULTS_DIR / f"get_ledger_revision_n{n_decisions}.json").write_text(json.dumps(result, indent=2))
+    (RESULTS_DIR / f"get_ledger_revision_n{n_decisions}.json").write_text(
+        json.dumps(result, indent=2)
+    )
 
     assert p95 < P95_THRESHOLD_MS, (
         f"get_ledger_revision p95 regression at N={n_decisions} on file-backed SurrealKV.\n"

--- a/tests/perf/test_ledger_revision_perf.py
+++ b/tests/perf/test_ledger_revision_perf.py
@@ -1,0 +1,120 @@
+"""File-backed SurrealKV perf gate for `get_ledger_revision` (#357 sub-task 2).
+
+The pre-#357 perf claim ("~0.4ms p95 at any ledger size", `ledger/queries.py:1145`)
+was measured on `memory://` — a CPU-cache benchmark, not a storage benchmark.
+This test runs against a real on-disk SurrealKV instance at four ledger sizes
+and asserts the constant-time-at-scale claim under real I/O.
+
+Threshold rationale: local file-backed measurements on a developer MacBook
+land around p95=0.15-0.20ms at all four N values. CI runners are typically
+2-5x slower for I/O-bound work, so an absolute threshold of 5ms catches
+order-of-magnitude regressions (the original v18 ORDER BY scan was 8ms p50)
+while leaving room for noise. The threshold tightens to 1-2ms in a follow-up
+PR once 3-5 CI runs land green numbers — that's how perf gates ratchet
+without flaking on first deployment.
+
+Marked with `perf` so it doesn't run by default. CI runs it via
+`.github/workflows/perf-gate.yml` with `pytest -m perf`.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import time
+from pathlib import Path
+
+import pytest
+
+from ledger.queries import get_ledger_revision
+
+# Absolute threshold — catches order-of-magnitude regressions. Tighten in a
+# follow-up after the gate has 3-5 green CI runs to learn the actual
+# CI-runner baseline. Until then, 5ms gives plenty of room while still
+# trapping the 8ms ORDER BY regression that originally motivated the v19
+# counter mechanism.
+P95_THRESHOLD_MS = 5.0
+
+# Number of warm-up iterations (discarded) before timed samples are taken.
+WARMUP_ITERATIONS = 5
+
+# Number of timed samples per N — 100 gives a usable p95 (sample 95).
+TIMED_SAMPLES = 100
+
+# Where to drop the structured perf results for CI artifact upload.
+RESULTS_DIR = Path(os.environ.get("PERF_RESULTS_DIR", "perf-results"))
+
+
+async def _seed_decisions(client, n: int) -> None:
+    """CREATE N decision rows with unique canonical_ids (the index requires uniqueness)."""
+    for i in range(n):
+        await client.query(
+            "CREATE decision SET description=$d, source_type='perf', source_ref='r', "
+            "status='ungrounded', canonical_id=$c",
+            {"d": f"perf-{i}", "c": f"perf-{i}"},
+        )
+
+
+def _percentile(sorted_samples: list[float], q: float) -> float:
+    """Linear-interpolation percentile (q in [0,1]). Standard textbook def."""
+    if not sorted_samples:
+        return 0.0
+    pos = q * (len(sorted_samples) - 1)
+    lo = int(pos)
+    hi = min(lo + 1, len(sorted_samples) - 1)
+    frac = pos - lo
+    return sorted_samples[lo] * (1 - frac) + sorted_samples[hi] * frac
+
+
+@pytest.mark.perf
+@pytest.mark.asyncio
+@pytest.mark.parametrize("n_decisions", [100, 500, 1000, 5000])
+async def test_get_ledger_revision_p95_under_threshold(surrealkv_client, n_decisions):
+    """Seed N decisions, time WARMUP+TIMED_SAMPLES revision lookups, assert
+    p95 stays under the absolute SLO threshold. The v19 counter mechanism
+    reads a single row from `bicameral_meta` — it must remain O(1) wrt N.
+    Any regression to ORDER-BY-shaped behaviour will scale with N and trip
+    the gate first at N=5000 where the regression is most visible.
+    """
+    await _seed_decisions(surrealkv_client, n_decisions)
+
+    for _ in range(WARMUP_ITERATIONS):
+        await get_ledger_revision(surrealkv_client)
+
+    samples_ms: list[float] = []
+    for _ in range(TIMED_SAMPLES):
+        t0 = time.perf_counter()
+        rev = await get_ledger_revision(surrealkv_client)
+        samples_ms.append((time.perf_counter() - t0) * 1000.0)
+        assert rev, "revision must be non-empty for a populated ledger"
+
+    samples_ms.sort()
+    p50 = _percentile(samples_ms, 0.50)
+    p95 = _percentile(samples_ms, 0.95)
+    p99 = _percentile(samples_ms, 0.99)
+    mean = sum(samples_ms) / len(samples_ms)
+
+    result = {
+        "metric": "get_ledger_revision",
+        "backend": "surrealkv",
+        "n_decisions": n_decisions,
+        "warmup_iterations": WARMUP_ITERATIONS,
+        "timed_samples": TIMED_SAMPLES,
+        "p50_ms": round(p50, 4),
+        "p95_ms": round(p95, 4),
+        "p99_ms": round(p99, 4),
+        "mean_ms": round(mean, 4),
+        "max_ms": round(samples_ms[-1], 4),
+        "p95_threshold_ms": P95_THRESHOLD_MS,
+    }
+    RESULTS_DIR.mkdir(parents=True, exist_ok=True)
+    (RESULTS_DIR / f"get_ledger_revision_n{n_decisions}.json").write_text(json.dumps(result, indent=2))
+
+    assert p95 < P95_THRESHOLD_MS, (
+        f"get_ledger_revision p95 regression at N={n_decisions} on file-backed SurrealKV.\n"
+        f"  p50={p50:.3f}ms  p95={p95:.3f}ms  p99={p99:.3f}ms  threshold={P95_THRESHOLD_MS}ms\n"
+        f"The v19 counter mechanism is meant to be O(1) wrt N. A p95 over the threshold "
+        f"suggests the read scales with ledger size — likely a regression to ORDER-BY-shaped "
+        f"behaviour (the v18 query this counter replaced was ~8ms p50 at N=1000).\n"
+        f"See ledger/queries.py::get_ledger_revision for the design history."
+    )


### PR DESCRIPTION
## Summary

Implements [#357](https://github.com/BicameralAI/bicameral-mcp/issues/357) sub-task 2: real-storage perf gate for `get_ledger_revision`. Closes the gap Devin's critique flagged — every perf claim in [#311](https://github.com/BicameralAI/bicameral-mcp/pull/311) (\"8ms p50 at N=1000\") and [#312](https://github.com/BicameralAI/bicameral-mcp/pull/312) (\"sub-3ms p95 at N=500\") was measured on `memory://`, a CPU-cache benchmark not a storage benchmark.

Stacks logically on [#359](https://github.com/BicameralAI/bicameral-mcp/pull/359) (sub-task 1) but branches independently from `dev` — they can land in either order.

## What's in this PR

### Test (`tests/perf/test_ledger_revision_perf.py`)
- Parametrized over **N ∈ {100, 500, 1000, 5000}** decisions
- 5-iteration warmup, 100 timed samples per N
- Asserts **p95 < 5ms** absolute on file-backed SurrealKV
- Writes structured JSON results to `PERF_RESULTS_DIR` for CI to summarize
- Marked `@pytest.mark.perf`; excluded from default `pytest` run via `pytest.ini` `addopts`

### Workflow (`.github/workflows/perf-gate.yml`)
- Runs on PR to `main`/`dev` + manual `workflow_dispatch`
- `ubuntu-latest`, Python 3.11 (matches lint workflow)
- Uploads JSON artifacts on every run (retention=30d)
- Emits a markdown summary table to `$GITHUB_STEP_SUMMARY` so reviewers see p50/p95/p99/mean inline

### Docstring update (`ledger/queries.py:get_ledger_revision`)
The pre-#357 line "~0.4ms p95 at any ledger size" was measured on `memory://`. Replaced with an explicit SLO framing pointing at this gate. Numbers, not adjectives.

### Why 5ms not 1ms

Local file-backed measurements on a developer MacBook land at **p95~0.15-0.20ms** across all four N values — well within Kevin's ≤1ms bar. But CI runners are typically 2-5x slower for I/O-bound work; a 5ms floor catches order-of-magnitude regressions (the original v18 ORDER BY was ~8ms p50) while leaving room for first-deploy noise. The threshold tightens to 1-2ms in a follow-up PR after 3-5 CI runs land green numbers — that's how perf gates ratchet without flaking on first deployment.

## Verification

### Local file-backed numbers (MacBook M-series, surrealkv:// tmpdir)

| N | cold (ms) | p50 (ms) | p95 (ms) | p99 (ms) |
|---|---|---|---|---|
| 100 | 0.185 | 0.139 | 0.177 | 0.193 |
| 500 | 0.205 | 0.140 | 0.175 | 0.190 |
| 1000 | 0.222 | 0.145 | 0.192 | 0.254 |
| 5000 | 0.177 | 0.142 | 0.187 | 0.223 |

Constant-time wrt N — confirmed.

### Negative test (gate fires correctly)

Swapped `get_ledger_revision` body for the v18 `ORDER BY DESC LIMIT 1` query (the query the v19 counter replaced) and re-measured at N=1000 on file-backed SurrealKV:

```
v18 ORDER BY at N=1000: p50=9.04ms p95=9.59ms p99=9.75ms
```

**9.59ms p95 = 1.9x over the 5ms gate.** The gate would have caught #309/#311's perf regression. Confirms the threshold is meaningful while still being CI-noise-tolerant.

## What this PR does NOT include

- **Rolling N-run baseline comparison** (relative regression gate). Ship the absolute-threshold gate first; add the ratchet once CI has 3-5 green data points to define the baseline from.
- **Tighter threshold** (1-2ms). Same reason — needs CI baseline first.
- **Perf coverage for other ledger functions**. `get_ledger_revision` is the original #87/#309 risk; expand opportunistically as more SurrealQL functions get sociable tests via the audit/regression cluster in #359.

## Test plan

- [ ] CI green on `dev` (perf-gate workflow runs and reports table)
- [ ] Verify the `Perf gate (file-backed SurrealKV)` job summary shows the numbers per N
- [ ] After 3-5 green runs, follow-up PR tightens the threshold based on observed CI baseline

🤖 Generated with [Claude Code](https://claude.com/claude-code)