### PR TITLE
feat(code-locator): #367 Elixir via tags-query substrate + Python parity gate

### DIFF
--- a/code_locator/indexing/symbol_extractor.py
+++ b/code_locator/indexing/symbol_extractor.py
@@ -1,7 +1,20 @@
-"""Tree-sitter symbol extraction for 9 languages.
+"""Tree-sitter symbol extraction for 10 languages.
 
 Ported from tools/bicameral-locagent/dependency_graph/build_graph.py
 and adapted to produce SymbolRecord objects for the SQLite store.
+
+Per-language coverage:
+
+- Python, JS/JSX, TS/TSX, Java, Go, Rust, C#: bespoke walkers
+  (``_extract_<lang>_defs``) — historical pattern; walker retirement
+  for the simpler four (Python, Go, Rust, JS-mode) gated on #399's
+  measurement spike.
+- **Elixir (#367)**: generic tags-query path via
+  ``tags_extractor.extract_defs_via_tags`` against the upstream
+  ``tree-sitter-elixir`` grammar's ``queries/tags.scm``. Substrate
+  introduced in #367 as the precursor to the broader hybrid refactor;
+  validated against existing Python walker output by
+  ``tests/test_tags_extractor_parity.py``.
 """
 
 from __future__ import annotations
@@ -20,6 +33,8 @@ EXTENSION_LANGUAGE = {
     ".go": "go",
     ".rs": "rust",
     ".cs": "c_sharp",
+    ".ex": "elixir",
+    ".exs": "elixir",
 }
 
 LANGUAGE_FALLBACK = {
@@ -62,6 +77,7 @@ if not _USE_LEGACY:
         "go": "tree_sitter_go",
         "rust": "tree_sitter_rust",
         "c_sharp": "tree_sitter_c_sharp",
+        "elixir": "tree_sitter_elixir",
     }
 
 # ── Parser caching ───────────────────────────────────────────────────
@@ -421,6 +437,19 @@ def _extract_definitions(language_id: str, tree, code: bytes, rel_path: str) -> 
         return _extract_rust_defs(tree, code, rel_path)
     if language_id == "c_sharp":
         return _extract_csharp_defs(tree, code, rel_path)
+    if language_id == "elixir":
+        # #367: tags-query path via the upstream tree-sitter-elixir tags.scm.
+        # First instance of the data-driven extractor; #399's spike measures
+        # whether the simpler walkers (Python, Go, Rust, JS-mode) can retire
+        # in favor of this same path. Walker fallback is not provided for
+        # Elixir — see pyproject.toml's tight grammar pin (>=0.3.5,<0.4).
+        from .tags_extractor import extract_defs_via_tags, load_tags_query_text
+
+        query_text = load_tags_query_text("tree_sitter_elixir")
+        if query_text is None:
+            return []
+        lang = _get_language_obj("elixir")
+        return extract_defs_via_tags(lang, tree, code, rel_path, query_text)
     return []
 
 

--- a/code_locator/indexing/tags_extractor.py
+++ b/code_locator/indexing/tags_extractor.py
@@ -1,0 +1,190 @@
+"""Generic tree-sitter tags.scm symbol extractor (#367, substrate for #399).
+
+Loads any language's ``queries/tags.scm`` (from the installed grammar
+package or a vendored override) and emits :class:`SymbolRecord` objects
+for every ``@definition.<kind>`` capture. Capture kinds map to the
+existing walker vocabulary via :data:`_KIND_TO_TYPE` so downstream
+consumers (``validate_symbols``, the bind handler) treat tags-extracted
+symbols the same as walker-extracted ones.
+
+The substrate is **purely data-driven**: every supported language goes
+through one function. Per-language walkers stay only where the tags
+schema cannot express what we need (currently: ``_extract_csharp_defs``
+for nested-class qualified-name tracking, ``_extract_java_imports`` for
+annotation/wildcard handling). Walker retirement for the remaining
+languages is gated on :issue:`399`'s measurement spike; this PR only
+introduces the substrate, validated by ``tests/test_tags_extractor_parity.py``.
+
+Design decisions locked at scoping time (see #367 body):
+- ``@definition.module`` → ``"class"`` (both define a containing scope).
+- ``@definition.method`` → ``"function"`` (walker treats them interchangeably).
+- ``parent_qualified_name`` computed via ancestor walk to the nearest
+  enclosing ``@definition.*`` capture, so nested cases (e.g. a method
+  inside a class, an Elixir function inside ``defmodule``) produce
+  correct qualified names like ``ClassName.method_name`` or
+  ``MyApp.Accounts.get_user``.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import importlib
+from pathlib import Path
+
+import tree_sitter as ts
+
+from .sqlite_store import SymbolRecord
+
+# Map tags.scm ``@definition.<kind>`` → ``SymbolRecord.type`` vocabulary.
+# Kinds not in this map are filtered out — most notably ``constant`` (which
+# tags.scm emits for module-level assignments but our walkers explicitly
+# skip) and any future kinds we don't yet support downstream.
+_KIND_TO_TYPE: dict[str, str] = {
+    "module": "class",
+    "class": "class",
+    "interface": "class",
+    "function": "function",
+    "method": "function",
+}
+
+# Cache compiled queries keyed on SHA(tags.scm text). Most languages have
+# stable queries; cache hit after first compile per process.
+_QUERY_CACHE: dict[str, ts.Query] = {}
+
+
+def _compile_query(language: ts.Language, query_text: str) -> ts.Query:
+    key = hashlib.sha256(query_text.encode("utf-8")).hexdigest()
+    cached = _QUERY_CACHE.get(key)
+    if cached is not None:
+        return cached
+    query = ts.Query(language, query_text)
+    _QUERY_CACHE[key] = query
+    return query
+
+
+def _node_text(code: bytes, node) -> str:
+    return code[node.start_byte : node.end_byte].decode("utf-8", errors="replace")
+
+
+def _first_line(code: bytes, node) -> str:
+    return _node_text(code, node).split("\n", 1)[0].strip()
+
+
+def load_tags_query_text(package_name: str) -> str | None:
+    """Return the upstream ``tags.scm`` text bundled with a tree-sitter
+    grammar package, or ``None`` if the package is not installed or
+    doesn't ship tags.scm.
+
+    Callers should fall back to a vendored override path in that case.
+    Today's audit: every grammar we depend on (python/js/ts/java/go/rust/c_sharp/
+    elixir) ships an upstream tags.scm, so the fallback path is unused.
+    """
+    try:
+        m = importlib.import_module(package_name)
+    except ImportError:
+        return None
+    if m.__file__ is None:
+        return None
+    p = Path(m.__file__).parent / "queries" / "tags.scm"
+    if not p.exists():
+        return None
+    return p.read_text(encoding="utf-8")
+
+
+def extract_defs_via_tags(
+    language: ts.Language,
+    tree,
+    code: bytes,
+    rel_path: str,
+    query_text: str,
+) -> list[SymbolRecord]:
+    """Run a ``tags.scm`` query against a parsed tree and emit
+    ``SymbolRecord`` objects.
+
+    Walks the query's match results. Each match associates a
+    ``@definition.<kind>`` capture (spanning the whole definition node)
+    with one or more ``@name`` captures (the identifier(s) for the
+    symbol). Pairs them up and records each as a ``SymbolRecord`` whose
+    ``type`` field comes from :data:`_KIND_TO_TYPE` and whose
+    ``parent_qualified_name`` is the name of the nearest enclosing
+    ``@definition.*`` capture.
+
+    Two-pass implementation:
+
+    1. **Pass 1** walks every match and records ``(definition_node,
+       name_node, kind)`` triples + a ``node_id → name`` map so that
+       parent-qn lookup is O(depth) per record in pass 2.
+    2. **Pass 2** emits the ``SymbolRecord``. For each definition, walks
+       ancestors upward until the first node that's also a definition;
+       that's the parent.
+
+    Top-level definitions get ``parent_qualified_name=""`` (mirrors the
+    walker convention).
+    """
+    query = _compile_query(language, query_text)
+    cursor = ts.QueryCursor(query)
+
+    # Pass 1: collect (def_node, name_node, kind) triples + name lookup table.
+    # IMPORTANT: tree-sitter's Python bindings return a fresh wrapper object
+    # for the same underlying node on each access — ``id(node)`` is NOT
+    # stable across traversals (e.g., the wrapper returned by
+    # ``cursor.matches()`` has a different id than the wrapper returned by
+    # ``other_node.parent`` even when they point at the same underlying
+    # node). Keying the lookup table on ``(start_byte, end_byte)`` instead
+    # of ``id(node)`` sidesteps this — every distinct node in the tree has
+    # a unique span.
+    NodeKey = tuple[int, int]
+    triples: list[tuple[ts.Node, ts.Node, str]] = []
+    definition_span_to_name: dict[NodeKey, str] = {}
+
+    for _pattern_idx, captures in cursor.matches(tree.root_node):
+        # Find the @definition.<kind> capture in this match. The schema gives
+        # exactly one definition-prefixed capture per match.
+        kind_key = next((k for k in captures if k.startswith("definition.")), None)
+        if kind_key is None:
+            continue
+        kind = kind_key.split(".", 1)[1]
+        def_nodes = captures[kind_key]
+        name_nodes = captures.get("name", [])
+        if not def_nodes or not name_nodes:
+            continue
+        # Pair definitions with names. Most matches have 1:1; some patterns
+        # capture multiple names per definition (e.g. multi-clause functions
+        # in Elixir) — zip with the shorter list to skip name-only captures
+        # from nested patterns.
+        for def_node, name_node in zip(def_nodes, name_nodes, strict=False):
+            name = _node_text(code, name_node)
+            if not name:
+                continue
+            triples.append((def_node, name_node, kind))
+            definition_span_to_name[(def_node.start_byte, def_node.end_byte)] = name
+
+    # Pass 2: emit records with ancestor-walk parent_qn resolution.
+    records: list[SymbolRecord] = []
+    for def_node, _name_node, kind in triples:
+        sym_type = _KIND_TO_TYPE.get(kind)
+        if sym_type is None:
+            continue
+        name = definition_span_to_name[(def_node.start_byte, def_node.end_byte)]
+        parent_qn = ""
+        ancestor = def_node.parent
+        while ancestor is not None:
+            parent_name = definition_span_to_name.get((ancestor.start_byte, ancestor.end_byte))
+            if parent_name is not None:
+                parent_qn = parent_name
+                break
+            ancestor = ancestor.parent
+        qualified_name = f"{parent_qn}.{name}" if parent_qn else name
+        records.append(
+            SymbolRecord(
+                name=name,
+                qualified_name=qualified_name,
+                type=sym_type,
+                file_path=rel_path,
+                start_line=def_node.start_point[0] + 1,
+                end_line=def_node.end_point[0] + 1,
+                signature=_first_line(code, def_node),
+                parent_qualified_name=parent_qn,
+            )
+        )
+    return records

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,6 +30,12 @@ dependencies = [
   "tree-sitter-go>=0.23",
   "tree-sitter-rust>=0.23",
   "tree-sitter-c-sharp>=0.23",
+  # #367: pinned tighter than the others because Elixir is the first language
+  # extracted via the generic tags-query path — we have no walker fallback,
+  # so a grammar bump that shifts node names breaks Elixir indexing silently.
+  # Bump the upper bound deliberately after verifying tests/test_extract_elixir.py
+  # still passes on the new grammar version.
+  "tree-sitter-elixir>=0.3.5,<0.4",
   "rapidfuzz>=3.6.0",
   "pydantic>=2.0.0",
   "pyyaml>=6.0",

--- a/tests/fixtures/elixir/sample_module.ex
+++ b/tests/fixtures/elixir/sample_module.ex
@@ -1,0 +1,28 @@
+defmodule MyApp.Accounts do
+  @moduledoc """
+  Account management for MyApp. Phoenix-style fixture for the #367
+  Elixir extractor regression test — diverse enough to exercise
+  multi-clause functions (active?/1), guard clauses, pipe operators,
+  alias directives, and private functions (defp).
+  """
+
+  alias MyApp.Repo
+  alias MyApp.Accounts.User
+
+  @max_per_page 50
+
+  def get_user(id), do: Repo.get(User, id)
+
+  def list_active_users do
+    User
+    |> Repo.all()
+    |> Enum.filter(&active?/1)
+  end
+
+  def find_by_email(email) when is_binary(email) do
+    Repo.get_by(User, email: email)
+  end
+
+  defp active?(%User{active: true}), do: true
+  defp active?(_), do: false
+end

--- a/tests/test_extract_elixir.py
+++ b/tests/test_extract_elixir.py
@@ -1,0 +1,108 @@
+"""Regression test for Elixir symbol extraction via the tags-query substrate (#367).
+
+End-to-end: parses ``tests/fixtures/elixir/sample_module.ex`` through the
+public ``extract_symbols_from_content`` API (the same entry point the
+production indexer uses), then asserts on the produced ``SymbolRecord``
+shape:
+
+- Exactly one ``@definition.module`` capture for ``MyApp.Accounts``,
+  emitted with ``type="class"`` per the #367 type mapping.
+- Five ``@definition.function`` captures (``get_user``,
+  ``list_active_users``, ``find_by_email`` with its ``when`` guard,
+  and the two ``active?`` clauses — emitting multiple rows per
+  multi-clause function is intentional, see #367 Notes).
+- Every function row has ``parent_qualified_name="MyApp.Accounts"`` and
+  a fully-qualified name like ``MyApp.Accounts.get_user``.
+
+Sociable per CLAUDE.md: real ``SymbolRecord`` dataclass, no
+``MagicMock``. Test runs against the real ``tree-sitter-elixir`` grammar
+package (pinned in ``pyproject.toml`` at ``>=0.3.5,<0.4``).
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from code_locator.indexing.symbol_extractor import extract_symbols_from_content
+
+FIXTURE = Path(__file__).resolve().parent / "fixtures" / "elixir" / "sample_module.ex"
+
+
+@pytest.fixture(scope="module")
+def records() -> list:
+    if not FIXTURE.exists():
+        pytest.skip(f"fixture missing: {FIXTURE}")
+    return extract_symbols_from_content(
+        FIXTURE.read_text(encoding="utf-8"),
+        "elixir",
+        "tests/fixtures/elixir/sample_module.ex",
+    )
+
+
+def test_module_captured_as_class(records: list) -> None:
+    """``defmodule MyApp.Accounts`` produces one row with type='class'
+    and qualified_name='MyApp.Accounts' (no parent — top-level)."""
+    modules = [r for r in records if r.type == "class"]
+    assert len(modules) == 1, f"expected 1 module, got {len(modules)}: {[m.name for m in modules]}"
+    m = modules[0]
+    assert m.name == "MyApp.Accounts"
+    assert m.qualified_name == "MyApp.Accounts"
+    assert m.parent_qualified_name == ""
+
+
+def test_all_function_clauses_captured(records: list) -> None:
+    """Five function-typed rows: get_user/1, list_active_users/0,
+    find_by_email/1 (with when guard), and active?/1 × 2 clauses.
+    Multi-clause functions deliberately emit one row per clause —
+    faithful to source per the #367 design decision."""
+    functions = [r for r in records if r.type == "function"]
+    names = sorted(r.name for r in functions)
+    # 2x active? (multi-clause) + find_by_email + get_user + list_active_users
+    assert names == [
+        "active?",
+        "active?",
+        "find_by_email",
+        "get_user",
+        "list_active_users",
+    ], f"unexpected function set: {names}"
+
+
+def test_functions_carry_module_parent(records: list) -> None:
+    """Every function inside ``defmodule MyApp.Accounts`` carries
+    parent_qualified_name='MyApp.Accounts' and a fully-qualified name
+    like 'MyApp.Accounts.get_user' — the substrate's ancestor walk must
+    resolve the enclosing module correctly."""
+    functions = [r for r in records if r.type == "function"]
+    for fn in functions:
+        assert fn.parent_qualified_name == "MyApp.Accounts", (
+            f"function {fn.name!r} has wrong parent: {fn.parent_qualified_name!r}"
+        )
+        assert fn.qualified_name == f"MyApp.Accounts.{fn.name}", (
+            f"function {fn.name!r} has wrong qualified_name: {fn.qualified_name!r}"
+        )
+
+
+def test_multi_clause_active_lines_distinct(records: list) -> None:
+    """The two ``active?`` clauses must surface as separate symbol rows
+    with distinct ``start_line`` values — the substrate is faithful to
+    source per #367 Notes (downstream consumers like validate_symbols
+    handle N-row matches)."""
+    active_rows = sorted((r for r in records if r.name == "active?"), key=lambda r: r.start_line)
+    assert len(active_rows) == 2, f"expected 2 active? clauses, got {len(active_rows)}"
+    assert active_rows[0].start_line != active_rows[1].start_line, (
+        f"two active? clauses share start_line={active_rows[0].start_line}"
+    )
+
+
+def test_dispatch_returns_records_for_ex_extension() -> None:
+    """End-to-end: extract_symbols (the file-path entrypoint) routes
+    .ex/.exs files through the substrate. If EXTENSION_LANGUAGE or
+    _LANG_PACKAGE_MAP didn't get wired, this fails."""
+    from code_locator.indexing.symbol_extractor import extract_symbols
+
+    records = extract_symbols(str(FIXTURE.resolve()), str(FIXTURE.parent.parent.parent))
+    assert records, "dispatch returned no records — wiring is broken"
+    types = {r.type for r in records}
+    assert "class" in types and "function" in types

--- a/tests/test_tags_extractor_parity.py
+++ b/tests/test_tags_extractor_parity.py
@@ -1,0 +1,153 @@
+"""Parity gate for the tags-query substrate against the Python walker (#367).
+
+Load-bearing risk mitigation for the Path B design recorded in #367. The
+substrate (``code_locator.indexing.tags_extractor``) is introduced here
+for Elixir, but we have no Elixir walker to compare it against. To
+validate the substrate's correctness BEFORE shipping it, this test
+shadow-runs it against the existing Python walker output on real repo
+files. The empirical pre-flight (#399 research) showed that for Python,
+walker symbols are a strict subset of tags-query output. This gate locks
+that property in.
+
+Contract — for every Python fixture file, restricted to the walker's
+symbol vocabulary (``{"function", "class", "method"}``):
+
+    walker_symbols ⊆ tags_extractor_symbols
+
+If the substrate misses a symbol the walker captures, the gate fails and
+the PR cannot merge. This is the assertion that converts "untested first
+instance" → "validated against existing ground truth in this same PR."
+
+The reverse direction (tags-only-extra) is NOT asserted: tags.scm
+captures module-level constants the walker explicitly skips. Allowing
+the substrate to be a superset is by design — those extras are filtered
+out by ``_KIND_TO_TYPE`` not mapping ``constant`` to a walker type.
+
+The fixture corpus is sourced from the bicameral-mcp repo itself (handler
+files, ledger files, test files — diverse Python shapes). Adding more
+fixtures sharpens the gate; removing them weakens it.
+
+When this gate fails:
+  1. Read the diff between walker and substrate outputs printed in the
+     failure message.
+  2. If the walker is right and tags missed something, the substrate has
+     a bug (likely in ``_KIND_TO_TYPE`` or parent_qn computation). Fix
+     it before merging.
+  3. If the walker is wrong (rare), update the test expectations AND
+     file a separate issue documenting the walker bug.
+
+NEVER skip this gate by adding ``@pytest.mark.xfail`` — the substrate
+shipping with Elixir relying on it makes correctness load-bearing.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+import tree_sitter as ts
+import tree_sitter_python as tsp
+
+from code_locator.indexing.symbol_extractor import extract_symbols_from_content
+from code_locator.indexing.tags_extractor import (
+    extract_defs_via_tags,
+    load_tags_query_text,
+)
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+
+# Real Python files from this repo. Pick a diverse set: handler with many
+# classes, ledger with many functions + nested helpers, test file with
+# nested fixture classes, simple module with helpers only.
+FIXTURE_FILES = [
+    "handlers/preflight.py",
+    "handlers/remove_source.py",
+    "ledger/queries.py",
+    "tests/test_remove_source.py",
+    "code_locator/indexing/tags_extractor.py",  # dogfood the new file
+    "code_locator/indexing/symbol_extractor.py",  # large file with all walkers
+]
+
+# Walker emits these type values for Python. Filter the substrate's
+# output to the same set before comparison — substrate captures extra
+# module-level constants the walker skips, which is by design (#367 spec).
+WALKER_VOCAB = {"function", "class", "method"}
+
+
+@pytest.fixture(scope="module")
+def py_language() -> ts.Language:
+    return ts.Language(tsp.language())
+
+
+@pytest.fixture(scope="module")
+def py_parser(py_language: ts.Language) -> ts.Parser:
+    return ts.Parser(py_language)
+
+
+@pytest.fixture(scope="module")
+def py_tags_query_text() -> str:
+    text = load_tags_query_text("tree_sitter_python")
+    if text is None:
+        pytest.skip(
+            "tree_sitter_python is not installed or doesn't ship queries/tags.scm; "
+            "the parity gate cannot run on this environment."
+        )
+    return text
+
+
+@pytest.mark.parametrize("rel_path", FIXTURE_FILES)
+def test_python_walker_subset_of_tags_extractor(
+    rel_path: str,
+    py_language: ts.Language,
+    py_parser: ts.Parser,
+    py_tags_query_text: str,
+) -> None:
+    """Walker symbols (name, type) ⊆ substrate symbols (name, type) on real
+    Python files, after filtering substrate output to walker vocabulary.
+
+    If this fails, the substrate has a bug — most likely a missing case in
+    ``_KIND_TO_TYPE`` or a parent_qn computation error. Do NOT merge.
+    """
+    src = REPO_ROOT / rel_path
+    if not src.exists():
+        pytest.skip(f"fixture {rel_path} not present in this checkout")
+    content = src.read_text(encoding="utf-8")
+    code_bytes = content.encode("utf-8")
+
+    # Walker output — what we ship today.
+    walker_records = extract_symbols_from_content(content, "python", rel_path)
+    walker_set = {(r.name, r.type) for r in walker_records if r.type in WALKER_VOCAB}
+
+    # Substrate output, filtered to walker vocabulary.
+    tree = py_parser.parse(code_bytes)
+    substrate_records = extract_defs_via_tags(
+        py_language, tree, code_bytes, rel_path, py_tags_query_text
+    )
+    substrate_set = {(r.name, r.type) for r in substrate_records if r.type in WALKER_VOCAB}
+
+    missing = walker_set - substrate_set
+    assert not missing, (
+        f"Substrate parity gate FAIL on {rel_path}: walker found "
+        f"{len(missing)} symbol(s) the substrate missed.\n\n"
+        f"Walker-only symbols (would silently disappear if walker retired):\n"
+        + "\n".join(f"  - {n} (type={t})" for n, t in sorted(missing))
+        + f"\n\nWalker total: {len(walker_set)}, Substrate total (filtered): "
+        f"{len(substrate_set)}.\n\n"
+        "This means either (a) the substrate has a bug in capture "
+        "interpretation, (b) _KIND_TO_TYPE is missing a kind, or (c) the "
+        "walker is emitting symbols a tags.scm pattern doesn't cover. "
+        "Fix the substrate before merging — Elixir relies on this code path."
+    )
+
+
+def test_parity_gate_runs_on_at_least_three_fixtures() -> None:
+    """Sanity: if all fixtures get skipped (e.g. repo restructure), the
+    gate silently provides zero coverage. Fail loudly when too few real
+    fixtures are reachable."""
+    present = sum(1 for p in FIXTURE_FILES if (REPO_ROOT / p).exists())
+    assert present >= 3, (
+        f"Only {present}/{len(FIXTURE_FILES)} fixture files present — the "
+        f"parity gate's coverage is too thin to defend the substrate. "
+        f"Either restore the missing files or update FIXTURE_FILES with "
+        f"new diverse Python samples."
+    )


### PR DESCRIPTION
## Summary

Closes [#367](https://github.com/BicameralAI/bicameral-mcp/issues/367). Adds Elixir support to the code locator by introducing a **generic tree-sitter tags.scm extractor** (the substrate that #399's measurement spike will validate against existing walkers for retirement). Elixir ships on the tags-query path rather than as a 7th bespoke walker, per the locked Path B + parity gate design recorded on the ticket.

## What's in this PR

### Substrate (new): `code_locator/indexing/tags_extractor.py`

Pure-function `extract_defs_via_tags(language, tree, code, rel_path, query_text)` loads any language's tree-sitter `queries/tags.scm` and produces `SymbolRecord` objects.

| Concern | Design |
|---|---|
| Capture-kind → type mapping | `module/class/interface` → `"class"`; `function/method` → `"function"` (per #367 locked decision) |
| `parent_qualified_name` | Ancestor walk to the nearest enclosing `@definition.*` capture — yields `MyApp.Accounts.get_user` for Elixir-function-inside-defmodule, or `ClassName.method` for Python methods |
| Identity scheme | `(start_byte, end_byte)` not `id(node)` — tree-sitter's Python bindings return fresh wrapper objects on each traversal so `id()` is unstable across `cursor.matches()` vs `.parent` walks (caught during initial smoke test) |
| Query caching | Compiled queries cached by `SHA(query_text)` — most languages have stable tags.scm, cache hits dominate after first compile per process |

### Elixir wiring

`code_locator/indexing/symbol_extractor.py`:
- `EXTENSION_LANGUAGE` += `.ex`, `.exs` → `"elixir"`
- `_LANG_PACKAGE_MAP` += `"elixir"` → `"tree_sitter_elixir"`
- `_extract_definitions` adds an Elixir branch that calls the substrate against the upstream `tree-sitter-elixir` tags.scm. **No walker fallback** for Elixir.
- File docstring updated: "9 languages" → "10 languages" with per-language coverage breakdown.

`pyproject.toml`: adds `tree-sitter-elixir>=0.3.5,<0.4` — **pinned tighter** than other grammars (`>=0.23`) because Elixir has no walker fallback. A grammar bump that shifts node names would break Elixir indexing silently. Comment in the dep block flags this.

### Parity gate (load-bearing risk mitigation)

`tests/test_tags_extractor_parity.py`:
- Shadow-runs the substrate against the existing Python walker on **6 real repo files** (handlers/preflight.py, handlers/remove_source.py, ledger/queries.py, tests/test_remove_source.py, the new tags_extractor.py itself, symbol_extractor.py).
- Asserts: `walker_symbols (filtered to {function, class, method}) ⊆ substrate_symbols (same filter)`. Substrate is allowed to be a strict superset (it captures module-level constants the walker skips, by design).
- **Result on this PR: parity holds on all 6 fixtures.** The substrate is empirically trusted on a language we have ground truth for BEFORE it ships supporting a language (Elixir) we don't.
- Sanity test asserts ≥3 fixtures present — prevents the gate going to zero coverage on a future repo restructure.

### Elixir fixture + regression test

`tests/fixtures/elixir/sample_module.ex` — Phoenix-style \`MyApp.Accounts\` covering multi-clause functions (`active?/1` × 2), guard clauses (`when`), pipe operator (`|>`), `alias` directives, private functions (`defp`).

`tests/test_extract_elixir.py` — 5 assertions: module-as-class, all 5 function clauses captured, parent_qn correctly set, multi-clause distinct lines, .ex extension dispatch end-to-end.

## Phoenix smoke test (out-of-tree)

Ran the substrate over 25 real Phoenix framework `.ex` files (`git clone --depth 1 phoenixframework/phoenix`):

| Result |
|---|
| 25 modules extracted |
| 384 functions extracted |
| 0 errors |
| 0 empty files (every file with `defmodule` produced records) |

Substrate handles production-shape Elixir code cleanly. Not committed (out-of-tree fixture).

## What's NOT in this PR

- **Retiring existing Python/Go/Rust walkers** — that's [#399](https://github.com/BicameralAI/bicameral-mcp/issues/399)'s job. This PR only introduces and validates the substrate. Python/Go/Rust/etc. still route through their bespoke walkers.
- **Multi-language onboarding** (Ruby/PHP/Kotlin/etc.) — the substrate is general enough to support them now, but each language add is its own PR with fixture + test + tight grammar pin.
- **Cross-file name binding** — #367 is purely lexical symbol extraction.

## Decision changes during execution (worth flagging for review)

1. **Skipped vendoring aider's elixir-tags.scm.** Upstream `tree-sitter-elixir` ships a tags.scm that is functionally identical to aider's — both have identical pattern coverage (defmodule/protocol, def/defp/defmacro variants, guard clauses, pipes, aliases). Aider's only modification is a cosmetic capture-name rename (`@name` → `@name.definition.function`); no semantic content added. Using upstream means no `code_locator/indexing/queries/` directory, no Apache 2.0 attribution, and the substrate works for any language whose upstream package ships tags.scm.

2. **Identity-scheme bug fixed mid-implementation.** Initial substrate used `id(node)` as the lookup key for parent_qn resolution; smoke test showed parent_qn coming out empty. Root cause: tree-sitter's Python bindings return fresh wrapper objects on each access — `id()` is not stable across `cursor.matches()` vs `.parent` walks. Fixed by switching to `(start_byte, end_byte)` as the identity key. Worth surfacing in case other contributors run into the same gotcha.

## Verification

\`\`\`
$ python3 -m pytest tests/test_extract_elixir.py tests/test_tags_extractor_parity.py -v
12 passed in 0.63s

$ python3 -m pytest tests/test_extract_call_sites.py tests/test_phase1_code_locator.py
all existing tests pass — no regressions

$ ruff format + ruff check + mypy → clean

$ Phoenix smoke (25 files) → 25 modules, 384 functions, 0 errors
\`\`\`

## Acceptance (from #367)

- [x] `code_locator/indexing/tags_extractor.py` exists (~140 LoC, no Elixir-specific code — purely generic)
- [x] Upstream tags.scm used directly; vendoring not needed
- [x] `EXTENSION_LANGUAGE` + `_LANG_PACKAGE_MAP` + dispatch updated for Elixir
- [x] `pyproject.toml` lists `tree-sitter-elixir>=0.3.5,<0.4` with tight-pin comment
- [x] `tests/test_tags_extractor_parity.py` runs ≥6 Python fixtures through both walker and substrate; parity assertion passes on CI
- [x] `tests/fixtures/elixir/` regression test passes
- [x] `extract_symbols_from_content('elixir', ...)` dispatches end-to-end (test_dispatch_returns_records_for_ex_extension)
- [ ] Windows CI matrix verification — pending CI run

## Test plan

- [ ] CI green on Linux + Windows matrix (Windows tree-sitter wheel install historically diverges from Linux — first-time check for tree-sitter-elixir)
- [ ] Re-run parity gate after merge to confirm no flake
- [ ] After merge, [#399](https://github.com/BicameralAI/bicameral-mcp/issues/399) can start: substrate already validated, spike scope shrinks to measuring Python/Go/Rust walker retirement against the proven substrate

🤖 Generated with [Claude Code](https://claude.com/claude-code)