### PR TITLE
infra(slack): post Linked decisions to Slack on dev merge

### DIFF
--- a/.github/workflows/notify-slack-on-merge.yml
+++ b/.github/workflows/notify-slack-on-merge.yml
@@ -1,0 +1,114 @@
+name: Slack — Linked decisions on dev merge
+
+# Fires on every PR-merge into `dev`. Extracts the `## Linked decisions`
+# section from the PR body and posts it to the configured Slack incoming
+# webhook. Skips silently when the section is absent or empty — no noise
+# on docs / chore / dependabot PRs.
+#
+# Companion to the native Slack GitHub integration (which posts basic
+# merge events). This workflow adds the decision-grounding view that
+# the native integration can't surface (it's template-locked).
+#
+# Pairs with DEV_CYCLE.md §4.3 "Linked decisions" section requirement
+# and decision:0ok1249n2tdrfud2a5j9 (triage eligibility) — once a PR
+# merges with a Linked decisions block, the team sees in Slack which
+# decisions just landed in code on dev.
+#
+# SECURITY: PR body is contributor-controlled text. We parse it inside
+# actions/github-script (Node sandbox), NEVER shell-interpolate via
+# `${{ github.event.pull_request.body }}` in a bash run-step. The same
+# audit lesson as #114 (see pr-body-refs-lint.yml's module docstring).
+#
+# Note: pull_request workflows execute the version of this file on the
+# base branch. First execution will be on the next qualifying merge
+# after THIS PR itself lands on dev.
+
+on:
+  pull_request:
+    branches: [dev]
+    types: [closed]
+
+permissions:
+  pull-requests: read
+  contents: read
+
+jobs:
+  notify:
+    name: Post Linked decisions to Slack
+    runs-on: ubuntu-latest
+    if: github.event.pull_request.merged == true
+    steps:
+      - name: Extract and post
+        uses: actions/github-script@v7
+        env:
+          SLACK_WEBHOOK: ${{ secrets.SLACK_MERGE_NOTIFY_WEBHOOK }}
+        with:
+          script: |
+            const webhook = process.env.SLACK_WEBHOOK;
+            if (!webhook) {
+              core.warning(
+                "SLACK_MERGE_NOTIFY_WEBHOOK secret is not set — " +
+                "skipping post. Configure at " +
+                "repo Settings -> Secrets and variables -> Actions."
+              );
+              return;
+            }
+
+            const pr = context.payload.pull_request;
+            const body = pr.body || "";
+
+            // Extract the `## Linked decisions` section. We anchor on
+            // the literal heading at line start (m flag), then take
+            // everything up to the next `^## ` heading or end of body.
+            const startRegex = /^## Linked decisions\s*$/m;
+            const startMatch = body.match(startRegex);
+            if (!startMatch) {
+              core.info(
+                `PR #${pr.number} has no '## Linked decisions' section; ` +
+                "skipping post."
+              );
+              return;
+            }
+            const startIdx = startMatch.index + startMatch[0].length;
+            const rest = body.slice(startIdx);
+            const endMatch = rest.match(/^## /m);
+            const sectionRaw = endMatch ? rest.slice(0, endMatch.index) : rest;
+            const section = sectionRaw.trim();
+
+            if (!section) {
+              core.info(
+                `PR #${pr.number} has an empty 'Linked decisions' ` +
+                "section; skipping post."
+              );
+              return;
+            }
+
+            // Build the Slack mrkdwn payload. Title and section go in
+            // as JS strings, then JSON.stringify escapes them safely.
+            const text = [
+              `*PR #${pr.number} merged to \`dev\`* — ${pr.title}`,
+              "",
+              "*Linked decisions:*",
+              section,
+              "",
+              `<${pr.html_url}|view PR>`,
+            ].join("\n");
+
+            const response = await fetch(webhook, {
+              method: "POST",
+              headers: { "Content-Type": "application/json" },
+              body: JSON.stringify({ text }),
+            });
+
+            if (!response.ok) {
+              const errText = await response.text();
+              core.setFailed(
+                `Slack post failed: ${response.status} ${response.statusText} — ${errText}`
+              );
+              return;
+            }
+
+            core.info(
+              `Posted Linked decisions for PR #${pr.number} to Slack ` +
+              `(${section.length} chars in section).`
+            );


### PR DESCRIPTION
## Summary

- Adds `.github/workflows/notify-slack-on-merge.yml` — fires on every PR-merge into `dev`, extracts the `## Linked decisions` section from the PR body, posts to Slack via `SLACK_MERGE_NOTIFY_WEBHOOK` secret.
- Silently no-ops when the section is absent / empty, or when the secret isn't configured — safe to land before the webhook is wired.
- Pairs with the native Slack GitHub integration (which is template-locked and can't surface body-content sections); this adds the decision-grounded view.

## Linked issues

No tracked issue — surfaced from the v0.15.0 release planning conversation. Users wanted Slack visibility into which decisions land on dev as each PR merges.

## Linked decisions

Refs decision:0ok1249n2tdrfud2a5j9 — §10.5.1 amendment turns every triage into a vehicle for shipping schema + decisions; Slack-on-merge becomes the timeline of which decisions reached dev when.

## Plan / Audit / Seal

- **Plan:** trigger shape mirrors `label-merged-to-dev.yml` exactly (`pull_request: branches: [dev], types: [closed]`, `merged == true` guard). Body parsing uses `actions/github-script@v7` (Node sandbox) — never shell-interpolates `${{ github.event.pull_request.body }}`, matching the `pr-body-refs-lint.yml` security pattern (#114 audit lesson).
- **Risk:** **L1** — single workflow file, no behavior change in shipped code. Workflow fires only on dev merges. Failure mode is "no Slack message posted" — never blocks a merge.
- **Audit:** no third-party Slack action — direct `fetch` to the webhook, zero supply-chain surface added.

## Behavior

| PR shape | What Slack gets |
|---|---|
| Merged to dev, body has `## Linked decisions` with content | One message: PR title + decisions section + view-PR link |
| Merged to dev, body has the section but it's empty / whitespace | Silent (logged in workflow output as `info`) |
| Merged to dev, body has no `## Linked decisions` heading | Silent (logged as `info`) |
| Closed without merge | Skipped at job-level `if` |
| Merged to non-`dev` branch | Workflow not triggered (branch filter) |
| Secret `SLACK_MERGE_NOTIFY_WEBHOOK` not configured | `core.warning` logged, no post attempted |

## Webhook setup (operator-side, one-time)

1. https://api.slack.com/apps → Create New App → "From scratch" → pick workspace
2. Incoming Webhooks → toggle on → "Add New Webhook to Workspace" → pick target channel
3. Copy the webhook URL (`https://hooks.slack.com/services/T.../B.../...`)
4. https://github.com/BicameralAI/bicameral-mcp/settings/secrets/actions → New repository secret → name: `SLACK_MERGE_NOTIFY_WEBHOOK`, value: paste

Workflow checks the secret at runtime and `core.warning`s if missing — landing this PR before the secret is set is safe.

## First-execution note

`pull_request` workflows execute the version of the file on the **base** branch. This workflow's first execution will be on the next qualifying dev merge AFTER this PR itself merges. The PR that merges this workflow file won't trigger it.

## Test plan

- [x] YAML syntax sanity — single-file workflow, no `act` run locally because GitHub Actions runtime quirks (Node fetch availability, github-script context shape) are best validated by GitHub itself on first real merge.
- [ ] After merge + webhook secret configured: open a test PR with a `## Linked decisions` section, merge, verify the Slack channel receives the message. Open another with no section, merge, verify no message posted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)