### PR TITLE
infra(pre-commit): #357 sub-task 3 — local ruff enforcement at commit time

### DIFF
--- a/.github/workflows/lint-and-typecheck.yml
+++ b/.github/workflows/lint-and-typecheck.yml
@@ -17,11 +17,37 @@ jobs:
       - name: Install
         run: pip install -e ".[test]"
       - name: Ruff check
+        id: ruff_check
         run: ruff check .
       - name: Ruff format check
+        id: ruff_format
         run: ruff format --check .
       - name: Mypy
+        id: mypy
         run: mypy .
+      - name: Pre-commit install hint (on lint failure)
+        if: failure() && (steps.ruff_check.outcome == 'failure' || steps.ruff_format.outcome == 'failure')
+        # #357 sub-task 3: many of the historical `style:` cleanup commits
+        # (eb32e80, ee24395, 0cf574b, 1d752cc, 1690a30, cacfb62) could
+        # have been caught at commit time by `pre-commit`. Surface this
+        # to the developer when the lint step fails so the next push is
+        # the fixed one, not a follow-up `style:` cleanup commit.
+        run: |
+          echo "::error::Lint failed. Install the pre-commit hook locally to catch this before push:"
+          echo "::error::    pip install pre-commit && pre-commit install"
+          echo "::error::Then either re-stage and re-commit, or run: pre-commit run --all-files"
+          echo "## Lint failed — pre-commit hook would have caught this" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "Install once per clone:" >> $GITHUB_STEP_SUMMARY
+          echo '```bash' >> $GITHUB_STEP_SUMMARY
+          echo "pip install pre-commit && pre-commit install" >> $GITHUB_STEP_SUMMARY
+          echo '```' >> $GITHUB_STEP_SUMMARY
+          echo "Then fix:" >> $GITHUB_STEP_SUMMARY
+          echo '```bash' >> $GITHUB_STEP_SUMMARY
+          echo "pre-commit run --all-files" >> $GITHUB_STEP_SUMMARY
+          echo "git add -u && git commit --amend --no-edit  # or new commit" >> $GITHUB_STEP_SUMMARY
+          echo '```' >> $GITHUB_STEP_SUMMARY
+          exit 1
       - name: Plan-grounding lint (#114 Check A)
         # Only lints plan-*.md files modified in this PR — historical
         # plans that referenced now-deleted files would otherwise block

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,36 @@
+# Pre-commit hooks for bicameral-mcp (#357 sub-task 3).
+#
+# Mirrors the .github/workflows/lint-and-typecheck.yml CI gate so the
+# common case — "I forgot to run ruff before pushing" — is caught at
+# commit time and never produces a post-push `style:` cleanup commit.
+# Six such commits between #279 and #310 (eb32e80, ee24395, 0cf574b,
+# 1d752cc, 1690a30, cacfb62) were the recurring tax this config removes.
+#
+# Activation:
+#   pip install pre-commit       # or via [project.optional-dependencies] test
+#   pre-commit install           # writes .git/hooks/pre-commit
+#
+# Run on all files (e.g., to check before a PR):
+#   pre-commit run --all-files
+
+repos:
+  - repo: https://github.com/astral-sh/ruff-pre-commit
+    # Pinned to the same ruff version CI runs (`pip install -e ".[test]"`
+    # resolves the `ruff>=0.5.0` floor in pyproject.toml to whatever
+    # latest is at install time). Different ruff versions produce
+    # different format outputs and different lint rules, so a stale pin
+    # here means "local says clean, CI says dirty" or vice versa — the
+    # opposite of what this hook is for. Bump on every ruff upgrade.
+    rev: v0.15.12
+    hooks:
+      - id: ruff-check
+        args: [--fix]
+        # ruff check + --fix mirrors the `ruff check .` step in
+        # lint-and-typecheck.yml. --fix means the hook applies safe
+        # autofixes (e.g., F541 f-string-no-placeholders) automatically;
+        # the commit re-stages the fixed content. If a check fails that
+        # ruff can't autofix, the hook fails and the commit is aborted
+        # — same behaviour as the CI step.
+      - id: ruff-format
+        # Mirrors `ruff format --check .` step in lint-and-typecheck.yml.
+        # Reformats in place; commit re-stages.

--- a/docs/DEV_CYCLE.md
+++ b/docs/DEV_CYCLE.md
@@ -533,6 +533,39 @@ land.
 
 Red CI blocks merge. Don't ask reviewers to look at red PRs.
 
+#### 4.5.5 Local enforcement — `pre-commit` (mandatory for committers)
+
+The lint gate (`ruff check` + `ruff format --check`) lives in CI, but
+running it only at PR time has produced a recurring tax: between #279
+and #310, six commits (`eb32e80`, `ee24395`, `0cf574b`, `1d752cc`,
+`1690a30`, `cacfb62`) were `style:` cleanups whose only purpose was
+appeasing CI after the actual feature commit landed unformatted. PR #357
+sub-task 3 closes this loop by enforcing the same checks at commit time.
+
+**Install once per clone:**
+
+```bash
+pip install pre-commit                  # already in [project.optional-dependencies] test
+pre-commit install                      # writes .git/hooks/pre-commit
+```
+
+The hook now runs `ruff check --fix` + `ruff format` on every staged
+Python file. Auto-fixable issues (F541, B007, etc.) are repaired in
+place and re-staged; non-fixable issues abort the commit so you can fix
+them before the commit lands.
+
+**To run on the whole repo** (e.g., one-shot cleanup):
+
+```bash
+pre-commit run --all-files
+```
+
+**CI fallback.** If you push without `pre-commit install` and the CI
+lint step fails, the workflow now emits an explicit install hint to
+`$GITHUB_STEP_SUMMARY` and to the job log via `::error::`. That hint
+exists exclusively to break the "push → red CI → push `style:` fixup"
+loop — see PR #357 commit message for the failure history.
+
 ### 4.6 Review feedback discipline
 
 CodeRabbit, Devin, and human reviewers all leave comments. The author's job:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -62,6 +62,7 @@ test = [
   "ruff>=0.5.0",
   "mypy>=1.10.0",
   "build>=1.0.0",
