### PR TITLE
infra(codeowners): require @jinhongkuan review for ledger/schema.py

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,17 @@
+# CODEOWNERS for BicameralAI/bicameral-mcp.
+#
+# Maps file paths to GitHub users / teams whose review is required by the
+# `dev` branch-protection rule (require_code_owner_reviews: true).
+#
+# Syntax: gitignore-style globs, then one or more @usernames or
+# @org/team-handles. The LAST matching pattern wins (so list narrowest-first
+# only matters when patterns overlap — use distinct file paths where you can).
+#
+# See DEV_CYCLE.md §4.4 (Reviewers) and §4.7 (Schema-touching PRs) for the
+# review-tier rules these owners enforce.
+
+# Schema and migration registry — every change here goes through the
+# expand-only + flag-gate doctrine (DEV_CYCLE.md §4.7). Code-owner review
+# enforces the §4.7.3 reviewer checklist; the PR must demonstrate compliance
+# before merge.
+ledger/schema.py            @jinhongkuan


### PR DESCRIPTION
## Summary

- Adds `.github/CODEOWNERS` mapping `ledger/schema.py` → `@jinhongkuan`.
- Pairs with a `dev` branch-protection rule update (`require_code_owner_reviews: true`, 1 approving review) landed alongside via direct GitHub API call — explicit codeowner approval required for any PR that touches schema before it can merge to `dev`.

## Linked issues

No tracked issue — surfaced during v0.15.0 release planning where the migration backlog risk became visible. The CODEOWNERS gate is the enforcement mechanism for the §4.7 doctrine.

## Linked decisions

Refs decision:cp25jfz1nt6h3u2gjzmu — Schema migrations must be expand-only. CODEOWNERS gate enforces the §4.7.3 reviewer checklist at merge time.

## Plan / Audit / Seal

- **Plan:** smallest enforceable CODEOWNERS pattern. `ledger/schema.py` holds the migration registry + `SCHEMA_VERSION` + `init_schema()` + helpers; any schema-touching change routes through `@jinhongkuan` review.
- **Risk:** **L1** — single config file, no behavior change in shipped code. Gate kicks in only on PRs that touch the matched file.

## Behavior

After branch protection flips and this PR merges:

| PR shape | Behavior |
|---|---|
| Touches `ledger/schema.py` | Auto-requests `@jinhongkuan` as reviewer; merge blocked until approval |
| Doesn't touch `ledger/schema.py` | Normal review flow per §4.4 |
| Authored by `@jinhongkuan`, touches `ledger/schema.py` | Will still need a second reviewer (GitHub doesn't allow self-approval) — or admin override |

## Tradeoff (chosen)

Scope is the whole `ledger/schema.py` file, including non-migration code (`_TABLES`, `init_schema()`, helpers). GitHub CODEOWNERS works at file/glob granularity, so the alternatives were:

1. Split `ledger/schema.py` into `schema.py` + `migrations.py` for finer-grained gating (~850 lines of refactor + import updates across the codebase).
2. Custom CI gate that pattern-matches the diff (non-CODEOWNERS path, more tooling).
3. Whole-file scope, accept the ~15% of changes that aren't migration-affecting will still request review.

Option 3 was chosen — quick LGTM for non-migration touches, no false negatives. Migration concentration in `schema.py` is currently high enough that the noise floor is low.

## Test plan

- [x] CODEOWNERS syntax sanity check via inspection (GitHub validates on PR open and will surface errors if any).
- [ ] After merge, open a probe PR that touches `ledger/schema.py` and verify `@jinhongkuan` is auto-requested and merge is blocked until approval.

🤖 Generated with [Claude Code](https://claude.com/claude-code)