### PR TITLE
test(code-locator): #399 Stage B — Go parity gate via clone-on-demand corpus

### DIFF
--- a/tests/_oss_corpus.py
+++ b/tests/_oss_corpus.py
@@ -1,0 +1,200 @@
+"""Clone-on-demand helper for OSS corpus parity tests (#399 Stage B).
+
+Used by ``tests/test_tags_extractor_parity.py`` to materialize a small,
+reproducible slice of real OSS Go/Rust code on first use, against which
+the walker ⊆ substrate parity contract can be measured.
+
+Why clone-on-demand (vs. vendoring or env-controlled pre-clone):
+
+- The #399 issue body explicitly recommends it ("avoid vendoring license
+  headers; vendor only when the parity gate needs a stable hash for
+  caching" — Stage B doesn't need a stable hash).
+- Matches the #367 Phoenix smoke-test pattern (one-off
+  ``git clone --depth 1 phoenixframework/phoenix``) — Stage B promotes
+  the same shape into the CI gate.
+- No new env-var contract, no workflow yaml changes. Stage B PR diff
+  stays focused on test code.
+
+Failure model — **fail loud, never silently skip**:
+
+- A gate that vanishes when GitHub blips is worse than one that fails
+  honestly. Per Jin's standing principle (memory: feedback_engineering_style),
+  fail-loud beats silent-fallback. If git or the network is unavailable,
+  ``pytest.fail`` with a clear message; CI re-runs are one click.
+- Pinned tags only (no branches, no HEAD) so the corpus is reproducible
+  run-to-run.
+
+Bandwidth budget — ``--depth=1 --filter=blob:none --sparse-checkout``:
+
+- ``--depth=1``: shallow clone, history not fetched.
+- ``--filter=blob:none``: defer blob fetches; only the blobs reachable
+  from the sparse-checkout set materialize.
+- ``--sparse-checkout``: working tree only materializes the requested
+  subtree.
+
+Net effect on a corpus like ``kubernetes/kubernetes@v1.30.0`` →
+``staging/src/k8s.io/api/core/v1/``: transfer drops from ~600MB (full
+clone) to a few MB (sparse blobs only). On Hugo's ``hugolib/``: ~2MB.
+A typical session pays one-time ~10-30s per source.
+"""
+
+from __future__ import annotations
+
+import subprocess
+from dataclasses import dataclass
+from pathlib import Path
+
+import pytest
+
+
+@dataclass(frozen=True)
+class OssSource:
+    """A pinned source slice within an OSS repo.
+
+    Attributes
+    ----------
+    repo : str
+        ``owner/name`` on github.com (e.g. ``kubernetes/kubernetes``).
+    ref : str
+        A git tag for reproducibility. Branches MUST NOT be used —
+        the parity gate's corpus must be deterministic run-to-run.
+    sparse_path : str
+        Directory within the repo to materialize via sparse-checkout.
+        Relative to the repo root. Files outside this path are not
+        fetched (saves bandwidth on large monorepos like k8s).
+    """
+
+    repo: str
+    ref: str
+    sparse_path: str
+
+    def cache_dirname(self) -> str:
+        """Filesystem-safe identifier for the sparse clone directory."""
+        return f"{self.repo.replace('/', '_')}_{self.ref}"
+
+
+def sparse_clone(source: OssSource, dest: Path, *, timeout: int = 180) -> None:
+    """Clone ``source.repo`` at ``source.ref`` into ``dest``, materializing
+    only files under ``source.sparse_path``.
+
+    Performs ``git clone --depth=1 --filter=blob:none --no-checkout``
+    followed by ``git sparse-checkout init --cone`` +
+    ``set <sparse_path>`` + ``git checkout``. The two-phase clone is
+    required because ``--filter=blob:none`` is only honored when no
+    initial checkout happens (else git fetches all blobs to populate the
+    working tree).
+
+    Fails loudly via ``pytest.fail`` on:
+        - Missing ``git`` binary
+        - Network timeout (default 180s)
+        - Non-zero git exit (e.g. tag does not exist upstream)
+
+    The CalledProcessError stderr is preserved verbatim in the failure
+    message so debugging starts from the actual git output.
+    """
+    dest.mkdir(parents=True, exist_ok=True)
+    url = f"https://github.com/{source.repo}.git"
+
+    try:
+        subprocess.run(
+            [
+                "git",
+                "clone",
+                "--depth=1",
+                "--filter=blob:none",
+                "--no-checkout",
+                "--branch",
+                source.ref,
+                url,
+                str(dest),
+            ],
+            check=True,
+            timeout=timeout,
+            capture_output=True,
+        )
+        subprocess.run(
+            ["git", "-C", str(dest), "sparse-checkout", "init", "--cone"],
+            check=True,
+            timeout=30,
+            capture_output=True,
+        )
+        subprocess.run(
+            ["git", "-C", str(dest), "sparse-checkout", "set", source.sparse_path],
+            check=True,
+            timeout=30,
+            capture_output=True,
+        )
+        subprocess.run(
+            ["git", "-C", str(dest), "checkout"],
+            check=True,
+            timeout=timeout,
+            capture_output=True,
+        )
+    except FileNotFoundError as e:
+        pytest.fail(
+            f"git binary not found ({e}); the corpus parity gate requires "
+            f"a working git installation on PATH."
+        )
+    except subprocess.TimeoutExpired:
+        pytest.fail(
+            f"sparse clone of {source.repo}@{source.ref} timed out after "
+            f"{timeout}s. The parity gate requires network access to "
+            f"github.com; check connectivity and re-run."
+        )
+    except subprocess.CalledProcessError as e:
+        stderr = e.stderr.decode("utf-8", errors="replace") if e.stderr else "(no stderr)"
+        pytest.fail(
+            f"sparse clone of {source.repo}@{source.ref} failed "
+            f"(git exit {e.returncode}):\n{stderr}\n\n"
+            f"The parity gate requires network access to github.com and "
+            f"the pinned tag must exist upstream."
+        )
+
+
+def discover_files(
+    clone_dir: Path,
+    source: OssSource,
+    *,
+    extension: str,
+    exclude_globs: tuple[str, ...] = (),
+    max_files: int | None = None,
+) -> list[Path]:
+    """Walk ``clone_dir / source.sparse_path`` for files matching
+    ``*.{extension}``, skip paths matching any ``exclude_globs``, and
+    return up to ``max_files`` sorted absolute paths.
+
+    Sort-then-cap is deliberate: deterministic file selection so the
+    parity gate scope doesn't drift between runs. Adding/removing files
+    in the upstream repo *can* still shift which files fall under the
+    cap — that's expected and surfaces as a corpus update in the next
+    PR that bumps the pinned tag.
+
+    Fails loudly via ``pytest.fail`` if zero files match — that means
+    either the sparse_path is wrong or upstream emptied the directory.
+    """
+    root = clone_dir / source.sparse_path
+    if not root.exists():
+        pytest.fail(
+            f"sparse-checkout did not materialize {root}. Either "
+            f"{source.sparse_path!r} is the wrong path in {source.repo}@"
+            f"{source.ref}, or upstream renamed/removed the directory."
+        )
+
+    candidates = sorted(root.rglob(f"*.{extension}"))
+    out: list[Path] = []
+    for p in candidates:
+        rel = p.relative_to(root)
+        if any(rel.match(g) for g in exclude_globs):
+            continue
+        out.append(p)
+        if max_files is not None and len(out) >= max_files:
+            break
+
+    if not out:
+        pytest.fail(
+            f"No *.{extension} files discovered under {root} "
+            f"(after exclude_globs={exclude_globs}). The corpus has no "
+            f"signal — either the sparse_path is wrong or every file was "
+            f"excluded."
+        )
+    return out

