### PR TITLE
feat(release): flip channel sources + CalVer nightlies

### DIFF
--- a/.github/workflows/publish-nightly.yml
+++ b/.github/workflows/publish-nightly.yml
@@ -2,16 +2,16 @@ name: Publish nightly to PyPI
 
 # Nightly pre-release channel for design partners.
 #
-# Publishes whatever is on `dev` to PyPI as a PEP 440 dev release, so testers
-# can pull bug fixes the day they land without waiting on the main-branch
-# review cycle. Stable installs are unaffected: `pip install bicameral-mcp`
-# never picks up a `.devN` version unless `--pre` is passed.
+# Publishes whatever is on `dev` to PyPI as a CalVer dev release. CalVer
+# (YYYY.M.D.dev<HHMMSS>) is deliberately orthogonal to stable's semver
+# (X.Y.Z): stable progresses by cherry-pick from dev, so there is no fixed
+# relationship between dev's content and the next stable version number.
+# Anchoring nightlies to "next patch above stable" would be a fiction.
+# Example: 2026.5.16.dev011742 (May 16 2026, 01:17:42 UTC).
 #
-# Versioning: BASE.dev<UTC-YYYYMMDDHHMM>, where BASE is the next patch above
-# whatever is currently in pyproject.toml. Example: pyproject says 0.14.6 →
-# nightly publishes 0.14.7.dev202605151430. PyPI sorts dev releases below
-# their target final, so the nightly is always "newer than current stable,
-# older than next stable."
+# Pilots install nightlies via `pip install --pre bicameral-mcp` (or
+# `uv tool install bicameral-mcp --prerelease=allow`). Stable installs are
+# unaffected: pip never picks up a `.devN` version unless `--pre` is passed.
 #
 # Heavy supply-chain ceremony (cosign signing, SBOM attestation, hooks/skills
 # manifests) is intentionally skipped here. Stable releases via publish.yml
@@ -21,12 +21,14 @@ on:
   schedule:
     - cron: '0 7 * * *'   # 07:00 UTC daily (~midnight PT)
   workflow_dispatch:
-  push:
-    branches: [dev]
+  # No push-to-dev trigger: classic "nightly" cadence is one build/day from
+  # the cron, with workflow_dispatch as the manual override for urgent fixes.
+  # Publishing on every dev commit was considered and dropped — too much
+  # version churn for pilots, no real benefit over a daily snapshot.
 
 permissions:
   id-token: write    # PyPI trusted publishing
-  contents: write    # commit RECOMMENDED_NIGHTLY_VERSION back to dev
+  contents: read     # checkout only; we no longer push anything back
 
 concurrency:
   group: publish-nightly
@@ -53,11 +55,13 @@ jobs:
       - name: Compute nightly version
         id: ver
         run: |
-          BASE=$(python -c "import tomllib; print(tomllib.loads(open('pyproject.toml','rb').read().decode())['project']['version'])")
-          IFS=. read -r MAJ MIN PAT <<<"$BASE"
-          NEXT_PATCH=$((PAT + 1))
-          STAMP=$(date -u +%Y%m%d%H%M)
-          NIGHTLY="${MAJ}.${MIN}.${NEXT_PATCH}.dev${STAMP}"
+          # CalVer release segment: YYYY.M.D (no zero-padding — PEP 440
+          # normalizes anyway, and the un-padded form reads naturally).
+          # Dev segment: HHMMSS UTC so simultaneous-minute dispatches still
+          # produce unique versions. Example: 2026.5.16.dev011742.
+          DATE_PART=$(date -u +%Y.%-m.%-d)
+          TIME_PART=$(date -u +%H%M%S)
+          NIGHTLY="${DATE_PART}.dev${TIME_PART}"
           echo "version=$NIGHTLY" >>"$GITHUB_OUTPUT"
           echo "Nightly version: $NIGHTLY"
 
@@ -84,25 +88,11 @@ jobs:
         with:
           verbose: true
 
