### PR TITLE
fix(schema): backfill bicameral_meta.decision_revision in v18→v19 + v22→v23

### DIFF
--- a/ledger/schema.py
+++ b/ledger/schema.py
@@ -1187,10 +1187,18 @@ async def _migrate_v18_to_v19(client: LedgerClient) -> None:
             "THEN (UPDATE bicameral_meta SET decision_revision = decision_revision + 1)"
         ),
     )
-    # Ensure the singleton row exists. Without this, the EVENT fires on
-    # decision writes but has no row to UPDATE; the counter stays at 0.
-    # _write_wire_format_sentinel (adapter.connect) creates the row on
-    # first connect, but the migration may run before that path.
+    # Ensure the singleton row exists AND has decision_revision = 0.
+    #
+    # Two failure modes the original v0.13.x migration missed:
+    # 1. No row at all — the DEFINE EVENT fires on decision writes with
+    #    nothing to UPDATE; the counter never increments. Seed via CREATE.
+    # 2. Row exists from an earlier ``_write_wire_format_sentinel`` call
+    #    (v16's ``adapter.connect`` path) but pre-dates the
+    #    ``decision_revision`` field. SurrealDB v2's ``DEFAULT 0`` only
+    #    applies on CREATE, not as a backfill — so the existing row's
+    #    ``decision_revision`` stays NONE, and every subsequent decision
+    #    UPDATE blows up the trigger with
+    #    "Cannot perform addition with 'NONE' and '1'". Backfill via UPDATE.
     try:
         rows = await client.query("SELECT id FROM bicameral_meta LIMIT 1")
     except Exception:
