### PR TITLE
test(preflight): #357 backfill — de-mock test_preflight_dedup_v2.py + decrement trap cap 8→5

### DIFF
--- a/tests/test_ledger_mock_regression.py
+++ b/tests/test_ledger_mock_regression.py
@@ -37,7 +37,7 @@ from audit_sociable_coverage import compute_audit  # noqa: E402
 # when a backfill PR fixes a trap row. NEVER increment. If you find
 # yourself wanting to increment, you are about to ship #309-class risk —
 # write a sociable test instead.
-EXPECTED_TRAP_CAP = 8
+EXPECTED_TRAP_CAP = 5
 
 
 def test_no_new_ledger_query_mock_traps():

--- a/tests/test_preflight_dedup_v2.py
+++ b/tests/test_preflight_dedup_v2.py
@@ -8,17 +8,22 @@ those exercise the end-to-end behavior; these pin the helper shape and
 the bypass semantics that Kevin's signoff specifically called out
 (issue #87 — "correctness over saving a preflight call").
 
-Mostly solitary (the unit under test is a pure key-formatter and a
-small dict-cache check). The integration test for the revision-lookup
-bypass uses a real ``handle_preflight`` call against a SimpleNamespace
-ctx; the underlying ``get_ledger_revision`` is the only seam.
+Helper-fn tests are solitary by design (pure functions). The two
+integration tests use a real ``memory://`` SurrealDB adapter (#357 sub-
+task 1 backfill — the preflight cluster's solitary-trap rows for
+``get_decisions_for_files``, ``get_collision_pending_decisions``, and
+``get_context_for_ready_decisions``). The only retained mock is on
+``ledger.queries.get_ledger_revision`` — the SPECIFIC behavior under
+test in both integration cases is "what happens when revision returns
+None / a stable value", and that's exactly the narrow seam CLAUDE.md
+permits (matches the ``patch time.monotonic for TTL math`` example).
 """
 
 from __future__ import annotations
 
 import asyncio
 from types import SimpleNamespace
-from unittest.mock import AsyncMock, MagicMock
+from unittest.mock import AsyncMock
 
 import pytest
 
@@ -27,6 +32,37 @@ from handlers.preflight import (
     _dedup_key_for,
     _normalize_file_paths_for_key,
 )
+from ledger.adapter import SurrealDBLedgerAdapter
+from ledger.client import LedgerClient
+from ledger.schema import init_schema, migrate
+
+_NS_COUNTER = 0
+
+
+async def _fresh_real_ctx(*, sync_state: dict) -> tuple[SimpleNamespace, LedgerClient]:
+    """Build a SimpleNamespace ctx backed by a real memory:// SurrealDB.
+
+    Mirrors the pre-#357 MagicMock pattern but executes real SurrealQL on
+    every call. Each test gets its own namespace so rows don't bleed
+    across tests. Returns (ctx, client); caller is responsible for closing
+    the client.
+    """
+    global _NS_COUNTER
+    _NS_COUNTER += 1
+    client = LedgerClient(url="memory://", ns=f"dedup_v2_{_NS_COUNTER}", db="ledger_test")
+    await client.connect()
+    await init_schema(client)
+    await migrate(client, allow_destructive=True)
+    adapter = SurrealDBLedgerAdapter(url="memory://")
+    adapter._client = client
+    adapter._connected = True
+    ctx = SimpleNamespace(
+        ledger=adapter,
+        guided_mode=False,
+        _sync_state=sync_state,
+    )
+    return ctx, client
+
 
 # ── _normalize_file_paths_for_key ─────────────────────────────────────
 
@@ -156,116 +192,96 @@ def test_check_dedup_does_not_dedup_when_topic_too_short():
 # ── Bypass path: ledger_revision=None ────────────────────────────────
 
 
-def test_handle_preflight_bypasses_dedup_when_revision_lookup_fails(monkeypatch):
+async def test_handle_preflight_bypasses_dedup_when_revision_lookup_fails(monkeypatch):
     """Kevin's amendment (#87 B2 signoff): when ``get_ledger_revision``
     returns None, ``handle_preflight`` MUST skip the dedup check entirely
     rather than degrade to a partial key. Verified end-to-end: two
     successive same-topic calls both reach the post-dedup region/HITL
     lookup, neither returns ``recently_checked``.
