### PR TITLE
docs(dev-cycle): require linked bicameral decision on org-member PRs

### DIFF
--- a/docs/DEV_CYCLE.md
+++ b/docs/DEV_CYCLE.md
@@ -400,6 +400,10 @@ The squash commit message inherits this; loose PR titles produce ugly history.
 Closes #61
 Refs #60 (depends on continuity matcher landed there)
 
+## Linked decisions
+Closes decision:ko8efq3z1zwhbof7kecq — Name "Ledger Locator"
+Refs decision:c2eqcwimhe4lpaexrddw — Supported environments scope lock
+
 ## Plan / Audit / Seal
 - Plan: docs/Planning/plan-codegenome-phase-4.md (v3, content hash sha256:911171cf…)
 - Audit: META_LEDGER Entry #13, chain hash 21ac210f… — verdict PASS
@@ -413,6 +417,25 @@ Refs #60 (depends on continuity matcher landed there)
 
 The Plan/Audit/Seal section is **mandatory for any PR > 100 LOC or risk:L2+**.
 Smaller PRs may use `Plan: trivial; risk:L1`.
+
+> **Linked decisions are required on PRs authored by BicameralAI org
+> members.** Every load-bearing change should trace to at least one
+> decision in the bicameral ledger — the PR body cites the
+> `decision:<surrealdb-id>` so reviewers can verify the change is
+> grounded in an explicit decision rather than ambient assumption. If
+> no relevant decision exists yet, run `bicameral.ingest` (or capture
+> via the dashboard's Ingest panel) **before** opening the PR; if the
+> change *was* the decision-of-record, ingest it then reference it
+> here. Use the same keyword vocabulary as `## Linked issues`:
+> `Closes decision:<id>` for the decision this PR satisfies / closes
+> the gap for, `Refs decision:<id>` for decisions that constrain or
+> motivate the change without being directly closed.
+>
+> **External contributors are exempt.** Bicameral access is
+> org-internal; gating community contributions on internal tooling is
+> not the goal. A maintainer shepherding an external PR SHOULD ingest
+> the load-bearing decision on the contributor's behalf at merge time
+> and add a post-merge comment linking it for the audit trail.
 
 > **PR-body issue references (Issue #114)**: every PR body that
 > mentions `#NUMBER` tokens should wrap them with one of:


### PR DESCRIPTION
## Summary

- Adds a `## Linked decisions` section to the §4.3 PR body template, parallel to `## Linked issues`.
- Codifies the rule: every PR authored by a BicameralAI org member references at least one `decision:<surrealdb-id>`.
- External contributors are exempt — the shepherding maintainer ingests the decision on their behalf at merge time.

## Why

The PR body already tells reviewers *what* changed and *which issue* it closes; the bicameral ledger tells us *which decision* it satisfies. Today the link between the two is implicit (a reviewer either knows the decision exists or they don't). Making it explicit:

- Forces the author to verify the change actually traces to an ingested decision before opening the PR (catches "drift via PR" — code that lands ahead of the decision-of-record).
- Gives reviewers a concrete artifact to verify against, alongside the linked issue.
- Closes the loop with `bicameral.preflight` — preflight surfaces the decision; the PR cites it; the post-commit sync resolves compliance against it.

External contributors are exempt because bicameral access is org-internal. Gating community PRs on internal tooling is the wrong tradeoff; a maintainer ingesting on their behalf at merge time keeps the audit trail intact without exporting our internal substrate.

## Linked issues

(none — this is a process change that doesn't close a specific issue)

## Linked decisions

(meta: this PR's *own* linked-decision section is empty by intent — the decision codified here was made in conversation today and ingestion is blocked by an unrelated MCP-server outage on the dev box. Will ingest + back-link in a follow-up comment once the MCP server is restored.)

## Plan / Audit / Seal

- Plan: trivial; risk:L1 (doc-only rule addition, no CI enforcement yet)

## Test plan

- [ ] Visual review of `docs/DEV_CYCLE.md` §4.3 diff — template renders correctly in GitHub markdown.
- [ ] No code paths touched; existing CI suites are sufficient.

## Out of scope

- CI lint that enforces a `decision:<id>` token in org-member PR bodies. Worth doing if compliance slips, but the doctrine update lands first so reviewers can hold the line manually.
- Updating the GitHub PR template (`.github/pull_request_template.md`) — that file doesn't exist yet; if/when it's added, mirror the §4.3 template.

🤖 Generated with [Claude Code](https://claude.com/claude-code)