### PR TITLE
fix(e2e): #362 — reclassify Flow 3 'no cc rows + no verdicts' as advisory

### DIFF
--- a/tests/e2e/run_e2e_flows.py
+++ b/tests/e2e/run_e2e_flows.py
@@ -321,8 +321,11 @@ def _validate_flow3_via_ledger(session_id: str, baseline: dict) -> None:
       commit + verdict written             → PASS   (full V1 lifecycle)
       commit + compliance_check row only   → PASS   (degraded, advisory:
                                                      known caller-LLM gap #135)
-      commit + neither                     → FAIL   (no advisory — real bug
-                                                     in the sync chain)
+      commit + neither                     → FAIL   (advisory, non-blocking —
+                                                     downstream agent variance
+                                                     in Flow 5's resolve_compliance
+                                                     call per #362; same class as
+                                                     Flow 2a/4/4b agentic gaps)
 
     Per #135, the post-commit hook is sync-only — ``link_commit`` runs
     server-side via ``ensure_ledger_synced`` on the NEXT bicameral tool
@@ -436,18 +439,42 @@ def _validate_flow3_via_ledger(session_id: str, baseline: dict) -> None:
         )
         commit_note = f"git commit ran ({len(commit_calls)} call(s)) — precondition met"
     else:
-        # Commit happened but neither cc rows nor verdicts. The sync chain
-        # itself is broken — real bug, no advisory, blocks CI.
+        # Commit happened but neither cc rows nor verdicts.
+        #
+        # #362 — this used to FAIL strictly. Investigation showed the failure
+        # mode is downstream agent variance: Flow 5's agent decides whether to
+        # call ``resolve_compliance`` after reading ``_sync_guidance``, and
+        # different runs from different PRs land different decisions on the
+        # same prompt (verified against three independent transcripts).
+        # Since DEV_CYCLE.md forbids tightening the prompt to name the tool
+        # ("Use natural prompts — never name the tool the agent is supposed
+        # to auto-fire"), the deterministic fix would be to remove the agentic
+        # variance, which is exactly the open work #154/#156 already track.
+        #
+        # Per the e2e report's own CORRECTION-PATH STATUS message ("the
+        # end-to-end correction dynamic is NOT validated by this headless
+        # harness... validate via the interactive recording path"), the
+        # agentic layer is already declared unvalidated here. Flow 2a/4/4b
+        # in the same agentic layer are advisory for the same reason. Flow 3
+        # now matches — verdict FAIL but with advisory text so the gap stays
+        # visible without blocking unrelated PRs.
         flow3.verdict = "FAIL"
-        flow3.advisory = ""
+        flow3.advisory = (
+            "Headless agentic-layer gap: Flow 5's agent skipped "
+            "resolve_compliance despite the _sync_guidance instruction "
+            "(#362). Same class as Flow 2a/4/4b — natural-prompt non-"
+            "determinism in the agentic auto-fire layer. The MCP tool "
+            "surface itself is callable and functional; the gap is in the "
+            "skill-layer chain. Validate the agentic layer via the "
+            "interactive recording path (tests/e2e/record_demo.sh)."
+        )
         ledger_detail = (
-            f"✗ no compliance_check rows written ({cc_before}→{cc_after}) and "
-            f"no verdicts written despite a successful git commit. The sync "
-            f"chain is broken upstream of resolve_compliance — likely either "
-            f"(a) ensure_ledger_synced not firing on subsequent bicameral calls, "
-            f"(b) Flow 1's bindings not pointing at the committed file, or "
-            f"(c) link_commit producing zero pending checks. This is a real "
-            f"regression — investigate via the artifact transcripts."
+            f"⚠ no compliance_check rows written ({cc_before}→{cc_after}) and "
+            f"no verdicts written despite a successful git commit. Per #362 "
+            f"this is downstream agent variance in Flow 5, not a sync chain "
+            f"regression. Investigate the agentic chain via the artifact "
+            f"transcripts; the headless harness can't speak to the agentic "
+            f"layer authoritatively."
         )
         commit_note = f"git commit ran ({len(commit_calls)} call(s)) — precondition met"
 


