### PR TITLE
ci(m_skill_preflight): flip warn → hard gate after stable baselines (#398)

### DIFF
--- a/.github/workflows/test-mcp-regression.yml
+++ b/.github/workflows/test-mcp-regression.yml
@@ -261,34 +261,48 @@ jobs:
         continue-on-error: true
         run: python tests/eval_preflight_m6_summary.py test-results/m6-preflight-recall.json >> "$GITHUB_STEP_SUMMARY"
 
-      # ── M_skill_preflight — skill-layer preflight eval (#306) ────────
+      # ── M_skill_preflight — skill-layer preflight eval (hard gate, #306) ─
       # Two-step eval driven by the bicameral-preflight SKILL.md:
       #   Step-1 = relevance recall over the 25-row dataset (Part A #396)
       #   Step-0 = history-invocation rate over the 15-row dataset (Part B)
-      # Both replay from cached fixtures; cache miss requires the
-      # ANTHROPIC_API_KEY secret. Warn-only at first run per the #288 M2
-      # warn→hard pattern — flip to --gate-mode hard in a followup PR
-      # once one stable baseline lands.
-      - name: M_skill_preflight Step-1 (warn-only)
+      # Both replay from cached fixtures at tests/eval/fixtures/skill_judge/
+      # and tests/eval/fixtures/skill_invocation_judge/ — cache miss requires
+      # the ANTHROPIC_API_KEY secret; commit the cache after a deliberate
+      # SKILL.md change.
+      #
+      # Gates flipped warn → hard (#398) after two stable baseline runs
+      # (#397 introduced the eval; #400 confirmed the substrate work
+      # didn't disturb the numbers):
+      #   Step-1: per-axis recall 100% (25/25 across M1/M4/FF1/D)
+      #   Step-0: recall 100% (8/8), precision 88.9%, fp_rate 14.3%
+      # All gates passed with ≥15 pp headroom on the load-bearing axes.
+      # Future PRs that touch skills/bicameral-preflight/SKILL.md or the
+      # eval datasets must EITHER keep:
+      #   Step-1 per-axis recall ≥ 70%
+      #   Step-0 should-invoke recall ≥ 50%
+      #   Step-0 fp_rate ≤ 30%
+      # OR explicitly re-record the cache via
+      # BICAMERAL_PREFLIGHT_EVAL_RECORD=1 /
+      # BICAMERAL_PREFLIGHT_INVOCATION_EVAL_RECORD=1 after a deliberate
+      # skill-prompt change. "Deliberate not drift."
+      - name: M_skill_preflight Step-1 (hard gate)
         if: matrix.os == 'ubuntu-latest'
-        continue-on-error: true
         env:
           ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
           BICAMERAL_PREFLIGHT_EVAL_MODEL: claude-haiku-4-5-20251001
         run: >
           python tests/eval_preflight_skill_step1.py
-          --gate-mode warn
+          --gate-mode hard
           -o test-results/skill-step1.json
 
-      - name: M_skill_preflight Step-0 (warn-only)
+      - name: M_skill_preflight Step-0 (hard gate)
         if: matrix.os == 'ubuntu-latest'
-        continue-on-error: true
         env:
           ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
           BICAMERAL_PREFLIGHT_INVOCATION_EVAL_MODEL: claude-haiku-4-5-20251001
         run: >
           python tests/eval_preflight_skill_invocation.py
-          --gate-mode warn
+          --gate-mode hard
           -o test-results/skill-step0.json
 
       # ── Surface M_skill_preflight metrics on the GitHub run summary ──

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,12 @@
 All notable changes to bicameral-mcp are tracked here. Format loosely follows
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
+## Unreleased
+
+### Changed
+
+- **`M_skill_preflight` Step-1 + Step-0 CI gates promoted warn → hard (#398).** After two stable baseline CI runs ([#397](https://github.com/BicameralAI/bicameral-mcp/pull/397), [#400](https://github.com/BicameralAI/bicameral-mcp/pull/400)) with Step-1 at 100% per-axis recall (25/25 across M1/M4/FF1/D) and Step-0 at 100% recall / 88.9% precision / 14.3% fp_rate — all gates passed with ≥15 pp headroom — `.github/workflows/test-mcp-regression.yml`'s M_skill_preflight steps no longer carry `continue-on-error: true` and now invoke the eval CLIs with `--gate-mode hard`. Future PRs that touch `skills/bicameral-preflight/SKILL.md` or the eval datasets must keep Step-1 per-axis recall ≥ 70%, Step-0 should-invoke recall ≥ 50%, Step-0 fp_rate ≤ 30% — OR explicitly re-record the cache via `BICAMERAL_PREFLIGHT_EVAL_RECORD=1` / `BICAMERAL_PREFLIGHT_INVOCATION_EVAL_RECORD=1` after a deliberate skill-prompt change. Mirrors the [#288](https://github.com/BicameralAI/bicameral-mcp/pull/288) M2 warn→hard pattern. Metrics-summary step keeps `always() + continue-on-error: true` so breach detail still renders inline on failures.
+
 ## v0.15.1 — hotfix: route `ledger_sync` deserialization warnings to a wipe-and-replay recovery path (#301)
 
 Hotfix for [#301](https://github.com/BicameralAI/bicameral-mcp/issues/301). v0.15.0 already added a row-level deserialization probe to `bicameral.diagnose` ([`cli/_diagnose_gather.py::_probe_row_deserialization`](cli/_diagnose_gather.py)), but the probe's findings stopped at the `suggestions` list — `_classify_recovery` in `handlers/diagnose.py` still inspected only `schema_meta.version`, so an agent that ran `diagnose` after a `link_commit` failure would see `recovery_path: "clean"` and `next_action: "No remediation needed."` while the ledger was actually unreadable.


### PR DESCRIPTION
## Summary

Closes [#398](https://github.com/BicameralAI/bicameral-mcp/issues/398). Promotes the \`M_skill_preflight\` Step-1 + Step-0 CI gates from warn-only to hard, mirroring the [#288](https://github.com/BicameralAI/bicameral-mcp/pull/288) M2 warn→hard pattern. Two stable baseline runs landed via [#397](https://github.com/BicameralAI/bicameral-mcp/pull/397) (introduced the eval) and [#400](https://github.com/BicameralAI/bicameral-mcp/pull/400) (substrate work didn't disturb the numbers).

## Baselines that justified the flip

**Step-1 — per-axis relevance recall** (25 cases):

| Axis | Recall | Gate |
|---|---|---|
| M1 vocab_mismatch | **100%** (8/8) | ≥ 70% ✅ |
| M4 ungrounded | **100%** (8/8) | ≥ 70% ✅ |
| FF1 false_fire | **100%** (6/6) | ≥ 70% ✅ |
| D direct_match | **100%** (3/3) | ≥ 70% ✅ |
| **Overall** | **100%** (25/25) | — |

**Step-0 — history-invocation rate** (15 cases):

| Metric | Value | Gate |
|---|---|---|
| **Recall** (should-invoke) | **100.0%** (8/8) | ≥ 50% ✅ |
| **Precision** (TP/(TP+FP)) | 88.9% (8/9) | — |
| **FP rate** (over-fetch) | 14.3% (1/7) | ≤ 30% ✅ |

All gates passed with ≥ 15 pp headroom on the load-bearing axes. Strong enough to lock in.

## Changes

\`.github/workflows/test-mcp-regression.yml\`:

- \`M_skill_preflight Step-1 (warn-only)\` → \`(hard gate)\`. Removed \`continue-on-error: true\`. \`--gate-mode warn\` → \`--gate-mode hard\`.
- \`M_skill_preflight Step-0 (warn-only)\` → \`(hard gate)\`. Same edits.
- \`M_skill_preflight metrics summary\` step **UNCHANGED** — keeps \`always() + continue-on-error: true\` so the breach detail still renders inline when the eval step fails the hard gate. Reviewers see *why* without hunting through logs.
- Comment block above the steps records the baselines, the rollback procedure (re-record cache via \`BICAMERAL_PREFLIGHT_*_EVAL_RECORD=1\` after a deliberate skill-prompt change), and the "deliberate not drift" framing from #288.

\`CHANGELOG.md\`:

- New \`## Unreleased\` section with \`### Changed\` subsection capturing the flip + baselines + criteria + rollback recipe. Keep-a-Changelog format (first such section in this file, following the format declaration at the top).

## What stays warn-only

The Phase 2 / Phase 2b steps in \`.github/workflows/preflight-eval.yml\` stay warn-only — that's the advisory dashboard workflow, intentionally non-blocking. #398's scope is \`test-mcp-regression.yml\` only.

## After this lands

PRs that touch \`skills/bicameral-preflight/SKILL.md\` or the eval datasets must EITHER:

- Keep Step-1 per-axis recall ≥ 70%, Step-0 recall ≥ 50%, Step-0 fp_rate ≤ 30%, **OR**
- Deliberately re-record the cache via \`BICAMERAL_PREFLIGHT_EVAL_RECORD=1\` / \`BICAMERAL_PREFLIGHT_INVOCATION_EVAL_RECORD=1\` after a justified skill-prompt change.

If the first CI run after merge surfaces an unexpected breach (grammar/model drift, fixture invalidation we missed in the substrate work), revert this PR — [#398](https://github.com/BicameralAI/bicameral-mcp/issues/398)'s pre-conditions section has an explicit escape hatch.

## Verification

\`\`\`
$ python3 -c "import yaml; yaml.safe_load(open('.github/workflows/test-mcp-regression.yml'))"
clean

$ grep -i "warn-only" .github/workflows/test-mcp-regression.yml | grep -i skill
[no matches — all M_skill_preflight steps are now hard gate]
\`\`\`

## Test plan

- [ ] CI green on this PR's run (cache-hits-only; if a baseline number drifted from when #400 landed, this PR fails — that's the design)
- [ ] After merge, monitor next ~3 dev CI runs to confirm no flake

🤖 Generated with [Claude Code](https://claude.com/claude-code)