+
+    Runs against a real memory:// ledger so ``get_decisions_for_files``
+    and the HITL queries execute real SurrealQL on an empty ledger.
+    The retained mock on ``get_ledger_revision`` is a narrow seam
+    (per CLAUDE.md) — it's the SPECIFIC failure mode under test.
     """
     import handlers.preflight as pf
+    import handlers.sync_middleware as sm
     import ledger.queries as lq
 
-    # Force revision lookup to fail (simulates transient SurrealDB error).
+    # Narrow seam: force revision lookup to return None to simulate
+    # the transient SurrealDB failure mode Kevin's amendment is about.
     monkeypatch.setattr(lq, "get_ledger_revision", AsyncMock(return_value=None))
-    monkeypatch.setattr(
-        lq,
-        "get_collision_pending_decisions",
-        AsyncMock(return_value=[]),
-    )
-    monkeypatch.setattr(
-        lq,
-        "get_context_for_ready_decisions",
-        AsyncMock(return_value=[]),
-    )
-    import handlers.sync_middleware as sm
-
+    # Narrow seam: keep the auto-sync stubbed so the test doesn't try
+    # to link_commit against the working tree. CLAUDE.md explicitly
+    # permits this pattern ("patching handle_link_commit when testing
+    # the caller's cache logic, not link_commit itself").
     monkeypatch.setattr(sm, "ensure_ledger_synced", AsyncMock(return_value=None))
     monkeypatch.setattr(pf, "_should_show_product_stage", lambda: False)
     monkeypatch.delenv("BICAMERAL_PREFLIGHT_MUTE", raising=False)
 
-    ledger = MagicMock()
-    ledger.get_decisions_for_files = AsyncMock(return_value=[])
-    inner = MagicMock()
-    inner._client = MagicMock()
-    ledger._inner = inner
-
     sync_state: dict = {}
-    ctx = SimpleNamespace(
-        ledger=ledger,
-        guided_mode=False,
-        _sync_state=sync_state,
-    )
+    ctx, client = await _fresh_real_ctx(sync_state=sync_state)
+    try:
+        # Two consecutive same-topic calls — without bypass, the second
+        # would be silenced. With bypass, both proceed to real evaluation.
+        r1 = await pf.handle_preflight(
+            ctx=ctx, topic="stripe webhook", file_paths=["payments/stripe.py"]
+        )
+        r2 = await pf.handle_preflight(
+            ctx=ctx, topic="stripe webhook", file_paths=["payments/stripe.py"]
+        )
 
-    # Two consecutive same-topic calls — without bypass, the second
-    # would be silenced. With bypass, both proceed to real evaluation.
-    r1 = asyncio.run(
-        pf.handle_preflight(ctx=ctx, topic="stripe webhook", file_paths=["payments/stripe.py"])
-    )
-    r2 = asyncio.run(
-        pf.handle_preflight(ctx=ctx, topic="stripe webhook", file_paths=["payments/stripe.py"])
-    )
-
-    assert r1.reason != "recently_checked", (
-        f"first call should not dedup-hit (clean cache), got reason={r1.reason!r}"
-    )
-    assert r2.reason != "recently_checked", (
-        "BYPASS broken: second call returned recently_checked despite revision "
-        f"lookup returning None (got reason={r2.reason!r}). Kevin's amendment "
-        "requires bypass over partial-key degrade."
-    )
-    # Cache must NOT have been populated either — the bypass branch
-    # short-circuits before _check_dedup is invoked.
-    assert sync_state.get("preflight_topics", {}) == {}, (
-        f"bypass branch must not write to the cache; got {sync_state.get('preflight_topics')!r}"
-    )
+        assert r1.reason != "recently_checked", (
+            f"first call should not dedup-hit (clean cache), got reason={r1.reason!r}"
+        )
+        assert r2.reason != "recently_checked", (
+            "BYPASS broken: second call returned recently_checked despite revision "
+            f"lookup returning None (got reason={r2.reason!r}). Kevin's amendment "
+            "requires bypass over partial-key degrade."
+        )
+        # Cache must NOT have been populated either — the bypass branch
+        # short-circuits before _check_dedup is invoked.
+        assert sync_state.get("preflight_topics", {}) == {}, (
+            f"bypass branch must not write to the cache; got {sync_state.get('preflight_topics')!r}"
+        )
+    finally:
+        await client.close()
 
 
-def test_handle_preflight_dedups_when_revision_lookup_succeeds(monkeypatch):
+async def test_handle_preflight_dedups_when_revision_lookup_succeeds(monkeypatch):
     """Mirror of the bypass test: when revision lookup returns a value,
     same-input second call hits the cache (legacy dedup behavior with
-    the broadened key)."""
+    the broadened key).
+
+    Same sociable-with-narrow-seam pattern as the bypass test above.
+    """
     import handlers.preflight as pf
+    import handlers.sync_middleware as sm
     import ledger.queries as lq
 
+    # Narrow seam: pin revision to a stable value so the second call's
+    # cache key matches the first. With a real ledger this would also
+    # naturally hold (no decisions added → counter unchanged), but the
+    # explicit pin keeps the test's intent legible and isolates the
+    # dedup-key contract from any future counter-mechanism changes.
     monkeypatch.setattr(lq, "get_ledger_revision", AsyncMock(return_value="stable-rev-1"))