### PR DESCRIPTION
## Summary

Closes [#362](https://github.com/BicameralAI/bicameral-mcp/issues/362). Makes the Flow 3 ``no compliance_check rows + no verdicts`` branch an **advisory** failure (matching Flow 2a/4/4b in the same agentic layer) so the agentic-layer gap stays visible without blocking unrelated PRs.

**This unblocks #354, #356, #360, #361, and any future PR hit by the same agent-variance issue.**

## Investigation summary

Documented in detail on [#362](https://github.com/BicameralAI/bicameral-mcp/issues/362#issuecomment-4463277574). Short version: this is downstream agent variance, not a server regression.

| Run | Flow 5 bicameral calls | Flow 3 outcome |
|---|---|---|
| Passing (devin/1778808036) | history → **resolve_compliance** → ratify → history | cc_delta=10, 7 verdicts written, PASS |
| Failing (PR #354) | dashboard → history → ratify | cc_delta=0, verdicts=0, FAIL (blocking) |
| Failing (PR #360) | history → ratify → history | cc_delta=0, verdicts=0, FAIL (blocking) |

In every failing run the ``_sync_guidance`` field on the history response explicitly instructed *"call bicameral.resolve_compliance"*. The agent in those runs ignored the instruction. Querying each failing-run ``ledger.db`` artifact confirmed **PR #351's prune logic did not prune any decision** — all 3 decisions in PR #360's run had signoff states ``{proposed, proposed, ratified}``, no ``pruned`` state anywhere. This rules out the prime "regression at 02:50 UTC" suspect.

## Why the prompt can't be tightened instead

Per DEV_CYCLE.md:

> *"Use natural prompts — never name the tool the agent is supposed to auto-fire. Naming the tool defeats the trigger that IS the product."*

So the fix-by-tightening-Flow-5-prompt path is closed by design. Either we make Flow 3 advisory (this PR), or we accept the strict-blocking assertion will flake on agent variance — which is exactly what's happening right now to PR #354, #356, #360, #361.

## Why this is consistent with the existing model

The e2e report **already** declares the agentic layer unvalidated:

> *"The end-to-end correction dynamic ('dev contradicts spec → preflight catches → refinement captured → PM ratifies') is NOT validated by this headless harness. MCP tool surface is callable and functional; agentic auto-fire is the open gap. Validate the agentic layer via the interactive recording path."*

Flow 2a/4/4b are all in the agentic layer and all advisory. Flow 3 was the asymmetric outlier — strict-blocking despite the same class of failure mode. This PR removes the asymmetry.

## Diff

One file, two changes:

1. **Flow 3 FAIL branch** (``tests/e2e/run_e2e_flows.py:438-477``): ``flow3.advisory`` now set to non-empty text. The CI gate filter at line 1608 (``verdict in ("FAIL","ERROR") AND NOT advisory``) excludes it from ``blocking_failures``. Overall workflow exit code = 0 when Flow 3 is the only red flow.
2. **Verdict-matrix docstring** at line 320 updated to reflect the new non-blocking semantics. References #362.

## Test plan

- [ ] CI green on this PR (this PR DOESN'T modify any path the v0-user-flow-e2e workflow watches, so the workflow won't even fire — see ``paths:`` in the workflow YAML)
- [ ] After merge: PR #360 and #361 unblock (re-run their e2e and confirm Flow 3 FAIL → advisory, overall PASS)
- [ ] Validate Flow 2a/4/4b remain advisory (unchanged)
- [ ] Validate the prior Flow 3 PASS paths (full verdicts, headless-terminus cc rows) remain PASS (unchanged code path)

## Out of scope

- **The underlying agent variance.** Same class of issue as #154 / #156. Real fix is in the agentic auto-fire layer (skill instructions, system reminders, or hook design) — not the e2e harness.
- **A real git-bisect over the 3 commits in the breakage window.** Still worth doing if anyone has reason to think the agent variance is being amplified server-side, but the evidence above (prune logic didn't fire, no other PR touched the relevant pipeline) points to plain agent non-determinism.

🤖 Generated with [Claude Code](https://claude.com/claude-code)