### PR TITLE
feat(code-locator): #399 Stage A — add type→class mapping for Go struct/interface (substrate)

### DIFF
--- a/code_locator/indexing/tags_extractor.py
+++ b/code_locator/indexing/tags_extractor.py
@@ -39,10 +39,27 @@ from .sqlite_store import SymbolRecord
 # Kinds not in this map are filtered out — most notably ``constant`` (which
 # tags.scm emits for module-level assignments but our walkers explicitly
 # skip) and any future kinds we don't yet support downstream.
+#
+# Per-grammar coverage (verified by reading upstream queries/tags.scm):
+# - Python: emits class/function/constant — constant filtered out (walker
+#   skips module-level assignments).
+# - JS/TS:  emits class/method/function/module/interface — all mapped.
+# - Java:   emits class/method/interface — all mapped.
+# - Go:     emits function/method/type — ``type`` is load-bearing because
+#   the Go walker emits struct/interface declarations as type='class'
+#   via the ``type_spec`` branch (symbol_extractor.py:_extract_go_defs).
+#   Without the ``type → class`` mapping, the substrate silently drops
+#   them and the parity gate would fail on any Go file. Stage A of
+#   #399 closes this gap.
+# - Rust:   emits class/method/function/interface/module/macro — macro
+#   filtered out (no walker emits it; substrate-only is the allowed
+#   direction).
+# - Elixir: emits module/function — both mapped.
 _KIND_TO_TYPE: dict[str, str] = {
     "module": "class",
     "class": "class",
     "interface": "class",
+    "type": "class",
     "function": "function",
     "method": "function",
 }