-      - name: Update RECOMMENDED_NIGHTLY_VERSION on dev
-        env:
-          NIGHTLY_VERSION: ${{ steps.ver.outputs.version }}
-        run: |
-          # `bicameral.update` on a tester's machine fetches this file from the
-          # dev branch to decide whether a newer nightly is out. Update it last,
-          # only after PyPI publish succeeded, so we never advertise a version
-          # that isn't actually installable.
-          #
-          # Restore pyproject.toml first — we mutated it in-CI for the build,
-          # and that mutation must NOT end up in the commit we push back.
-          git checkout -- pyproject.toml
-          echo "$NIGHTLY_VERSION" > RECOMMENDED_NIGHTLY_VERSION
-          if git diff --quiet RECOMMENDED_NIGHTLY_VERSION; then
-            echo "RECOMMENDED_NIGHTLY_VERSION unchanged; skipping commit."
-            exit 0
-          fi
-          git config user.name "github-actions[bot]"
-          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
-          git add RECOMMENDED_NIGHTLY_VERSION
-          git commit -m "nightly: bump RECOMMENDED_NIGHTLY_VERSION to $NIGHTLY_VERSION [skip ci]"
-          git push origin HEAD:dev
+      # NOTE: there is intentionally no post-publish step here.
+      # Pilots' `bicameral.update` reads `RECOMMENDED_NIGHTLY_VERSION` on the
+      # `dev` branch, which is **developer-curated** — bumped manually by a
+      # maintainer when a nightly contains a "major bugfix" worth surfacing
+      # (see docs/DEV_CYCLE.md §6.9). The workflow does NOT auto-update that
+      # file, by design: surfacing every nightly to pilots would spam them.
+      # Every nightly still lands on PyPI; the file just controls "which one
+      # is worth notifying about."

--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ bicameral-mcp --smoke-test
 
 ### Nightly channel (design partners)
 
-Design partners opt into the nightly build to receive bug fixes the day they land on `dev`, ahead of the stable release on `main`. Nightlies are PEP 440 dev releases (`X.Y.Z.devYYYYMMDDHHMM`) published to PyPI; `pip` and `uv` skip them by default, so a plain `pip install bicameral-mcp` never picks one up unintentionally.
+Design partners opt into the nightly build to receive bug fixes the day they land on `dev`, ahead of the stable release on `main`. Nightlies use a CalVer scheme (`YYYY.M.D.devHHMMSS`, e.g. `2026.5.16.dev011742`) deliberately orthogonal to stable's semver — stable progresses by cherry-pick from dev, so anchoring nightlies to "next patch above stable" would be a fiction. `pip` and `uv` skip dev releases by default, so a plain `pip install bicameral-mcp` never picks one up unintentionally.
 
 **Step 1 — install with pre-releases enabled:**
 
