### PR TITLE
test(remove_source): #357 backfill — de-mock remove_source trap cluster + cap 4→0

### DIFF
--- a/tests/test_ledger_mock_regression.py
+++ b/tests/test_ledger_mock_regression.py
@@ -37,7 +37,7 @@ from audit_sociable_coverage import compute_audit  # noqa: E402
 # when a backfill PR fixes a trap row. NEVER increment. If you find
 # yourself wanting to increment, you are about to ship #309-class risk —
 # write a sociable test instead.
-EXPECTED_TRAP_CAP = 4
+EXPECTED_TRAP_CAP = 0
 
 
 def test_no_new_ledger_query_mock_traps():

--- a/tests/test_remove_source.py
+++ b/tests/test_remove_source.py
@@ -9,350 +9,463 @@ Pins:
      pre-deletion span content (recoverability anchor).
   5. Idempotent on missing span (no exception; structured response).
   6. Cascaded decisions carry removed_by_source back-pointer to the span_id.
+
+#357 backfill — the remove_source cluster's four solitary-trap rows
+(``decision_exists``, ``get_decisions_for_span``, ``input_span_exists``,
+``get_input_span_row``). Replaces the prior ``_FakeClient`` that parsed
+SurrealQL with string matching — a #309-class trap that masked any
+parse error or contract drift in the real SurrealQL. Tests now seed a
+real ``SurrealDBLedgerAdapter`` over ``memory://`` and exercise the
+handler against the real client, per CLAUDE.md's sociable-testing rule
+for handler + ledger UX paths.
+
+The only retained narrow seam is the in-memory ``_FakeWriter`` — the
+event writer is an emitter contract, not a ledger query, and CLAUDE.md
+rule 5 explicitly permits this kind of narrow boundary mock.
 """
 
 from __future__ import annotations
 
+from types import SimpleNamespace
+
 import pytest
+
+from ledger.adapter import SurrealDBLedgerAdapter
+from ledger.client import LedgerClient
+from ledger.queries import (
+    relate_yields,
+    upsert_decision,
+    upsert_input_span,
+)
+from ledger.schema import init_schema, migrate
 
 pytestmark = pytest.mark.asyncio
 
 
-# Minimal fakes mirroring the test_remove_decision pattern. The fakes record
-# every SQL query the handler issues so tests can assert on the
-# cascade-mutation shape without spinning up a real SurrealDB.
+_NS_COUNTER = 0
 
 
-class _FakeClient:
-    def __init__(
-        self,
-        spans: dict[str, dict] | None = None,
-        decisions: dict[str, dict] | None = None,
-        edges: list[tuple[str, str]] | None = None,
-    ) -> None:
-        self._spans = spans or {}
-        self._decisions = decisions or {}
-        self._edges = list(edges or [])  # (span_id, decision_id) yields edges
-        self.queries: list[tuple[str, dict | None]] = []
+async def _fresh_adapter() -> tuple[SurrealDBLedgerAdapter, LedgerClient]:
+    """Build a fresh ``memory://`` SurrealDB adapter with schema migrated.
 