+  "pre-commit>=3.5.0",
 ]
 release = [
   "cyclonedx-bom>=4.0",


### PR DESCRIPTION
## Summary

Implements [#357](https://github.com/BicameralAI/bicameral-mcp/issues/357) sub-task 3: pre-commit hook that mirrors the CI lint gate, plus the dep, docs section, and CI failure hint to wire it into the contributor workflow. Closes the recurring `style:` fixup-commit tax Devin's #357 critique flagged.

Stacks logically on [#359](https://github.com/BicameralAI/bicameral-mcp/pull/359) (sub-task 1) and [#360](https://github.com/BicameralAI/bicameral-mcp/pull/360) (sub-task 2) but branches independently from `dev` — can merge in any order.

## Why

Six commits between #279 and #310 were post-push `style:` cleanup commits whose only purpose was appeasing CI after a feature commit shipped unformatted (`eb32e80`, `ee24395`, `0cf574b`, `1d752cc`, `1690a30`, `cacfb62`). Worse: during this very #357 arc I had to push **two more** such commits — `5769663` on PR #359 and `12ee765` on PR #360 — proving the gap is still live. Pre-commit + a clear CI hint when it's missing closes it.

## Changes

### `.pre-commit-config.yaml` (NEW)

`ruff-check --fix` + `ruff-format` hooks, both pinned to `v0.15.12`. The version pin matters: running v0.5.0 (the floor in pyproject.toml) vs v0.15.12 (resolved latest) on the same file produces different format outputs and different lint rules. I discovered this the hard way during verification — see "Verification" section.

### `pyproject.toml`

`pre-commit>=3.5.0` added to `[project.optional-dependencies].test` so `pip install -e .[test]` pulls it in.

### `docs/DEV_CYCLE.md`

New **§4.5.5 Local enforcement — pre-commit (mandatory for committers)**, slotted right after §4.5 (CI gates) since pre-commit is the local mirror of those gates. Includes:
- Install command (`pre-commit install`)
- One-shot full-repo run (`pre-commit run --all-files`)
- The failure history that motivates the requirement

### `.github/workflows/lint-and-typecheck.yml`

Adds an `if: failure()` step that emits a clear pre-commit install hint to `::error::` annotations and `$GITHUB_STEP_SUMMARY` when `ruff-check` or `ruff-format` steps fail. The hint exists exclusively to break the "push → red CI → push style: fixup commit" loop.

## Verification

### Positive test (clean repo)

```
$ pre-commit run --all-files
ruff check..........................................Passed
ruff format.........................................Passed
```

371 files unchanged, 0 reformatted, 0 lint errors on dev tip.

### Negative test (malformed code aborts the commit)

Introduced `scripts/_negative_test_temp.py` containing `import json,os` + `def foo(  x,y  ):` + `f"hello"`. Ran `git commit`:

```
ruff check...........................................Failed
- hook id: ruff-check
- files were modified by this hook
Found 3 errors (3 fixed, 0 remaining).

ruff format..........................................Failed
- hook id: ruff-format
- files were modified by this hook
1 file reformatted
```

**Commit was aborted.** `git log` confirmed no test commit landed; the file's bad whitespace + unnecessary f-prefix were autofixed and left unstaged for review.

### Version-pin discovery

First run with `rev: v0.5.0` (matching the pyproject.toml floor) "reformatted" 41 production files that `ruff format --check .` standalone (v0.15.12) considered clean. Repinning to v0.15.12 produced identical behavior between pre-commit and CI. Documented in the config comment so the next contributor knows to bump both pins together.

## What this PR does NOT include

- Other pre-commit hook families (end-of-file fixers, trailing whitespace, YAML lint). Keep MVP scope at the ruff scope that mirrors CI; expand opportunistically.
- Sweeping the existing 6 `style:` commits into their feature commits. Those have already landed via dev merge; can't be unwound without history rewrite. This PR prevents the **next** instance.
- Mypy in pre-commit. It's slow (10–30s on this codebase) and would push commit time past the user-tolerable threshold. CI handles it.

## Test plan

- [ ] CI green (ruff + mypy workflow passes, demonstrating pre-commit-output parity)
- [ ] Manual: `pre-commit install` after merge, intentionally push a malformed file, confirm hook blocks the commit
- [ ] Manual: temporarily uninstall pre-commit, push malformed code, confirm CI failure includes the install hint in the job summary

🤖 Generated with [Claude Code](https://claude.com/claude-code)