--- a/tests/test_tags_extractor_parity.py
+++ b/tests/test_tags_extractor_parity.py
@@ -1,40 +1,45 @@
-"""Parity gate for the tags-query substrate against the Python walker (#367).
+"""Parity gate for the tags-query substrate against per-language walkers.
 
 Load-bearing risk mitigation for the Path B design recorded in #367. The
-substrate (``code_locator.indexing.tags_extractor``) is introduced here
-for Elixir, but we have no Elixir walker to compare it against. To
-validate the substrate's correctness BEFORE shipping it, this test
-shadow-runs it against the existing Python walker output on real repo
-files. The empirical pre-flight (#399 research) showed that for Python,
-walker symbols are a strict subset of tags-query output. This gate locks
-that property in.
+substrate (``code_locator.indexing.tags_extractor``) is the data-driven
+extractor that powers Elixir today and is targeted to replace bespoke
+walkers for Python/Go/Rust per the #399 shadow-mode rollout. Each
+language progression depends on this gate proving:
 
-Contract — for every Python fixture file, restricted to the walker's
-symbol vocabulary (``{"function", "class", "method"}``):
+    walker_symbols ⊆ tags_extractor_symbols    (restricted to walker vocab)
 
-    walker_symbols ⊆ tags_extractor_symbols
-
-If the substrate misses a symbol the walker captures, the gate fails and
-the PR cannot merge. This is the assertion that converts "untested first
-instance" → "validated against existing ground truth in this same PR."
+If the substrate misses any symbol the walker captures, the gate fails
+and the PR cannot merge. This is the assertion that converts "untested"
+→ "validated against existing ground truth in the same PR."
 
 The reverse direction (tags-only-extra) is NOT asserted: tags.scm
-captures module-level constants the walker explicitly skips. Allowing
-the substrate to be a superset is by design — those extras are filtered
-out by ``_KIND_TO_TYPE`` not mapping ``constant`` to a walker type.
+captures module-level constants, type aliases, and macros that walkers
+explicitly skip. Substrate-as-superset is by design — those extras are
+filtered out before downstream consumers by ``_KIND_TO_TYPE`` and the
+``walker_vocab`` restriction below.
 
-The fixture corpus is sourced from the bicameral-mcp repo itself (handler
-files, ledger files, test files — diverse Python shapes). Adding more
-fixtures sharpens the gate; removing them weakens it.
+## Coverage
 
-When this gate fails:
-  1. Read the diff between walker and substrate outputs printed in the
-     failure message.
-  2. If the walker is right and tags missed something, the substrate has
-     a bug (likely in ``_KIND_TO_TYPE`` or parent_qn computation). Fix
-     it before merging.
-  3. If the walker is wrong (rare), update the test expectations AND
-     file a separate issue documenting the walker bug.
+- **Python** (#367 / #400): in-repo fixture files exercising handler,
+  ledger, and test shapes.
+- **Go** (#399 Stage B): clone-on-demand corpus from
+  ``kubernetes/kubernetes@v1.30.0`` (``staging/src/k8s.io/api/core/v1``)
+  and ``gohugoio/hugo@v0.130.0`` (``hugolib``). Sourced live via
+  ``tests/_oss_corpus.py``'s sparse-clone helper — see that module's
+  docstring for the "why clone-on-demand" rationale and bandwidth
+  budget.
+
+Rust is out of scope for this PR (Stage B follow-up).
+
+## When this gate fails
+
+1. Read the failure message — every walker-only (name, type) pair is
+   listed per file.
+2. If the walker is right and tags missed something, the substrate has
+   a bug. Likely culprits: missing entry in ``_KIND_TO_TYPE``, broken
+   ``parent_qn`` ancestor walk, or an upstream tags.scm gap.
+3. If the walker is wrong (rare), update test expectations AND file a
+   separate issue documenting the walker bug.
 
 NEVER skip this gate by adding ``@pytest.mark.xfail`` — the substrate
 shipping with Elixir relying on it makes correctness load-bearing.
@@ -46,6 +51,7 @@ from pathlib import Path
 
 import pytest
 import tree_sitter as ts
+import tree_sitter_go as tsgo
 import tree_sitter_python as tsp
 
 from code_locator.indexing.symbol_extractor import extract_symbols_from_content
@@ -53,13 +59,16 @@ from code_locator.indexing.tags_extractor import (
     extract_defs_via_tags,
     load_tags_query_text,
 )
+from tests._oss_corpus import OssSource, discover_files, sparse_clone
 
 REPO_ROOT = Path(__file__).resolve().parent.parent
+
+# ── Python corpus (in-repo fixtures, #367 / #400) ───────────────────
 
 # Real Python files from this repo. Pick a diverse set: handler with many
 # classes, ledger with many functions + nested helpers, test file with
 # nested fixture classes, simple module with helpers only.
-FIXTURE_FILES = [
+PY_FIXTURE_FILES = [
     "handlers/preflight.py",
     "handlers/remove_source.py",
     "ledger/queries.py",
@@ -68,10 +77,50 @@ FIXTURE_FILES = [
     "code_locator/indexing/symbol_extractor.py",  # large file with all walkers
 ]
 
-# Walker emits these type values for Python. Filter the substrate's
-# output to the same set before comparison — substrate captures extra
-# module-level constants the walker skips, which is by design (#367 spec).
-WALKER_VOCAB = {"function", "class", "method"}
+# Python walker emits these type values. Filter substrate output to this
+# vocabulary before comparison — substrate also captures module-level
+# constants the walker skips, which is by design (#367 spec).
+PY_WALKER_VOCAB = {"function", "class", "method"}
+
+# ── Go corpus (clone-on-demand, #399 Stage B) ───────────────────────
+
+# kubernetes/kubernetes — large idiomatic Go corpus; covers structs,
+# interfaces, methods on pointer receivers, embedded types. Sparse
+# path: the canonical core API types live at
+# staging/src/k8s.io/api/core/v1 (the path the #399 issue body referred
+# to as "pkg/api/v1" in modern k8s is a thin wrapper over this; the
+# actual types live in staging/).
+GO_SOURCE_K8S = OssSource(
+    repo="kubernetes/kubernetes",
+    ref="v1.30.0",
+    sparse_path="staging/src/k8s.io/api/core/v1",
+)
+
+# gohugoio/hugo — smaller idiomatic codebase; covers single-file
+# packages, type aliases, function types.
+GO_SOURCE_HUGO = OssSource(
+    repo="gohugoio/hugo",
+    ref="v0.130.0",
+    sparse_path="hugolib",
+)
+
+# Max files per source (the #399 plan targets ~20 from k8s + ~5 from
+# hugo). Sort-then-cap = deterministic file selection across runs.
+GO_MAX_FILES_K8S = 20
+GO_MAX_FILES_HUGO = 5
+
+# Test files have unrepresentative shapes (table-driven test funcs etc.)
+# and add noise without adding coverage. Exclude them.
+GO_EXCLUDE_GLOBS = ("*_test.go",)
+
+# Go walker (symbol_extractor._extract_go_defs) emits "function" for
+# both top-level funcs and methods, and "class" for struct/interface
+# type_specs. It does NOT emit a "method" vocabulary value (methods
+# fold into "function" — see locked #367 mapping decision).
+GO_WALKER_VOCAB = {"function", "class"}
+
+
+# ── Tree-sitter language/parser fixtures ────────────────────────────
 
 
 @pytest.fixture(scope="module")
@@ -95,35 +144,91 @@ def py_tags_query_text() -> str:
     return text
 
 
-@pytest.mark.parametrize("rel_path", FIXTURE_FILES)
+@pytest.fixture(scope="module")
+def go_language() -> ts.Language:
+    return ts.Language(tsgo.language())
+
+
+@pytest.fixture(scope="module")
+def go_parser(go_language: ts.Language) -> ts.Parser:
+    return ts.Parser(go_language)
+
+
+@pytest.fixture(scope="module")
+def go_tags_query_text() -> str:
+    text = load_tags_query_text("tree_sitter_go")
+    if text is None:
+        pytest.skip(
+            "tree_sitter_go is not installed or doesn't ship queries/tags.scm; "
+            "the parity gate cannot run on this environment."
+        )
+    return text
+
+
+# ── Go corpus fixture (session-scoped: one clone per pytest run) ────
+
+
+@pytest.fixture(scope="session")
+def go_corpus_files(tmp_path_factory: pytest.TempPathFactory) -> list[Path]:
+    """Materialize the Go corpus once per session via sparse clones.
+
+    Two sparse clones (k8s + hugo) into ``tmp_path_factory.mktemp(...)``.
+    Returns the discovered ``.go`` file list (test files excluded, capped
+    per source). The clones live for the duration of the pytest session
+    and are auto-cleaned by pytest's tmp_path machinery.
+
+    On clone failure (network, missing tag, no git) the underlying
+    helper calls ``pytest.fail`` — never silent-skip. See
+    ``tests/_oss_corpus.py`` for the failure-loud rationale.
+    """
+    cache_root = tmp_path_factory.mktemp("oss_corpus_go")
+    files: list[Path] = []
+
+    for source, max_files in (
+        (GO_SOURCE_K8S, GO_MAX_FILES_K8S),
+        (GO_SOURCE_HUGO, GO_MAX_FILES_HUGO),
+    ):
+        clone_dir = cache_root / source.cache_dirname()
+        sparse_clone(source, clone_dir)
+        files.extend(
+            discover_files(
+                clone_dir,
+                source,
+                extension="go",
+                exclude_globs=GO_EXCLUDE_GLOBS,
+                max_files=max_files,
+            )
+        )
+
+    return files
+
+
+# ── Parity tests ────────────────────────────────────────────────────
+
+
+@pytest.mark.parametrize("rel_path", PY_FIXTURE_FILES)
 def test_python_walker_subset_of_tags_extractor(
     rel_path: str,
     py_language: ts.Language,
     py_parser: ts.Parser,
     py_tags_query_text: str,
 ) -> None:
-    """Walker symbols (name, type) ⊆ substrate symbols (name, type) on real
-    Python files, after filtering substrate output to walker vocabulary.
-
-    If this fails, the substrate has a bug — most likely a missing case in
-    ``_KIND_TO_TYPE`` or a parent_qn computation error. Do NOT merge.
-    """
+    """Per-file Python parity check. Iterates one file at a time so
+    failures point at the exact fixture that regressed."""
     src = REPO_ROOT / rel_path
     if not src.exists():
         pytest.skip(f"fixture {rel_path} not present in this checkout")
     content = src.read_text(encoding="utf-8")
     code_bytes = content.encode("utf-8")
 
-    # Walker output — what we ship today.
     walker_records = extract_symbols_from_content(content, "python", rel_path)
-    walker_set = {(r.name, r.type) for r in walker_records if r.type in WALKER_VOCAB}
+    walker_set = {(r.name, r.type) for r in walker_records if r.type in PY_WALKER_VOCAB}
 
-    # Substrate output, filtered to walker vocabulary.
     tree = py_parser.parse(code_bytes)
     substrate_records = extract_defs_via_tags(
         py_language, tree, code_bytes, rel_path, py_tags_query_text
     )
-    substrate_set = {(r.name, r.type) for r in substrate_records if r.type in WALKER_VOCAB}
+    substrate_set = {(r.name, r.type) for r in substrate_records if r.type in PY_WALKER_VOCAB}
 
     missing = walker_set - substrate_set
     assert not missing, (
@@ -133,21 +238,97 @@ def test_python_walker_subset_of_tags_extractor(
         + "\n".join(f"  - {n} (type={t})" for n, t in sorted(missing))
         + f"\n\nWalker total: {len(walker_set)}, Substrate total (filtered): "
         f"{len(substrate_set)}.\n\n"
-        "This means either (a) the substrate has a bug in capture "
-        "interpretation, (b) _KIND_TO_TYPE is missing a kind, or (c) the "
-        "walker is emitting symbols a tags.scm pattern doesn't cover. "
-        "Fix the substrate before merging — Elixir relies on this code path."
+        "Most likely (a) substrate bug in capture interpretation, (b) "
+        "_KIND_TO_TYPE missing a kind, or (c) walker emits symbols a "
+        "tags.scm pattern doesn't cover. Fix the substrate before "
+        "merging — Elixir relies on this code path."
     )
 
 
-def test_parity_gate_runs_on_at_least_three_fixtures() -> None:
+def test_parity_gate_runs_on_at_least_three_python_fixtures() -> None:
     """Sanity: if all fixtures get skipped (e.g. repo restructure), the
-    gate silently provides zero coverage. Fail loudly when too few real
-    fixtures are reachable."""
-    present = sum(1 for p in FIXTURE_FILES if (REPO_ROOT / p).exists())
+    gate silently provides zero Python coverage. Fail loudly when too
+    few real fixtures are reachable."""
+    present = sum(1 for p in PY_FIXTURE_FILES if (REPO_ROOT / p).exists())
     assert present >= 3, (
-        f"Only {present}/{len(FIXTURE_FILES)} fixture files present — the "
-        f"parity gate's coverage is too thin to defend the substrate. "
-        f"Either restore the missing files or update FIXTURE_FILES with "
-        f"new diverse Python samples."
+        f"Only {present}/{len(PY_FIXTURE_FILES)} Python fixture files "
+        f"present — the parity gate's coverage is too thin to defend the "
+        f"substrate. Either restore the missing files or update "
+        f"PY_FIXTURE_FILES with new diverse Python samples."
     )
+
+
+def test_go_walker_subset_of_substrate(
+    go_corpus_files: list[Path],
+    go_language: ts.Language,
+    go_parser: ts.Parser,
+    go_tags_query_text: str,
+) -> None:
+    """Go parity check — aggregates failures across the full Go corpus
+    so one clone runs once per session, but per-file violations are
+    still surfaced individually in the failure message.
+
+    Restricted to ``GO_WALKER_VOCAB`` (``{"function", "class"}``)
+    because the Go walker doesn't emit a ``method`` value (methods
+    fold into ``function`` per the locked #367 vocabulary mapping).
+
+    See module docstring for the "what to do if this fails" runbook.
+    """
+    assert go_corpus_files, (
+        "Go corpus fixture produced zero files; investigate _oss_corpus.discover_files"
+    )
+
+    violations: list[tuple[Path, set[tuple[str, str]], int, int]] = []
+    total_walker = 0
+    total_substrate = 0
+
+    for fp in go_corpus_files:
+        content = fp.read_text(encoding="utf-8")
+        code_bytes = content.encode("utf-8")
+        rel = str(fp)
+
+        walker_records = extract_symbols_from_content(content, "go", rel)
+        walker_set = {(r.name, r.type) for r in walker_records if r.type in GO_WALKER_VOCAB}
+
+        tree = go_parser.parse(code_bytes)
+        substrate_records = extract_defs_via_tags(
+            go_language, tree, code_bytes, rel, go_tags_query_text
+        )
+        substrate_set = {(r.name, r.type) for r in substrate_records if r.type in GO_WALKER_VOCAB}
+
+        total_walker += len(walker_set)
+        total_substrate += len(substrate_set)
+
+        missing = walker_set - substrate_set
+        if missing:
+            violations.append((fp, missing, len(walker_set), len(substrate_set)))
+
+    if violations:
+        # Format every violation in the same failure message — debugging
+        # starts from a single read of one assertion error, not from
+        # re-running with --tb=long across N parametrized cases.
+        blocks = []
+        for fp, missing, w_total, s_total in violations:
+            try:
+                pretty = fp.relative_to(fp.parents[3])  # strip up to clone root
+            except (ValueError, IndexError):
+                pretty = fp
+            blocks.append(
+                f"FILE: {pretty}\n"
+                f"  walker total: {w_total}, substrate total (filtered): {s_total}\n"
+                f"  walker-only symbols (substrate gap):\n"
+                + "\n".join(f"    - {n} (type={t})" for n, t in sorted(missing))
+            )
+        pytest.fail(
+            f"Go parity gate FAIL — {len(violations)}/{len(go_corpus_files)} "
+            f"corpus file(s) had walker-only symbols the substrate missed.\n\n"
+            + "\n\n".join(blocks)
+            + "\n\nAggregate: walker emitted "
+            f"{total_walker} symbols, substrate emitted {total_substrate} "
+            "(filtered to walker vocab).\n\n"
+            "Most likely (a) substrate bug in capture interpretation, (b) "
+            "_KIND_TO_TYPE missing a kind, or (c) walker emits symbols a "
+            "tags.scm pattern doesn't cover. Fix the substrate before "
+            "merging — Elixir relies on this code path and Stages C-E of "
+            "#399 cannot proceed without this guarantee."
+        )


### PR DESCRIPTION
## Summary

Stage B of [#399](https://github.com/BicameralAI/bicameral-mcp/issues/399) (tags-query hybrid extractor spike), Go half. Extends the parity gate from Python-only (#367 / #400) to Python + Go by clone-on-demanding a small real-OSS corpus from `kubernetes/kubernetes@v1.30.0` (`staging/src/k8s.io/api/core/v1`) and `gohugoio/hugo@v0.130.0` (`hugolib`).

Same contract as Python: `walker_symbols ⊆ substrate_symbols`, restricted to per-language walker vocabulary. If the substrate misses anything the walker catches, the gate fails and the PR cannot merge.

## Why clone-on-demand

Per the #399 issue body's explicit recommendation — "avoid vendoring license headers; vendor only when the parity gate needs a stable hash for caching" (Stage B does not need a stable hash). Matches the #367 Phoenix smoke-test pattern. Keeps this PR scoped to test code — no workflow yaml changes, no env-var contract.

**Failure model is fail-loud, never silent-skip.** A gate that vanishes when GitHub blips is worse than one that fails honestly. On clone failure (network down, missing git, missing tag) the helper calls `pytest.fail` with the actual git stderr captured verbatim. CI re-runs are one click.

## Bandwidth budget

`git clone --depth=1 --filter=blob:none --no-checkout`, then `sparse-checkout init --cone` + `set <path>` + `checkout`. Net effect on a k8s clone: full ~600MB → a few MB sparse. Measured locally:

- k8s sparse clone: **~1.0s**, 14 .go files materialized
- hugo sparse clone: **~1.9s**, 5 .go files materialized
- Go branch end-to-end: **4.6s** (parser + query + parity check)

The session-scoped fixture means one clone per pytest run, not per test.

## Coverage measured

19 real Go files, **4,146 walker symbols** (229 class + 3,917 function), walker ⊆ substrate verified for every `(name, type)` pair. k8s `generated.pb.go` alone exercises hundreds of methods on pointer receivers, embedded types, and DeepCopy implementations — the corpus is denser than the ~20-file target suggests.

## What changed

- **`tests/_oss_corpus.py` (new)** — `OssSource` dataclass + `sparse_clone` + `discover_files` helpers. Module docstring carries the why-clone-on-demand + bandwidth-budget + failure-model rationale so future maintainers don't re-litigate the design when adding Rust (Stage B follow-up) or other languages.
- **`tests/test_tags_extractor_parity.py`** — refactored to parametrize by language. Python branch preserved verbatim (still per-file parametrize, deterministic test IDs). Go branch added as a single aggregating test that iterates the session-scoped corpus and surfaces per-file violations in one rich assert message — debugging starts from a single read of one error, not from `--tb=long` across N parametrized cases.

## What didn't change

| Surface | State |
|---|---|
| `code_locator/indexing/tags_extractor.py` | Untouched — Stage A's `_KIND_TO_TYPE` map already covers Go |
| `code_locator/indexing/symbol_extractor.py` | Untouched — Stage B measures the substrate against today's walkers; walker retirement is Stages D-E |
| `.github/workflows/*` | Untouched — clone-on-demand keeps corpus delivery in-test |

## Vocab note

Go walker (`_extract_go_defs`) emits `"function"` for both top-level funcs and methods, and `"class"` for `struct_type` / `interface_type` via `type_spec`. It does NOT emit a `"method"` value — methods fold into `"function"` per the locked #367 vocabulary mapping. The gate uses `GO_WALKER_VOCAB = {"function", "class"}`.

## Out of scope (Rust follow-up)

Rust gets its own PR per the issue body's "one PR per language family" pattern (ripgrep + cargo, same shape as this one).

## Verification

```
$ python3 -m pytest tests/test_tags_extractor_parity.py \
                   tests/test_extract_go_substrate.py \
                   tests/test_phase1_code_locator.py \
                   tests/test_extract_call_sites.py
26 passed, 1 skipped in 4.12s

$ python3 -m ruff format + ruff check → clean
```

## Test plan

- [ ] CI green on Linux + Windows matrix — Windows git ships sparse-checkout natively, no extra setup
- [ ] No regression on existing Python parity tests (same 6 fixture files, same per-file parametrize)
- [ ] Go parity branch fires the real clone in CI and verifies walker ⊆ substrate across the corpus

## Next steps in the #399 chain

- **Stage B (Rust)** — separate PR. Corpus: `BurntSushi/ripgrep` + `rust-lang/cargo`. Reuses `tests/_oss_corpus.py` helpers as-is.
- **Stage C** — `_SHADOW_MODES` table + dual-path dispatch in `_extract_definitions`, divergence telemetry plumbing.
- **Stages D + E** — observation window + per-language walker retirement.

🤖 Generated with [Claude Code](https://claude.com/claude-code)