--- a/tests/test_extract_go_substrate.py
+++ b/tests/test_extract_go_substrate.py
@@ -1,0 +1,146 @@
+"""Substrate-side smoke test for Go symbol extraction (#399 Stage A).
+
+Validates that the generic tags-query substrate emits Go struct and
+interface declarations as ``SymbolRecord.type="class"`` via the
+``"type" → "class"`` mapping in
+``code_locator.indexing.tags_extractor._KIND_TO_TYPE``. Without that
+mapping, the upstream ``tree-sitter-go/queries/tags.scm``'s
+``@definition.type`` captures get silently dropped — but the Go walker
+(``_extract_go_defs``) DOES emit struct/interface as ``type='class'``,
+so the parity gate would fail on any Go file. This test pins the fix
+ahead of the Stage B full parity gate extension.
+
+Inline Go fixture is intentional — the full per-language corpus
+expansion lives in Stage B per the #399 plan. This Stage A test only
+needs to demonstrate that the new mapping closes the gap; an inline
+fixture is sufficient and keeps the test independent of any future
+corpus changes.
+
+Companion to ``tests/test_extract_elixir.py`` (#367 — Elixir runs
+through the same substrate) and ``tests/test_tags_extractor_parity.py``
+(#400 — Python walker ⊆ substrate parity gate).
+"""
+
+from __future__ import annotations
+
+import pytest
+import tree_sitter as ts
+import tree_sitter_go as tsgo
+
+from code_locator.indexing.tags_extractor import (
+    extract_defs_via_tags,
+    load_tags_query_text,
+)
+
+# Phoenix-shaped Go fixture — covers the three @definition.<kind>
+# captures the upstream tags.scm produces (function/method/type) plus
+# a regular package-level function to anchor the function path.
+_FIXTURE = """\
+package accounts
+
+import "fmt"
+
+type User struct {
+    ID   int
+    Name string
+}
+
+type Repository interface {
+    Get(id int) (*User, error)
+    List() ([]*User, error)
+}
+
+func GetUser(id int) (*User, error) {
+    fmt.Println("getting user", id)
+    return nil, nil
+}
+
+func (u *User) DisplayName() string {
+    return u.Name
+}
+"""
+
+
+@pytest.fixture(scope="module")
+def go_language() -> ts.Language:
+    return ts.Language(tsgo.language())
+
+
+@pytest.fixture(scope="module")
+def go_parser(go_language: ts.Language) -> ts.Parser:
+    return ts.Parser(go_language)
+
+
+@pytest.fixture(scope="module")
+def go_tags_query() -> str:
+    text = load_tags_query_text("tree_sitter_go")
+    if text is None:
+        pytest.skip("tree_sitter_go is not installed or doesn't ship queries/tags.scm")
+    return text
+
+
+@pytest.fixture(scope="module")
+def go_records(go_language, go_parser, go_tags_query) -> list:
+    code = _FIXTURE.encode("utf-8")
+    tree = go_parser.parse(code)
+    return extract_defs_via_tags(go_language, tree, code, "fixture.go", go_tags_query)
+
+
+def test_struct_captured_as_class(go_records: list) -> None:
+    """Go ``type User struct {…}`` should produce a SymbolRecord with
+    name='User', type='class' via the new ``@definition.type → class``
+    mapping. If this fails, the Stage A mapping fix regressed."""
+    user = next((r for r in go_records if r.name == "User"), None)
+    assert user is not None, (
+        f"User struct missing from substrate output. Got: {[(r.name, r.type) for r in go_records]}"
+    )
+    assert user.type == "class", (
+        f"User struct should map to type='class' (matches Go walker output); "
+        f"got type='{user.type}'. Likely the '_KIND_TO_TYPE['type']' mapping "
+        f"is missing or wrong."
+    )
+
+
+def test_interface_captured_as_class(go_records: list) -> None:
+    """Go ``type Repository interface {…}`` should also produce
+    type='class' — both struct_type and interface_type go through the
+    same ``type_spec → @definition.type`` capture in tree-sitter-go's
+    tags.scm. The walker treats both as classes; substrate must agree."""
+    repo = next((r for r in go_records if r.name == "Repository"), None)
+    assert repo is not None, "Repository interface missing from substrate output"
+    assert repo.type == "class", (
+        f"Repository interface should map to type='class'; got type='{repo.type}'."
+    )
+
+
+def test_function_captured_as_function(go_records: list) -> None:
+    """Top-level Go func → @definition.function → type='function'.
+    This was already covered by the existing mapping but pin it so a
+    refactor doesn't silently break the baseline."""
+    fn = next((r for r in go_records if r.name == "GetUser"), None)
+    assert fn is not None, "GetUser function missing from substrate output"
+    assert fn.type == "function", f"GetUser should map to type='function'; got type='{fn.type}'."
+
+
+def test_method_captured_as_function(go_records: list) -> None:
+    """Go ``func (u *User) DisplayName()`` → @definition.method →
+    type='function'. The method kind folds into the walker's
+    'function' vocabulary per the locked #367 mapping decision."""
+    method = next((r for r in go_records if r.name == "DisplayName"), None)
+    assert method is not None, "DisplayName method missing from substrate output"
+    assert method.type == "function", (
+        f"DisplayName method should map to type='function'; got type='{method.type}'."
+    )
+
+
+def test_no_unexpected_extras(go_records: list) -> None:
+    """The substrate should emit exactly four records on this fixture
+    (User, Repository, GetUser, DisplayName). If a new record appears,
+    upstream tree-sitter-go's tags.scm added a new ``@definition.*``
+    capture — investigate before merging this PR (the new kind may need
+    a ``_KIND_TO_TYPE`` mapping or may be a substrate-only extra)."""
+    names = sorted(r.name for r in go_records)
+    assert names == ["DisplayName", "GetUser", "Repository", "User"], (
+        f"Unexpected substrate output on Go fixture: {names}. "
+        f"Audit whether tree-sitter-go's tags.scm added new captures."
+    )


### PR DESCRIPTION
## Summary