@@ -1201,6 +1209,18 @@ async def _migrate_v18_to_v19(client: LedgerClient) -> None:
         except Exception as exc:
             logger.warning(
                 "[migration] v18 → v19: could not seed bicameral_meta singleton (%s)",
+                exc,
+            )
+    else:
+        try:
+            await client.execute(
+                "UPDATE bicameral_meta SET decision_revision = 0 "
+                "WHERE decision_revision IS NONE"
+            )
+        except Exception as exc:
+            logger.warning(
+                "[migration] v18 → v19: could not backfill decision_revision on "
+                "existing bicameral_meta row (%s)",
                 exc,
             )
     logger.info(
@@ -1351,6 +1371,30 @@ async def _migrate_v22_to_v23(client: LedgerClient) -> None:
     We therefore UPDATE per-row and skip (with a warning) any row
     whose record is too broken for an in-place patch.
     """
+    # Step 0: defense-in-depth. The v18→v19 migration was historically
+    # buggy — when ``bicameral_meta`` already had a row written by
+    # ``_write_wire_format_sentinel``, the seed branch was skipped and
+    # ``decision_revision`` stayed NONE forever. Every per-row UPDATE
+    # below fires the ``decision_revision_bump`` event, which does
+    # ``decision_revision + 1`` and blows up on NONE. Without this
+    # backfill, the per-row try/except below silently swallows the
+    # trigger failure for every row, ``skip_count`` ticks up to N, and
+    # the migration "succeeds" while classifying zero rows. The fix in
+    # ``_migrate_v18_to_v19`` covers DBs upgrading from <v19 today; this
+    # one-liner covers a DB that already ran the buggy v19 and is
+    # arriving at v23 with ``decision_revision`` still NONE.
+    try:
+        await client.execute(
+            "UPDATE bicameral_meta SET decision_revision = 0 "
+            "WHERE decision_revision IS NONE"
+        )
+    except Exception as exc:
+        logger.warning(
+            "[migration] v22 → v23: decision_revision pre-backfill failed (%s); "
+            "classification UPDATEs may silently skip",
+            exc,
+        )
+
     # Step 1: decisions with code-region bindings → L2.
     # Bound decision IDs come from the binds_to edge table (not
     # ``->binds_to->code_region IS NOT EMPTY``, which returns True for

--- a/ledger/schema.py
+++ b/ledger/schema.py
@@ -1214,8 +1214,7 @@ async def _migrate_v18_to_v19(client: LedgerClient) -> None:
     else:
         try:
             await client.execute(
-                "UPDATE bicameral_meta SET decision_revision = 0 "
-                "WHERE decision_revision IS NONE"
+                "UPDATE bicameral_meta SET decision_revision = 0 WHERE decision_revision IS NONE"
             )
         except Exception as exc:
             logger.warning(
@@ -1385,8 +1384,7 @@ async def _migrate_v22_to_v23(client: LedgerClient) -> None:
     # arriving at v23 with ``decision_revision`` still NONE.
     try:
         await client.execute(
-            "UPDATE bicameral_meta SET decision_revision = 0 "
-            "WHERE decision_revision IS NONE"
+            "UPDATE bicameral_meta SET decision_revision = 0 WHERE decision_revision IS NONE"
         )
     except Exception as exc:
         logger.warning(

--- a/tests/test_ledger_bicameral_meta_migration.py
+++ b/tests/test_ledger_bicameral_meta_migration.py
@@ -132,8 +132,7 @@ async def test_migrate_v18_to_v19_backfills_decision_revision_on_preexisting_row
         f"migrate must keep exactly one bicameral_meta row, got {post_rows!r}"
     )
     assert post_rows[0].get("decision_revision") == 0, (
-        f"v18→v19 must backfill decision_revision=0 on existing rows; "
-        f"got {post_rows[0]!r}"
+        f"v18→v19 must backfill decision_revision=0 on existing rows; got {post_rows[0]!r}"
     )
 
     # 3. Trigger contract: a decision UPDATE must increment the counter
@@ -144,9 +143,7 @@ async def test_migrate_v18_to_v19_backfills_decision_revision_on_preexisting_row
         "CREATE decision SET description = 'probe', source_type = 'manual', "
         "canonical_id = 'probe-cid', status = 'ungrounded'"
     )
-    after_create = await fresh_client.query(
-        "SELECT decision_revision FROM bicameral_meta LIMIT 1"
-    )
+    after_create = await fresh_client.query("SELECT decision_revision FROM bicameral_meta LIMIT 1")
     assert after_create[0]["decision_revision"] >= 1, (
         "decision_revision_bump event must increment counter on decision CREATE; "
         f"got {after_create[0]!r}"

--- a/tests/test_ledger_bicameral_meta_migration.py
+++ b/tests/test_ledger_bicameral_meta_migration.py
@@ -64,3 +64,90 @@ async def test_init_schema_creates_bicameral_meta_table(fresh_client):
     # is the canonical existence check).
     rows = await fresh_client.query("SELECT * FROM bicameral_meta LIMIT 1")
     assert rows == []
+
+
+async def test_migrate_v18_to_v19_backfills_decision_revision_on_preexisting_row(
+    fresh_client,
+):
+    """Regression: pre-v19 ``bicameral_meta`` rows (written by
+    ``_write_wire_format_sentinel`` on first connect) must have
+    ``decision_revision`` backfilled to 0 by the v18→v19 migration.
+
+    The original v0.13.x migration only seeded the row when the table
+    was empty (``if not rows: CREATE``). If a sentinel row already
+    existed, the seed branch was skipped and ``decision_revision``
+    stayed NONE forever because SurrealDB v2's ``DEFINE FIELD ... DEFAULT
+    0`` doesn't backfill existing rows. Every subsequent decision
+    UPDATE then blew up the ``decision_revision_bump`` event with
+    "Cannot perform addition with 'NONE' and '1'", which the
+    ``_migrate_v22_to_v23`` per-row try/except silently swallowed —
+    causing the classification migration to "succeed" while skipping
+    every legacy row.
+
+    Simulate that state and assert v19 (and v23 defense-in-depth)
+    rescue it.
+    """
+    # 1. Set up a DB that looks like "post-v18, pre-v19 sentinel-row state":
+    #    schema_meta=18, bicameral_meta has a sentinel row whose
+    #    decision_revision is NONE.
+    #
+    # The real-world failure mode: the row was CREATEd by
+    # ``_write_wire_format_sentinel`` (v16) BEFORE the
+    # ``decision_revision`` field was ever defined. SurrealDB v2's
+    # ``DEFAULT 0`` only fires on subsequent CREATEs; existing rows
+    # keep whatever state they had (NONE). We can't replay that exact
+    # ordering after init_schema has already DEFINEd the field — so
+    # we REMOVE FIELD to drop the constraint, CREATE the row in the
+    # constraint-less state, then re-DEFINE the field. The end state
+    # is identical to the real bug: a row whose ``decision_revision``
+    # is NONE because it was never touched after the field landed.
+    await init_schema(fresh_client)
+    await fresh_client.execute("DELETE FROM schema_meta")
+    await fresh_client.execute(
+        "CREATE schema_meta SET version = $v, migrated_at = time::now()", {"v": 18}
+    )
+    await fresh_client.execute("DELETE FROM bicameral_meta")
+    await fresh_client.execute("REMOVE FIELD decision_revision ON bicameral_meta")
+    await fresh_client.execute(
+        "CREATE bicameral_meta SET "
+        "surrealdb_client_version_at_first_write = '2.0.0', "
+        "surrealdb_client_version_at_last_write = '2.0.0', "
+        "last_write_at = time::now()"
+    )
+    # Re-define the field — DEFAULT 0 won't backfill the existing row.
+    await fresh_client.execute(
+        "DEFINE FIELD decision_revision ON bicameral_meta TYPE int DEFAULT 0"
+    )
+    pre_rows = await fresh_client.query("SELECT * FROM bicameral_meta")
+    assert len(pre_rows) == 1
+    assert pre_rows[0].get("decision_revision") is None, (
+        f"setup precondition: row must have NONE decision_revision, got {pre_rows[0]!r}"
+    )
+
+    # 2. Run migrate. v18→v19 must backfill decision_revision = 0.
+    await migrate(fresh_client, allow_destructive=True)
+
+    post_rows = await fresh_client.query("SELECT * FROM bicameral_meta")
+    assert len(post_rows) == 1, (
+        f"migrate must keep exactly one bicameral_meta row, got {post_rows!r}"
+    )
+    assert post_rows[0].get("decision_revision") == 0, (
+        f"v18→v19 must backfill decision_revision=0 on existing rows; "
+        f"got {post_rows[0]!r}"
+    )
+
+    # 3. Trigger contract: a decision UPDATE must increment the counter
+    # (i.e., NONE + 1 no longer blows up). This is the load-bearing
+    # invariant — without backfill, every UPDATE fails and the
+    # downstream v22→v23 silently skips.
+    await fresh_client.execute(
+        "CREATE decision SET description = 'probe', source_type = 'manual', "
+        "canonical_id = 'probe-cid', status = 'ungrounded'"
+    )
+    after_create = await fresh_client.query(
+        "SELECT decision_revision FROM bicameral_meta LIMIT 1"
+    )
+    assert after_create[0]["decision_revision"] >= 1, (
+        "decision_revision_bump event must increment counter on decision CREATE; "
+        f"got {after_create[0]!r}"
+    )

--- a/tests/test_v23_decision_level_backfill.py
+++ b/tests/test_v23_decision_level_backfill.py
@@ -250,3 +250,85 @@ async def test_v23_bound_product_source_still_l2() -> None:
         assert await _get_level(c, did) == "L2"
     finally:
         await c.close()
+
+
+@pytest.mark.phase2
+@pytest.mark.asyncio
+async def test_v23_classifies_when_decision_revision_was_none() -> None:
+    """Regression: v22→v23 must classify legacy rows even when the
+    ``bicameral_meta.decision_revision`` field is NONE on entry.
+
+    The ``decision_revision_bump`` event fires on every decision UPDATE
+    and does ``decision_revision = decision_revision + 1``. If the field
+    is NONE (because the v18→v19 migration historically skipped the
+    backfill when a sentinel row already existed), the trigger raises
+    "Cannot perform addition with 'NONE' and '1'". The per-row try/except
+    inside ``_migrate_v22_to_v23`` then silently catches the failure,
+    increments ``skip_count``, and the classification UPDATE never lands
+    — so every legacy row that needed classification is silently
+    skipped, and the migration "succeeds" while doing nothing.
+
+    The defense-in-depth backfill at the top of ``_migrate_v22_to_v23``
+    must rescue this case.
+    """
+    c = await _fresh_client()
+    try:
+        # Force the broken state. SurrealDB v2 enforces ``TYPE int`` on
+        # an UPDATE, so we can't just SET decision_revision = NONE.
+        # Drop the field, re-CREATE the singleton row (which now lacks
+        # the field), and re-define the field — DEFAULT 0 won't
+        # backfill existing rows. End state matches a real DB whose
+        # v18→v19 ran the buggy original "skip seed if row exists" logic.
+        await c.execute("DELETE FROM bicameral_meta")
+        await c.execute("REMOVE FIELD decision_revision ON bicameral_meta")
+        await c.execute(
+            "CREATE bicameral_meta SET "
+            "surrealdb_client_version_at_first_write = '2.0.0', "
+            "surrealdb_client_version_at_last_write = '2.0.0', "
+            "last_write_at = time::now()"
+        )
+        await c.execute(
+            "DEFINE FIELD decision_revision ON bicameral_meta TYPE int DEFAULT 0"
+        )
+        pre = await c.query("SELECT decision_revision FROM bicameral_meta LIMIT 1")
+        assert pre and pre[0].get("decision_revision") is None, (
+            f"setup: bicameral_meta.decision_revision must be NONE, got {pre!r}"
+        )
+
+        # Seed a legacy unclassified decision. The CREATE fires the
+        # decision_revision_bump trigger — which would blow up under
+        # the unfixed code path. With the v22→v23 pre-backfill in
+        # place, the trigger only fires AFTER step 0 has rescued the
+        # counter, so this CREATE itself can't reproduce the failure.
+        # We instead seed first (succeeds because field is still NONE
+        # before the trigger tries to add — actually, the trigger DOES
+        # try, but we want this seed to land regardless). Easiest:
+        # seed via raw INSERT bypassing the trigger by temporarily
+        # removing the event.
+        await c.execute("REMOVE EVENT decision_revision_bump ON TABLE decision")
+        did = await _seed_decision(
+            c, description="legacy-row", source_type="transcript"
+        )
+        await c.execute(f"UPDATE {did} SET decision_level = NONE")
+        # Re-define the event so the migration runs in realistic conditions.
+        await c.execute(
+            "DEFINE EVENT decision_revision_bump ON TABLE decision "
+            "WHEN $event = 'CREATE' OR $event = 'UPDATE' "
+            "THEN (UPDATE bicameral_meta SET decision_revision = decision_revision + 1)"
+        )
+        assert await _get_level(c, did) is None
+
+        # Run v22→v23 — must classify, not silently skip.
+        await _migrate_v22_to_v23(c)
+
+        assert await _get_level(c, did) == "L1", (
+            "transcript-source decision must be classified as L1; if it's NONE, "
+            "the trigger blew up and the per-row try/except silently skipped it"
+        )
+        # Counter is now back to a usable int.
+        post = await c.query("SELECT decision_revision FROM bicameral_meta LIMIT 1")
+        assert isinstance(post[0]["decision_revision"], int), (
+            f"decision_revision must be int after v22→v23 pre-backfill, got {post[0]!r}"
+        )
+    finally:
+        await c.close()

--- a/tests/test_v23_decision_level_backfill.py
+++ b/tests/test_v23_decision_level_backfill.py
@@ -287,9 +287,7 @@ async def test_v23_classifies_when_decision_revision_was_none() -> None:
             "surrealdb_client_version_at_last_write = '2.0.0', "
             "last_write_at = time::now()"
         )
-        await c.execute(
-            "DEFINE FIELD decision_revision ON bicameral_meta TYPE int DEFAULT 0"
-        )
+        await c.execute("DEFINE FIELD decision_revision ON bicameral_meta TYPE int DEFAULT 0")
         pre = await c.query("SELECT decision_revision FROM bicameral_meta LIMIT 1")
         assert pre and pre[0].get("decision_revision") is None, (
             f"setup: bicameral_meta.decision_revision must be NONE, got {pre!r}"
@@ -306,9 +304,7 @@ async def test_v23_classifies_when_decision_revision_was_none() -> None:
         # seed via raw INSERT bypassing the trigger by temporarily
         # removing the event.
         await c.execute("REMOVE EVENT decision_revision_bump ON TABLE decision")
-        did = await _seed_decision(
-            c, description="legacy-row", source_type="transcript"
-        )
+        did = await _seed_decision(c, description="legacy-row", source_type="transcript")
         await c.execute(f"UPDATE {did} SET decision_level = NONE")
         # Re-define the event so the migration runs in realistic conditions.
         await c.execute(


### PR DESCRIPTION
## Why

The v18→v19 migration only seeded the `bicameral_meta` singleton when the row was absent. When `_write_wire_format_sentinel` had already written a row (v16's `adapter.connect` path), the seed branch was skipped and `decision_revision` stayed NONE because SurrealDB v2's `DEFAULT 0` does not backfill existing rows. Every subsequent decision UPDATE then blew up the `decision_revision_bump` trigger with `Cannot perform addition with 'NONE' and '1'`, which `_migrate_v22_to_v23`'s per-row try/except silently swallowed — so the `decision_level` classification migration "succeeded" while skipping every legacy row, and any later ingest / link_commit / dashboard write hit the same trigger and failed.

Symptom on the bicameral-mcp repo's own ledger: dashboard `/history` returned a SurrealDB query rejection, and all 14 decisions stayed `decision_level = NONE` after migrate claimed success.

## What

Fix in two places:

- **`_migrate_v18_to_v19`** (root cause, schema.py:1190): UPDATE existing `bicameral_meta` rows when `decision_revision` is NONE. Prevents recurrence for any DB upgrading from <v19 today.
- **`_migrate_v22_to_v23`** (defense-in-depth, schema.py:1354): same backfill at the top, so the per-row UPDATEs below land their classifications instead of silently failing if a DB somehow arrives at v22 with the broken counter state.

## Out of scope

- A new `_migrate_v23_to_v24` forward-fix. The buggy nightly (`dev15124` on the abandoned `chore/bump-nightly-pointer-2026.5.16` branch) was never downloaded outside the dev box, so `SCHEMA_VERSION` stays at 23.
- Repairing already-corrupted v23 DBs in the field. Verified locally via direct SQL repair + migrate replay (`UPDATE bicameral_meta SET decision_revision = 0 WHERE decision_revision IS NONE` → roll `schema_meta.version` back to 22 → re-run `migrate()`).
- The `_write_wire_format_sentinel` v16 path that originally caused the row-without-field state — adding the missing fields there would be belt-and-suspenders but the migration backfill is the durable contract.

## Acceptance

- [x] `tests/test_ledger_bicameral_meta_migration.py::test_migrate_v18_to_v19_backfills_decision_revision_on_preexisting_row` — sentinel row with NONE `decision_revision` is rescued by v19 migrate, and a real decision CREATE bumps the counter (trigger contract intact).
- [x] `tests/test_v23_decision_level_backfill.py::test_v23_classifies_when_decision_revision_was_none` — v22→v23 classifies legacy rows even when entering with the broken counter state (no silent skips).
- [x] All 30 tests across `test_ledger_bicameral_meta_migration.py`, `test_v23_decision_level_backfill.py`, `test_v19_revision_counter.py` pass.
- [x] Adjacent suites green: `test_phase2_ledger.py` (15) + `test_schema_recoverable_errors.py` (3).
- [x] `ruff check` clean.

## Follow-up

After this merges and a new CalVer nightly cuts from dev with the fix, open a separate `chore(nightly): bump RECOMMENDED_NIGHTLY_VERSION` PR (matches the #382 pattern) to point pilots at the fix-included nightly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)