-    async def query(self, sql: str, params: dict | None = None):
-        self.queries.append((sql, params))
-        sql_l = sql.lower()
-
-        # input_span_exists / get_input_span_row / decision_exists
-        if "select id from input_span:" in sql_l and "limit 1" in sql_l:
-            sid = sql.split("FROM ", 1)[1].split(" ", 1)[0]
-            return [{"id": sid}] if sid in self._spans else []
-        if sql_l.startswith("select text, source_ref, source_type") and "from input_span:" in sql_l:
-            sid = sql.split("FROM ", 1)[1].split(" ", 1)[0]
-            row = self._spans.get(sid)
-            return [row] if row else []
-        if "select id from decision:" in sql_l and "limit 1" in sql_l:
-            did = sql.split("FROM ", 1)[1].split(" ", 1)[0]
-            return [{"id": did}] if did in self._decisions else []
-
-        # get_decisions_for_span
-        if "from decision" in sql_l and "<-yields<-input_span contains" in sql_l:
-            span_id = sql.split("CONTAINS ", 1)[1].strip()
-            matching = [d for (s, d) in self._edges if s == span_id]
-            return [{"decision_id": d} for d in matching]
-
-        # SELECT signoff FROM decision:...
-        if "select signoff from decision:" in sql_l:
-            did = sql.split("FROM ", 1)[1].split(" ", 1)[0]
-            return [{"signoff": self._decisions.get(did, {}).get("signoff")}]
-
-        # UPDATE decision:... SET signoff = $signoff
-        if "update decision:" in sql_l and "set signoff" in sql_l:
-            did = sql.split("UPDATE ", 1)[1].split(" SET")[0].strip()
-            row = self._decisions.setdefault(did, {})
-            row["signoff"] = params["signoff"]
-            return [row]
-
-        # DELETE yields WHERE in = <span_id>
-        if sql_l.startswith("delete yields where in"):
-            span_id = sql.rsplit("=", 1)[1].strip()
-            self._edges = [(s, d) for (s, d) in self._edges if s != span_id]
-            return []
-
-        # DELETE input_span:... — hard delete the span row
-        if sql_l.startswith("delete input_span:"):
-            sid = sql.split("DELETE ", 1)[1].strip()
-            self._spans.pop(sid, None)
-            return []
-
-        return []
-
-
-class _FakeLedger:
-    def __init__(self, client, writer=None) -> None:
-        self._inner = self
-        self._client = client
-        if writer is not None:
-            self._writer = writer
-
-    async def connect(self) -> None:
-        return None
+    Mirrors the ``_fresh_adapter`` pattern in
+    ``tests/test_codegenome_phase4_link_commit.py`` and
+    ``tests/test_codegenome_continuity_service.py`` so every test gets a
+    private namespace — no cross-test row leakage.
+    """
+    global _NS_COUNTER
+    _NS_COUNTER += 1
+    client = LedgerClient(url="memory://", ns=f"remove_source_{_NS_COUNTER}", db="ledger_test")
+    await client.connect()
+    await init_schema(client)
+    await migrate(client, allow_destructive=True)
+    adapter = SurrealDBLedgerAdapter(url="memory://")
+    adapter._client = client
+    adapter._connected = True
+    return adapter, client
 
 
 class _FakeWriter:
+    """Narrow-seam event collector.
+
+    The event writer is a side-effect emitter, not a ledger query — it
+    is the canonical example of CLAUDE.md rule 5 ("narrow seams are
+    fine when the alternative is impossible or fragile"). Tests need
+    to assert what event payload the handler emits; spinning up the
+    real event subsystem (SQLite journal, archive, replayer) would
+    test the emitter, not the handler under test.
+    """
+
     def __init__(self) -> None:
         self.events: list[tuple[str, dict]] = []
 
-    def write(self, event_type: str, payload: dict):
+    def write(self, event_type: str, payload: dict) -> None:
         self.events.append((event_type, payload))
 
 
-class _FakeCtx:
-    def __init__(self, ledger, session_id="sess-1", sha="deadbeef") -> None:
-        self.ledger = ledger
-        self.session_id = session_id
-        self.authoritative_sha = sha
+def _make_ctx(
+    adapter: SurrealDBLedgerAdapter,
+    *,
+    writer: _FakeWriter | None = None,
+    session_id: str = "sess-1",
+    authoritative_sha: str = "deadbeef",
+) -> SimpleNamespace:
+    """``SimpleNamespace`` per CLAUDE.md — missing attrs raise honestly."""
+    if writer is not None:
+        # Handler reads via ``getattr(ledger, "_writer", None)`` — see
+        # handlers/remove_source.py. ``_writer`` is not a declared field
+        # on the adapter; team-mode wiring injects it dynamically in
+        # production, so the test mirrors that pattern.
+        adapter._writer = writer  # type: ignore[attr-defined]
+    return SimpleNamespace(
+        ledger=adapter,
+        session_id=session_id,
+        authoritative_sha=authoritative_sha,
+    )
 
 
-@pytest.fixture(autouse=True)
-def _stub_project_queries(monkeypatch):
-    """Stub the status-projection helpers so tests don't need the full
-    schema. These are exercised by other tests (project_decision_status
-    is well-covered elsewhere)."""
+async def _seed_span_with_decisions(
+    client: LedgerClient,
+    *,
+    span_text: str = "verbatim transcript excerpt",
+    source_ref: str = "meeting-001",
+    source_type: str = "transcript",
+    speakers: tuple[str, ...] = ("Jin",),
+    meeting_date: str = "2026-05-14",
+    decision_payloads: tuple[dict, ...] = (),
+) -> tuple[str, list[str]]:
+    """Seed one input_span + N decisions linked by yields edges.
 
-    async def _project(client, did):
-        return "ungrounded"
+    Returns ``(span_id, [decision_id, ...])`` using the real ids the
+    ledger assigned. Tests must use these ids — there is no
+    ``decision:d1`` literal anymore.
+    """
+    span_id = await upsert_input_span(
+        client,
+        text=span_text,
+        source_type=source_type,
+        source_ref=source_ref,
+        speakers=list(speakers),
+        meeting_date=meeting_date,
+    )
+    decision_ids: list[str] = []
+    for i, payload in enumerate(decision_payloads):
+        did = await upsert_decision(
+            client,
+            description=payload.get("description", f"decision {i}"),
+            source_type=source_type,
+            source_ref=f"{source_ref}#dec{i}",  # distinct canonical_id per decision
+            signoff=payload.get("signoff"),
+        )
+        await relate_yields(client, span_id, did)
+        decision_ids.append(did)
+    return span_id, decision_ids
 
-    async def _update(client, did, status):
-        return None
 
-    monkeypatch.setattr("handlers.remove_source.project_decision_status", _project)
-    monkeypatch.setattr("handlers.remove_source.update_decision_status", _update)
-
-
-def _seed_fixture():
-    """One span with 3 decisions linked via yields."""
-    span_id = "input_span:span001"
-    span_row = {
-        "text": "verbatim transcript excerpt",
-        "source_ref": "meeting-001",
-        "source_type": "transcript",
-        "meeting_date": "2026-05-14",
-        "speakers": ["Jin"],
-        "created_at": "2026-05-14T00:00:00+00:00",
-    }
-    decisions = {
-        "decision:d1": {"signoff": {"state": "ratified", "signer": "old"}},
-        "decision:d2": {"signoff": {"state": "proposed"}},
-        "decision:d3": {"signoff": None},  # never signed off
-    }
-    edges = [(span_id, did) for did in decisions]
-    return span_id, span_row, decisions, edges
+# ── Tests ───────────────────────────────────────────────────────────
 
 
 async def test_remove_source_rejects_empty_reason() -> None:
+    """Discipline #1 — reason is a hard audit-trail obligation."""
     from handlers.remove_source import handle_remove_source
 
-    span_id, span_row, decisions, edges = _seed_fixture()
-    client = _FakeClient({span_id: span_row}, decisions, edges)
-    ctx = _FakeCtx(_FakeLedger(client))
-
-    with pytest.raises(ValueError, match="non-empty 'reason'"):
-        await handle_remove_source(ctx, span_id=span_id, signer="x@y", reason="", confirm=True)
+    adapter, client = await _fresh_adapter()
+    try:
+        span_id, _ = await _seed_span_with_decisions(
+            client,
+            decision_payloads=({"description": "d"},),
+        )
+        ctx = _make_ctx(adapter)
+        with pytest.raises(ValueError, match="non-empty 'reason'"):
+            await handle_remove_source(ctx, span_id=span_id, signer="x@y", reason="", confirm=True)
+    finally:
+        await client.close()
 
 
 async def test_remove_source_dry_run_returns_plan_with_cascaded_decision_ids() -> None:
+    """Discipline #2 — confirm=False is a pure dry-run."""
     from contracts import RemoveSourcePlan
     from handlers.remove_source import handle_remove_source
 
-    span_id, span_row, decisions, edges = _seed_fixture()
-    client = _FakeClient({span_id: span_row}, decisions, edges)
-    ctx = _FakeCtx(_FakeLedger(client))
+    adapter, client = await _fresh_adapter()
+    try:
+        span_id, decision_ids = await _seed_span_with_decisions(
+            client,
+            decision_payloads=(
+                {"description": "d1", "signoff": {"state": "ratified", "signer": "old"}},
+                {"description": "d2", "signoff": {"state": "proposed"}},
+                {"description": "d3"},  # never signed off → signoff=None
+            ),
+        )
+        ctx = _make_ctx(adapter)
 
-    plan = await handle_remove_source(
-        ctx, span_id=span_id, signer="x@y", reason="bad ingest", confirm=False
-    )
+        plan = await handle_remove_source(
+            ctx, span_id=span_id, signer="x@y", reason="bad ingest", confirm=False
+        )
 
-    assert isinstance(plan, RemoveSourcePlan)
-    assert plan.span_id == span_id
-    assert plan.span_existed is True
-    assert plan.input_span_content["text"] == "verbatim transcript excerpt"
-    assert plan.input_span_content["source_ref"] == "meeting-001"
-    assert set(plan.decision_ids) == {"decision:d1", "decision:d2", "decision:d3"}
-    # CRITICAL: dry-run must not mutate
-    assert span_id in client._spans
-    assert decisions["decision:d1"]["signoff"]["state"] == "ratified"
+        assert isinstance(plan, RemoveSourcePlan)
+        assert plan.span_id == span_id
+        assert plan.span_existed is True
+        assert plan.input_span_content["text"] == "verbatim transcript excerpt"
+        assert plan.input_span_content["source_ref"] == "meeting-001"
+        assert set(plan.decision_ids) == set(decision_ids)
+
+        # CRITICAL: dry-run must not mutate. Observable check — query the
+        # real ledger to confirm the span row is still there and the
+        # ratified decision still says "ratified".
+        span_rows = await client.query(f"SELECT id FROM {span_id} LIMIT 1")
+        assert span_rows, "dry-run must not delete the span row"
+        d1_rows = await client.query(f"SELECT signoff FROM {decision_ids[0]} LIMIT 1")
+        assert d1_rows[0]["signoff"]["state"] == "ratified"
+    finally:
+        await client.close()
 
 
 async def test_remove_source_dry_run_idempotent_on_missing_span() -> None:
+    """Discipline #5 — missing span returns structured response, not error."""
     from contracts import RemoveSourcePlan
     from handlers.remove_source import handle_remove_source
 
-    client = _FakeClient({}, {}, [])  # empty store
-    ctx = _FakeCtx(_FakeLedger(client))
-
-    plan = await handle_remove_source(
-        ctx, span_id="input_span:missing", signer="x@y", reason="ghost", confirm=False
-    )
-    assert isinstance(plan, RemoveSourcePlan)
-    assert plan.span_existed is False
-    assert plan.decision_ids == []
+    adapter, client = await _fresh_adapter()
+    try:
+        ctx = _make_ctx(adapter)
+        plan = await handle_remove_source(
+            ctx, span_id="input_span:missing", signer="x@y", reason="ghost", confirm=False
+        )
+        assert isinstance(plan, RemoveSourcePlan)
+        assert plan.span_existed is False
+        assert plan.decision_ids == []
+    finally:
+        await client.close()
 
 
 async def test_remove_source_confirm_true_hard_deletes_span_and_soft_deletes_decisions() -> None:
+    """Discipline #3 + #6 — cascade soft-deletes decisions with back-pointer,
+    hard-deletes the span row and its outgoing yields edges."""
     from contracts import RemoveSourceResponse
     from handlers.remove_source import handle_remove_source
 
-    span_id, span_row, decisions, edges = _seed_fixture()
-    client = _FakeClient({span_id: span_row}, decisions, edges)
-    ctx = _FakeCtx(_FakeLedger(client))
+    adapter, client = await _fresh_adapter()
+    try:
+        span_id, decision_ids = await _seed_span_with_decisions(
+            client,
+            decision_payloads=(
+                {"description": "d1", "signoff": {"state": "ratified", "signer": "old"}},
+                {"description": "d2", "signoff": {"state": "proposed"}},
+                {"description": "d3"},  # signoff=None
+            ),
+        )
+        ctx = _make_ctx(adapter)
 
-    resp = await handle_remove_source(
-        ctx,
-        span_id=span_id,
-        signer="kim@x",
-        reason="duplicate transcript",
-        confirm=True,
-    )
+        resp = await handle_remove_source(
+            ctx,
+            span_id=span_id,
+            signer="kim@x",
+            reason="duplicate transcript",
+            confirm=True,
+        )
 
-    assert isinstance(resp, RemoveSourceResponse)
-    assert resp.span_existed is True
-    assert set(resp.cascaded_decision_ids) == {"decision:d1", "decision:d2", "decision:d3"}
-    # input_span row is hard-deleted
-    assert span_id not in client._spans
-    # yields edges from this span are gone
-    assert not any(s == span_id for (s, _d) in client._edges)
-    # Every cascaded decision has signoff.state="removed" + back-pointer
-    for did in ("decision:d1", "decision:d2", "decision:d3"):
-        signoff = client._decisions[did]["signoff"]
-        assert signoff["state"] == "removed"
-        assert signoff["removed_by_source"] == span_id
-        assert signoff["reason"] == "duplicate transcript"
-        assert signoff["signer"] == "kim@x"
-        assert signoff["removed_at"]
-    # previous_state recorded for forensic review
-    assert client._decisions["decision:d1"]["signoff"]["previous_state"] == "ratified"
-    assert client._decisions["decision:d2"]["signoff"]["previous_state"] == "proposed"
-    assert client._decisions["decision:d3"]["signoff"]["previous_state"] is None
+        assert isinstance(resp, RemoveSourceResponse)
+        assert resp.span_existed is True
+        assert set(resp.cascaded_decision_ids) == set(decision_ids)
+
+        # input_span row is hard-deleted
+        remaining = await client.query(f"SELECT id FROM {span_id} LIMIT 1")
+        assert remaining == [] or remaining is None
+
+        # yields edges from this span are gone
+        yields_rows = await client.query(
+            "SELECT id FROM yields WHERE in = $s",
+            {"s": span_id},
+        )
+        assert yields_rows == [] or yields_rows is None
+
+        # Every cascaded decision has signoff.state="removed" + back-pointer.
+        # SurrealDB strips None-valued keys from FLEXIBLE objects on
+        # round-trip — the previously-unsigned decision's previous_state
+        # therefore comes back as a missing key, not a present null. Use
+        # ``.get()`` so the test asserts what the agent observes.
+        prev_states = {
+            decision_ids[0]: "ratified",
+            decision_ids[1]: "proposed",
+            decision_ids[2]: None,
+        }
+        for did in decision_ids:
+            rows = await client.query(f"SELECT signoff FROM {did} LIMIT 1")
+            signoff = rows[0]["signoff"]
+            assert signoff["state"] == "removed"
+            assert signoff["removed_by_source"] == span_id
+            assert signoff["reason"] == "duplicate transcript"
+            assert signoff["signer"] == "kim@x"
+            assert signoff["removed_at"]
+            assert signoff.get("previous_state") == prev_states[did]
+    finally:
+        await client.close()
 
 
 async def test_remove_source_confirm_emits_single_event_with_full_span_content() -> None:
-    """Discipline #3: the source_removed.completed event payload carries the
+    """Discipline #4 — the source_removed.completed event payload carries the
     FULL pre-deletion span content so the action is recoverable from the
     event log."""
     from handlers.remove_source import handle_remove_source
 
-    span_id, span_row, decisions, edges = _seed_fixture()
+    adapter, client = await _fresh_adapter()
     writer = _FakeWriter()
-    client = _FakeClient({span_id: span_row}, decisions, edges)
-    ctx = _FakeCtx(_FakeLedger(client, writer=writer))
+    try:
+        span_id, decision_ids = await _seed_span_with_decisions(
+            client,
+            decision_payloads=(
+                {"description": "d1"},
+                {"description": "d2"},
+                {"description": "d3"},
+            ),
+        )
+        ctx = _make_ctx(adapter, writer=writer)
 
-    resp = await handle_remove_source(
-        ctx, span_id=span_id, signer="kim@x", reason="bad", confirm=True
-    )
+        resp = await handle_remove_source(
+            ctx, span_id=span_id, signer="kim@x", reason="bad", confirm=True
+        )
 
-    assert resp.event_logged is True
-    assert len(writer.events) == 1  # single event for the entire cascade
-    event_type, payload = writer.events[0]
-    assert event_type == "source_removed.completed"
-    assert payload["span_id"] == span_id
-    # Full pre-deletion span content is in the payload
-    assert payload["input_span_content"]["text"] == "verbatim transcript excerpt"
-    assert payload["input_span_content"]["source_ref"] == "meeting-001"
-    assert payload["input_span_content"]["source_type"] == "transcript"
-    assert set(payload["cascaded_decision_ids"]) == {
-        "decision:d1",
-        "decision:d2",
-        "decision:d3",
-    }
-    assert payload["signer"] == "kim@x"
-    assert payload["reason"] == "bad"
-    assert payload["removed_at"]
+        from contracts import RemoveSourceResponse
+
+        assert isinstance(resp, RemoveSourceResponse)
+        assert resp.event_logged is True
+        assert len(writer.events) == 1  # single event for the entire cascade
+        event_type, payload = writer.events[0]
+        assert event_type == "source_removed.completed"
+        assert payload["span_id"] == span_id
+        assert payload["input_span_content"]["text"] == "verbatim transcript excerpt"
+        assert payload["input_span_content"]["source_ref"] == "meeting-001"
+        assert payload["input_span_content"]["source_type"] == "transcript"
+        assert set(payload["cascaded_decision_ids"]) == set(decision_ids)
+        assert payload["signer"] == "kim@x"
+        assert payload["reason"] == "bad"
+        assert payload["removed_at"]
+    finally:
+        await client.close()
 
 
 async def test_remove_source_dry_run_emits_no_event() -> None:
+    """A dry-run must not write to the event log."""
     from handlers.remove_source import handle_remove_source
 
-    span_id, span_row, decisions, edges = _seed_fixture()
+    adapter, client = await _fresh_adapter()
     writer = _FakeWriter()
-    client = _FakeClient({span_id: span_row}, decisions, edges)
-    ctx = _FakeCtx(_FakeLedger(client, writer=writer))
-
-    await handle_remove_source(ctx, span_id=span_id, signer="x@y", reason="check", confirm=False)
-    assert writer.events == []
+    try:
+        span_id, _ = await _seed_span_with_decisions(
+            client,
+            decision_payloads=({"description": "d1"},),
+        )
+        ctx = _make_ctx(adapter, writer=writer)
+        await handle_remove_source(
+            ctx, span_id=span_id, signer="x@y", reason="check", confirm=False
+        )
+        assert writer.events == []
+    finally:
+        await client.close()
 
 
 async def test_remove_source_confirm_idempotent_on_missing_span() -> None:
     """confirm=True on a non-existent span returns structured response, not
-    an exception. Pins idempotency Discipline #1."""
+    an exception. Pins idempotency Discipline #5."""
     from contracts import RemoveSourceResponse
     from handlers.remove_source import handle_remove_source
 
+    adapter, client = await _fresh_adapter()
     writer = _FakeWriter()
-    client = _FakeClient({}, {}, [])
-    ctx = _FakeCtx(_FakeLedger(client, writer=writer))
+    try:
+        ctx = _make_ctx(adapter, writer=writer)
+        resp = await handle_remove_source(
+            ctx,
+            span_id="input_span:missing",
+            signer="x@y",
+            reason="ghost cleanup",
+            confirm=True,
+        )
 
-    resp = await handle_remove_source(
-        ctx,
-        span_id="input_span:missing",
-        signer="x@y",
-        reason="ghost cleanup",
-        confirm=True,
-    )
-
-    assert isinstance(resp, RemoveSourceResponse)
-    assert resp.span_existed is False
-    assert resp.cascaded_decision_ids == []
-    assert resp.event_logged is False
-    # No event emitted on the no-op path even though writer was attached
-    assert writer.events == []
+        assert isinstance(resp, RemoveSourceResponse)
+        assert resp.span_existed is False
+        assert resp.cascaded_decision_ids == []
+        assert resp.event_logged is False
+        # No event emitted on the no-op path even though writer was attached
+        assert writer.events == []
+    finally:
+        await client.close()
 
 
 async def test_remove_source_skips_already_removed_decisions_in_cascade() -> None:
-    """If a decision was previously soft-deleted (e.g., by an earlier
-    remove_decision call), the cascade includes it in the returned list but
-    does not re-UPDATE the row. Pins per-decision idempotency inside the
-    cascade helper."""
+    """Per-decision idempotency: a decision previously soft-deleted (by an
+    earlier remove_decision call) is reported in cascaded_decision_ids but
+    its signoff row is not re-written."""
     from handlers.remove_source import handle_remove_source
 
-    span_id = "input_span:span001"
-    span_row = {
-        "text": "t",
-        "source_ref": "r",
-        "source_type": "manual",
-        "meeting_date": "",
-        "speakers": [],
-        "created_at": "",
-    }
     pre_existing_removed = {
         "state": "removed",
         "signer": "earlier@x",
         "reason": "earlier removal",
         "previous_state": "ratified",
     }
-    decisions = {
-        "decision:d1": {"signoff": pre_existing_removed},
-        "decision:d2": {"signoff": {"state": "proposed"}},
-    }
-    edges = [(span_id, "decision:d1"), (span_id, "decision:d2")]
-    client = _FakeClient({span_id: span_row}, decisions, edges)
-    ctx = _FakeCtx(_FakeLedger(client))
 
-    resp = await handle_remove_source(
-        ctx, span_id=span_id, signer="kim@x", reason="cascade", confirm=True
-    )
+    adapter, client = await _fresh_adapter()
+    try:
+        span_id, decision_ids = await _seed_span_with_decisions(
+            client,
+            decision_payloads=(
+                {"description": "d1", "signoff": pre_existing_removed},
+                {"description": "d2", "signoff": {"state": "proposed"}},
+            ),
+        )
+        d1, d2 = decision_ids
+        ctx = _make_ctx(adapter)
 
-    assert set(resp.cascaded_decision_ids) == {"decision:d1", "decision:d2"}
-    # d1's signoff was NOT overwritten — it kept its earlier removal record
-    assert client._decisions["decision:d1"]["signoff"] == pre_existing_removed
-    # d2 was newly removed
-    assert client._decisions["decision:d2"]["signoff"]["state"] == "removed"
-    assert client._decisions["decision:d2"]["signoff"]["reason"] == "cascade"
+        resp = await handle_remove_source(
+            ctx, span_id=span_id, signer="kim@x", reason="cascade", confirm=True
+        )
+
+        from contracts import RemoveSourceResponse
+
+        assert isinstance(resp, RemoveSourceResponse)
+        assert set(resp.cascaded_decision_ids) == {d1, d2}
+
+        # d1's signoff was NOT overwritten — it kept its earlier removal record.
+        # Compare on the load-bearing keys to avoid coupling to insertion-order
+        # quirks of FLEXIBLE objects.
+        rows = await client.query(f"SELECT signoff FROM {d1} LIMIT 1")
+        d1_signoff = rows[0]["signoff"]
+        assert d1_signoff["state"] == "removed"
+        assert d1_signoff["signer"] == "earlier@x"
+        assert d1_signoff["reason"] == "earlier removal"
+        assert d1_signoff["previous_state"] == "ratified"
+        # No removed_by_source key — that's what the new cascade would have added.
+        assert "removed_by_source" not in d1_signoff
+
+        # d2 was newly removed by the cascade
+        rows = await client.query(f"SELECT signoff FROM {d2} LIMIT 1")
+        d2_signoff = rows[0]["signoff"]
+        assert d2_signoff["state"] == "removed"
+        assert d2_signoff["reason"] == "cascade"
+        assert d2_signoff["removed_by_source"] == span_id
+        assert d2_signoff["previous_state"] == "proposed"
+    finally:
+        await client.close()
 
 
 async def test_get_decisions_for_span_returns_yield_traversal_ids() -> None:
-    """Unit test for the new ledger.queries helper. Independent of handler."""
+    """Sociable unit test for the ``get_decisions_for_span`` ledger query.
+
+    Replaces the old SQL-string-matching fake. Exercises the real
+    ``<-yields<-input_span CONTAINS ...`` graph traversal against a
+    seeded ledger — a parse error or contract drift now fails honestly
+    here instead of silently green-lighting drift in production."""
     from ledger.queries import get_decisions_for_span
 
-    span_id = "input_span:span001"
-    edges = [(span_id, "decision:a"), (span_id, "decision:b"), ("input_span:other", "decision:c")]
-    client = _FakeClient({}, {}, edges)
-    result = await get_decisions_for_span(client, span_id)
-    assert set(result) == {"decision:a", "decision:b"}
-    assert "decision:c" not in result
+    adapter, client = await _fresh_adapter()
+    try:
+        span_id, decision_ids = await _seed_span_with_decisions(
+            client,
+            decision_payloads=(
+                {"description": "a"},
+                {"description": "b"},
+            ),
+        )
+        # Seed a second span with its own decision so we can prove the
+        # traversal filters by span_id, not "all decisions".
+        other_span_id = await upsert_input_span(
+            client,
+            text="other excerpt",
+            source_type="manual",
+            source_ref="other-001",
+        )
+        other_decision_id = await upsert_decision(
+            client,
+            description="c",
+            source_type="manual",
+            source_ref="other-001#dec0",
+        )
+        await relate_yields(client, other_span_id, other_decision_id)
+
+        result = await get_decisions_for_span(client, span_id)
+        assert set(result) == set(decision_ids)
+        assert other_decision_id not in result
+    finally:
+        await client.close()


### PR DESCRIPTION
## Summary

Third trap-row backfill PR driven by the [#359](https://github.com/BicameralAI/bicameral-mcp/pull/359) sub-task 1 audit. Clears the **remaining 4 traps** in the remove_source cluster (`decision_exists`, `get_decisions_for_span`, `input_span_exists`, `get_input_span_row`), dropping trap count **4 → 0**. Closes out the #357 sub-task 1 inventory.

## What changed

`tests/test_remove_source.py`:
- Replaced the SurrealQL-string-matching `_FakeClient` with per-test `_fresh_adapter()` spinning up a real `LedgerClient(url="memory://")` + `init_schema` + `migrate`. Mirrors the [PR #394](https://github.com/BicameralAI/bicameral-mcp/pull/394) pattern.
- `ctx` is now `SimpleNamespace` per CLAUDE.md ("ctx should be SimpleNamespace, not MagicMock") — missing attributes raise honestly.
- Seeding uses real `upsert_input_span` / `upsert_decision` / `relate_yields`. The ledger assigns ids; tests use the returned ids rather than literal `"decision:d1"` strings.
- Mutation assertions query the real ledger (`SELECT id FROM <span>`, `SELECT signoff FROM <did>`) instead of inspecting fake-client state — **what the agent observes in production is what the test asserts**.
- The sociable rewrite caught a real-world contract that the old `_FakeClient` masked: SurrealDB `FLEXIBLE TYPE option<object>` **strips `None`-valued keys on round-trip**. A previously-unsigned decision's `signoff.previous_state` comes back as a missing key, not a present null. Test now asserts via `.get()`, mirroring what production callers must do.

`tests/test_ledger_mock_regression.py`:
- `EXPECTED_TRAP_CAP`: 4 → 0 (locks in the one-way-ratchet improvement).

## Retained narrow-seam mock (per CLAUDE.md rule 5)

| Mock | Why |
|---|---|
| `_FakeWriter` | Event writer is an emitter contract, not a ledger query. Spinning up the real event subsystem (SQLite journal, archive, replayer) would test the emitter, not the handler under test. |

## Audit impact

| Category | Before | After | Δ |
|---|---|---|---|
| Direct sociable | 29 | **33** | +4 |
| **Solitary trap** | **4** | **0** | **-4** |
| Indirect sociable | 24 | 24 | 0 |
| Uncovered | 0 | 0 | 0 |

**The #357 sub-task 1 trap-row inventory is now empty.**

## Verification

```
$ pytest tests/test_remove_source.py tests/test_ledger_mock_regression.py
12 passed in 9.08s

$ ruff check + format + mypy
clean

$ python3 scripts/audit_sociable_coverage.py
trap_count = 0
```

## Test plan

- [ ] CI green
- [ ] Audit confirms trap count = 0 post-merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)