-    monkeypatch.setattr(
-        lq,
-        "get_collision_pending_decisions",
-        AsyncMock(return_value=[]),
-    )
-    monkeypatch.setattr(
-        lq,
-        "get_context_for_ready_decisions",
-        AsyncMock(return_value=[]),
-    )
-    import handlers.sync_middleware as sm
-
     monkeypatch.setattr(sm, "ensure_ledger_synced", AsyncMock(return_value=None))
     monkeypatch.setattr(pf, "_should_show_product_stage", lambda: False)
     monkeypatch.delenv("BICAMERAL_PREFLIGHT_MUTE", raising=False)
 
-    ledger = MagicMock()
-    ledger.get_decisions_for_files = AsyncMock(return_value=[])
-    inner = MagicMock()
-    inner._client = MagicMock()
-    ledger._inner = inner
-
     sync_state: dict = {}
-    ctx = SimpleNamespace(
-        ledger=ledger,
-        guided_mode=False,
-        _sync_state=sync_state,
-    )
+    ctx, client = await _fresh_real_ctx(sync_state=sync_state)
+    try:
+        r1 = await pf.handle_preflight(
+            ctx=ctx, topic="stripe webhook", file_paths=["payments/stripe.py"]
+        )
+        r2 = await pf.handle_preflight(
+            ctx=ctx, topic="stripe webhook", file_paths=["payments/stripe.py"]
+        )
 
-    r1 = asyncio.run(
-        pf.handle_preflight(ctx=ctx, topic="stripe webhook", file_paths=["payments/stripe.py"])
-    )
-    r2 = asyncio.run(
-        pf.handle_preflight(ctx=ctx, topic="stripe webhook", file_paths=["payments/stripe.py"])
-    )
-
-    assert r1.reason != "recently_checked"
-    assert r2.reason == "recently_checked", (
-        f"expected dedup hit on identical-input second call, got reason={r2.reason!r}"
-    )
+        assert r1.reason != "recently_checked"
+        assert r2.reason == "recently_checked", (
+            f"expected dedup hit on identical-input second call, got reason={r2.reason!r}"
+        )
+    finally:
+        await client.close()


### PR DESCRIPTION
## Summary

First trap-row backfill PR driven by the [#359](https://github.com/BicameralAI/bicameral-mcp/pull/359) sub-task 1 audit. Converts the two integration tests in \`tests/test_preflight_dedup_v2.py\` from \`MagicMock\`-based ctx to a real \`memory://\` SurrealDB adapter. Drops trap count from **8 to 5** in one go — all three preflight-cluster traps (\`get_decisions_for_files\`, \`get_collision_pending_decisions\`, \`get_context_for_ready_decisions\`) flip from solitary to direct-sociable.

## What changed

\`tests/test_preflight_dedup_v2.py\`:
- New \`_fresh_real_ctx\` helper: builds a per-test \`memory://\` SurrealDB with schema migrated, returns the ctx + client
- The 9 pure-function tests stay solitary (testing pure functions — correct posture)
- The 2 integration tests are now \`async def\` and use the real adapter
- Retained narrow-seam mocks (per CLAUDE.md):
  - \`ledger.queries.get_ledger_revision\` — the SPECIFIC failure/success behavior under test
  - \`handlers.sync_middleware.ensure_ledger_synced\` — keeps the auto-sync from touching the working tree

\`tests/test_ledger_mock_regression.py\`:
- \`EXPECTED_TRAP_CAP\`: 8 → 5 (locks in the one-way-ratchet improvement)

## Audit impact

| Category | Before | After | Δ |
|---|---|---|---|
| Direct sociable | 24 | **27** | +3 |
| Solitary trap | 8 | **5** | -3 |
| Indirect sociable | 25 | 25 | 0 |
| Uncovered | 0 | 0 | 0 |

The three preflight-cluster trap rows are gone. Remaining traps are in two clusters:
- **remove_source** (4 fns): \`decision_exists\`, \`get_decisions_for_span\`, \`input_span_exists\`, \`get_input_span_row\`
- **link_commit** (1 fn): \`get_region_metadata\`

## Out of scope

- \`tests/test_preflight_dedup_telemetry.py\` and \`tests/test_v055_region_anchored_preflight.py\` still mock the preflight-cluster functions, but they no longer contribute to trap status (every preflight function is now sociable-covered via this PR's de-mocked tests). They get optional follow-up PRs.
- The remove_source and link_commit cluster traps are separate follow-up PRs.

## Verification

\`\`\`
$ pytest tests/test_preflight_dedup_v2.py
18 passed in 0.77s

$ pytest tests/test_ledger_mock_regression.py
3 passed
\`\`\`

Ruff check + format clean.

## Test plan

- [ ] CI green
- [ ] Adjacent: \`tests/test_preflight_dedup_telemetry.py\` and \`tests/test_v055_region_anchored_preflight.py\` unchanged → no regression

🤖 Generated with [Claude Code](https://claude.com/claude-code)