### PR TITLE
fix(diagnose,reset): unbreak in-agent recovery path (#410)

### DIFF
--- a/cli/diagnose.py
+++ b/cli/diagnose.py
@@ -202,25 +202,47 @@ def format_diagnosis(d: Diagnosis) -> str:
 def main(repo_path: str | None = None) -> int:
     """CLI entrypoint for ``bicameral-mcp diagnose``.
 
-    Connects an adapter against the resolved ledger URL, gathers the
-    Diagnosis, prints the rendered markdown to stdout, returns 0.
-    Exits 1 on adapter-connect failure (operator needs the failure
-    context in the bug report).
+    Opens a raw ``LedgerClient`` (no ``init_schema``/``migrate``) and
+    forwards to ``gather_diagnosis_raw`` — the same defensive path the
+    MCP ``bicameral_diagnose`` handler uses (#410). Going through the
+    adapter would re-run the migration step that's the very thing
+    likely to be broken when an operator runs ``diagnose``.
+
+    Exits 0 on success, 1 on raw-connect failure (operator still gets
+    the failure-class envelope to paste into the bug report).
     """
     import asyncio
+    import os
 
-    from cli._diagnose_gather import gather_diagnosis
-    from ledger.adapter import SurrealDBLedgerAdapter
+    from cli._diagnose_gather import gather_diagnosis_raw
+    from ledger.adapter import _default_db_url
+    from ledger.client import LedgerClient
+
+    ledger_url = os.environ.get("SURREAL_URL", _default_db_url())
 
     async def _run() -> Diagnosis:
-        adapter = SurrealDBLedgerAdapter()
-        await adapter.connect()
-        return await gather_diagnosis(adapter)
+        client = LedgerClient(url=ledger_url)
+        await client.connect()
+        try:
+            return await gather_diagnosis_raw(client, ledger_url)
+        finally:
+            try:
+                await client.close()
+            except Exception:  # noqa: BLE001 — close is best-effort
+                pass
 
     try:
         diagnosis = asyncio.run(_run())
     except Exception as exc:  # noqa: BLE001 — operator needs failure context
-        sys.stdout.write(f"# bicameral-mcp diagnose — adapter connect failed\n\n```\n{exc}\n```\n")
+        sys.stdout.write(
+            "# bicameral-mcp diagnose — raw client connect failed\n\n"
+            f"- ledger URL: `{ledger_url}`\n\n"
+            f"```\n{type(exc).__name__}: {exc}\n```\n\n"
+            "Recovery: the DB file may be missing, locked, or unreadable. "
+            "Run `bicameral-mcp reset --confirm` to reinitialise, or "
+            "`bicameral-mcp reset --confirm --replay-from-events` to rebuild "
+            "from `.bicameral/events/` after wipe.\n"
+        )
         return 1
 
     sys.stdout.write(format_diagnosis(diagnosis))

--- a/cli/reset_cli.py
+++ b/cli/reset_cli.py
@@ -1,0 +1,141 @@
+"""reset CLI subcommand — non-interactive ledger reset (#410).
+
+Thin wrapper over ``handlers.reset.handle_reset`` for the case where the
+agent (or operator) needs a non-interactive escape hatch:
+
+* the MCP ``bicameral_reset`` tool isn't reachable in the running
+  session (tool-surface pinning bug — see project memory note
+  ``project_mcp_tool_schema_pinned_at_startup``), or
+* the MCP server itself can't start because ``init_schema``/``migrate``
+  is crashing on a corrupted on-disk ledger.
+
+The interactive ``setup_wizard.run_reset_wizard`` still handles the
+human-driven case (no ``--confirm`` flag).
+
+Filesystem-only fallback: when ``--confirm --wipe-mode=full`` is given
+and ``BicameralContext.from_env()``/``ledger.connect()`` raises (the
+exact scenario described in #410), we drop down to a direct
+``shutil.rmtree`` on the resolved ``.bicameral/`` directory. The whole
+point of full-wipe is that the DB is unreadable; requiring a working
+DB connection to recover from that would be circular.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import os
+import shutil
+import sys
+from pathlib import Path
+
+
+def run_noninteractive_reset(
+    *,
+    wipe_mode: str,
+    replay_from_events: bool,
+) -> int:
+    """Execute a confirmed reset and emit a JSON result to stdout.
+
+    Returns 0 on success (including the filesystem-only fallback), 1 on
+    failures the operator must act on.
+    """
+    try:
+        return asyncio.run(_run(wipe_mode=wipe_mode, replay_from_events=replay_from_events))
+    except KeyboardInterrupt:
+        sys.stderr.write("reset: aborted by user\n")
+        return 1
+
+
+async def _run(*, wipe_mode: str, replay_from_events: bool) -> int:
+    try:
+        from context import BicameralContext
+        from handlers.reset import handle_reset
+
+        ctx = BicameralContext.from_env()
+        response = await handle_reset(
+            ctx,
+            replay=True,
+            confirm=True,
+            wipe_mode=wipe_mode,
+            replay_from_events=replay_from_events,
+        )
+        sys.stdout.write(json.dumps(response.model_dump(), default=str, indent=2) + "\n")
+        return 0 if response.wiped else 1
+    except Exception as exc:  # noqa: BLE001 — recovery-path fallback by design
+        # The recovery tool itself failed to bring up a working ledger.
+        # For wipe_mode='full' this is exactly the situation the
+        # filesystem-only fallback is designed for: the DB is unreadable,
+        # so we delete .bicameral/ at the filesystem level.
+        if wipe_mode != "full":
+            sys.stderr.write(
+                f"reset: ledger connect failed ({type(exc).__name__}: {exc}).\n"
+                "       ledger-mode wipe requires a working connection.\n"
+                "       Re-run with `--wipe-mode=full` for a filesystem-only wipe.\n"
+            )
+            return 1
+        return _fallback_full_wipe(connect_error=exc)
+
+
+def _fallback_full_wipe(*, connect_error: BaseException) -> int:
+    """Filesystem-only ``.bicameral/`` wipe when the DB can't even connect.
+
+    Resolves the directory from ``SURREAL_URL`` (or the embedded default)
+    and ``shutil.rmtree``s it. Emits a JSON result mirroring the shape
+    of ``ResetResponse`` so callers can parse it the same way.
+    """
+    from ledger.adapter import _default_db_url
+
+    ledger_url = os.environ.get("SURREAL_URL", _default_db_url())
+    bicameral_dir = _bicameral_dir_for_url(ledger_url)
+
+    if not bicameral_dir:
+        sys.stderr.write(
+            f"reset: ledger URL {ledger_url!r} has no on-disk directory to wipe.\n"
+            f"       Original connect error: {type(connect_error).__name__}: {connect_error}\n"
+        )
+        return 1
+
+    try:
+        shutil.rmtree(bicameral_dir, ignore_errors=True)
+    except Exception as exc:  # noqa: BLE001 — last-resort fallback
+        sys.stderr.write(
+            f"reset: filesystem wipe of {bicameral_dir!r} failed: "
+            f"{type(exc).__name__}: {exc}\n"
+        )
+        return 1
+
+    sys.stdout.write(
+        json.dumps(
+            {
+                "wiped": True,
+                "wipe_mode": "full",
+                "ledger_url": ledger_url,
+                "bicameral_dir": bicameral_dir,
+                "fallback": "filesystem_only",
+                "connect_error": f"{type(connect_error).__name__}: {connect_error}",
+                "next_action": (
+                    f"Full wipe complete (filesystem fallback). {bicameral_dir!r} "
+                    "deleted. The next bicameral tool call will reinitialise the "
+                    "schema from scratch."
+                ),
+            },
+            indent=2,
+        )
+        + "\n"
+    )
+    return 0
+
+
+def _bicameral_dir_for_url(url: str) -> str:
+    """Return the ``.bicameral/`` path for ``surrealkv://<path>/ledger.db``.
+
+    Mirrors ``handlers.reset._resolve_bicameral_dir`` but works off a
+    bare URL string — we can't ask the (broken) adapter for it.
+    """
+    if not url.startswith("surrealkv://"):
+        return ""
+    db_path = url[len("surrealkv://") :]
+    if not db_path:
+        return ""
+    return str(Path(db_path).expanduser().parent)

--- a/cli/reset_cli.py
+++ b/cli/reset_cli.py
@@ -100,8 +100,7 @@ def _fallback_full_wipe(*, connect_error: BaseException) -> int:
         shutil.rmtree(bicameral_dir, ignore_errors=True)
     except Exception as exc:  # noqa: BLE001 — last-resort fallback
         sys.stderr.write(
-            f"reset: filesystem wipe of {bicameral_dir!r} failed: "
-            f"{type(exc).__name__}: {exc}\n"
+            f"reset: filesystem wipe of {bicameral_dir!r} failed: {type(exc).__name__}: {exc}\n"
         )
         return 1
 
@@ -128,11 +127,33 @@ def _fallback_full_wipe(*, connect_error: BaseException) -> int:
 
 
 def _bicameral_dir_for_url(url: str) -> str:
-    """Return the ``.bicameral/`` path for ``surrealkv://<path>/ledger.db``.
+    """Return the on-disk dir to filesystem-wipe in the recovery fallback.
 
-    Mirrors ``handlers.reset._resolve_bicameral_dir`` but works off a
-    bare URL string — we can't ask the (broken) adapter for it.
+    Resolution order (#410):
+        1. ``BICAMERAL_DATA_PATH`` override (tests / pre-#368 installs).
+        2. When no explicit ``SURREAL_URL`` is set, route through the
+           locator — the URL came from the locator default, so the
+           canonical state dir is the locator's project dir.
+        3. Otherwise (explicit ``SURREAL_URL``, or locator can't
+           resolve), derive from the URL via ``Path(db).parent`` — the
+           user has signalled where their ledger lives and we operate
+           on that dir.
+
+    The locator branch matters because this fallback runs when the
+    adapter can't even connect; the locator itself only needs
+    ``REPO_PATH`` + git common-dir, so it's still available.
     """
+    if dp := os.environ.get("BICAMERAL_DATA_PATH"):
+        return str(Path(dp) / ".bicameral")
+
+    if "SURREAL_URL" not in os.environ:
+        try:
+            from ledger_locator import ProjectIdResolutionError, project_dir_for
+
+            return str(project_dir_for())
+        except ProjectIdResolutionError:
+            pass
+
     if not url.startswith("surrealkv://"):
         return ""
     db_path = url[len("surrealkv://") :]

--- a/docs/META_LEDGER.md
+++ b/docs/META_LEDGER.md
@@ -2828,3 +2828,44 @@ All three findings classify as **Plan-text** per `qor/references/doctrine-audit-
 - Documentation drift: `docs/architecture/ledger-locator.md` (declared in plan frontmatter) does not yet exist; hard-blocks at `/qor-substantiate`, not at `/qor-audit`.
 
 **Required next action**: Governor proceeds to `/qor-implement` against R4-bis PASS.
+
+---
+
+### Entry #53: GATE TRIBUNAL — Ledger equality key indexes for symbol.name + vocab_cache.(query_text, repo)
+
+**Timestamp**: 2026-05-19T06:20:00Z
+**Phase**: audit
+**Plan target**: `thoughts/shared/plans/2026-05-18-ledger-equality-key-indexes.md`
+**Plan hash**: `sha256:0c739952c05c68ea5b281467ba34962040a78baf93bde9d2d7e636bbfb676294`
+**Auditor**: The Judge (solo mode — codex-plugin capability shortfall logged)
+**Infrastructure**: qor/ Python package not installed in this worktree; gate artifact emission skipped, verdict stands on report content
+**Verdict**: **VETO**
+**Risk grade**: L1
+**Audit report**: `.agent/staging/AUDIT_REPORT.md`
+**Audit report hash**: `sha256:0574c1959663140cf16955362070d18ac637df88e201a2ac2cf540a9694ec05c`
+
+**Findings summary**:
+- V1 (test-failure): `test_v25_migration_defines_both_lookup_indexes` description hedges the observation mechanism (`INFO FOR TABLE` returns empty in embedded mode per `pilot/mcp/CLAUDE.md`; "or the SurrealDB v2 equivalent path" is unspecified). Per `qor/references/doctrine-test-functionality.md` and SG-035, the test must commit to a verification mechanism that fails when `_migrate_v24_to_v25` is silently broken.
+
+All other passes (Security L3, OWASP Top 10, Ghost UI, Razor, Dependency, Macro-Level Architecture, Infrastructure Alignment, Orphan Detection) returned no findings. The veto is narrow — one test description.
+
+**Required next action**: Governor amends the plan's Phase 1 Unit Tests section to either (a) commit to `EXPLAIN`-based query-plan inspection asserting the new lookup index is referenced, or (b) replace the index-existence test with a perf-budget assertion that fails loudly when the index is absent. Re-run `/qor-audit` after amendment. Classifies as **Plan-text** per `qor/references/doctrine-audit-report-language.md` — no `/qor-debug` invocation.
+
+---
+
+### Entry #53-R2: GATE TRIBUNAL — Ledger equality key indexes (re-audit after V1 remediation)
+
+**Timestamp**: 2026-05-19T06:30:00Z
+**Phase**: audit (R2)
+**Plan target**: `thoughts/shared/plans/2026-05-18-ledger-equality-key-indexes.md`
+**Plan hash**: `sha256:c615a74e4e6bfce81593ea830d7685b5a6926d0af4d5031b8ba3d1cdab912449` (was `sha256:0c739952...`)
+**Auditor**: The Judge (solo mode)
+**Verdict**: **PASS**
+**Risk grade**: L1
+**Cleared findings**: V1 (test mechanism committed to SurrealDB 2.x trailing `EXPLAIN` modifier; empirically validated against `memory://` adapter — pre-migration plans to `Iterate Table`, post-migration plans to `Iterate Index` with the new index name in `detail.index`)
+**Audit report**: `.agent/staging/AUDIT_REPORT.md`
+**Audit report hash**: `sha256:231aaf3d36899fbc7c790f70de5d6f8a100eb79b58ec4a8aac5072ffade8f182`
+
+**Mechanism verification recorded** (R2-specific): the Judge ran `SELECT * FROM symbol WHERE name = 'x' EXPLAIN` and `SELECT * FROM symbol WHERE file_path = 'x' EXPLAIN` against a live `memory://` SurrealDB on the audit branch. The first returned `Iterate Table` (today's bug); the second returned `Iterate Index` with `detail.index = "idx_sym_file"`. The mechanism is deterministic, embedded-mode-compatible, and the amended tests will fail loudly if `_migrate_v24_to_v25` is silently broken.
+
+**Required next action**: Governor proceeds to `/qor-implement` against R2 PASS.

--- a/docs/SHADOW_GENOME.md
+++ b/docs/SHADOW_GENOME.md
@@ -626,3 +626,46 @@ The cumulative catalog now reads (1-9):
 - F-B2-1: regex switched to `re.MULTILINE | re.DOTALL` flags + non-greedy span pattern; meta-test `test_anti_test_catches_fabricated_multiline_select` added.
 - F-B2-2: signature reconciled — `def _resolve_span_text(archive, row) -> str` (sync, no client param) across all sections.
 - F-B2-3: filter at `queries.py:~204` extended to exclude `[ERASED]` from `real_spans`; `_ERASED_SENTINEL` constant hoisted; test `test_post_erasure_spans_excluded_from_real_spans_filter` added.
+
+---
+
+## Entry #54: VETO — equality key indexes plan, test mechanism unanchored
+
+**Timestamp**: 2026-05-19T06:20:00Z
+**Phase**: audit
+**Plan target**: `thoughts/shared/plans/2026-05-18-ledger-equality-key-indexes.md`
+**Verdict**: VETO (narrow, one test description)
+**SG pattern**: SG-035 ("doctrine-content test unanchored")
+
+### Failure mode
+
+The plan's `test_v25_migration_defines_both_lookup_indexes` proposes to verify post-migration index existence by querying `INFO FOR TABLE symbol` / `INFO FOR TABLE vocab_cache`. The plan itself notes that `INFO FOR TABLE returns empty in embedded mode` (per `pilot/mcp/CLAUDE.md` § "Known v2 quirks") and hedges with "or the SurrealDB v2 equivalent path used in `tests/test_phase2_ledger.py`" — but the equivalent path is not enumerated in either the plan or `tests/test_phase2_ledger.py` (which has no index-introspection precedent).
+
+### Why this matters as a recurrent pattern
+
+Schema/migration tests are particularly vulnerable to presence-only weakness because the natural language of migration verification ("did the index get defined?") aliases to artifact-presence checks. When the introspection API is itself disabled in the test substrate (as `INFO FOR TABLE` is in `memory://`), the plan author defaults to "we'll figure out the mechanism at implementation" — a hedge that survives plan review precisely because it sounds plausible.
+
+The Judge's `Test Functionality Pass` (doctrine §test-functionality) is the catch. Doctrine question: *"if the unit's behavior were silently broken but the artifact still existed, would this test fail?"* Index-existence-by-INFO-FOR-TABLE in embedded mode has no observable artifact, so the test would also be silent if the migration silently failed. Three-way silence: broken migration + empty INFO + ambiguous test = green CI.
+
+### Catalog addition — heuristic #10
+
+10. **Introspection-mechanism commitment**: when a plan asserts on schema state (index presence, table definition, constraint enforcement) AND the test substrate is `memory://` or another in-memory backend with limited introspection, the plan MUST name the exact query/API that produces the observation. Hedged "or equivalent" language is rejected. Audit re-runs scan for "INFO FOR TABLE", "DESCRIBE", "PRAGMA" tokens in test descriptions and verify the cited introspection actually returns non-empty in the backend the test uses.
+
+The cumulative catalog now reads (1-10):
+
+1. Existence check
+2. Signature check
+3. Type-boundary check
+4. Helper-symmetry check
+5. Upstream-consumer check
+6. Wrapper-side-effect check
+7. Codebase-wide-grep check
+8. Cross-section signature consistency check
+9. Sentinel-value downstream-consumer audit
+10. Introspection-mechanism commitment
+
+### Remediation prescribed
+
+Replace the index-existence test with one of:
+- `EXPLAIN`-based query-plan inspection: issue `EXPLAIN UPSERT symbol ... WHERE name = $name` against a fresh `memory://` adapter post-migrate, parse the returned plan, assert the new lookup index is referenced. Loud failure when the index is missing.
+- Perf-budget assertion: seed N=5000 symbol rows; assert `upsert_symbol` returns under a fixed budget. Without the index the UPSERT runs O(n) and crosses the budget; with the index it stays O(log n).

--- a/handlers/diagnose.py
+++ b/handlers/diagnose.py
@@ -132,19 +132,28 @@ def _classify_recovery(diagnosis) -> tuple[RecoveryPath, str]:
     if row_warnings:
         path: RecoveryPath = "reset_rebuild" if has_events else "reset_destructive"
         tables = ", ".join(sorted({w.split(":", 1)[0] for w in row_warnings}))
+        replay_flag = " --replay-from-events" if has_events else ""
         return path, (
             f"Row-level deserialization warnings on {tables} — likely a "
-            "SurrealDB embedded-SDK record-format mismatch. Run "
+            "SurrealDB embedded-SDK record-format mismatch. Recover via shell "
+            "(reachable even when the MCP `bicameral_reset` tool is gated, "
+            "#410):\n"
+            f"  `bicameral-mcp reset --confirm --wipe-mode=ledger{replay_flag}`\n"
+            "MCP equivalent: "
             f"`bicameral_reset(wipe_mode='ledger', replay_from_events={has_events}, "
-            "confirm=True)` to wipe and replay from .bicameral/events/."
+            "confirm=True)`."
         )
 
     if rec is not None and rec > exp:
         path = "reset_rebuild" if has_events else "reset_destructive"
+        replay_flag = " --replay-from-events" if has_events else ""
         return path, (
             f"Ledger schema v{rec} is newer than this binary (v{exp}). "
             f"Upgrade `bicameral-mcp` to a version that understands v{rec}, "
-            f"or run `bicameral_reset(replay_from_events={has_events}, confirm=True)`."
+            f"or recover via shell:\n"
+            f"  `bicameral-mcp reset --confirm --wipe-mode=ledger{replay_flag}`\n"
+            f"MCP equivalent: "
+            f"`bicameral_reset(replay_from_events={has_events}, confirm=True)`."
         )
 
     if rec is not None and rec < exp:

--- a/handlers/reset.py
+++ b/handlers/reset.py
@@ -103,9 +103,9 @@ async def handle_reset(
     ]
 
     ledger_url = _resolve_ledger_url(ctx, ledger)
-    bicameral_dir = _resolve_bicameral_dir(ledger) if wipe_mode == "full" else ""
+    bicameral_dir = _resolve_bicameral_dir(ledger, ctx.repo_path) if wipe_mode == "full" else ""
 
-    events_on_disk = _count_events_on_disk(ledger) if replay_from_events else 0
+    events_on_disk = _count_events_on_disk(ctx.repo_path) if replay_from_events else 0
 
     if not confirm:
         if wipe_mode == "full":
@@ -158,7 +158,7 @@ async def handle_reset(
 
     try:
         if wipe_mode == "full":
-            bicameral_dir = await _wipe_bicameral_dir(ledger)
+            bicameral_dir = await _wipe_bicameral_dir(ledger, ctx.repo_path)
         else:
             await _wipe_ledger(ledger, ctx.repo_path)
     except Exception as exc:
@@ -190,7 +190,7 @@ async def handle_reset(
     replay_errors: list[str] = []
     if replay_from_events and wipe_mode != "full":
         try:
-            events_replayed = await _replay_events_into_ledger(ledger)
+            events_replayed = await _replay_events_into_ledger(ctx.repo_path, ledger)
         except Exception as exc:  # noqa: BLE001 — surface failure but keep wipe done
             logger.exception("[reset] replay_from_events failed: %s", exc)
             replay_errors.append(f"replay_from_events failed: {exc}")
@@ -242,35 +242,48 @@ async def handle_reset(
 # ── Wipe implementations ─────────────────────────────────────────────
 
 
-def _resolve_events_dir(ledger) -> Path | None:
-    """Return ``.bicameral/events/`` for the resolved ledger URL, or None
-    when the ledger is in-memory or the directory does not exist.
+def _resolve_events_dir(repo_path: str | None = None) -> Path | None:
+    """Return the repo-scoped events directory, or None when no
+    on-disk substrate exists.
 
-    Honours ``BICAMERAL_DATA_PATH`` symmetrically with
-    ``adapters/ledger.py:_real_ledger_instance`` so `replay_from_events`
-    targets the same substrate the team-mode write path uses.
+    Events are the canonical SOURCE for the ledger and live in the
+    REPO (committed to git pre-#373, pushed to the configured remote
+    backend post-#373). They are NOT user-local state — that bucket
+    is the locator's domain (ledger.db, code-graph, bm25, watermark,
+    transcript queues, operator.yaml). Conflating the two was the
+    root cause of the pre-#410 silent zero-replay regression: the
+    old resolver inverted the locator-resolved ledger URL to derive
+    the events dir, which only worked while ledger and events shared
+    a parent. Once R4 moved the ledger out from under the repo, the
+    inverse silently pointed at an empty path.
+
+    Forward-resolution (mirrors the production read site in
+    ``cli/sync_and_brief_cli.py``):
+        1. ``BICAMERAL_DATA_PATH`` override → ``<data>/.bicameral/events``
+           (test escape hatch).
+        2. ``<repo_path>/.bicameral/events`` — the canonical
+           committed/synced location.
     """
     import os as _os
 
-    bicameral_dir = _resolve_bicameral_dir(ledger)
     data_path = _os.environ.get("BICAMERAL_DATA_PATH")
     if data_path:
         events_dir = Path(data_path) / ".bicameral" / "events"
-    elif bicameral_dir:
-        events_dir = Path(bicameral_dir) / "events"
+    elif repo_path:
+        events_dir = Path(repo_path) / ".bicameral" / "events"
     else:
-        return None
+        events_dir = Path.cwd() / ".bicameral" / "events"
     return events_dir if events_dir.exists() else None
 
 
-def _count_events_on_disk(ledger) -> int:
+def _count_events_on_disk(repo_path: str | None = None) -> int:
     """Tally non-empty lines across every ``<author>.jsonl`` under events/.
 
-    Best-effort: returns 0 when the directory is missing, ledger is
-    in-memory, or any file read fails. Used only to surface a count in
-    the dry-run; not load-bearing for the replay itself.
+    Best-effort: returns 0 when the directory is missing or any file
+    read fails. Used only to surface a count in the dry-run; not
+    load-bearing for the replay itself.
     """
-    events_dir = _resolve_events_dir(ledger)
+    events_dir = _resolve_events_dir(repo_path)
     if events_dir is None:
         return 0
     total = 0
@@ -285,34 +298,63 @@ def _count_events_on_disk(ledger) -> int:
     return total
 
 
-async def _replay_events_into_ledger(ledger) -> int:
+async def _replay_events_into_ledger(repo_path: str | None, ledger) -> int:
     """Reset the materializer watermark and replay every event back
     through the ingest path. Returns the count of events the
     materializer applied.
+
+    Raises ``FileNotFoundError`` when the events substrate cannot be
+    located — caller surfaces it via ``replay_errors`` so a missing
+    events dir produces a loud failure rather than a passing-looking
+    zero-replay response (this was the actual symptom of the pre-fix
+    resolver bug; #410).
 
     Uses the same ``EventMaterializer`` instance team mode uses, so
     replay-vs-live divergence is impossible by construction. Determinism
     is tracked separately under issue #296.
     """
+    import os as _os
+
     inner = getattr(ledger, "_inner", ledger)
-    events_dir = _resolve_events_dir(ledger)
+    events_dir = _resolve_events_dir(repo_path)
     if events_dir is None:
-        return 0
+        expected = (
+            Path(repo_path) / ".bicameral" / "events" if repo_path else "<repo>/.bicameral/events"
+        )
+        raise FileNotFoundError(
+            f"events dir not found at {expected!s}. The replay source is "
+            "repo-local: pre-#373 these JSONLs are committed to git, "
+            "post-#373 they are pulled from the configured remote backend "
+            "via `bicameral-mcp sync-and-brief`. Run sync-and-brief first "
+            "if you're on a fresh clone with no local cache yet."
+        )
 
-    # #368 Phase 2B-ii: watermark lives at the locator-resolved project
-    # dir. The locator's `_resolved_project_dir` mkdir's parent on first
-    # use via `assert_origin`, so no explicit mkdir needed here.
-    from ledger_locator import resolve_watermark_path
-
-    watermark_path = resolve_watermark_path()
     # Reset the watermark so every event replays from offset 0. The
     # materializer's offset map is `{author: byte_offset}`; writing an
-    # empty object is the canonical "start over" signal.
-    watermark_path.write_text("{}\n", encoding="utf-8")
+    # empty object is the canonical "start over" signal. Mirrored seams:
+    # tests using BICAMERAL_DATA_PATH route the watermark to a sibling
+    # of events under .bicameral/local/ (no git context required);
+    # production routes through the locator's project dir.
+    data_path = _os.environ.get("BICAMERAL_DATA_PATH")
+    watermark_override: Path | None = None
+    if data_path:
+        watermark_override = Path(data_path) / ".bicameral" / "local" / "watermark"
+        watermark_override.parent.mkdir(parents=True, exist_ok=True)
+        watermark_override.write_text("{}\n", encoding="utf-8")
+    else:
+        from ledger_locator import resolve_watermark_path
+
+        resolve_watermark_path(Path(repo_path) if repo_path else None).write_text(
+            "{}\n", encoding="utf-8"
+        )
 
     from events.materializer import EventMaterializer
 
-    materializer = EventMaterializer(events_dir)
+    materializer = EventMaterializer(
+        events_dir,
+        repo_path=Path(repo_path) if repo_path else None,
+        watermark_override=watermark_override,
+    )
     return await materializer.replay_new_events(inner)
 
 
@@ -337,14 +379,14 @@ async def _wipe_ledger(ledger, repo_path: str) -> None:
     await inner._ensure_connected()
 
 
-async def _wipe_bicameral_dir(ledger) -> str:
+async def _wipe_bicameral_dir(ledger, repo_path: str | None = None) -> str:
     """Delete the entire .bicameral/ directory and reinitialise the schema.
 
     Returns the path that was deleted (empty string for in-memory URLs).
     """
     import shutil
 
-    bicameral_dir = _resolve_bicameral_dir(ledger)
+    bicameral_dir = _resolve_bicameral_dir(ledger, repo_path)
 
     # Close the connection on the innermost adapter.
     inner = getattr(ledger, "_inner", ledger)
@@ -366,12 +408,33 @@ async def _wipe_bicameral_dir(ledger) -> str:
     return bicameral_dir
 
 
-def _resolve_bicameral_dir(ledger) -> str:
-    """Return the .bicameral/ directory path derived from the ledger URL.
+def _resolve_bicameral_dir(ledger, repo_path: str | None = None) -> str:
+    """Return the on-disk dir to delete in a full-wipe, or "" for in-memory.
 
-    For surrealkv://<path>/ledger.db the .bicameral/ dir is the parent of
-    the ledger.db directory. Returns empty string for in-memory URLs.
+    Resolution order (#410 / #368):
+        1. ``BICAMERAL_DATA_PATH`` override (tests / pre-#368 installs)
+           → ``<data>/.bicameral`` symmetrically with
+           ``adapters/ledger.py:_real_ledger_instance``.
+        2. When no explicit ``SURREAL_URL`` is set, the URL came from
+           the locator default → return the locator's project dir.
+        3. Otherwise derive from the adapter URL — the operator
+           pointed ``SURREAL_URL`` at a specific location and we
+           operate on that dir.
     """
+    import os as _os
+
+    if _os.environ.get("BICAMERAL_DATA_PATH"):
+        data_path = _os.environ["BICAMERAL_DATA_PATH"]
+        return str(Path(data_path) / ".bicameral")
+
+    if "SURREAL_URL" not in _os.environ:
+        try:
+            from ledger_locator import ProjectIdResolutionError, project_dir_for
+
+            return str(project_dir_for(Path(repo_path) if repo_path else None))
+        except ProjectIdResolutionError:
+            pass
+
     for obj in (ledger, getattr(ledger, "_inner", None)):
         if obj is None:
             continue

--- a/ledger/client.py
+++ b/ledger/client.py
@@ -133,10 +133,15 @@ class LedgerDeserializationError(LedgerError):
 
     RECOVERY_HINT = (
         "Row-level deserialization failed — likely a SurrealDB embedded SDK "
-        "revision mismatch on persisted rows. Run "
-        "`bicameral_reset(wipe_mode='ledger', replay_from_events=True, "
-        "confirm=True)` to wipe and replay from .bicameral/events/, or "
-        "`bicameral-mcp diagnose` for a full report."
+        "revision mismatch on persisted rows. Recover via the shell (works "
+        "even when the MCP `bicameral_reset` tool isn't reachable in this "
+        "session, #410):\n"
+        "  `bicameral-mcp reset --confirm --wipe-mode=ledger --replay-from-events`\n"
+        "or, if the DB is fully unreadable:\n"
+        "  `bicameral-mcp reset --confirm --wipe-mode=full`\n"
+        "MCP equivalent: `bicameral_reset(wipe_mode='ledger', "
+        "replay_from_events=True, confirm=True)`. "
+        "Run `bicameral-mcp diagnose` first for a full report."
     )
 
     def __init__(self, *, raw: str, sql_prefix: str) -> None:

--- a/ledger/schema.py
+++ b/ledger/schema.py
@@ -28,7 +28,7 @@ logger = logging.getLogger(__name__)
 #   - edges: yields(input_span→decision), binds_to(decision→code_region),
 #             locates(symbol→code_region)
 #   - removed: maps_to, implements
-SCHEMA_VERSION = 24
+SCHEMA_VERSION = 25
 
 # Maps schema version → minimum bicameral-mcp code version that understands it.
 # Used to produce actionable "upgrade your binary" messages.
@@ -50,6 +50,7 @@ SCHEMA_COMPATIBILITY: dict[int, str] = {
     19: "0.14.x",  # bicameral_meta.decision_revision counter + DEFINE EVENT on decision (#87 Phase 6 — constant-time replacement for ORDER BY DESC); placeholder, release-eng pins final value at PR merge
     23: "0.15.x",  # decision_level backfill for legacy rows; placeholder, release-eng pins final value at PR merge
     24: "0.15.x",  # idx_input_span_dedup extended with archive_key so distinct archive-keyed spans in the same (source_type, source_ref) bucket no longer collide; placeholder, release-eng pins final value at PR merge
+    25: "0.15.x",  # equality key indexes on symbol.name + vocab_cache.(query_text, repo) — UPSERT-WHERE lookups now use Iterate Index instead of full table scan; placeholder, release-eng pins final value at PR merge
 }
 
 # SurrealDB error substrings that init_schema treats as recoverable: the row
@@ -199,6 +200,7 @@ _TABLES = [
     "DEFINE FIELD last_seen      ON symbol TYPE datetime DEFAULT time::now()",
     "DEFINE FIELD hit_count      ON symbol TYPE int DEFAULT 0",
     "DEFINE INDEX idx_sym_name   ON symbol FIELDS name SEARCH ANALYZER code_analyzer BM25(1.2, 0.75)",
+    "DEFINE INDEX idx_sym_name_lookup ON symbol FIELDS name",
     "DEFINE INDEX idx_sym_file   ON symbol FIELDS file_path",
     # code_region — a specific span within a file. Shared between the two tiers:
     # decision tier addresses it via binds_to; retrieval tier via locates.
@@ -221,6 +223,7 @@ _TABLES = [
     "DEFINE FIELD hit_count      ON vocab_cache TYPE int DEFAULT 0",
     "DEFINE FIELD last_hit       ON vocab_cache TYPE datetime DEFAULT time::now()",
     "DEFINE INDEX idx_vocab_query ON vocab_cache FIELDS query_text SEARCH ANALYZER biz_analyzer BM25(1.2, 0.75)",
+    "DEFINE INDEX idx_vocab_query_lookup ON vocab_cache FIELDS query_text, repo",
     "DEFINE INDEX idx_vocab_repo  ON vocab_cache FIELDS repo",
     # ledger_sync — idempotency cursor (last synced commit per repo)
     "DEFINE TABLE ledger_sync SCHEMAFULL",
@@ -1498,6 +1501,37 @@ async def _migrate_v23_to_v24(client: LedgerClient) -> None:
         "DEFINE INDEX OVERWRITE idx_input_span_dedup ON input_span "
         "FIELDS source_type, source_ref, text, archive_key UNIQUE",
     )
+
+
+async def _migrate_v24_to_v25(client: LedgerClient) -> None:
+    """v24 → v25: Add equality key indexes for UPSERT-WHERE lookups on
+    ``symbol.name`` and ``vocab_cache.(query_text, repo)``.
+
+    Pre-v25 both columns were indexed only via SEARCH/BM25
+    (``idx_sym_name``, ``idx_vocab_query``), which accelerates ``@0@``
+    matches but **not** ``WHERE field = $value`` equality. The UPSERT
+    call sites in ``ledger/queries.py`` (``upsert_symbol`` line ~838,
+    vocab_cache UPSERT line ~419) fell back to full table scans —
+    O(n) per call. Replays of large event logs (>2,500 symbols) crossed
+    the 5.0s read budget near the end of ``reset --replay-from-events``
+    runs, surfacing as ``LedgerTimeoutError`` (#410 dogfood).
+
+    Both indexes are additive and non-unique — rows valid under the old
+    schema remain valid post-migration. Per ``docs/DEV_CYCLE.md`` §4.7.1
+    these are in the ✅ Allowed column (new index, only relaxes nothing,
+    discriminator-free). ``init_schema`` re-issues every DEFINE on
+    connect; this migration is the version-boundary safety belt that
+    runs the DEFINE INDEX OVERWRITE explicitly even when init_schema's
+    pass is interrupted. Idempotent via ``_execute_define_idempotent``.
+    """
+    await _execute_define_idempotent(
+        client,
+        "DEFINE INDEX OVERWRITE idx_sym_name_lookup ON symbol FIELDS name",
+    )
+    await _execute_define_idempotent(
+        client,
+        "DEFINE INDEX OVERWRITE idx_vocab_query_lookup ON vocab_cache FIELDS query_text, repo",
+    )
     logger.info("[migration] v23 → v24: idx_input_span_dedup extended with archive_key")
 
 
@@ -1586,6 +1620,7 @@ _MIGRATIONS: dict[int, ...] = {
     22: _migrate_v21_to_v22,
     23: _migrate_v22_to_v23,
     24: _migrate_v23_to_v24,
+    25: _migrate_v24_to_v25,
 }
 
 

--- a/server.py
+++ b/server.py
@@ -1447,7 +1447,30 @@ def cli_main(argv: list[str] | None = None) -> int:
 def _register_subparsers(parser: ArgumentParser, subparsers: Any) -> None:
     """Wire all subparser definitions + top-level flags onto parser."""
     subparsers.add_parser("config", help="interactive config editor")
-    subparsers.add_parser("reset", help="interactive ledger reset — wipes state with confirmation")
+    reset = subparsers.add_parser(
+        "reset",
+        help=(
+            "ledger reset — interactive wizard by default; with --confirm runs "
+            "non-interactively (the agent escape hatch when the MCP "
+            "`bicameral_reset` tool isn't reachable, #410)"
+        ),
+    )
+    reset.add_argument(
+        "--confirm",
+        action="store_true",
+        help="execute the wipe non-interactively (skips the wizard)",
+    )
+    reset.add_argument(
+        "--wipe-mode",
+        choices=("ledger", "full"),
+        default="ledger",
+        help="ledger = wipe DB rows only (default); full = delete .bicameral/ entirely",
+    )
+    reset.add_argument(
+        "--replay-from-events",
+        action="store_true",
+        help="after wipe (ledger-mode only), replay .bicameral/events/*.jsonl",
+    )
     setup = subparsers.add_parser("setup", help="interactive setup — configure MCP client")
     setup.add_argument("repo_path", nargs="?", default=None, help="repo path (auto-detected)")
     setup.add_argument(
@@ -1525,6 +1548,13 @@ def _dispatch(args: Any) -> int:
 
         return run_config_wizard()
     if args.command == "reset":
+        if getattr(args, "confirm", False):
+            from cli.reset_cli import run_noninteractive_reset
+
+            return run_noninteractive_reset(
+                wipe_mode=args.wipe_mode,
+                replay_from_events=args.replay_from_events,
+            )
         from setup_wizard import run_reset_wizard
 
         return run_reset_wizard()

--- a/tests/test_diagnose_cli.py
+++ b/tests/test_diagnose_cli.py
@@ -61,22 +61,57 @@ def test_diagnose_main_emits_all_required_sections(monkeypatch, capsys):
         assert header in out
 
 
-def test_diagnose_main_returns_one_on_adapter_connect_failure(monkeypatch, capsys):
+def test_diagnose_main_returns_one_on_raw_client_connect_failure(monkeypatch, capsys):
+    """#410: CLI diagnose now uses a raw LedgerClient (no init_schema/migrate),
+    so the failure surface is ``LedgerClient.connect``, not the adapter. The
+    error envelope must still surface a recovery path that the agent can act
+    on without an MCP session."""
     monkeypatch.setenv("SURREAL_URL", "ws://invalid-host-no-such-server:99999")
 
-    # Force a connect failure by patching the adapter to raise on connect.
-    from ledger import adapter as adapter_mod
+    from ledger import client as client_mod
 
-    class _BoomAdapter(adapter_mod.SurrealDBLedgerAdapter):
-        async def connect(self):
-            raise RuntimeError("synthetic connect failure")
+    async def _boom(self):
+        raise RuntimeError("synthetic connect failure")
 
-    monkeypatch.setattr(adapter_mod, "SurrealDBLedgerAdapter", _BoomAdapter)
+    monkeypatch.setattr(client_mod.LedgerClient, "connect", _boom)
 
     from cli.diagnose import main
 
     rc = main()
     captured = capsys.readouterr()
     assert rc == 1
-    assert "adapter connect failed" in captured.out
+    assert "raw client connect failed" in captured.out
     assert "synthetic connect failure" in captured.out
+    # Recovery hint must surface the now-callable CLI form (#410).
+    assert "bicameral-mcp reset --confirm" in captured.out
+
+
+def test_diagnose_main_cli_does_not_use_adapter_path(monkeypatch, capsys):
+    """#410 regression: the CLI must NOT route through SurrealDBLedgerAdapter
+    (which runs init_schema/migrate). If the adapter were used here, a
+    corrupted DefineTableStatement on disk would crash the bug-report tool
+    in exactly the moment it's needed.
+
+    We assert this structurally: patch the adapter's connect to blow up and
+    confirm diagnose still returns 0 against a fresh memory:// ledger.
+    """
+    monkeypatch.setenv("SURREAL_URL", "memory://")
+
+    from ledger import adapter as adapter_mod
+
+    async def _adapter_should_not_be_called(self):
+        raise AssertionError(
+            "cli.diagnose must not use SurrealDBLedgerAdapter — it should "
+            "open a raw LedgerClient that skips init_schema/migrate (#410)."
+        )
+
+    monkeypatch.setattr(
+        adapter_mod.SurrealDBLedgerAdapter, "connect", _adapter_should_not_be_called
+    )
+
+    from cli.diagnose import main
+
+    rc = main()
+    captured = capsys.readouterr()
+    assert rc == 0, captured.out
+    assert "## Versions" in captured.out

--- a/tests/test_reset_cli_410.py
+++ b/tests/test_reset_cli_410.py
@@ -1,0 +1,162 @@
+"""Non-interactive ``bicameral-mcp reset`` CLI (#410).
+
+Tests the new flag surface (``--confirm``, ``--wipe-mode``,
+``--replay-from-events``) and the filesystem-only fallback that fires
+when the ledger can't connect — the exact scenario that motivated the
+issue.
+
+Sociable: builds a real ``BicameralContext.from_env()`` against
+``memory://`` for the happy path. The fallback test uses a real
+``surrealkv://`` directory on disk so the rmtree path is exercised
+end-to-end.
+"""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+
+@pytest.fixture(autouse=True)
+def _patch_network(monkeypatch):
+    """Avoid live HTTP fetches during reset (the update-version probe)."""
+    try:
+        from handlers import update as update_mod
+
+        monkeypatch.setattr(
+            update_mod, "_fetch_recommended_version", lambda channel="stable": None
+        )
+        monkeypatch.setattr(update_mod, "fetch_recommended_version", lambda channel="stable": None)
+    except ImportError:
+        pass
+    yield
+
+
+def test_reset_cli_help_lists_noninteractive_flags():
+    """The flag set is the agent's contract — guard against silent removal."""
+    from argparse import ArgumentParser
+
+    from server import _register_subparsers
+
+    parser = ArgumentParser()
+    subparsers = parser.add_subparsers(dest="command")
+    _register_subparsers(parser, subparsers)
+    args = parser.parse_args(
+        ["reset", "--confirm", "--wipe-mode", "full", "--replay-from-events"]
+    )
+    assert args.command == "reset"
+    assert args.confirm is True
+    assert args.wipe_mode == "full"
+    assert args.replay_from_events is True
+
+
+def test_reset_cli_ledger_wipe_against_memory_ledger(monkeypatch, capsys):
+    """Happy path: --confirm --wipe-mode=ledger against memory:// succeeds
+    end-to-end and emits a parseable JSON ResetResponse."""
+    monkeypatch.setenv("SURREAL_URL", "memory://")
+    monkeypatch.setenv("REPO_PATH", str(monkeypatch.__class__.__name__))  # any string repo id
+
+    from cli.reset_cli import run_noninteractive_reset
+
+    rc = run_noninteractive_reset(wipe_mode="ledger", replay_from_events=False)
+    out = capsys.readouterr().out
+    assert rc == 0, out
+    payload = json.loads(out)
+    assert payload["wiped"] is True
+    assert payload["wipe_mode"] == "ledger"
+
+
+def test_reset_cli_full_wipe_falls_back_to_filesystem_when_connect_fails(
+    monkeypatch, capsys, tmp_path
+):
+    """#410 core: when BicameralContext.from_env() raises (e.g. corrupted DB
+    that the SDK can't deserialize), --wipe-mode=full must still recover via
+    direct ``shutil.rmtree`` of the resolved .bicameral/ dir."""
+    bicameral_dir = tmp_path / ".bicameral"
+    db_dir = bicameral_dir / "ledger.db"
+    db_dir.mkdir(parents=True)
+    (db_dir / "corrupted.kv").write_bytes(b"\x00\x01\x02")
+    (bicameral_dir / "config.yaml").write_text("# stale\n", encoding="utf-8")
+    ledger_url = f"surrealkv://{db_dir}"
+    monkeypatch.setenv("SURREAL_URL", ledger_url)
+
+    # Force the high-level path to fail — simulates the on-disk corruption
+    # without us having to write a malformed surrealkv archive.
+    import context as context_mod
+
+    def _boom_from_env(cls):
+        raise RuntimeError(
+            "SurrealDB row deserialization failed: Invalid revision `101` for "
+            "type `DefineTableStatement`"
+        )
+
+    monkeypatch.setattr(context_mod.BicameralContext, "from_env", classmethod(_boom_from_env))
+
+    from cli.reset_cli import run_noninteractive_reset
+
+    rc = run_noninteractive_reset(wipe_mode="full", replay_from_events=False)
+    out = capsys.readouterr().out
+    assert rc == 0, out
+    payload = json.loads(out)
+    assert payload["wiped"] is True
+    assert payload["fallback"] == "filesystem_only"
+    assert payload["bicameral_dir"] == str(bicameral_dir)
+    # The directory must actually be gone — recovery is observable, not advisory.
+    assert not bicameral_dir.exists()
+
+
+def test_reset_cli_ledger_mode_does_not_silently_fallback_when_connect_fails(
+    monkeypatch, capsys, tmp_path
+):
+    """Ledger-mode wipe needs a working connection (we delete by SurrealQL,
+    not rmtree). If from_env() raises, we must NOT silently rmtree —
+    that would surprise the operator. Return 1 with a clear error and
+    point them at --wipe-mode=full."""
+    bicameral_dir = tmp_path / ".bicameral"
+    (bicameral_dir / "ledger.db").mkdir(parents=True)
+    monkeypatch.setenv("SURREAL_URL", f"surrealkv://{bicameral_dir / 'ledger.db'}")
+
+    import context as context_mod
+
+    def _boom_from_env(cls):
+        raise RuntimeError("synthetic connect failure")
+
+    monkeypatch.setattr(context_mod.BicameralContext, "from_env", classmethod(_boom_from_env))
+
+    from cli.reset_cli import run_noninteractive_reset
+
+    rc = run_noninteractive_reset(wipe_mode="ledger", replay_from_events=False)
+    captured = capsys.readouterr()
+    assert rc == 1
+    assert "synthetic connect failure" in captured.err
+    assert "--wipe-mode=full" in captured.err
+    # Side-effect-free: the directory must still be on disk.
+    assert bicameral_dir.exists()
+
+
+def test_recovery_hint_in_LedgerDeserializationError_mentions_cli_form():
+    """The error message agents see must surface the shell escape hatch (#410)."""
+    from ledger.client import LedgerDeserializationError
+
+    hint = LedgerDeserializationError.RECOVERY_HINT
+    assert "bicameral-mcp reset --confirm" in hint
+    # MCP form should still be present as the alternative.
+    assert "bicameral_reset(" in hint
+
+
+def test_diagnose_classify_recovery_row_warning_surfaces_cli_form():
+    """The diagnose handler's next_action must include the CLI form when
+    row-warnings classify as reset_rebuild / reset_destructive."""
+    from handlers.diagnose import _classify_recovery
+
+    class _D:
+        schema_version_recorded = 25
+        schema_version_expected = 25
+        ledger_url = "surrealkv:///nonexistent/ledger.db"
+        row_probe_warnings = ["ledger_sync: LedgerDeserializationError: Invalid revision `0`"]
+        table_counts = {"decision": 5}
+
+    path, next_action = _classify_recovery(_D())
+    assert path in ("reset_rebuild", "reset_destructive")
+    assert "bicameral-mcp reset --confirm" in next_action

--- a/tests/test_reset_cli_410.py
+++ b/tests/test_reset_cli_410.py
@@ -24,9 +24,7 @@ def _patch_network(monkeypatch):
     try:
         from handlers import update as update_mod
 
-        monkeypatch.setattr(
-            update_mod, "_fetch_recommended_version", lambda channel="stable": None
-        )
+        monkeypatch.setattr(update_mod, "_fetch_recommended_version", lambda channel="stable": None)
         monkeypatch.setattr(update_mod, "fetch_recommended_version", lambda channel="stable": None)
     except ImportError:
         pass
@@ -42,9 +40,7 @@ def test_reset_cli_help_lists_noninteractive_flags():
     parser = ArgumentParser()
     subparsers = parser.add_subparsers(dest="command")
     _register_subparsers(parser, subparsers)
-    args = parser.parse_args(
-        ["reset", "--confirm", "--wipe-mode", "full", "--replay-from-events"]
-    )
+    args = parser.parse_args(["reset", "--confirm", "--wipe-mode", "full", "--replay-from-events"])
     assert args.command == "reset"
     assert args.confirm is True
     assert args.wipe_mode == "full"
@@ -133,6 +129,102 @@ def test_reset_cli_ledger_mode_does_not_silently_fallback_when_connect_fails(
     assert "--wipe-mode=full" in captured.err
     # Side-effect-free: the directory must still be on disk.
     assert bicameral_dir.exists()
+
+
+def test_resolve_events_dir_under_legacy_local_layout_finds_sibling_events(monkeypatch, tmp_path):
+    """Regression for the silent-zero-replay bug (#410 follow-up):
+
+    Pre-fix, ``_resolve_events_dir`` derived its target via
+    ``Path(ledger.db).parent / events``. Under the layout where the
+    ledger sits at ``<bicameral_dir>/local/ledger.db`` (BICAMERAL_DATA_PATH
+    test harness, and pre-#368 production), that lands at
+    ``<bicameral_dir>/local/events/`` — one directory too deep — and
+    silently returns ``None`` while real events sit at the sibling
+    ``<bicameral_dir>/events/``. Replay then short-circuits to 0 with
+    no error surfaced.
+
+    Post-fix the resolver routes forward (env override → repo-local
+    path) and finds the canonical events dir regardless of where the
+    user-local ledger file lives.
+    """
+    monkeypatch.setenv("BICAMERAL_DATA_PATH", str(tmp_path))
+
+    events_dir = tmp_path / ".bicameral" / "events"
+    events_dir.mkdir(parents=True)
+    (events_dir / "test@example.com.jsonl").write_text(
+        '{"event_type":"ingest.completed"}\n', encoding="utf-8"
+    )
+
+    from handlers.reset import _count_events_on_disk, _resolve_events_dir
+
+    resolved = _resolve_events_dir(repo_path=None)
+    assert resolved == events_dir, (
+        f"resolver landed at {resolved!r}, expected sibling-of-local events dir "
+        f"{events_dir!r} — the silent-zero-replay regression has returned."
+    )
+    assert _count_events_on_disk(repo_path=None) == 1
+
+
+def test_resolve_events_dir_uses_repo_path_not_locator_project_dir(monkeypatch, tmp_path):
+    """Events are repo-local (committed to git pre-#373, gdrive post-#373),
+    NOT user-local state. The locator owns user-local paths only
+    (ledger.db, code-graph, bm25, watermark, transcript queues,
+    operator.yaml). Routing events through ``project_dir_for() / events``
+    would silently break on fresh clones — events would resolve to an
+    empty user-local cache instead of the in-repo source. Guard the
+    boundary with a direct assertion.
+    """
+    monkeypatch.delenv("BICAMERAL_DATA_PATH", raising=False)
+
+    repo = tmp_path / "fake-repo"
+    events_dir = repo / ".bicameral" / "events"
+    events_dir.mkdir(parents=True)
+    (events_dir / "test@example.com.jsonl").write_text(
+        '{"event_type":"ingest.completed"}\n', encoding="utf-8"
+    )
+
+    from handlers.reset import _resolve_events_dir
+
+    resolved = _resolve_events_dir(repo_path=str(repo))
+    assert resolved == events_dir, (
+        f"events dir must be repo-relative (resolved={resolved!r}, "
+        f"expected={events_dir!r}). If this routes through the locator's "
+        f"project_dir_for(), the resolver has confused user-local state "
+        f"with the repo-local event substrate — see #373."
+    )
+
+
+def test_reset_cli_replay_surfaces_missing_events_dir_as_replay_error(
+    monkeypatch, capsys, tmp_path
+):
+    """Regression for the silent-zero-replay bug (#410 follow-up):
+
+    When the events substrate can't be located, the response must NOT
+    look successful with ``events_replayed: 0``. The handler must
+    raise from ``_replay_events_into_ledger`` and the wrapper must
+    surface the failure via ``replay_errors`` so an agent (or
+    operator) sees that recovery is incomplete.
+    """
+    monkeypatch.setenv("BICAMERAL_DATA_PATH", str(tmp_path))
+    monkeypatch.setenv("SURREAL_URL", "memory://")
+    # Deliberately do NOT create tmp_path/.bicameral/events/ — that's
+    # the failure mode under test.
+
+    from cli.reset_cli import run_noninteractive_reset
+
+    rc = run_noninteractive_reset(wipe_mode="ledger", replay_from_events=True)
+    out = capsys.readouterr().out
+    assert rc == 0, out  # wipe still succeeds; only replay fails
+    payload = json.loads(out)
+    assert payload["wiped"] is True
+    assert payload["events_replayed"] == 0
+    assert payload["replay_errors"], (
+        "missing events dir must surface in replay_errors — silent "
+        "zero-replay is the bug we're guarding against"
+    )
+    assert any("events dir not found" in err for err in payload["replay_errors"]), (
+        f"replay_errors did not name the missing-events-dir failure: {payload['replay_errors']!r}"
+    )
 
 
 def test_recovery_hint_in_LedgerDeserializationError_mentions_cli_form():

--- a/tests/test_schema_index_lookup_perf.py
+++ b/tests/test_schema_index_lookup_perf.py
@@ -1,0 +1,170 @@
+"""Equality-key indexes on symbol.name + vocab_cache.(query_text, repo).
+
+Today's bug: both fields are indexed only via SEARCH/BM25, which accelerates
+`@0@` semantic match but NOT `WHERE field = $value` equality. The UPSERT call
+sites in `ledger/queries.py` (``upsert_symbol``, vocab_cache UPSERT) fall back
+to full table scans; latency grows linearly and the 5.0s read budget breaks
+near the end of large ``reset --replay-from-events`` runs (#410 dogfood).
+
+Verification mechanism: SurrealDB 2.x's trailing ``EXPLAIN`` modifier returns
+a parseable query-plan row sequence. Pre-migration, `WHERE name = 'x'` plans
+to ``Iterate Table`` (full scan); post-migration the new ``idx_sym_name_lookup``
+makes it plan to ``Iterate Index``. Empirically validated against
+``memory://`` SurrealDB during the audit (AUDIT_REPORT.md, R2).
+
+Sociable per ``pilot/mcp/CLAUDE.md`` § "Sociable Testing for UX Paths": no
+``MagicMock``; no hand-crafted row dicts; the real ledger writes through the
+real schema.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from ledger.client import LedgerClient
+from ledger.queries import upsert_symbol
+from ledger.schema import (
+    _MIGRATIONS,
+    SCHEMA_VERSION,
+    _migrate_v24_to_v25,
+    init_schema,
+    migrate,
+)
+
+
+@pytest.fixture
+async def fresh_client():
+    client = LedgerClient("memory://")
+    await client.connect()
+    await init_schema(client)
+    await migrate(client)
+    yield client
+    await client.close()
+
+
+async def test_upsert_symbol_returns_single_row_for_unique_name(fresh_client):
+    """UPSERT semantics: novel name → exactly one row inserted, id returned."""
+    for i in range(1000):
+        await fresh_client.execute(
+            "CREATE symbol SET name=$n, file_path=$fp, sym_type='function'",
+            {"n": f"seeded_symbol_{i:04d}", "fp": f"seed_file_{i % 50}.py"},
+        )
+
+    sym_id = await upsert_symbol(
+        fresh_client,
+        name="unique_marker_x",
+        file_path="src/module.py",
+        sym_type="function",
+    )
+    assert sym_id, "upsert_symbol must return a non-empty id"
+
+    rows = await fresh_client.query(
+        "SELECT id FROM symbol WHERE name = $n", {"n": "unique_marker_x"}
+    )
+    assert len(rows) == 1, f"expected exactly 1 matching row, got {len(rows)}: {rows!r}"
+
+
+async def test_upsert_vocab_cache_returns_single_row_for_unique_compound_key(
+    fresh_client,
+):
+    """UPSERT semantics on vocab_cache compound key: novel (query_text, repo)
+    → exactly one row, no duplicates."""
+    for i in range(1000):
+        await fresh_client.execute(
+            "CREATE vocab_cache SET query_text=$q, repo=$r, symbols=[], hit_count=0",
+            {"q": f"seeded query {i:04d}", "r": "/repo/a"},
+        )
+
+    await fresh_client.execute(
+        """
+        UPSERT vocab_cache SET
+            query_text = $query_text,
+            repo       = $repo,
+            symbols    = $symbols,
+            hit_count  = 1,
+            last_hit   = time::now()
+        WHERE query_text = $query_text AND repo = $repo
+        """,
+        {
+            "query_text": "novel marker query",
+            "repo": "/repo/marker",
+            "symbols": ["marker_symbol"],
+        },
+    )
+
+    rows = await fresh_client.query(
+        "SELECT id FROM vocab_cache WHERE query_text = $q AND repo = $r",
+        {"q": "novel marker query", "r": "/repo/marker"},
+    )
+    assert len(rows) == 1, f"expected exactly 1 matching row, got {len(rows)}: {rows!r}"
+
+
+async def test_symbol_name_lookup_uses_equality_index_post_migration(fresh_client):
+    """Post-migration the query plan for ``WHERE name = $x`` must select
+    ``idx_sym_name_lookup`` rather than fall back to a full table scan.
+
+    Fail mode the test catches: ``_migrate_v24_to_v25`` runs without exception
+    but ``_execute_define_idempotent`` silently swallows the DEFINE INDEX. The
+    query plan stays at ``Iterate Table`` and this assertion fails loudly.
+    """
+    plan = await fresh_client.query("SELECT * FROM symbol WHERE name = 'probe' EXPLAIN")
+    assert plan, f"EXPLAIN returned no rows: {plan!r}"
+    head = plan[0]
+    assert head.get("operation") == "Iterate Index", (
+        f"symbol.name lookup is not using an index — query plan reports "
+        f"{head.get('operation')!r}. Full plan: {plan!r}. "
+        f"This means ``idx_sym_name_lookup`` did not land — either the "
+        f"v25 migration is silently broken or the schema DEFINE INDEX "
+        f"was not applied."
+    )
+    detail = head.get("detail") or {}
+    plan_detail = detail.get("plan") or {}
+    assert plan_detail.get("index") == "idx_sym_name_lookup", (
+        f"symbol.name lookup is using the wrong index. detail={detail!r}. "
+        f"Expected ``idx_sym_name_lookup`` (the equality index added in v25). "
+        f"BM25 ``idx_sym_name`` does not accelerate equality lookups."
+    )
+
+
+async def test_vocab_cache_lookup_uses_compound_index_post_migration(fresh_client):
+    """Post-migration the query plan for ``WHERE query_text = $q AND repo = $r``
+    must select ``idx_vocab_query_lookup``. Same failure-mode coverage as
+    the symbol test."""
+    plan = await fresh_client.query(
+        "SELECT * FROM vocab_cache WHERE query_text = 'probe' AND repo = '/r' EXPLAIN"
+    )
+    assert plan, f"EXPLAIN returned no rows: {plan!r}"
+    head = plan[0]
+    assert head.get("operation") == "Iterate Index", (
+        f"vocab_cache compound-key lookup is not using an index — query plan "
+        f"reports {head.get('operation')!r}. Full plan: {plan!r}."
+    )
+    detail = head.get("detail") or {}
+    plan_detail = detail.get("plan") or {}
+    assert plan_detail.get("index") == "idx_vocab_query_lookup", (
+        f"vocab_cache compound-key lookup is using the wrong index. "
+        f"detail={detail!r}. Expected ``idx_vocab_query_lookup`` "
+        f"(the equality index added in v25)."
+    )
+
+
+async def test_schema_version_advances_to_25():
+    """``init_schema`` + ``migrate`` on a fresh ledger must record
+    schema_meta.version = 25. Loud failure when the migration registry,
+    ``SCHEMA_VERSION`` constant, and migration function drift."""
+    client = LedgerClient("memory://")
+    await client.connect()
+    try:
+        await init_schema(client)
+        await migrate(client)
+        rows = await client.query("SELECT version FROM schema_meta LIMIT 1")
+        assert rows and rows[0]["version"] == 25, (
+            f"schema_meta.version must equal 25 after init+migrate, got "
+            f"{rows!r}. SCHEMA_VERSION constant = {SCHEMA_VERSION}."
+        )
+        assert SCHEMA_VERSION == 25
+        assert _MIGRATIONS[25] is _migrate_v24_to_v25, (
+            f"_MIGRATIONS[25] is not the v24→v25 function: {_MIGRATIONS.get(25)!r}"
+        )
+    finally:
+        await client.close()

--- a/thoughts/shared/plans/2026-05-18-ledger-equality-key-indexes.md
+++ b/thoughts/shared/plans/2026-05-18-ledger-equality-key-indexes.md
@@ -1,0 +1,184 @@
+# Plan: ledger equality key indexes for symbol.name + vocab_cache.(query_text, repo)
+
+**change_class**: hotfix
+
+**doc_tier**: standard
+
+**boundaries**:
+
+- limitations: New indexes are **non-unique**. They accelerate `WHERE field = $x`
+  lookups but do not enforce single-row-per-key. The UPSERT call sites
+  (`upsert_symbol`, `vocab_cache` UPSERT in `ledger/queries.py`) read the first
+  matching row, which implies a single-row-per-key invariant that the absence
+  of a UNIQUE index has historically failed to enforce. Tightening to UNIQUE
+  would require a backfill that merges or drops existing duplicates; per
+  `docs/DEV_CYCLE.md` §4.7.1 that is a destructive operation and belongs in a
+  dedicated commit + later release. Out of scope here.
+- non_goals: Enforcing single-row-per-name uniqueness on `symbol`. Compound
+  index optimisation for the `code_region`, `input_span`, and `subject_version`
+  UPSERT-WHERE sites (those already match an existing index prefix). Raising
+  the `BICAMERAL_QUERY_TIMEOUT_READ_SECONDS` default. Auditing UPSERT call
+  sites outside `ledger/queries.py`.
+- exclusions: Deduplication or migration of existing `symbol` or `vocab_cache`
+  rows. The new indexes are additive; rows valid before this migration remain
+  valid after it.
+
+## Open Questions
+
+- None. The audit narrowed the scope to two indexes; both follow the same
+  pattern. The migration function below is a safety belt — `init_schema` is
+  the actual mechanism that defines the new indexes on connect.
+
+## Context (read-only — do not include in the implementation diff)
+
+- The originating timeout: `bicameral-mcp reset --confirm --wipe-mode=ledger
+  --replay-from-events` against a 3,002-event log fails near the end of replay
+  with `LedgerTimeoutError: Ledger query exceeded read timeout (5.61s > 5.0s
+  budget): UPSERT symbol SET ... WHERE name = $name`. The `symbol` table has
+  `idx_sym_name` defined as `SEARCH ANALYZER ... BM25`, which accelerates
+  `name @0@ $query` semantic match but **cannot** accelerate `name = $name`
+  equality lookup. The UPSERT falls back to a full table scan; latency grows
+  linearly with table size; by the ~2,500th symbol the per-call cost exceeds
+  the 5.0s read budget.
+- `vocab_cache` has the identical pattern: `idx_vocab_query` is BM25 only,
+  yet `ledger/queries.py:419` runs `UPSERT vocab_cache SET ... WHERE
+  query_text = $query_text AND repo = $repo`. This issue has not produced a
+  caller-visible failure yet, but the same O(n) scan applies and the
+  recovery path #410 advertises will surface it on any sufficiently large
+  vocab cache.
+- The fix is structurally tied to PR #412 (the #410 recovery path): without
+  it the resolver fix is correct but `--replay-from-events` end-to-end still
+  fails. Filing as a separate PR after #412 lands would ship a recovery path
+  that times out for every user with a real-size events log.
+- Per `docs/DEV_CYCLE.md` §4.7.1 these are additive `DEFINE INDEX` operations
+  in the ✅ Allowed column. Per §4.7.2 the carve-out applies — this is an
+  invariant fix, not new feature surface, so no flag-gate is required.
+
+## Phase 1: Add equality key indexes alongside the existing BM25 indexes
+
+### Affected Files
+
+- `ledger/schema.py` — bump `SCHEMA_VERSION` 24 → 25; add `SCHEMA_COMPATIBILITY[25]` entry; add two `DEFINE INDEX` entries to the schema definitions list; define `_migrate_v24_to_v25` as a safety-belt that re-issues the indexes via `_execute_define_idempotent`; register `25: _migrate_v24_to_v25` in `_MIGRATIONS`.
+- `tests/test_schema_index_lookup_perf.py` — new file (sociable).
+- `tests/test_phase2_ledger.py` — no edits; existing schema-version assertions update naturally once `SCHEMA_VERSION` bumps. Listed only as a re-run target.
+
+### Changes
+
+`ledger/schema.py` deltas (no surrounding code rewrites):
+
+1. Line 31: `SCHEMA_VERSION = 24` → `SCHEMA_VERSION = 25`.
+
+2. `SCHEMA_COMPATIBILITY` map gains:
+   ```python
+   25: "0.15.x",  # equality key indexes on symbol.name + vocab_cache.(query_text, repo); release-eng pins final value at PR merge
+   ```
+
+3. In the `symbol`-table block (currently lines ~195–202), append after the
+   existing `idx_sym_name` BM25 line and `idx_sym_file` line:
+   ```python
+   "DEFINE INDEX idx_sym_name_lookup ON symbol FIELDS name",
+   ```
+   The BM25 `idx_sym_name` stays as-is — `code-locator` reads against it via
+   `name @0@ $query` and that path is unchanged.
+
+4. In the `vocab_cache`-table block (currently lines ~223–224), append:
+   ```python
+   "DEFINE INDEX idx_vocab_query_lookup ON vocab_cache FIELDS query_text, repo",
+   ```
+   The compound shape matches the WHERE in `ledger/queries.py:419` exactly.
+   The existing BM25 `idx_vocab_query` and single-field `idx_vocab_repo` stay
+   — they serve other read paths.
+
+5. New migration function near line ~1471 (pattern lifted from
+   `_migrate_v23_to_v24`):
+   ```python
+   async def _migrate_v24_to_v25(client: LedgerClient) -> None:
+       """v24 → v25: Add equality key indexes for UPSERT-WHERE lookups.
+
+       Pre-v25 the `symbol.name` and `vocab_cache.query_text` columns were
+       indexed only via SEARCH/BM25, which accelerates `@0@` matches but not
+       `WHERE field = $value` equality lookups. The UPSERT call sites in
+       `ledger/queries.py` (`upsert_symbol`, `vocab_cache` UPSERT) fell back
+       to full table scans, producing O(n) per-call latency that crossed the
+       5.0s read timeout near the end of large `reset --replay-from-events`
+       runs (#410 dogfood).
+
+       Both indexes are additive and non-unique — rows valid under the old
+       schema remain valid post-migration. `init_schema` re-issues every
+       DEFINE on connect; this migration is the version-boundary safety belt
+       that runs the OVERWRITE explicitly even when init_schema's pass is
+       interrupted. Idempotent via `_execute_define_idempotent`.
+       """
+       await _execute_define_idempotent(
+           client,
+           "DEFINE INDEX OVERWRITE idx_sym_name_lookup ON symbol FIELDS name",
+       )
+       await _execute_define_idempotent(
+           client,
+           "DEFINE INDEX OVERWRITE idx_vocab_query_lookup ON vocab_cache "
+           "FIELDS query_text, repo",
+       )
+   ```
+
+6. `_MIGRATIONS` registry gains:
+   ```python
+   25: _migrate_v24_to_v25,
+   ```
+
+### Unit Tests
+
+- `tests/test_schema_index_lookup_perf.py` (new) — sociable; instantiates a
+  real `LedgerClient` over `memory://`, runs `init_schema` + `migrate`, then
+  exercises the two UPSERT paths and verifies query-plan selection via
+  SurrealDB 2.x's trailing `EXPLAIN` modifier:
+
+  - `test_upsert_symbol_returns_single_row_for_unique_name` — seeds the
+    `symbol` table with 1,000 rows of synthetic names, calls
+    `upsert_symbol(client, name="unique_marker_x", file_path="…")`, asserts
+    the call returns a non-empty `id` string AND the table contains exactly
+    one row matching `name = "unique_marker_x"`. Pins observable behaviour
+    (right row returned, no duplicates).
+
+  - `test_upsert_vocab_cache_returns_single_row_for_unique_compound_key` —
+    same shape against `vocab_cache`; seeds 1,000 rows, runs the UPSERT on a
+    novel `(query_text, repo)` pair, asserts a single matching row exists
+    and the call returned successfully.
+
+  - `test_symbol_name_lookup_uses_equality_index_post_migration` — runs
+    `init_schema` + `migrate` on a fresh `memory://` client, then issues
+    `SELECT * FROM symbol WHERE name = $name EXPLAIN`. Parses the returned
+    plan rows and asserts the first row's `operation == "Iterate Index"`
+    with `detail.index == "idx_sym_name_lookup"`. Empirically validated:
+    pre-migration the same query plans to `operation: "Iterate Table"`
+    (full scan) because `idx_sym_name` is BM25-only and cannot accelerate
+    equality. Post-migration the new equality index is selected. The
+    EXPLAIN modifier works in embedded mode (verified against
+    `memory://`) — the failure mode the test catches is precisely:
+    `_migrate_v24_to_v25` runs without exception but the DEFINE INDEX
+    did not land (the plan stays at `Iterate Table`, the assertion fails
+    loudly).
+
+  - `test_vocab_cache_lookup_uses_compound_index_post_migration` — same
+    pattern: `SELECT * FROM vocab_cache WHERE query_text = $q AND repo = $r EXPLAIN`,
+    assert `operation == "Iterate Index"` with `detail.index ==
+    "idx_vocab_query_lookup"`.
+
+  - `test_schema_version_advances_to_25` — runs `init_schema` + `migrate` on
+    a fresh adapter, reads `schema_meta.version`, asserts it equals `25`.
+    Loud failure when `SCHEMA_VERSION` and registry drift.
+
+  All five tests are sociable per the project's mandate (`pilot/mcp/CLAUDE.md`
+  § "Sociable Testing for UX Paths"). No `MagicMock`; no row-dict
+  hand-crafting; the real adapter writes through the real schema. The
+  EXPLAIN-based assertions deterministically detect a silently-broken
+  migration — without the new indexes the query plan reports
+  `Iterate Table`, which fails the assertion regardless of whether the
+  migration function returned without exception.
+
+## CI Commands
+
+- `pytest tests/test_schema_index_lookup_perf.py -q` — the five new sociable tests above.
+- `pytest tests/test_phase2_ledger.py tests/test_replay_determinism.py tests/test_team_event_replay.py -q` — existing ledger + replay regression suite; must stay green across the schema bump.
+- `pytest tests/test_reset_cli_410.py -q` — confirms the PR's resolver fix still passes alongside the schema change.
+- `ruff check ledger/schema.py tests/test_schema_index_lookup_perf.py` — lint.
+- `ruff format --check ledger/schema.py tests/test_schema_index_lookup_perf.py` — format.


### PR DESCRIPTION
## Summary

Closes #410. When the ledger hits a SurrealDB row-deserialization error, the agent's named recovery path (`bicameral_reset`) is often unreachable — either because Claude Code's tool surface has pinned the old schema, or because the MCP server itself can't finish init. This PR makes the CLI form genuinely callable from inside the agent loop, and (as part of the recovery substrate) fixes a silent zero-replay regression in `--replay-from-events`.

## What changed

### Diagnose + reset CLI escape hatch (the original #410 scope)

- **`cli/diagnose.py`** now opens a raw `LedgerClient` and forwards to `gather_diagnosis_raw` — the same defensive path `handlers/diagnose.py` already uses. The old code went through `SurrealDBLedgerAdapter`, which re-runs `init_schema`+`migrate` (the step the operator is trying to diagnose around).
- **`bicameral-mcp reset`** gains `--confirm`, `--wipe-mode={ledger,full}`, and `--replay-from-events`. With `--confirm` we bypass the interactive wizard and dispatch through `cli/reset_cli.py:run_noninteractive_reset`, a thin wrapper around `handle_reset`. No `--confirm` keeps the wizard for human-driven use.
- **Filesystem-only fallback**: when `--confirm --wipe-mode=full` is given and `BicameralContext.from_env()`/`ledger.connect()` raises (the literal #410 scenario), we `shutil.rmtree` the resolved `.bicameral/` directly.
- **Recovery hints** in `LedgerDeserializationError.RECOVERY_HINT` and `handlers/diagnose.py:_classify_recovery` now lead with the shell form, which works even when the MCP `bicameral_reset` tool isn't in the agent's pinned surface.

### Silent zero-replay regression (`d9737d7`)

While dogfooding the new CLI against a real R4-layout install, `--replay-from-events` reported `events_replayed: 0` with **zero entries in `replay_errors`** despite 3,002 valid events on disk. The pre-fix `_resolve_events_dir` derived its target by string-mangling the SurrealKV URL — `Path(db_path).parent / "events"`. That inverse only worked while the ledger and events shared a parent. Once #408 (Ledger Locator) moved the ledger to `~/.bicameral/projects/<id>/ledger.db` while events stayed repo-local at `<repo>/.bicameral/events/`, the inverse silently pointed at an empty path.

The fix splits two distinct concerns the inverse function had collapsed:

| | Domain | Resolver |
|---|---|---|
| **Events** | Repo-local **source** — committed to git pre-#373, pulled from remote backend post-#373 | `<repo_path>/.bicameral/events` (matches `cli/sync_and_brief_cli.py:65`) |
| **Watermark** | User-local **derived state** — per-author offset into the events stream | `ledger_locator.resolve_watermark_path()` |
| **Bicameral dir** (full-wipe target) | User-local **derived state** — what to delete in a nuclear restart | `ledger_locator.project_dir_for()` when no explicit `SURREAL_URL` is set; URL inverse otherwise (preserves the corruption-recovery test contract) |

Replay now raises `FileNotFoundError` when the events substrate can't be located, and the caller surfaces it via `replay_errors`. Silent zero-replay becomes an explicit failure that names where events were expected and points the user at `sync-and-brief` for fresh-clone repopulation.

## Linked decisions (from #408)

Forward-resolution through the locator is grounded in:

- `decision:ko8efq3z1zwhbof7kecq` — Ledger Locator naming + scope
- `decision:rfbnlw7ghe175iu42u6b` — Project identity via `git rev-parse --git-common-dir` hash
- `decision:5nr66wvmapjpt58rrji8` — R4 config split (the layout transition that exposed the URL-inverse bug)

Boundary between user-local state (locator) and repo-local events tracks the deprecation arc in **#373** — the event substrate must not be conflated with the user-local derived-state bucket.

## Why this works for the original reproduction

| Symptom in #410 | Fix |
|---|---|
| `bicameral.dashboard` returns `LedgerDeserializationError`, recovery hint names `bicameral_reset` (not reachable) | Hint now points at `bicameral-mcp reset --confirm ...` first |
| `bicameral_reset` MCP tool gated / unregistered in running session | Agent can shell out via Bash to the now-non-interactive CLI |
| `bicameral-mcp diagnose` from shell crashes on migrate (`Invalid revision 101 for type DefineTableStatement`) | CLI now uses raw client; no migrate runs |
| `--replay-from-events` silently zero-replays under R4 layout | `_resolve_events_dir` forward-resolves repo-local; missing dir raises and surfaces via `replay_errors` |

## Test plan

- [x] `tests/test_reset_cli_410.py` — 9 tests cover the flag surface, happy-path ledger wipe against `memory://`, filesystem fallback when `from_env()` raises during `--wipe-mode=full`, the explicit refusal to silently rmtree under `--wipe-mode=ledger`, the CLI-form presence in both recovery-hint surfaces, **and three new regression tests for the silent zero-replay**:
  - `test_resolve_events_dir_under_legacy_local_layout_finds_sibling_events` — guards the layout where ledger sits at `<bicameral_dir>/local/ledger.db` and events at `<bicameral_dir>/events/`. Pre-fix this returns None; post-fix returns the sibling events dir.
  - `test_resolve_events_dir_uses_repo_path_not_locator_project_dir` — pins the architectural boundary: events stay repo-local, never routed through `project_dir_for() / "events"`. Guards against re-conflating user-local with repo-local in future refactors.
  - `test_reset_cli_replay_surfaces_missing_events_dir_as_replay_error` — end-to-end: missing `events_dir` produces a non-empty `replay_errors`, never a passing-looking zero-replay response.
- [x] `tests/test_diagnose_cli.py` — updated `test_diagnose_main_returns_one_on_raw_client_connect_failure` (failure surface moved from adapter to raw client). Added `test_diagnose_main_cli_does_not_use_adapter_path` — patches `SurrealDBLedgerAdapter.connect` to raise; asserts diagnose still returns 0.
- [x] `ruff check` + `ruff format --check` clean on every changed file.
- [x] Existing `test_diagnose_*`, `test_reset.py`, `test_ledger_sync_deserialization_recovery_301.py`, `test_ledger_locator.py` all pass.

## Out of scope (pre-existing on `origin/dev`)

- `tests/test_diagnose_format.py` — 8 failures from a fixture missing `row_probe_warnings` (field added in #301, fixture never updated). Confirmed on `origin/dev` independent of this PR.
- `server.py --smoke-test` — `EXPECTED_TOOL_NAMES` constant is missing `bicameral.diagnose`. Same one-liner drift on `origin/dev`. Worth a tiny follow-up.

## Note on this session

Bicameral sync against the new commit was attempted but blocked by a stale SDK in the running MCP server (PID spawned pre-#408, partial-replay state with the newer SDK's revision). Restart the MCP host to pick it up; decisions linked manually above are the load-bearing set.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
