### PR TITLE
feat(code-locator): #399 Stage C — shadow-mode dispatch + M_shadow_parity gate

### DIFF
--- a/.github/workflows/test-mcp-regression.yml
+++ b/.github/workflows/test-mcp-regression.yml
@@ -134,6 +134,11 @@ jobs:
           clone_at_commit https://github.com/medusajs/medusa test-results/.repos/medusa dbff8196af90042829a5b8fd06adb27d7b8b5df3
 
       # ── Run all phases in a single pytest invocation ───────────────
+      # #399 Stage C: shadow-mode tests + parity gate join the regression
+      # suite. The parity tests (test_tags_extractor_parity.py,
+      # test_extract_go_substrate.py) do clone-on-demand sparse fetches of
+      # k8s / hugo / ripgrep / cargo — net effect adds ~10s per CI run.
+      # The shadow dispatch + telemetry tests are pure-function and add ~0.3s.
       - name: Run MCP regression tests
         run: >
           pytest
@@ -144,9 +149,39 @@ jobs:
           tests/test_schema_recoverable_errors.py
           tests/test_replay_helpers_unit.py
           tests/test_replay_determinism.py
+          tests/test_tags_extractor_parity.py
+          tests/test_extract_go_substrate.py
+          tests/test_m_shadow_divergence_log.py
+          tests/test_shadow_dispatch.py
           -v --tb=short
           --junitxml=test-results/results.xml
           --html=test-results/report.html --self-contained-html
+
+      # ── M_shadow_parity — rate-based CI gate (#399 Stage C) ─────────
+      # Walks the Python in-repo corpus + clone-on-demand Go/Rust corpora
+      # used by the parity tests, runs walker AND substrate per file,
+      # aggregates ``divergence_kind`` counts per language, and fails the
+      # gate when ``substrate-subset`` rate > 1% per the #399 plan.
+      #
+      # Different from the pytest parity gate (binary pass/fail per file) —
+      # M_shadow_parity is the rate-based metric mirroring how production
+      # shadow telemetry will surface drift once Stages D-E flip languages
+      # to shadow mode. Both gates currently agree (every file passes both)
+      # but M_shadow_parity gives the per-language summary needed for
+      # operating the rollout.
+      #
+      # Ubuntu-only: corpora live on Ubuntu (mirrors the existing
+      # Linux-only eval steps). Cache is per-job; the script re-clones each
+      # run (~5s for all four sources combined via sparse-checkout).
+      - name: M_shadow_parity (hard gate)
+        if: matrix.os == 'ubuntu-latest'
+        run: >
+          python tests/eval_shadow_parity.py
+          --gate-mode hard
+          --max-subset-rate 0.01
+          -o test-results/m-shadow-parity.json
+          --github-summary
+          >> "$GITHUB_STEP_SUMMARY"
 
       # ── Diagnostic: report ANTHROPIC_API_KEY visibility ───────────
       # GitHub masks secret values in logs, but we can safely report

--- a/code_locator/indexing/symbol_extractor.py
+++ b/code_locator/indexing/symbol_extractor.py
@@ -6,18 +6,42 @@ and adapted to produce SymbolRecord objects for the SQLite store.
 Per-language coverage:
 
 - Python, JS/JSX, TS/TSX, Java, Go, Rust, C#: bespoke walkers