Stage A of [#399](https://github.com/BicameralAI/bicameral-mcp/issues/399) (tags-query hybrid extractor spike). Closes a latent bug surfaced during pre-spike research: the substrate's \`_KIND_TO_TYPE\` map is missing the \`type → class\` entry, so the upstream \`tree-sitter-go/queries/tags.scm\`'s \`@definition.type\` captures get silently dropped. But the Go walker (\`_extract_go_defs\`) DOES emit struct/interface as \`type='class'\` via its \`type_spec\` branch (\`symbol_extractor.py:301\`) — so today's parity gate would fail on any Go file.

Stage A closes that gap ahead of Stage B's full per-language parity-gate extension.

## What changed

\`code_locator/indexing/tags_extractor.py\`:
- \`_KIND_TO_TYPE\` gains \`\"type\": \"class\"\`.
- Docstring above the dict now enumerates per-grammar coverage with the audit reasoning for each entry (Python, JS/TS, Java, Go, Rust, Elixir all walked through their upstream tags.scm). The audit captured in this comment is the load-bearing artifact of Stage A — future grammar bumps that add new \`@definition.*\` kinds will be obvious to spot.

## What didn't change

| Surface | State |
|---|---|
| Walker code | Untouched — Stages D + E are where walkers retire |
| Dispatch | Untouched — Python/Go/Rust/JS-TS/Java/C# still route through their walkers; only Elixir runs through the substrate today |
| Parity gate | Still Python-only — full Go corpus + parametrized gate lands in Stage B per the #399 plan |

## New test

\`tests/test_extract_go_substrate.py\` — five assertions on a small inline Go fixture:

1. \`User struct\` → \`type='class'\` via the new mapping
2. \`Repository interface\` → \`type='class'\` (both go through \`type_spec → @definition.type\`)
3. \`GetUser\` → \`type='function'\` (regression pin on existing mapping)
4. \`(*User).DisplayName\` → \`type='function'\` via the \`method → function\` locked-at-#367 mapping
5. **Exactly four records emitted** — sentinel that pins the upstream tags.scm captures we depend on. If \`tree-sitter-go\` adds a new \`@definition.*\` kind, this test fails loudly, prompting a \`_KIND_TO_TYPE\` audit before merge.

Inline fixture is intentional — the real OSS Go corpus (Kubernetes, Hugo per #399 body) lands at Stage B. Stage A only needs to demonstrate the mapping fix.

## Audit performed (load-bearing context)

Read every grammar package's \`queries/tags.scm\` (Python, JS, TS, Java, Go, Rust, Elixir) and cross-referenced \`@definition.<kind>\` against walker \`type\` values emitted in \`symbol_extractor.py\`:

| Grammar | Tags kinds emitted | Walker types emitted | Coverage |
|---|---|---|---|
| Python | class, function, constant | class, function | ✓ (constant filtered, walker skips) |
| JS/TS | class, method, function, module, interface | class, function | ✓ |
| Java | class, method, interface | class, function | ✓ |
| **Go** | function, method, **type** | class, function | **✗ → fixed by this PR** |
| Rust | class, method, function, interface, module, macro | class, function | ✓ (macro intentionally unmapped — substrate-only allowed) |
| Elixir | module, function | (none — substrate-only language) | ✓ |

The audit log is captured in the new docstring above \`_KIND_TO_TYPE\`.

## Verification

\`\`\`
$ python3 -m pytest tests/test_extract_go_substrate.py \\
                   tests/test_tags_extractor_parity.py \\
                   tests/test_extract_elixir.py \\
                   tests/test_extract_call_sites.py \\
                   tests/test_phase1_code_locator.py
30 passed, 1 skipped

$ ruff format + ruff check + mypy → clean
\`\`\`

## Test plan

- [ ] CI green on Linux + Windows matrix (no new platform-specific surfaces; \`tree-sitter-go\` was already on the dep list)
- [ ] No regression on existing Python parity gate

## Next steps in the #399 chain

- **Stage B** — source ~20 Go files from Kubernetes/Hugo + ~20 Rust files from ripgrep/cargo; extend \`test_tags_extractor_parity.py\` to parametrize over languages; verify walker ⊆ substrate on real OSS code. ~1 day.
- **Stage C** — shadow-mode infrastructure (dual-path dispatch in \`_extract_definitions\` + divergence telemetry). ~1.5 days.
- **Stages D + E** — observation window + per-language walker retirement. External calendar time (~2-4 weeks per language).

🤖 Generated with [Claude Code](https://claude.com/claude-code)