@@ -63,7 +63,7 @@ pip install --pre --upgrade bicameral-mcp
 channel: nightly  # was: stable
 ```
 
-With `channel: nightly`, `bicameral.update` reads the recommended version from `RECOMMENDED_NIGHTLY_VERSION` on the `dev` branch (updated by `publish-nightly.yml` after each successful publish) and offers to upgrade to the newest nightly. Without flipping the channel, the handler keeps pointing you at stable releases on `main` — and would try to "upgrade" you off your nightly install onto an older stable version. Version comparison is PEP 440-aware: `0.14.7.dev*` sorts between `0.14.6` (newer than) and `0.14.7` (older than), so the channel keeps you on the right ladder.
+With `channel: nightly`, `bicameral.update` reads the **developer-curated** `RECOMMENDED_NIGHTLY_VERSION` file on the `dev` branch and offers to upgrade to it. Every nightly publishes to PyPI, but the pointer file is only bumped when a maintainer judges the nightly worth surfacing — major bugfix, schema migration, new tool field — so pilots aren't notified on every cron tick. See `docs/DEV_CYCLE.md` §6.9 for the bump heuristic. Stable (`channel: stable`) queries PyPI's `info.version` directly — the `dev → main` release-PR process is the curation lever there. The two channels use deliberately incompatible version schemes (CalVer for nightly, semver for stable), so `bicameral.update` never tries to cross-upgrade you from one channel to the other; flipping the `channel:` field in your config is the only way to switch.
 
 **To roll back to stable:** flip `channel: stable` in your config, then:
 

--- a/docs/DEV_CYCLE.md
+++ b/docs/DEV_CYCLE.md
@@ -772,6 +772,49 @@ attach platform builds here.
 - Announce: README badge bump, project README "Latest" line, optional Slack /
   Discord drop. Use the headline sentence verbatim.
 
+### 6.9 Nightly channel curation (`RECOMMENDED_NIGHTLY_VERSION`)
+
+The nightly channel ships every successful `publish-nightly.yml` run to PyPI
+as a CalVer pre-release (e.g. `2026.5.16.dev011742`; one per cron tick or
+manual dispatch). Pilots on `channel: nightly` would get spammed if
+`bicameral.update` notified them of each one, so notifications are gated by a
+**developer-curated pointer file**: `/RECOMMENDED_NIGHTLY_VERSION` at the
+repo root, tracked on `dev`.
+
+The CalVer scheme (`YYYY.M.D.devHHMMSS`) is deliberately orthogonal to
+stable's semver (`X.Y.Z`). Stable progresses by cherry-pick from dev, so
+dev's content has no fixed relationship to any specific upcoming stable
+version — anchoring nightlies to "next patch above stable" would be a
+fiction. PEP 440 sorts CalVer above any plausible stable, so nightly users
+never see a "downgrade" nag.
+
+Jin (or any maintainer) bumps it manually via a PR to `dev` when a nightly
+crosses one of these thresholds:
+
+- **Major bugfix lands.** A fix that addresses a tester-reported issue,
+  unblocks a workflow, or restores broken functionality.
+- **Schema migration that lands cleanly.** Pilots should pull this nightly
+  before their next ledger touch so they're on the new schema.
+- **New tool / new field in an existing tool response** that affects skill
+  contracts — pilots need it for their agent to render correctly.
+- **A previous nightly was broken** and the next clean one is out (skip the
+  broken nightly).
+
+Do **NOT** bump for: every new commit, documentation-only changes, test-only
+changes, refactors with no behavioral change, performance work below ~10%
+delta, or batch-able fixes that can ride the next "major bugfix" bump.
+
+**How to bump:**
+
+1. Confirm the target nightly is on PyPI (`pip index versions --pre bicameral-mcp`).
+2. Open a PR to `dev` with a one-line change to `RECOMMENDED_NIGHTLY_VERSION`.
+3. PR title: `chore(nightly): bump RECOMMENDED_NIGHTLY_VERSION to YYYY.M.D.devN`.
+4. Body: one paragraph naming which threshold from the list above applies.
+5. Single-approval merge (this is not a release PR — it's a pointer flip).
+
+Pilots' `bicameral.update` is cached for 1 hour, so the upgrade notification
+appears within an hour of the file landing on `dev`.
+
 ---
 
 ## 7. CHANGELOG.md conventions

--- a/handlers/update.py
+++ b/handlers/update.py
@@ -1,19 +1,36 @@
 """Handler for bicameral.update — check for and apply recommended updates.
 
-Two release channels:
-  - ``stable``  → tracks ``RECOMMENDED_VERSION`` on the ``main`` branch.
-  - ``nightly`` → tracks ``RECOMMENDED_NIGHTLY_VERSION`` on the ``dev`` branch,
-    updated by ``.github/workflows/publish-nightly.yml`` after each successful
-    PyPI dev-release publish.
+Two release channels, each with a different source of truth for "latest":
+
+  - ``stable``  → queries PyPI's ``/pypi/bicameral-mcp/json`` ``info.version``
+    field, which is the latest non-pre-release. No file pointer needed:
+    stable releases are naturally curated by the ``dev → main`` release PR
+    process (see docs/DEV_CYCLE.md §6), so whatever reaches PyPI as a final
+    release is by definition the recommended version.
+
+  - ``nightly`` → tracks ``RECOMMENDED_NIGHTLY_VERSION`` on the ``dev``
+    branch. The file is **developer-curated** — maintainers bump it manually
+    when a nightly contains a "major bugfix" worth surfacing to pilots (see
+    docs/DEV_CYCLE.md §6.9 for the bump heuristic). Without this curation
+    layer, pilots would get notified on every nightly publish, which defeats
+    the "quiet by default" UX. The workflow does NOT auto-update this file;
+    bumps land via normal PRs to ``dev``.
 
 Channel is read from ``.bicameral/config.yaml`` (``channel: stable|nightly``),
 defaulting to ``stable``. Testers opt into nightly by editing the config or
 re-running the wizard; the wizard writes ``channel: stable`` on a fresh install.
 
-Version comparison uses ``packaging.version.Version`` (PEP 440), so dev
-releases (``0.14.7.dev202605151430``) compare correctly against final
-releases (``0.14.6``, ``0.14.7``). The previous ``int(x) for x in v.split('.')``
-parser crashed on ``.devN`` suffixes and silently downgraded nightly users.
+Version comparison uses ``packaging.version.Version`` (PEP 440). Stable
+uses semver (``0.14.6``); nightly uses CalVer (``2026.5.16.dev011742``).
+The two schemes are deliberately orthogonal — stable progresses by
+cherry-pick from dev, so dev's content has no fixed relationship to any
+specific upcoming stable version. CalVer sorts above any plausible stable
+release, so a pilot on nightly never gets nagged to "downgrade" to stable
+even though stable's semver number is much smaller.
+
+The previous ``int(x) for x in v.split('.')`` parser crashed on ``.devN``
+suffixes and silently downgraded nightly users; the PEP 440 parser fixes
+this regardless of the version scheme.
 
 Update check is cached at ``~/.bicameral/update-check.json`` with a 1-hour
 TTL, keyed by channel.
@@ -36,11 +53,11 @@ from packaging.version import InvalidVersion, Version
 
 logger = logging.getLogger(__name__)
 
-_RECOMMENDED_VERSION_URLS: dict[str, str] = {
-    "stable": "https://raw.githubusercontent.com/BicameralAI/bicameral-mcp/main/RECOMMENDED_VERSION",
-    "nightly": "https://raw.githubusercontent.com/BicameralAI/bicameral-mcp/dev/RECOMMENDED_NIGHTLY_VERSION",
-}
-_VALID_CHANNELS = frozenset(_RECOMMENDED_VERSION_URLS)
+_NIGHTLY_RECOMMENDED_VERSION_URL = (
+    "https://raw.githubusercontent.com/BicameralAI/bicameral-mcp/dev/RECOMMENDED_NIGHTLY_VERSION"
+)
+_PYPI_JSON_URL = "https://pypi.org/pypi/bicameral-mcp/json"
+_VALID_CHANNELS = frozenset({"stable", "nightly"})
 _DEFAULT_CHANNEL = "stable"
 
 _CACHE_PATH = os.path.expanduser("~/.bicameral/update-check.json")
@@ -133,7 +150,13 @@ def fetch_recommended_version(channel: str = _DEFAULT_CHANNEL) -> str | None:
 
 
 def _fetch_recommended_version(channel: str = _DEFAULT_CHANNEL) -> str | None:
-    """Fetch the recommended version for ``channel`` from GitHub with a 1-hour cache."""
+    """Fetch the recommended version for ``channel`` with a 1-hour cache.
+
+    ``stable`` queries PyPI's ``info.version`` (latest non-pre-release).
+    ``nightly`` reads the developer-curated pointer file on ``dev``. Both
+    paths fall back to a stale cached value on network failure rather than
+    ``None``.
+    """
     channel = _normalize_channel(channel)
     cache = _load_cache()
     now = time.time()
@@ -143,10 +166,14 @@ def _fetch_recommended_version(channel: str = _DEFAULT_CHANNEL) -> str | None:
     if bucket.get("fetched_at", 0) + _CACHE_TTL_SECONDS > now:
         return bucket.get("recommended_version")
 
-    url = _RECOMMENDED_VERSION_URLS[channel]
     try:
-        with urllib.request.urlopen(url, timeout=3) as resp:
-            version = resp.read().decode().strip()
+        if channel == "stable":
+            version = _fetch_latest_stable_from_pypi()
+        else:
+            with urllib.request.urlopen(_NIGHTLY_RECOMMENDED_VERSION_URL, timeout=3) as resp:
+                version = resp.read().decode().strip()
+        if not version:
+            return bucket.get("recommended_version")
         cache[channel] = {"recommended_version": version, "fetched_at": now}
         _save_cache(cache)
         return version
@@ -154,6 +181,24 @@ def _fetch_recommended_version(channel: str = _DEFAULT_CHANNEL) -> str | None:
         logger.debug("[update] version check failed for channel=%s: %s", channel, exc)
         # Return stale cache value rather than nothing
         return bucket.get("recommended_version")
+
+
+def _fetch_latest_stable_from_pypi() -> str | None:
+    """Return the latest non-pre-release version of ``bicameral-mcp`` on PyPI.
+
+    PyPI's ``info.version`` field is canonically "the latest non-pre-release"
+    — it hides ``.devN`` / ``rcN`` / ``aN`` / ``bN`` automatically, which is
+    exactly what the stable channel wants. Returns ``None`` if the response
+    is malformed or the field is missing; the caller treats that the same
+    as a network failure and falls back to cache.
+    """
+    with urllib.request.urlopen(_PYPI_JSON_URL, timeout=5) as resp:
+        data = json.load(resp)
+    if not isinstance(data, dict):
+        return None
+    info = data.get("info") or {}
+    version = info.get("version")
+    return str(version) if version else None
 
 
 def _parse_version(v: str) -> Version:


### PR DESCRIPTION
## Summary

Two interlocking refinements arriving from real-world use of the v0.14.6 channel-aware flow:

### 1. Channel sources swap

Old design had it backwards:

| | Old | New |
|---|---|---|
| **Stable** | curated `RECOMMENDED_VERSION` file on `main` | queries PyPI's `info.version` directly |
| **Nightly** | auto-pushed `RECOMMENDED_NIGHTLY_VERSION` from workflow | developer-curated `RECOMMENDED_NIGHTLY_VERSION` on `dev` |

Stable is *naturally* curated by the `dev → main` release-PR process — whatever lands on PyPI as a final release IS the recommendation, no separate pointer needed. Nightly publishes on every cron tick, so the curation must come from somewhere else: a manual maintainer bump of `RECOMMENDED_NIGHTLY_VERSION` only when a nightly contains a "major bugfix" worth surfacing to pilots. The bump heuristic lives in `docs/DEV_CYCLE.md` §6.9.

Workflow consequences:
- Post-publish step that pushed `RECOMMENDED_NIGHTLY_VERSION` back to dev is **removed** (it was rejected by branch protection on dev anyway — `GH006: 4 of 4 required status checks are expected`).
- `contents: write` → `contents: read` (no longer pushes anything).
- `push: branches: [dev]` trigger **removed** (cron-only + `workflow_dispatch`). This was meant to land via #374's fixup commit `1a92a3e` but the PR merged before that fixup; rolling it in here.

### 2. Nightly version scheme → CalVer

Old: `{next-patch-above-stable}.devYYYYMMDDHHMM` (e.g. `0.14.7.dev202605151430`)
New: `YYYY.M.D.devHHMMSS` (e.g. `2026.5.16.dev011742`)

The old scheme implicitly anchored nightlies to "the next stable version" — but stable progresses by **cherry-pick** from dev, so dev's content has no fixed relationship to any specific upcoming stable. CalVer is orthogonal: PEP 440 sorts it above any plausible semver release, so nightly users never see a "downgrade to stable" nag, and a maintainer never has to think about what semver number a nightly should claim.

## Test plan

- [x] `ruff check`, `ruff format --check`, `mypy handlers/update.py` all clean
- [x] PEP 440 sanity: `Version("2026.5.16.dev011742") > Version("0.14.6")`, same-day monotonicity, day-rollover monotonicity
- [x] Live PyPI query: `_fetch_latest_stable_from_pypi()` returns `0.14.6` (current `info.version`)
- [x] YAML schema validated
- [x] Existing handler tests (`tests/test_diagnose_cli.py`, `tests/test_preflight_id_plumbing.py`) green except for pre-existing-on-dev `test_ratify_passes_through_preflight_id` failure (unrelated)
- [ ] First scheduled cron after merge produces a `YYYY.M.D.devHHMMSS` wheel on PyPI
- [ ] Manual `RECOMMENDED_NIGHTLY_VERSION` bump PR (separate, when warranted) propagates to pilots' `bicameral.update` within the 1-hour TTL

## Follow-ups (separate PRs)

- Mirror the workflow change to `main` (the cron host) — small parallel PR; without this, cron-triggered runs from `main` still use the old version-compute and still try to push back.
- `chore/nightly-cron-registration` left `RECOMMENDED_VERSION` on main intact; once we're confident stable-via-PyPI works, that file can be deleted (it has no consumer anymore).