-  (``_extract_<lang>_defs``) — historical pattern; walker retirement
-  for the simpler four (Python, Go, Rust, JS-mode) gated on #399's
-  measurement spike.
+  (``_extract_<lang>_defs``) — historical pattern.
 - **Elixir (#367)**: generic tags-query path via
   ``tags_extractor.extract_defs_via_tags`` against the upstream
   ``tree-sitter-elixir`` grammar's ``queries/tags.scm``. Substrate
-  introduced in #367 as the precursor to the broader hybrid refactor;
-  validated against existing Python walker output by
-  ``tests/test_tags_extractor_parity.py``.
+  introduced in #367 as the precursor to the broader hybrid refactor.
+
+Dispatch routing (#399 Stage C):
+
+  Per-language ``ShadowMode`` enum in ``_SHADOW_MODES`` controls how
+  ``_extract_definitions`` routes a given language. Four modes per the
+  #399 rollout pattern:
+
+  - ``walker-only`` — runs the bespoke walker, authoritative. Current
+    state for Python/Go/Rust/JS/TS/Java/C#.
+  - ``shadow-substrate`` — runs walker AND substrate; walker
+    authoritative, divergence logged to ``m_shadow_divergence``
+    telemetry. Stage D flips Python/Go/Rust here.
+  - ``shadow-walker`` — runs walker AND substrate; substrate
+    authoritative, divergence logged. Stage E pre-retirement.
+  - ``substrate-only`` — runs the tags-query substrate only. Current
+    state for Elixir (no walker exists).
+
+  Per-language ``_WALKER_VOCAB`` defines the symbol-type vocabulary
+  the walker emits for that language. Shadow mode filters substrate
+  output to this vocabulary before comparing — substrate-only kinds
+  (e.g. Rust ``macro``, Python ``constant``) are by design and aren't
+  divergences.
+
+  Walker retirement is staged behind these modes; mode flips are one-
+  line edits to ``_SHADOW_MODES`` that ship in their own small PRs
+  (see #399 Stages D and E).
 """
 
 from __future__ import annotations
+
+from enum import StrEnum
 
 from .sqlite_store import SymbolRecord
 
@@ -421,10 +445,76 @@ def _extract_csharp_defs(tree, code: bytes, rel_path: str) -> list[SymbolRecord]
     return records
 
 
-# ── Dispatch ─────────────────────────────────────────────────────────
+# ── Shadow-mode dispatch (#399 Stage C) ──────────────────────────────
 
 
-def _extract_definitions(language_id: str, tree, code: bytes, rel_path: str) -> list[SymbolRecord]:
+class ShadowMode(StrEnum):
+    """How ``_extract_definitions`` routes a given language.
+
+    See module docstring for the four-stage rollout pattern. Each
+    transition (walker-only → shadow-substrate → shadow-walker →
+    substrate-only) is a one-line edit to ``_SHADOW_MODES``, gated by
+    the observation windows in #399 Stages D and E.
+    """
+
+    WALKER_ONLY = "walker-only"
+    SHADOW_SUBSTRATE = "shadow-substrate"  # walker authoritative, substrate runs silently
+    SHADOW_WALKER = "shadow-walker"  # substrate authoritative, walker runs silently
+    SUBSTRATE_ONLY = "substrate-only"
+
+
+# Per-language dispatch table. Initial state per #399's locked rollout:
+# every walker-backed language starts at WALKER_ONLY; Elixir is
+# substrate-only because no walker was ever written.
+#
+# JS/TS, Java, C# are documented as walker-only forever (#399 Stage A):
+# the upstream tags.scm grammars have gaps these walkers fill (JS/TS
+# overlap, Java annotation/wildcard handling, C# nested-class qualified
+# names). Stage D/E flips do NOT apply to these three languages.
+_SHADOW_MODES: dict[str, ShadowMode] = {
+    "python": ShadowMode.WALKER_ONLY,
+    "javascript": ShadowMode.WALKER_ONLY,
+    "jsx": ShadowMode.WALKER_ONLY,
+    "typescript": ShadowMode.WALKER_ONLY,
+    "tsx": ShadowMode.WALKER_ONLY,
+    "java": ShadowMode.WALKER_ONLY,
+    "go": ShadowMode.WALKER_ONLY,
+    "rust": ShadowMode.WALKER_ONLY,
+    "c_sharp": ShadowMode.WALKER_ONLY,
+    "elixir": ShadowMode.SUBSTRATE_ONLY,
+}
+
+
+# Per-language walker vocabulary — the ``SymbolRecord.type`` values
+# the bespoke walker emits for this language. Used by shadow-mode
+# dispatch to filter substrate output to a comparable vocabulary
+# before computing divergence. Substrate-only kinds outside this set
+# (e.g. Python ``constant``, Rust ``macro``, JS ``module``) are by
+# design and aren't divergences.
+#
+# Locked in by ``tests/test_tags_extractor_parity.py`` — these match
+# ``PY_WALKER_VOCAB`` / ``GO_WALKER_VOCAB`` / ``RUST_WALKER_VOCAB``
+# defined there.
+_WALKER_VOCAB: dict[str, frozenset[str]] = {
+    "python": frozenset({"function", "class", "method"}),
+    "javascript": frozenset({"function", "class"}),
+    "jsx": frozenset({"function", "class"}),
+    "typescript": frozenset({"function", "class"}),
+    "tsx": frozenset({"function", "class"}),
+    "java": frozenset({"function", "class"}),
+    "go": frozenset({"function", "class"}),
+    "rust": frozenset({"function", "class"}),
+    "c_sharp": frozenset({"function", "class"}),
+    # Elixir is substrate-only — no walker, no vocab.
+}
+
+
+def _run_walker(language_id: str, tree, code: bytes, rel_path: str) -> list[SymbolRecord]:
+    """Dispatch to the bespoke walker for ``language_id``.
+
+    Returns ``[]`` if the language has no walker — caller should check
+    ``_SHADOW_MODES`` before calling and never invoke this for Elixir.
+    """
     if language_id == "python":
         return _extract_python_defs(tree, code, rel_path)
     if language_id in ("javascript", "jsx", "typescript", "tsx"):
@@ -437,20 +527,96 @@ def _extract_definitions(language_id: str, tree, code: bytes, rel_path: str) -> 
         return _extract_rust_defs(tree, code, rel_path)
     if language_id == "c_sharp":
         return _extract_csharp_defs(tree, code, rel_path)
-    if language_id == "elixir":
-        # #367: tags-query path via the upstream tree-sitter-elixir tags.scm.
-        # First instance of the data-driven extractor; #399's spike measures
-        # whether the simpler walkers (Python, Go, Rust, JS-mode) can retire
-        # in favor of this same path. Walker fallback is not provided for
-        # Elixir — see pyproject.toml's tight grammar pin (>=0.3.5,<0.4).
-        from .tags_extractor import extract_defs_via_tags, load_tags_query_text
-
-        query_text = load_tags_query_text("tree_sitter_elixir")
-        if query_text is None:
-            return []
-        lang = _get_language_obj("elixir")
-        return extract_defs_via_tags(lang, tree, code, rel_path, query_text)
     return []
+
+
+def _run_substrate(language_id: str, tree, code: bytes, rel_path: str) -> list[SymbolRecord]:
+    """Dispatch to the tags-query substrate for ``language_id``.
+
+    Returns ``[]`` if the grammar package's ``queries/tags.scm`` is
+    missing — matches the pre-Stage-C Elixir fallback behavior.
+    """
+    from .tags_extractor import extract_defs_via_tags, load_tags_query_text
+
+    pkg_name = _LANG_PACKAGE_MAP.get(language_id)
+    if pkg_name is None:
+        return []
+    query_text = load_tags_query_text(pkg_name)
+    if query_text is None:
+        return []
+    try:
+        lang = _get_language_obj(language_id)
+    except (ImportError, KeyError):
+        return []
+    return extract_defs_via_tags(lang, tree, code, rel_path, query_text)
+
+
+def _log_shadow_divergence(
+    language_id: str,
+    mode: ShadowMode,
+    rel_path: str,
+    walker_records: list[SymbolRecord],
+    substrate_records: list[SymbolRecord],
+) -> None:
+    """Compute the (name, type) sets, filter to walker vocabulary, and
+    hand them to the divergence log. Wrapped in try/except so a
+    telemetry failure can never break extraction — same pattern as
+    ``handlers/bind.py``'s m2 telemetry call site.
+    """
+    vocab = _WALKER_VOCAB.get(language_id)
+    if vocab is None:
+        return  # no walker vocab → no meaningful comparison
+    walker_set = {(r.name, r.type) for r in walker_records if r.type in vocab}
+    substrate_set = {(r.name, r.type) for r in substrate_records if r.type in vocab}
+    try:
+        from m_shadow_divergence_log import record_divergence
+
+        record_divergence(
+            language_id=language_id,
+            mode=mode.value,
+            rel_path=rel_path,
+            walker_set=walker_set,
+            substrate_set=substrate_set,
+        )
+    except Exception:
+        # Telemetry must never break extraction. Swallow silently —
+        # the import-side fail-loud invariant is for the user-facing
+        # parity gate, not the in-process indexer.
+        pass
+
+
+def _extract_definitions(language_id: str, tree, code: bytes, rel_path: str) -> list[SymbolRecord]:
+    """Extract definitions for ``language_id``, routing through the
+    shadow-mode dispatch table.
+
+    Unknown languages return ``[]`` — preserves the pre-Stage-C
+    behavior for an extension whose grammar isn't wired.
+    """
+    mode = _SHADOW_MODES.get(language_id)
+    if mode is None:
+        return []
+
+    if mode is ShadowMode.WALKER_ONLY:
+        return _run_walker(language_id, tree, code, rel_path)
+
+    if mode is ShadowMode.SUBSTRATE_ONLY:
+        return _run_substrate(language_id, tree, code, rel_path)
+
+    # Shadow modes: run BOTH, log divergence, return authoritative side.
+    walker_records = _run_walker(language_id, tree, code, rel_path)
+    substrate_records = _run_substrate(language_id, tree, code, rel_path)
+
+    _log_shadow_divergence(language_id, mode, rel_path, walker_records, substrate_records)
+
+    if mode is ShadowMode.SHADOW_SUBSTRATE:
+        return walker_records  # walker authoritative
+    if mode is ShadowMode.SHADOW_WALKER:
+        return substrate_records  # substrate authoritative
+
+    # Unreachable — exhaustive over the four enum members. Defensive
+    # fallback returns the walker side so the indexer never crashes
+    # on a future enum value introduced without updating this branch.
+    return walker_records
 
 
 # ── Public API ───────────────────────────────────────────────────────

--- a/m_shadow_divergence_log.py
+++ b/m_shadow_divergence_log.py
@@ -1,0 +1,281 @@
+"""Shadow-mode divergence event log (#399 Stage C).
+
+Owns the contract for the ``m_shadow_divergence`` event emitted by
+``code_locator/indexing/symbol_extractor.py``'s ``_extract_definitions``
+when a language is running in ``shadow-substrate`` or ``shadow-walker``
+mode. Each call writes:
+
+  1. A JSONL row to ``~/.bicameral/m_shadow_divergence.jsonl`` — the
+     local mirror that the dashboard panel reads (and that the
+     ``M_shadow_parity`` CI gate consumes via ``tests/eval_shadow_parity.py``).
+     Always appended (subject to size-based rotation), regardless of
+     telemetry consent.
+  2. A PostHog event via ``telemetry.send_event`` — only when the
+     consolidated ``BICAMERAL_TELEMETRY`` flag includes ``relay``.
+     The relay payload carries **numeric aggregates only** — counts
+     and the ``divergence_kind`` enum. Symbol-name lists never reach
+     the relay; they exist only in the local mirror.
+
+Privacy invariants (mirrors ``m2_grounding_log.py:14-37``):
+  - ``file_hash`` (sha256 of ``rel_path``) replaces the raw path in
+    both local mirror and relay — the relay never sees user file paths.
+  - ``walker_only`` / ``substrate_only`` symbol-name lists live in the
+    local mirror only. The relay carries only ``walker_count``,
+    ``substrate_count``, ``divergence_kind`` — no user code identifiers
+    cross the network boundary.
+  - The ``telemetry.send_event`` relay's defensive `isinstance` filter
+    (``telemetry.py:140``) strips any non-numeric ``diagnostic`` value
+    that does slip through, so the symbol-name fields here are safe
+    even if a future refactor accidentally routes them through diagnostic.
+
+Sampling budget (per #399 plan):
+  - Every disagreement (``divergence_kind != "equal"``) → log.
+  - Agreements → 1-in-50 via deterministic file-hash modulo. Same file
+    always samples or doesn't — useful for reproducibility when an
+    investigator wants to know "was this file ever shadow-logged?"
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import logging
+import os
+import threading
+from datetime import UTC, datetime
+from pathlib import Path
+
+logger = logging.getLogger(__name__)
+
+_LOG_FILE = Path.home() / ".bicameral" / "m_shadow_divergence.jsonl"
+_LOCK = threading.Lock()
+
+# Local-mirror rotation: 10 MB cap, keep most recent 3 files. Matches
+# m2_grounding_log.py — the dashboard panel reads the live file plus
+# rotated siblings, so panels survive log roll.
+_MAX_BYTES = 10 * 1024 * 1024
+_MAX_ROTATIONS = 3
+
+# 1-in-N agreement sampling — every disagreement always logs.
+_AGREEMENT_SAMPLE_RATE = 50
+
+# divergence_kind → relay-safe numeric encoding for `diagnostic`.
+# Strings are not relayable; numeric makes PostHog aggregation trivial.
+_DIVERGENCE_KIND_TO_INT = {
+    "equal": 0,
+    "substrate-superset": 1,  # substrate has extras — expected, allowed
+    "substrate-subset": 2,  # walker has extras — forbidden, signals substrate bug
+    "symmetric": 3,  # neither is a subset; both have unique entries
+}
+
+# Modes that warrant logging (the two shadow modes — single-path
+# modes never call into here).
+_LOGGABLE_MODES = frozenset({"shadow-substrate", "shadow-walker"})
+
+
+def _now_iso() -> str:
+    return datetime.now(UTC).isoformat(timespec="seconds")
+
+
+def _hash_path(rel_path: str) -> str:
+    """SHA-256 of the relative path. Privacy-preserving identity that
+    is stable across runs (so dashboards can group by file) but reveals
+    no path component."""
+    return hashlib.sha256(rel_path.encode("utf-8")).hexdigest()
+
+
+def _should_sample_agreement(file_hash: str) -> bool:
+    """Deterministic 1-in-50 sampling: same file_hash always returns
+    the same boolean. Uses the first 8 hex chars as a uniform-ish
+    32-bit integer, mod the sample rate.
+
+    Deterministic (not probabilistic) so an investigator chasing a
+    divergence can ask "would this file have been sampled?" and get a
+    repeatable answer without re-running the indexer.
+    """
+    return int(file_hash[:8], 16) % _AGREEMENT_SAMPLE_RATE == 0
+
+
+def classify_divergence(walker_set: set, substrate_set: set) -> str:
+    """Compute the ``divergence_kind`` label from two (name, type) sets.
+
+    Returns one of:
+      - ``"equal"`` — sets are identical
+      - ``"substrate-superset"`` — substrate has extras; walker is a
+        strict subset (expected, allowed direction)
+      - ``"substrate-subset"`` — walker has extras; substrate is a
+        strict subset (forbidden — signals a substrate gap)
+      - ``"symmetric"`` — neither side is a subset; both have unique
+        entries (rare; usually means a (name, type) pair has a
+        different type label between walker and substrate)
+
+    Symmetric difference matters as much as missing direction — if a
+    walker emits ``("foo", "function")`` and substrate emits
+    ``("foo", "method")``, both sides have unique entries even though
+    the symbol is "the same". Investigate as a vocabulary mismatch.
+    """
+    if walker_set == substrate_set:
+        return "equal"
+    walker_only = walker_set - substrate_set
+    substrate_only = substrate_set - walker_set
+    if not walker_only and substrate_only:
+        return "substrate-superset"
+    if walker_only and not substrate_only:
+        return "substrate-subset"
+    return "symmetric"
+
+
+def _maybe_rotate(path: Path) -> None:
+    """Roll ``path`` → ``path.1`` when over _MAX_BYTES. Best-effort."""
+    try:
+        if not path.exists() or path.stat().st_size < _MAX_BYTES:
+            return
+        for i in range(_MAX_ROTATIONS, 0, -1):
+            src = path.with_suffix(path.suffix + f".{i}")
+            if src.exists():
+                if i == _MAX_ROTATIONS:
+                    src.unlink()
+                else:
+                    src.rename(path.with_suffix(path.suffix + f".{i + 1}"))
+        path.rename(path.with_suffix(path.suffix + ".1"))
+    except OSError as exc:
+        logger.debug("[m_shadow_divergence] rotation failed (non-fatal): %s", exc)
+
+
+def _append_jsonl(row: dict) -> None:
+    """Write a single JSONL row to the local mirror. Best-effort, never raises."""
+    try:
+        _LOG_FILE.parent.mkdir(parents=True, exist_ok=True)
+        with _LOCK:
+            _maybe_rotate(_LOG_FILE)
+            with _LOG_FILE.open("a", encoding="utf-8") as f:
+                f.write(json.dumps(row, ensure_ascii=False) + "\n")
+    except OSError as exc:
+        logger.debug("[m_shadow_divergence] local-mirror append failed (non-fatal): %s", exc)
+
+
+def _send_relay(diagnostic: dict, language_id: str, mode: str, divergence_kind: str) -> None:
+    """Forward to PostHog via ``telemetry.send_event``. The relay payload
+    carries only:
+
+      - ``language_id`` (top-level, controlled enum)
+      - ``mode`` (top-level, controlled enum)
+      - ``divergence_kind`` (top-level, controlled enum)
+      - ``diagnostic`` — int-only counts and the divergence_kind int
+
+    No symbol names. No file paths. ``send_event``'s own defensive
+    filter strips any non-numeric ``diagnostic`` value as belt-and-
+    suspenders against future refactors.
+    """
+    try:
+        from server import SERVER_VERSION  # local import — avoid circular
+        from telemetry import send_event
+
+        send_event(
+            SERVER_VERSION,
+            event_type="m_shadow_divergence",
+            language_id=language_id,
+            mode=mode,
+            divergence_kind=divergence_kind,
+            diagnostic=diagnostic,
+        )
+    except Exception as exc:
+        logger.debug("[m_shadow_divergence] relay send failed (non-fatal): %s", exc)
+
+
+# ── Public API ──────────────────────────────────────────────────────────────
+
+
+def record_divergence(
+    *,
+    language_id: str,
+    mode: str,
+    rel_path: str,
+    walker_set: set,
+    substrate_set: set,
+) -> None:
+    """Record a shadow-mode comparison between walker and substrate output.
+
+    ``walker_set`` and ``substrate_set`` are sets of ``(name, type)`` tuples
+    pre-filtered to the walker vocabulary. The caller is responsible for
+    that filtering — same as the parity gate in
+    ``tests/test_tags_extractor_parity.py``.
+
+    No-op when ``mode`` is not a shadow mode (defensive: callers shouldn't
+    invoke for ``walker-only`` / ``substrate-only`` but a guard here makes
+    the contract explicit).
+
+    No-op for sampled-out agreements. Disagreements always log.
+    """
+    if mode not in _LOGGABLE_MODES:
+        return
+
+    divergence_kind = classify_divergence(walker_set, substrate_set)
+    file_hash = _hash_path(rel_path)
+
+    if divergence_kind == "equal" and not _should_sample_agreement(file_hash):
+        return
+
+    walker_only = sorted(walker_set - substrate_set)
+    substrate_only = sorted(substrate_set - walker_set)
+
+    # Local mirror: full event including symbol-name lists. file_hash
+    # (not rel_path) is used for the on-disk record too, matching the
+    # #399 issue body's privacy-preserving event shape — investigators
+    # who need to map a hash back to a path keep that mapping locally.
+    _append_jsonl(
+        {
+            "ts": _now_iso(),
+            "event_type": "m_shadow_divergence",
+            "language_id": language_id,
+            "mode": mode,
+            "file_hash": file_hash,
+            "walker_count": len(walker_set),
+            "substrate_count": len(substrate_set),
+            "walker_only": [f"{n}:{t}" for n, t in walker_only],
+            "substrate_only": [f"{n}:{t}" for n, t in substrate_only],
+            "divergence_kind": divergence_kind,
+        }
+    )
+
+    # Relay: numeric aggregates only. The defensive filter in
+    # telemetry.send_event silently drops any non-int diagnostic value,
+    # so even if someone refactors this dict to include strings, the
+    # network boundary stays clean.
+    diagnostic = {
+        "walker_count": len(walker_set),
+        "substrate_count": len(substrate_set),
+        "walker_only_count": len(walker_only),
+        "substrate_only_count": len(substrate_only),
+        "divergence_kind_int": _DIVERGENCE_KIND_TO_INT.get(divergence_kind, -1),
+    }
+    _send_relay(diagnostic, language_id, mode, divergence_kind)
+
+
+def reset_for_tests() -> None:
+    """Truncate the local mirror — test-only hook."""
+    if _LOG_FILE.exists():
+        try:
+            _LOG_FILE.unlink()
+        except OSError:
+            pass
+    for i in range(1, _MAX_ROTATIONS + 1):
+        sibling = _LOG_FILE.with_suffix(_LOG_FILE.suffix + f".{i}")
+        if sibling.exists():
+            try:
+                sibling.unlink()
+            except OSError:
+                pass
+
+
+# Test-environment hook: redirect log file when BICAMERAL_M_SHADOW_LOG_PATH
+# is set. Mirrors m2_grounding_log.py's _override_log_path_for_tests so
+# pytest tmp_path can isolate per-test mirrors without touching $HOME.
+def _override_log_path_for_tests() -> None:
+    override = os.getenv("BICAMERAL_M_SHADOW_LOG_PATH")
+    if override:
+        global _LOG_FILE
+        _LOG_FILE = Path(override)
+
+
+_override_log_path_for_tests()

--- a/tests/eval_shadow_parity.py
+++ b/tests/eval_shadow_parity.py
@@ -1,0 +1,329 @@
+"""M_shadow_parity — rate-based CI gate for walker ⊆ substrate (#399 Stage C).
+
+Runs walker AND substrate over the same per-language corpus as
+``tests/test_tags_extractor_parity.py`` (Python in-repo + Go from k8s/hugo
++ Rust from ripgrep/cargo), aggregates ``divergence_kind`` counts per
+language, and fails the gate when ``substrate-subset`` rate exceeds 1%.
+
+The pytest parity gate (``test_tags_extractor_parity.py``) is a binary
+pass/fail per file — useful for local dev iteration. M_shadow_parity is
+the rate-based CI metric: it tolerates a small percentage of failures
+across a large corpus, mirroring how production-scale shadow telemetry
+will surface drift once Stages D-E flip languages to shadow mode.
+
+CLI shape mirrors the other M_* evals (M2 grounding-recall, M_skill_preflight):
+
+    python tests/eval_shadow_parity.py --gate-mode hard -o test-results/shadow.json
+
+Gate modes:
+- ``warn`` — print metrics, exit 0 always. Baseline-discovery mode for
+  first integration into CI.
+- ``hard`` — exit non-zero if any language has ``substrate-subset`` rate
+  above ``--max-subset-rate`` (default 0.01 = 1%, per #399 plan).
+
+Output (stdout + optional --output JSON):
+- Per-language counts of each divergence_kind
+- Per-language substrate-subset rate
+- Aggregate counts
+- Pass/fail per gate mode
+
+Renders a markdown summary to stdout when ``--github-summary`` is passed
+(used by the workflow step that pipes to $GITHUB_STEP_SUMMARY).
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from collections import Counter, defaultdict
+from dataclasses import dataclass
+from pathlib import Path
+
+import tree_sitter as ts
+import tree_sitter_go as tsgo
+import tree_sitter_python as tsp
+import tree_sitter_rust as tsrs
+
+# Ensure repo root is on sys.path when run as a script (so the
+# code_locator + tests packages resolve).
+_REPO_ROOT = Path(__file__).resolve().parent.parent
+if str(_REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(_REPO_ROOT))
+
+from code_locator.indexing.symbol_extractor import (  # noqa: E402
+    _WALKER_VOCAB,
+    extract_symbols_from_content,
+)
+from code_locator.indexing.tags_extractor import (  # noqa: E402
+    extract_defs_via_tags,
+    load_tags_query_text,
+)
+from m_shadow_divergence_log import classify_divergence  # noqa: E402
+from tests._oss_corpus import OssSource, discover_files, sparse_clone  # noqa: E402
+from tests.test_tags_extractor_parity import (  # noqa: E402
+    GO_EXCLUDE_GLOBS,
+    GO_MAX_FILES_HUGO,
+    GO_MAX_FILES_K8S,
+    GO_SOURCE_HUGO,
+    GO_SOURCE_K8S,
+    PY_FIXTURE_FILES,
+    RUST_EXCLUDE_GLOBS,
+    RUST_MAX_FILES_CARGO,
+    RUST_MAX_FILES_RIPGREP,
+    RUST_SOURCE_CARGO,
+    RUST_SOURCE_RIPGREP,
+)
+
+# Per-language tree-sitter parser + tags-query text. Built once per run.
+_LANGUAGE_PKGS = {
+    "python": ("tree_sitter_python", tsp),
+    "go": ("tree_sitter_go", tsgo),
+    "rust": ("tree_sitter_rust", tsrs),
+}
+
+
+@dataclass(frozen=True)
+class LangResult:
+    """Per-language aggregate result."""
+
+    language: str
+    files: int
+    divergence_counts: dict[str, int]
+
+    @property
+    def substrate_subset_rate(self) -> float:
+        if self.files == 0:
+            return 0.0
+        return self.divergence_counts.get("substrate-subset", 0) / self.files
+
+
+def _setup_language(language_id: str):
+    """Build (language, parser, query_text) for a target language.
+    Returns None when the grammar package or its tags.scm is missing.
+    """
+    pkg_name, mod = _LANGUAGE_PKGS[language_id]
+    try:
+        lang = ts.Language(mod.language())
+    except Exception:
+        return None
+    parser = ts.Parser(lang)
+    query_text = load_tags_query_text(pkg_name)
+    if query_text is None:
+        return None
+    return lang, parser, query_text
+
+
+def _measure_file(
+    language_id: str,
+    rel_path: str,
+    content: str,
+    lang: ts.Language,
+    parser: ts.Parser,
+    query_text: str,
+) -> str:
+    """Run walker + substrate on a single file, classify divergence."""
+    code_bytes = content.encode("utf-8")
+    vocab = _WALKER_VOCAB.get(language_id, frozenset())
+
+    walker_records = extract_symbols_from_content(content, language_id, rel_path)
+    walker_set = {(r.name, r.type) for r in walker_records if r.type in vocab}
+
+    tree = parser.parse(code_bytes)
+    substrate_records = extract_defs_via_tags(lang, tree, code_bytes, rel_path, query_text)
+    substrate_set = {(r.name, r.type) for r in substrate_records if r.type in vocab}
+
+    return classify_divergence(walker_set, substrate_set)
+
+
+def measure_python_corpus() -> LangResult:
+    setup = _setup_language("python")
+    if setup is None:
+        return LangResult("python", 0, {})
+    lang, parser, query_text = setup
+    counts: Counter[str] = Counter()
+    files = 0
+    for rel in PY_FIXTURE_FILES:
+        src = _REPO_ROOT / rel
+        if not src.exists():
+            continue
+        content = src.read_text(encoding="utf-8")
+        counts[_measure_file("python", rel, content, lang, parser, query_text)] += 1
+        files += 1
+    return LangResult("python", files, dict(counts))
+
+
+def measure_go_corpus(cache_root: Path) -> LangResult:
+    setup = _setup_language("go")
+    if setup is None:
+        return LangResult("go", 0, {})
+    lang, parser, query_text = setup
+    counts: Counter[str] = Counter()
+    files = 0
+    for source, max_files in (
+        (GO_SOURCE_K8S, GO_MAX_FILES_K8S),
+        (GO_SOURCE_HUGO, GO_MAX_FILES_HUGO),
+    ):
+        clone_dir = cache_root / source.cache_dirname()
+        sparse_clone(source, clone_dir)
+        for fp in discover_files(
+            clone_dir, source, extension="go", exclude_globs=GO_EXCLUDE_GLOBS, max_files=max_files
+        ):
+            content = fp.read_text(encoding="utf-8")
+            counts[_measure_file("go", str(fp), content, lang, parser, query_text)] += 1
+            files += 1
+    return LangResult("go", files, dict(counts))
+
+
+def measure_rust_corpus(cache_root: Path) -> LangResult:
+    setup = _setup_language("rust")
+    if setup is None:
+        return LangResult("rust", 0, {})
+    lang, parser, query_text = setup
+    counts: Counter[str] = Counter()
+    files = 0
+    for source, max_files in (
+        (RUST_SOURCE_RIPGREP, RUST_MAX_FILES_RIPGREP),
+        (RUST_SOURCE_CARGO, RUST_MAX_FILES_CARGO),
+    ):
+        clone_dir = cache_root / source.cache_dirname()
+        sparse_clone(source, clone_dir)
+        for fp in discover_files(
+            clone_dir, source, extension="rs", exclude_globs=RUST_EXCLUDE_GLOBS, max_files=max_files
+        ):
+            content = fp.read_text(encoding="utf-8")
+            counts[_measure_file("rust", str(fp), content, lang, parser, query_text)] += 1
+            files += 1
+    return LangResult("rust", files, dict(counts))
+
+
+def _render_markdown(results: list[LangResult], passed: bool, max_subset_rate: float) -> str:
+    lines = ["## M_shadow_parity (#399 Stage C)\n"]
+    lines.append(f"Gate threshold: `substrate-subset rate <= {max_subset_rate:.1%}`")
+    lines.append(f"Result: {'PASS ✅' if passed else 'FAIL ❌'}\n")
+    lines.append(
+        "| Language | Files | equal | substrate-superset | substrate-subset | symmetric | subset rate |"
+    )
+    lines.append("|---|---:|---:|---:|---:|---:|---:|")
+    for r in results:
+        eq = r.divergence_counts.get("equal", 0)
+        sup = r.divergence_counts.get("substrate-superset", 0)
+        sub = r.divergence_counts.get("substrate-subset", 0)
+        sym = r.divergence_counts.get("symmetric", 0)
+        rate = r.substrate_subset_rate
+        lines.append(f"| {r.language} | {r.files} | {eq} | {sup} | {sub} | {sym} | {rate:.2%} |")
+    return "\n".join(lines) + "\n"
+
+
+def _collect_results(cache_root: Path) -> list[LangResult]:
+    return [
+        measure_python_corpus(),
+        measure_go_corpus(cache_root),
+        measure_rust_corpus(cache_root),
+    ]
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description="M_shadow_parity — walker ⊆ substrate rate gate")
+    ap.add_argument("--gate-mode", choices=("warn", "hard"), default="warn")
+    ap.add_argument(
+        "--max-subset-rate",
+        type=float,
+        default=0.01,
+        help="Per-language substrate-subset rate threshold. Default 0.01 (1%%) per #399 plan.",
+    )
+    ap.add_argument("-o", "--output", help="Write JSON results to this path")
+    ap.add_argument(
+        "--github-summary",
+        action="store_true",
+        help="Also print markdown summary suitable for $GITHUB_STEP_SUMMARY",
+    )
+    ap.add_argument(
+        "--cache-dir",
+        help="Pre-existing dir to reuse for OSS sparse clones (CI cache). "
+        "Defaults to a tmp dir scoped to this run.",
+    )
+    args = ap.parse_args()
+
+    if args.cache_dir:
+        cache_root = Path(args.cache_dir)
+        cache_root.mkdir(parents=True, exist_ok=True)
+    else:
+        import tempfile
+
+        cache_root = Path(tempfile.mkdtemp(prefix="m_shadow_parity_"))
+
+    results = _collect_results(cache_root)
+
+    breaches: list[str] = []
+    aggregate_counts: dict[str, int] = defaultdict(int)
+    for r in results:
+        for k, v in r.divergence_counts.items():
+            aggregate_counts[k] += v
+        if r.substrate_subset_rate > args.max_subset_rate:
+            breaches.append(
+                f"{r.language}: substrate-subset rate "
+                f"{r.substrate_subset_rate:.2%} > threshold "
+                f"{args.max_subset_rate:.1%} "
+                f"({r.divergence_counts.get('substrate-subset', 0)}/{r.files} files)"
+            )
+
+    passed = not breaches
+
+    # Output routing: --github-summary prints ONLY markdown to stdout
+    # (consumed by the workflow via `>> $GITHUB_STEP_SUMMARY`); regular
+    # mode prints only the human-readable text (consumed by step logs).
+    # Diagnostic / breach details land on stderr in both modes so
+    # they're visible in the step log even when stdout is redirected.
+    if args.github_summary:
+        sys.stdout.write(_render_markdown(results, passed, args.max_subset_rate))
+    else:
+        print("=" * 64)
+        print("M_shadow_parity results (#399 Stage C)")
+        print("=" * 64)
+        for r in results:
+            sub = r.divergence_counts.get("substrate-subset", 0)
+            print(
+                f"  {r.language}: {r.files} files | "
+                + ", ".join(f"{k}={v}" for k, v in sorted(r.divergence_counts.items()))
+                + f" | subset rate {r.substrate_subset_rate:.2%}"
+                + (f" ! {sub} files" if sub else "")
+            )
+        print()
+        print(f"Aggregate: {dict(aggregate_counts)}")
+        print(f"Gate threshold: substrate-subset rate <= {args.max_subset_rate:.1%}")
+        print(f"Result: {'PASS' if passed else 'FAIL'}")
+
+    if breaches:
+        sys.stderr.write("\nBreaches:\n")
+        for b in breaches:
+            sys.stderr.write(f"  - {b}\n")
+
+    if args.output:
+        out = {
+            "gate_mode": args.gate_mode,
+            "max_subset_rate": args.max_subset_rate,
+            "passed": passed,
+            "breaches": breaches,
+            "aggregate_counts": dict(aggregate_counts),
+            "per_language": [
+                {
+                    "language": r.language,
+                    "files": r.files,
+                    "divergence_counts": r.divergence_counts,
+                    "substrate_subset_rate": r.substrate_subset_rate,
+                }
+                for r in results
+            ],
+        }
+        Path(args.output).parent.mkdir(parents=True, exist_ok=True)
+        Path(args.output).write_text(json.dumps(out, indent=2))
+        sys.stderr.write(f"\nWrote JSON: {args.output}\n")
+
+    if args.gate_mode == "hard" and not passed:
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/test_m_shadow_divergence_log.py
+++ b/tests/test_m_shadow_divergence_log.py
@@ -1,0 +1,203 @@
+"""Unit tests for m_shadow_divergence_log (#399 Stage C).
+
+Pure-function tests against the real module — no MagicMock. Uses
+``BICAMERAL_M_SHADOW_LOG_PATH`` env override to redirect the mirror
+file into pytest's tmp_path so each test runs in isolation, matching
+the pattern in tests/test_m2_grounding_log.py.
+"""
+
+from __future__ import annotations
+
+import importlib
+import json
+
+
+def _reload_module_with_path(monkeypatch, tmp_path):
+    """Reload m_shadow_divergence_log so it picks up the env override."""
+    log_path = tmp_path / "m_shadow_divergence.jsonl"
+    monkeypatch.setenv("BICAMERAL_M_SHADOW_LOG_PATH", str(log_path))
+    import m_shadow_divergence_log as mod  # noqa: WPS433 — test-only import
+
+    importlib.reload(mod)
+    return mod, log_path
+
+
+def _read_rows(log_path):
+    if not log_path.exists():
+        return []
+    return [json.loads(line) for line in log_path.read_text().splitlines() if line.strip()]
+
+
+# ── classify_divergence — pure function ─────────────────────────────
+
+
+def test_classify_equal_sets(monkeypatch, tmp_path):
+    mod, _ = _reload_module_with_path(monkeypatch, tmp_path)
+    s = {("foo", "function"), ("Bar", "class")}
+    assert mod.classify_divergence(s, s) == "equal"
+
+
+def test_classify_substrate_superset(monkeypatch, tmp_path):
+    """Substrate has extras; walker is a strict subset. Allowed direction
+    — substrate captures module constants / macros that walkers skip."""
+    mod, _ = _reload_module_with_path(monkeypatch, tmp_path)
+    walker = {("foo", "function")}
+    substrate = {("foo", "function"), ("CONST", "function")}
+    assert mod.classify_divergence(walker, substrate) == "substrate-superset"
+
+
+def test_classify_substrate_subset(monkeypatch, tmp_path):
+    """Walker has extras; substrate is a strict subset. Forbidden —
+    signals a substrate gap that breaks the parity contract."""
+    mod, _ = _reload_module_with_path(monkeypatch, tmp_path)
+    walker = {("foo", "function"), ("bar", "function")}
+    substrate = {("foo", "function")}
+    assert mod.classify_divergence(walker, substrate) == "substrate-subset"
+
+
+def test_classify_symmetric(monkeypatch, tmp_path):
+    """Both sides have unique entries — usually means a (name, type)
+    pair has a different type label between walker and substrate."""
+    mod, _ = _reload_module_with_path(monkeypatch, tmp_path)
+    walker = {("foo", "function")}
+    substrate = {("foo", "method")}
+    assert mod.classify_divergence(walker, substrate) == "symmetric"
+
+
+# ── Deterministic sampling ──────────────────────────────────────────
+
+
+def test_sample_decision_is_deterministic(monkeypatch, tmp_path):
+    """Same file_hash → same sampling answer across calls. Determinism
+    is the load-bearing property — an investigator chasing a missing
+    log entry needs to ask 'would this file have been sampled?' and
+    get a repeatable answer."""
+    mod, _ = _reload_module_with_path(monkeypatch, tmp_path)
+    h = mod._hash_path("handlers/preflight.py")
+    assert mod._should_sample_agreement(h) == mod._should_sample_agreement(h)
+
+
+def test_sample_rate_is_roughly_one_in_fifty(monkeypatch, tmp_path):
+    """Across 1000 distinct paths, ~2% should sample (1-in-50). Allow
+    ±1.5% slack since the hash uniformity isn't perfect at small N."""
+    mod, _ = _reload_module_with_path(monkeypatch, tmp_path)
+    sampled = sum(
+        1 for i in range(1000) if mod._should_sample_agreement(mod._hash_path(f"f{i}.py"))
+    )
+    rate = sampled / 1000
+    assert 0.005 <= rate <= 0.035, f"sampling rate {rate:.3f} outside [0.5%, 3.5%]"
+
+
+# ── record_divergence — end-to-end behavior ─────────────────────────
+
+
+def test_record_disagreement_always_logs(monkeypatch, tmp_path):
+    """Any non-equal divergence_kind must log regardless of file_hash —
+    we never miss a substrate-subset signal."""
+    mod, log_path = _reload_module_with_path(monkeypatch, tmp_path)
+
+    mod.record_divergence(
+        language_id="python",
+        mode="shadow-substrate",
+        rel_path="handlers/preflight.py",
+        walker_set={("foo", "function"), ("missing", "function")},
+        substrate_set={("foo", "function")},
+    )
+
+    rows = _read_rows(log_path)
+    assert len(rows) == 1
+    row = rows[0]
+    assert row["event_type"] == "m_shadow_divergence"
+    assert row["language_id"] == "python"
+    assert row["mode"] == "shadow-substrate"
+    assert row["divergence_kind"] == "substrate-subset"
+    assert row["walker_count"] == 2
+    assert row["substrate_count"] == 1
+    assert row["walker_only"] == ["missing:function"]
+    assert row["substrate_only"] == []
+    # rel_path must not appear — only file_hash
+    assert "rel_path" not in row
+    assert "file_hash" in row
+    assert row["file_hash"] != "handlers/preflight.py"
+
+
+def test_record_agreement_samples_consistently(monkeypatch, tmp_path):
+    """For an equal walker/substrate pair, sampling decision is
+    deterministic per file_hash. Call twice — same outcome."""
+    mod, log_path = _reload_module_with_path(monkeypatch, tmp_path)
+    s = {("foo", "function")}
+
+    mod.record_divergence(
+        language_id="python",
+        mode="shadow-substrate",
+        rel_path="some/file.py",
+        walker_set=s,
+        substrate_set=s,
+    )
+    rows1 = _read_rows(log_path)
+
+    mod.record_divergence(
+        language_id="python",
+        mode="shadow-substrate",
+        rel_path="some/file.py",
+        walker_set=s,
+        substrate_set=s,
+    )
+    rows2 = _read_rows(log_path)
+
+    # Either both calls landed (file sampled) or both were dropped
+    # (file not sampled). Asymmetric outcome would mean
+    # non-determinism — fail.
+    assert len(rows2) == 2 * len(rows1), (
+        f"non-deterministic sampling: first call wrote {len(rows1)} rows, "
+        f"second call wrote {len(rows2) - len(rows1)} rows. Same input MUST "
+        f"produce same outcome."
+    )
+
+
+def test_record_skips_non_shadow_modes(monkeypatch, tmp_path):
+    """walker-only and substrate-only callers should never invoke
+    record_divergence, but the function defends with a no-op anyway
+    so a future refactor can't accidentally pollute the log with
+    irrelevant single-path events."""
+    mod, log_path = _reload_module_with_path(monkeypatch, tmp_path)
+
+    mod.record_divergence(
+        language_id="python",
+        mode="walker-only",
+        rel_path="x.py",
+        walker_set={("a", "function")},
+        substrate_set={("a", "function"), ("b", "function")},
+    )
+    mod.record_divergence(
+        language_id="elixir",
+        mode="substrate-only",
+        rel_path="y.ex",
+        walker_set=set(),
+        substrate_set={("a", "function")},
+    )
+
+    assert _read_rows(log_path) == []
+
+
+def test_record_writes_no_raw_path_anywhere(monkeypatch, tmp_path):
+    """Even with a path that contains identifying info (a user's home
+    dir, a private module name), the only thing on disk should be the
+    sha256 hex — not the raw path. Privacy invariant load-bearing for
+    the optional PostHog relay; this test pins it for the local mirror
+    too (defense in depth)."""
+    mod, log_path = _reload_module_with_path(monkeypatch, tmp_path)
+    private_path = "/Users/sensitive/repo/secret_module.py"
+
+    mod.record_divergence(
+        language_id="python",
+        mode="shadow-substrate",
+        rel_path=private_path,
+        walker_set={("foo", "function"), ("bar", "function")},
+        substrate_set={("foo", "function")},
+    )
+
+    raw_log = log_path.read_text()
+    assert private_path not in raw_log
+    assert "secret_module" not in raw_log
+    assert "/Users/sensitive" not in raw_log

--- a/tests/test_shadow_dispatch.py
+++ b/tests/test_shadow_dispatch.py
@@ -1,0 +1,280 @@
+"""Tests for the shadow-mode dispatch in ``_extract_definitions`` (#399 Stage C).
+
+Sociable per CLAUDE.md — uses the real ``extract_symbols_from_content``
+entry point and real telemetry log writes, redirected via the
+``BICAMERAL_M_SHADOW_LOG_PATH`` env override into pytest's tmp_path.
+No MagicMock; collaborators we ship to users (the symbol_extractor
+dispatch, the m_shadow_divergence_log writer) run as themselves.
+
+What's pinned here:
+
+1. **walker-only mode** (default for Python/Go/Rust/JS/TS/Java/C#)
+   produces walker output and emits no shadow log entries.
+2. **substrate-only mode** (Elixir) produces substrate output and
+   emits no shadow log entries.
+3. **shadow-substrate mode** runs both paths, returns walker output
+   (authoritative), AND logs a divergence event when results differ.
+4. **shadow-walker mode** runs both paths, returns substrate output
+   (authoritative).
+5. The dispatch table is the only switch — flipping a mode via the
+   table changes behavior without touching ``_extract_definitions``.
+
+The mode flips here use monkeypatch on ``_SHADOW_MODES``; this same
+mechanism is what Stage D and Stage E PRs will use, just persistently
+via a one-line edit instead of a test-scoped monkeypatch.
+"""
+
+from __future__ import annotations
+
+import importlib
+import json
+from pathlib import Path
+
+import pytest
+
+# Small Python fixture with a known walker output: 1 class, 2 funcs.
+# The substrate (Python tags.scm) emits these PLUS module-level
+# constants — which fall outside the walker vocab and are stripped
+# before divergence classification, so this fixture produces an
+# "equal" comparison.
+_PY_FIXTURE_EQUAL = '''\
+"""Test fixture."""
+
+X = 1
+
+class Foo:
+    pass
+
+def bar():
+    return 1
+
+def baz():
+    return 2
+'''
+
+
+def _reset_shadow_log(monkeypatch, tmp_path):
+    """Redirect the shadow-divergence log into tmp_path and reload the
+    module so the env override takes effect."""
+    log_path = tmp_path / "m_shadow_divergence.jsonl"
+    monkeypatch.setenv("BICAMERAL_M_SHADOW_LOG_PATH", str(log_path))
+    import m_shadow_divergence_log as mod  # noqa: WPS433
+
+    importlib.reload(mod)
+    return log_path
+
+
+def _read_log(log_path: Path) -> list[dict]:
+    if not log_path.exists():
+        return []
+    return [json.loads(line) for line in log_path.read_text().splitlines() if line.strip()]
+
+
+# ── Mode default state ─────────────────────────────────────────────
+
+
+def test_default_modes_match_stage_c_initial_state():
+    """The dispatch table starts every walker-backed language at
+    WALKER_ONLY and Elixir at SUBSTRATE_ONLY. Flipping these is Stages
+    D and E — if this test fails after a Stage C-and-below PR, somebody
+    edited the table prematurely."""
+    from code_locator.indexing.symbol_extractor import _SHADOW_MODES, ShadowMode
+
+    assert _SHADOW_MODES["python"] is ShadowMode.WALKER_ONLY
+    assert _SHADOW_MODES["go"] is ShadowMode.WALKER_ONLY
+    assert _SHADOW_MODES["rust"] is ShadowMode.WALKER_ONLY
+    assert _SHADOW_MODES["javascript"] is ShadowMode.WALKER_ONLY
+    assert _SHADOW_MODES["typescript"] is ShadowMode.WALKER_ONLY
+    assert _SHADOW_MODES["java"] is ShadowMode.WALKER_ONLY
+    assert _SHADOW_MODES["c_sharp"] is ShadowMode.WALKER_ONLY
+    assert _SHADOW_MODES["elixir"] is ShadowMode.SUBSTRATE_ONLY
+
+
+# ── walker-only mode ───────────────────────────────────────────────
+
+
+def test_walker_only_writes_no_shadow_log(monkeypatch, tmp_path):
+    """Default Python (walker-only) runs without touching the shadow
+    log. Pins the cost-zero property — production indexing of a fully-
+    walker-only workload pays nothing for telemetry."""
+    log_path = _reset_shadow_log(monkeypatch, tmp_path)
+
+    from code_locator.indexing.symbol_extractor import extract_symbols_from_content
+
+    records = extract_symbols_from_content(_PY_FIXTURE_EQUAL, "python", "fixture.py")
+
+    names = {r.name for r in records}
+    assert "Foo" in names and "bar" in names and "baz" in names
+    assert _read_log(log_path) == []
+
+
+# ── substrate-only mode ────────────────────────────────────────────
+
+
+def test_substrate_only_writes_no_shadow_log(monkeypatch, tmp_path):
+    """Elixir's substrate-only path runs without touching the shadow
+    log. Same cost-zero property as walker-only — divergence only
+    matters in shadow modes."""
+    log_path = _reset_shadow_log(monkeypatch, tmp_path)
+
+    # Tiny inline Elixir module — avoids depending on the
+    # tests/fixtures/elixir fixture file being installed.
+    elixir_src = "defmodule MyMod do\n  def hello, do: :world\nend\n"
+
+    from code_locator.indexing.symbol_extractor import extract_symbols_from_content
+
+    try:
+        records = extract_symbols_from_content(elixir_src, "elixir", "m.ex")
+    except Exception:
+        pytest.skip("tree_sitter_elixir not installed in this environment")
+
+    if not records:
+        pytest.skip("tree_sitter_elixir present but tags.scm did not yield records")
+
+    assert _read_log(log_path) == []
+
+
+# ── shadow-substrate mode (walker authoritative) ────────────────────
+
+
+def test_shadow_substrate_returns_walker_output(monkeypatch, tmp_path):
+    """In shadow-substrate mode the walker is authoritative — what
+    callers see is walker output, even though both paths ran. This is
+    the invariant Stage D depends on: flipping Python to shadow-
+    substrate must not change behavior visible to indexer consumers."""
+    _reset_shadow_log(monkeypatch, tmp_path)
+
+    from code_locator.indexing import symbol_extractor
+    from code_locator.indexing.symbol_extractor import (
+        _SHADOW_MODES,
+        ShadowMode,
+        extract_symbols_from_content,
+    )
+
+    monkeypatch.setitem(_SHADOW_MODES, "python", ShadowMode.SHADOW_SUBSTRATE)
+
+    records = extract_symbols_from_content(_PY_FIXTURE_EQUAL, "python", "fixture.py")
+    names = {r.name for r in records}
+    # Walker output: class + 2 funcs. Module constant X is substrate-
+    # only and would appear if the substrate side leaked through.
+    assert names == {"Foo", "bar", "baz"}, (
+        f"shadow-substrate must return walker output; got {names}"
+    )
+
+    # Also ensure the symbol_extractor module wasn't accidentally
+    # mutated outside the monkeypatch scope.
+    assert symbol_extractor._SHADOW_MODES is _SHADOW_MODES
+
+
+def test_shadow_substrate_logs_divergence_when_walker_extras_exist(monkeypatch, tmp_path):
+    """Build a synthetic divergence by patching the walker dispatch
+    to return an extra symbol the substrate won't have. Forces a
+    ``substrate-subset`` event in the log — the forbidden direction
+    the parity gate is designed to catch."""
+    log_path = _reset_shadow_log(monkeypatch, tmp_path)
+
+    from code_locator.indexing import symbol_extractor
+    from code_locator.indexing.sqlite_store import SymbolRecord
+    from code_locator.indexing.symbol_extractor import (
+        _SHADOW_MODES,
+        ShadowMode,
+        extract_symbols_from_content,
+    )
+
+    monkeypatch.setitem(_SHADOW_MODES, "python", ShadowMode.SHADOW_SUBSTRATE)
+
+    # Synthetic walker: append a phantom symbol the substrate can't see.
+    original_walker = symbol_extractor._run_walker
+
+    def fake_walker(language_id, tree, code, rel_path):
+        records = original_walker(language_id, tree, code, rel_path)
+        records.append(
+            SymbolRecord(
+                name="phantom",
+                qualified_name="phantom",
+                type="function",
+                file_path=rel_path,
+                start_line=999,
+                end_line=999,
+                signature="def phantom()",
+                parent_qualified_name="",
+            )
+        )
+        return records
+
+    monkeypatch.setattr(symbol_extractor, "_run_walker", fake_walker)
+
+    extract_symbols_from_content(_PY_FIXTURE_EQUAL, "python", "synthetic.py")
+
+    rows = _read_log(log_path)
+    assert len(rows) == 1, f"expected 1 divergence row, got {len(rows)}"
+    row = rows[0]
+    assert row["language_id"] == "python"
+    assert row["mode"] == "shadow-substrate"
+    assert row["divergence_kind"] == "substrate-subset"
+    assert "phantom:function" in row["walker_only"]
+
+
+# ── shadow-walker mode (substrate authoritative) ────────────────────
+
+
+def test_shadow_walker_returns_substrate_output(monkeypatch, tmp_path):
+    """In shadow-walker mode the substrate is authoritative — Stage
+    E's pre-retirement state. The walker still runs (for divergence
+    detection) but its output isn't what callers see.
+
+    For Python the walker and substrate produce overlapping name sets
+    (the parity gate enforces walker ⊆ substrate, and substrate's only
+    Python extras are module constants that ``_KIND_TO_TYPE`` filters
+    out via the ``constant`` kind being unmapped). So we can't tell
+    sides apart by inspecting names alone. Patch ``_run_substrate`` to
+    return a distinct sentinel and assert the dispatch returns it.
+    """
+    _reset_shadow_log(monkeypatch, tmp_path)
+
+    from code_locator.indexing import symbol_extractor
+    from code_locator.indexing.sqlite_store import SymbolRecord
+    from code_locator.indexing.symbol_extractor import (
+        _SHADOW_MODES,
+        ShadowMode,
+        extract_symbols_from_content,
+    )
+
+    sentinel = SymbolRecord(
+        name="SUBSTRATE_SENTINEL",
+        qualified_name="SUBSTRATE_SENTINEL",
+        type="function",
+        file_path="fixture.py",
+        start_line=1,
+        end_line=1,
+        signature="def SUBSTRATE_SENTINEL()",
+        parent_qualified_name="",
+    )
+
+    def fake_substrate(language_id, tree, code, rel_path):
+        return [sentinel]
+
+    monkeypatch.setitem(_SHADOW_MODES, "python", ShadowMode.SHADOW_WALKER)
+    monkeypatch.setattr(symbol_extractor, "_run_substrate", fake_substrate)
+
+    records = extract_symbols_from_content(_PY_FIXTURE_EQUAL, "python", "fixture.py")
+    assert records == [sentinel], (
+        "shadow-walker must return the substrate side; got walker output instead"
+    )
+
+
+# ── Unknown language ───────────────────────────────────────────────
+
+
+def test_unknown_language_returns_empty(monkeypatch, tmp_path):
+    """A language not in _SHADOW_MODES returns []. Preserves the
+    pre-Stage-C behavior for unrecognized extensions."""
+    _reset_shadow_log(monkeypatch, tmp_path)
+
+    from code_locator.indexing.symbol_extractor import _extract_definitions
+
+    # The dispatch needs a tree, but for an unknown language we never
+    # parse — pass None and confirm the early-exit before any tree
+    # access.
+    records = _extract_definitions("haskell", None, b"", "x.hs")
+    assert records == []


### PR DESCRIPTION
## Summary

Stage C of [#399](https://github.com/BicameralAI/bicameral-mcp/issues/399) — the runtime infrastructure that lets the indexer compare bespoke walker output against the tags-query substrate without changing user-visible behavior. Per-language `ShadowMode` enum controls how `_extract_definitions` routes each language. Today every walker-backed language stays `walker-only` and Elixir stays `substrate-only`; flipping individual languages to `shadow-substrate` is **Stage D's one-line edit**, blocked on this PR.

## Mode taxonomy

| Mode | Walker runs | Substrate runs | Authority | Divergence logged |
|---|---|---|---|---|
| `walker-only` (Python/Go/Rust/JS/TS/Java/C# today) | yes | no | walker | n/a |
| `shadow-substrate` (Stage D target for Python/Go/Rust) | yes | yes (silent) | walker | yes |
| `shadow-walker` (Stage E pre-retirement) | yes (silent) | yes | substrate | yes |
| `substrate-only` (Elixir today) | no | yes | substrate | n/a |

Each transition is a one-line edit to `_SHADOW_MODES` — reviewable independently, revertable in seconds.

## What changed

### Source code
- **`code_locator/indexing/symbol_extractor.py`** — `ShadowMode` (StrEnum), `_SHADOW_MODES` per-language dispatch table, `_WALKER_VOCAB` (centralizes constants the parity tests had been hardcoding), refactored `_extract_definitions` to dispatch via the table, helper `_run_walker` / `_run_substrate` / `_log_shadow_divergence` functions. Telemetry call wrapped in try/except — telemetry failures never break extraction.

- **`m_shadow_divergence_log.py` (new)** — telemetry module parallel to `m2_grounding_log.py`. JSONL local mirror at `~/.bicameral/m_shadow_divergence.jsonl` (10MB rotation, keep 3), optional PostHog relay gated on existing `BICAMERAL_TELEMETRY=relay`. Sampling: every disagreement logs; agreements sampled 1-in-50 via deterministic file-hash modulo.

### Privacy invariants

- File paths → sha256 in **both** local mirror and relay
- `walker_only` / `substrate_only` symbol-name lists live in local mirror only; relay sees only numeric aggregates
- `telemetry.send_event`'s defensive int-only `diagnostic` filter is a second line of defense against future refactors leaking strings

### CI gate
- **`tests/eval_shadow_parity.py` (new)** — rate-based M_shadow_parity gate. Same corpus as `test_tags_extractor_parity.py`, aggregates `divergence_kind` per language, fails on `substrate-subset > 1%`. CLI matches the M2 / M_skill_preflight pattern (`--gate-mode warn|hard`, `-o JSON`, `--github-summary` emits markdown to stdout).
- **`.github/workflows/test-mcp-regression.yml`** — adds the parity tests + shadow tests to the regression pytest invocation (closes a Stage B CI coverage gap — they were running locally but never in CI), plus a new `M_shadow_parity (hard gate)` step.

### Tests
- **`tests/test_m_shadow_divergence_log.py`** — 10 sociable tests against the real module: classify_divergence pure function (equal / superset / subset / symmetric), deterministic sampling (~1-in-50 across 1k paths), end-to-end record_divergence behavior, privacy invariant (raw path must not appear in mirror).
- **`tests/test_shadow_dispatch.py`** — 7 sociable tests against `extract_symbols_from_content` with real telemetry writes redirected via `BICAMERAL_M_SHADOW_LOG_PATH`. Pins the initial mode state, the zero-cost property of single-path modes, walker authority in shadow-substrate, substrate authority in shadow-walker (sentinel-based check), unknown-language behavior.

## Verification

```
$ python3 -m pytest tests/test_m_shadow_divergence_log.py \
                   tests/test_shadow_dispatch.py \
                   tests/test_tags_extractor_parity.py \
                   tests/test_extract_go_substrate.py \
                   tests/test_phase1_code_locator.py \
                   tests/test_extract_call_sites.py
43 passed, 2 skipped in 5.66s

$ python3 tests/eval_shadow_parity.py --gate-mode hard
  python: 6 files  | equal=5, substrate-superset=1  | 0% subset
  go:     19 files | equal=18, substrate-superset=1 | 0% subset
  rust:   25 files | equal=15, substrate-superset=10 | 0% subset
  Result: PASS

$ python3 -m ruff format + ruff check → clean
```

## What didn't change

| Surface | State |
|---|---|
| User-visible extraction output for any language | Identical — every entry in `_SHADOW_MODES` starts at the same effective behavior as before |
| Tags-query substrate (`tags_extractor.py`) | Untouched. Stage A's `_KIND_TO_TYPE` map is unchanged |
| Per-language walker bodies | Untouched. Stage C is dispatch + telemetry layer; walker retirement is Stages D-E |
| `test_tags_extractor_parity.py` | Unchanged. Pytest gate (per-file binary) + M_shadow_parity (per-language rate) give complementary signal |

## Test plan

- [ ] CI green on Linux + Windows matrix
- [ ] M_shadow_parity gate fires green on the regression run (0% substrate-subset across python/go/rust)
- [ ] Markdown summary renders correctly to the GitHub Actions step summary

## Next: Stage D + E

With this infrastructure in place, Stage D is a one-line edit per language:

```python
_SHADOW_MODES["python"] = ShadowMode.SHADOW_SUBSTRATE
```

Flip → ship → observe `m_shadow_divergence.jsonl` for 2 weeks → if zero `substrate-subset` events, advance to Stage E (`SHADOW_WALKER`) → another 2 weeks → if still clean, retire the walker.

🤖 Generated with [Claude Code](https://claude.com/claude-code)