### PR TITLE
test(link_commit): #357 backfill — de-mock get_region_metadata trap + cap 5→4

### DIFF
--- a/tests/test_codegenome_phase4_link_commit.py
+++ b/tests/test_codegenome_phase4_link_commit.py
@@ -10,19 +10,78 @@ Covers ``handlers.link_commit._run_drift_classification_pass``:
 - ``LinkCommitResponse.auto_resolved_count`` reflects the strip count.
 - Continuity-then-classification ordering: a moved+cosmetic region is
   stripped by continuity first; classification doesn't see it.
+
+#357 backfill — the link_commit cluster's single solitary-trap row.
+``ctx.ledger`` is now a real ``SurrealDBLedgerAdapter`` over ``memory://``;
+``ctx`` itself is a ``SimpleNamespace`` per CLAUDE.md's posture rule
+("ctx should be SimpleNamespace, not MagicMock"). The
+``get_region_metadata=AsyncMock(return_value=None)`` narrow seam from
+the pre-#357 version is gone — the failure mode is now produced by
+querying a non-existent ``code_region:doesnotexist`` id against the
+real adapter, which naturally returns None. That's strictly better
+than mocking the function we're trying to exercise.
+
+The remaining mocks (``evaluate_drift_classification``,
+``get_git_content``, the codegenome adapter, ``code_graph``) are
+collaborators with their own test surfaces and simulate specific
+outcomes the test docstrings name. Permitted narrow seams.
 """
 
 from __future__ import annotations
 
-from unittest.mock import AsyncMock, MagicMock
+from types import SimpleNamespace
+from unittest.mock import MagicMock
 
 import pytest
 
 from codegenome.drift_service import DriftClassificationOutcome
 from contracts import PendingComplianceCheck, PreClassificationHint
+from ledger.adapter import SurrealDBLedgerAdapter
+from ledger.client import LedgerClient
+from ledger.queries import upsert_code_region
+from ledger.schema import init_schema, migrate
+
+_NS_COUNTER = 0
 
 
-def _make_pending(decision_id="d:1", region_id="r:1") -> PendingComplianceCheck:
+async def _fresh_adapter() -> tuple[SurrealDBLedgerAdapter, LedgerClient]:
+    """Build a fresh memory:// SurrealDB adapter with schema migrated."""
+    global _NS_COUNTER
+    _NS_COUNTER += 1
+    client = LedgerClient(url="memory://", ns=f"link_commit_p4_{_NS_COUNTER}", db="ledger_test")
+    await client.connect()
+    await init_schema(client)
+    await migrate(client, allow_destructive=True)
+    adapter = SurrealDBLedgerAdapter(url="memory://")
+    adapter._client = client
+    adapter._connected = True
+    return adapter, client
+
+
+async def _seed_code_region(
+    client: LedgerClient,
+    *,
+    file_path: str = "src/foo.py",
+    symbol_name: str = "handle_webhook",
+    start_line: int = 1,
+    end_line: int = 5,
+) -> str:
+    """Seed one code_region row and return its real ID."""
+    return await upsert_code_region(
+        client,
+        file_path=file_path,
+        symbol_name=symbol_name,
+        start_line=start_line,
+        end_line=end_line,
+        repo="test",
+        content_hash="h-test",
+    )
+
+
+def _make_pending(
+    decision_id: str = "decision:test1",
+    region_id: str = "code_region:r1",
+) -> PendingComplianceCheck:
     return PendingComplianceCheck(
         phase="drift",
         decision_id=decision_id,
@@ -36,31 +95,26 @@ def _make_pending(decision_id="d:1", region_id="r:1") -> PendingComplianceCheck:
 
 
 def _make_ctx(
+    adapter: SurrealDBLedgerAdapter | None,
     *,
     enhance_drift: bool = True,
     enabled: bool = True,
     code_graph=None,
-    region_meta=None,
-) -> MagicMock:
-    """Build a fake BicameralContext for the pass."""
-    ctx = MagicMock()
-    ctx.repo_path = "/repo"
-    ctx.authoritative_sha = "abc123"
-    ctx.code_graph = code_graph or MagicMock(neighbors_for=MagicMock(return_value=("n1",)))
-    ctx.codegenome_config = MagicMock(enabled=enabled, enhance_drift=enhance_drift)
-    ctx.codegenome = MagicMock()
-    ctx.ledger = MagicMock()
-    ctx.ledger.get_region_metadata = AsyncMock(
-        return_value=region_meta
-        or {
-            "file_path": "src/foo.py",
-            "symbol_name": "handle_webhook",
-            "start_line": 1,
-            "end_line": 5,
-            "identity_type": "function",
-        },
+) -> SimpleNamespace:
+    """Build a SimpleNamespace ctx with a real ledger adapter.
+
+    ``adapter=None`` for tests that exit before any ledger call (config
+    missing / pending empty / enhance_drift=False) — those exits are
+    gated on attributes that come before the ledger touch.
+    """
+    return SimpleNamespace(
+        repo_path="/repo",
+        authoritative_sha="abc123",
+        code_graph=code_graph or MagicMock(neighbors_for=MagicMock(return_value=("n1",))),
+        codegenome_config=MagicMock(enabled=enabled, enhance_drift=enhance_drift),
+        codegenome=MagicMock(),
+        ledger=adapter,
     )
-    return ctx
 
 
 # ── Off-mode tests ──────────────────────────────────────────────────
@@ -68,9 +122,14 @@ def _make_ctx(
 
 @pytest.mark.asyncio
 async def test_run_drift_classification_pass_off_when_flag_disabled() -> None:
+    """``enhance_drift=False`` → early return before any ledger touch.
+
+    No adapter needed; the function exits at the gate before reaching
+    ``ctx.ledger.get_region_metadata``.
+    """
     from handlers.link_commit import _run_drift_classification_pass
 
-    ctx = _make_ctx(enhance_drift=False)
+    ctx = _make_ctx(None, enhance_drift=False)
     pending = [_make_pending()]
     survivors, count = await _run_drift_classification_pass(
         ctx,
@@ -83,11 +142,10 @@ async def test_run_drift_classification_pass_off_when_flag_disabled() -> None:
 
 @pytest.mark.asyncio
 async def test_run_drift_classification_pass_off_when_config_missing() -> None:
+    """``cg_config = None`` → early return before any ledger touch."""
     from handlers.link_commit import _run_drift_classification_pass
 
-    ctx = MagicMock()
-    ctx.codegenome_config = None
-    ctx.codegenome = None
+    ctx = SimpleNamespace(codegenome_config=None, codegenome=None, ledger=None)
     pending = [_make_pending()]
     survivors, count = await _run_drift_classification_pass(
         ctx,
@@ -100,9 +158,10 @@ async def test_run_drift_classification_pass_off_when_config_missing() -> None:
 
 @pytest.mark.asyncio
 async def test_run_drift_classification_pass_off_when_pending_empty() -> None:
+    """Empty ``pending`` → early return before any ledger touch."""
     from handlers.link_commit import _run_drift_classification_pass
 
-    ctx = _make_ctx()
+    ctx = _make_ctx(None)
     survivors, count = await _run_drift_classification_pass(
         ctx,
         [],
@@ -120,7 +179,8 @@ async def test_run_drift_classification_pass_strips_cosmetic_pendings(
     monkeypatch,
 ) -> None:
     """When ``evaluate_drift_classification`` returns ``auto_resolved=True``,
-    the pending check is stripped and the count incremented."""
+    the pending check is stripped and the count incremented. The classifier
+    itself runs against the real ``code_region`` row this test seeds."""
     from handlers.link_commit import _run_drift_classification_pass
 
     async def fake_eval(**kwargs):
@@ -139,15 +199,20 @@ async def test_run_drift_classification_pass_strips_cosmetic_pendings(
         lambda *a, **k: "def handle_webhook(): pass",
     )
 
-    ctx = _make_ctx()
-    pending = [_make_pending()]
-    survivors, count = await _run_drift_classification_pass(
-        ctx,
-        pending,
-        commit_hash="abc",
-    )
-    assert survivors == []
-    assert count == 1
+    adapter, client = await _fresh_adapter()
+    try:
+        region_id = await _seed_code_region(client)
+        ctx = _make_ctx(adapter)
+        pending = [_make_pending(region_id=region_id)]
+        survivors, count = await _run_drift_classification_pass(
+            ctx,
+            pending,
+            commit_hash="abc",
+        )
+        assert survivors == []
+        assert count == 1
+    finally:
+        await client.close()
 
 
 @pytest.mark.asyncio
@@ -172,16 +237,21 @@ async def test_run_drift_classification_pass_keeps_semantic_pendings_unchanged(
         lambda *a, **k: "def handle_webhook(): pass",
     )
 
-    ctx = _make_ctx()
-    pending = [_make_pending()]
-    survivors, count = await _run_drift_classification_pass(
-        ctx,
-        pending,
-        commit_hash="abc",
-    )
-    assert len(survivors) == 1
-    assert survivors[0].pre_classification is None  # no hint
-    assert count == 0
+    adapter, client = await _fresh_adapter()
+    try:
+        region_id = await _seed_code_region(client)
+        ctx = _make_ctx(adapter)
+        pending = [_make_pending(region_id=region_id)]
+        survivors, count = await _run_drift_classification_pass(
+            ctx,
+            pending,
+            commit_hash="abc",
+        )
+        assert len(survivors) == 1
+        assert survivors[0].pre_classification is None  # no hint
+        assert count == 0
+    finally:
+        await client.close()
 
 
 @pytest.mark.asyncio
@@ -213,16 +283,21 @@ async def test_run_drift_classification_pass_attaches_hint_to_uncertain(
         lambda *a, **k: "def handle_webhook(): pass",
     )
 
-    ctx = _make_ctx()
-    pending = [_make_pending()]
-    survivors, count = await _run_drift_classification_pass(
-        ctx,
-        pending,
-        commit_hash="abc",
-    )
-    assert len(survivors) == 1
-    assert survivors[0].pre_classification == hint
-    assert count == 0
+    adapter, client = await _fresh_adapter()
+    try:
+        region_id = await _seed_code_region(client)
+        ctx = _make_ctx(adapter)
+        pending = [_make_pending(region_id=region_id)]
+        survivors, count = await _run_drift_classification_pass(
+            ctx,
+            pending,
+            commit_hash="abc",
+        )
+        assert len(survivors) == 1
+        assert survivors[0].pre_classification == hint
+        assert count == 0
+    finally:
+        await client.close()
 
 
 # ── Failure isolation ──────────────────────────────────────────────
@@ -248,37 +323,51 @@ async def test_run_drift_classification_pass_failure_isolated(
         lambda *a, **k: "def handle_webhook(): pass",
     )
 
-    ctx = _make_ctx()
-    pending = [_make_pending()]
-    survivors, count = await _run_drift_classification_pass(
-        ctx,
-        pending,
-        commit_hash="abc",
-    )
-    assert len(survivors) == 1
-    assert survivors[0].pre_classification is None
-    assert count == 0
+    adapter, client = await _fresh_adapter()
+    try:
+        region_id = await _seed_code_region(client)
+        ctx = _make_ctx(adapter)
+        pending = [_make_pending(region_id=region_id)]
+        survivors, count = await _run_drift_classification_pass(
+            ctx,
+            pending,
+            commit_hash="abc",
+        )
+        assert len(survivors) == 1
+        assert survivors[0].pre_classification is None
+        assert count == 0
+    finally:
+        await client.close()
 
 
 @pytest.mark.asyncio
-async def test_run_drift_classification_pass_no_region_metadata_falls_through(
-    monkeypatch,
-) -> None:
-    """When ``get_region_metadata`` returns None, the pending stays
-    in the survivors list unchanged."""
+async def test_run_drift_classification_pass_no_region_metadata_falls_through() -> None:
+    """When ``get_region_metadata`` returns None (region absent from
+    ledger), the pending stays in the survivors list unchanged.
+
+    #357 backfill: the pre-#357 version mocked this with
+    ``AsyncMock(return_value=None)``. The de-mocked version uses a
+    real adapter and a region_id that doesn't exist in the ledger —
+    the real query returns None naturally, which is strictly better
+    than mocking the function we're trying to exercise.
+    """
     from handlers.link_commit import _run_drift_classification_pass
 
-    ctx = _make_ctx()
-    ctx.ledger.get_region_metadata = AsyncMock(return_value=None)
-
-    pending = [_make_pending()]
-    survivors, count = await _run_drift_classification_pass(
-        ctx,
-        pending,
-        commit_hash="abc",
-    )
-    assert len(survivors) == 1
-    assert count == 0
+    adapter, client = await _fresh_adapter()
+    try:
+        ctx = _make_ctx(adapter)
+        # Valid `code_region:<id>` shape but no such row exists →
+        # real get_region_metadata returns None.
+        pending = [_make_pending(region_id="code_region:doesnotexist")]
+        survivors, count = await _run_drift_classification_pass(
+            ctx,
+            pending,
+            commit_hash="abc",
+        )
+        assert len(survivors) == 1
+        assert count == 0
+    finally:
+        await client.close()
 
 
 # ── Response-shape contract ────────────────────────────────────────

--- a/tests/test_ledger_mock_regression.py
+++ b/tests/test_ledger_mock_regression.py
@@ -37,7 +37,7 @@ from audit_sociable_coverage import compute_audit  # noqa: E402
 # when a backfill PR fixes a trap row. NEVER increment. If you find
 # yourself wanting to increment, you are about to ship #309-class risk —
 # write a sociable test instead.
-EXPECTED_TRAP_CAP = 5
+EXPECTED_TRAP_CAP = 4
 
 
 def test_no_new_ledger_query_mock_traps():


### PR DESCRIPTION
## Summary

Second trap-row backfill PR driven by the [#359](https://github.com/BicameralAI/bicameral-mcp/pull/359) sub-task 1 audit. Clears the link_commit cluster's single solitary-trap row (\`get_region_metadata\`), dropping trap count **5 → 4**.

## What changed

\`tests/test_codegenome_phase4_link_commit.py\`:

- Replaced \`ctx = MagicMock()\` with \`ctx = SimpleNamespace(...)\` per CLAUDE.md's posture rule. \`ctx.ledger\` is now a real \`SurrealDBLedgerAdapter\` over \`memory://\`.
- New per-test \`_fresh_adapter\` + \`_seed_code_region\` helpers (modeled on the PR #365 pattern).
- Tests that need region metadata now seed a real \`code_region\` via \`upsert_code_region\` and pass the returned real ID into \`_make_pending\`.
- **The narrow-seam \`AsyncMock(return_value=None)\` is gone** from \`test_no_region_metadata_falls_through\`. Replaced with a real adapter querying a valid \`code_region:doesnotexist\` id — the real query returns None naturally. Strictly better than mocking the function we're trying to exercise.

\`tests/test_ledger_mock_regression.py\`:
- \`EXPECTED_TRAP_CAP\`: 5 → 4 (locks in the one-way-ratchet improvement).

## Retained narrow-seam mocks (per CLAUDE.md)

| Mock | Why |
|---|---|
| \`evaluate_drift_classification\` | The classifier under test — monkeypatched to simulate specific cosmetic/semantic/uncertain/error outcomes the test docstrings name |
| \`get_git_content\` | Simulates file-content extraction; not a ledger query |
| \`code_graph\` adapter | Not a ledger query |
| codegenome adapter + config | Not ledger queries |

## Audit impact

| Category | Before | After | Δ |
|---|---|---|---|
| Direct sociable | 28 | **29** | +1 |
| **Solitary trap** | **5** | **4** | **-1** |
| Indirect sociable | 24 | 24 | 0 |
| Uncovered | 0 | 0 | 0 |

Remaining 4 trap rows are all in the **remove_source cluster** (\`decision_exists\`, \`get_decisions_for_span\`, \`input_span_exists\`, \`get_input_span_row\`). Separate follow-up PR.

## Verification

\`\`\`
$ pytest tests/test_codegenome_phase4_link_commit.py
9 passed in 1.18s

$ pytest tests/test_ledger_mock_regression.py
3 passed (cap=4 holds, no regression)

$ ruff check + format + mypy
clean
\`\`\`

## Test plan

- [ ] CI green
- [ ] Audit confirms trap count = 4 post-merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)