### PR TITLE
feat(code-locator): #399 Stage D (Python) — flip to shadow-substrate

### DIFF
--- a/code_locator/indexing/symbol_extractor.py
+++ b/code_locator/indexing/symbol_extractor.py
@@ -472,7 +472,16 @@ class ShadowMode(StrEnum):
 # overlap, Java annotation/wildcard handling, C# nested-class qualified
 # names). Stage D/E flips do NOT apply to these three languages.
 _SHADOW_MODES: dict[str, ShadowMode] = {
-    "python": ShadowMode.WALKER_ONLY,
+    # #399 Stage D (Python): flipped from WALKER_ONLY → SHADOW_SUBSTRATE
+    # on 2026-05-19. Walker stays authoritative; substrate runs silently
+    # alongside and divergence lands in ~/.bicameral/m_shadow_divergence.jsonl.
+    # Observation window: ≥2 weeks of dev telemetry. If zero
+    # "substrate-subset" events (the forbidden direction the parity gate
+    # already enforces in CI), advance to ShadowMode.SHADOW_WALKER per
+    # Stage E. If any "substrate-subset" surfaces, revert THIS LINE in a
+    # one-line PR — the substrate has a real-world gap the CI corpus
+    # didn't catch, file an issue with the divergence event payload.
+    "python": ShadowMode.SHADOW_SUBSTRATE,
     "javascript": ShadowMode.WALKER_ONLY,
     "jsx": ShadowMode.WALKER_ONLY,
     "typescript": ShadowMode.WALKER_ONLY,

--- a/tests/test_shadow_dispatch.py
+++ b/tests/test_shadow_dispatch.py
@@ -73,14 +73,23 @@ def _read_log(log_path: Path) -> list[dict]:
 # ── Mode default state ─────────────────────────────────────────────
 
 
-def test_default_modes_match_stage_c_initial_state():
-    """The dispatch table starts every walker-backed language at
-    WALKER_ONLY and Elixir at SUBSTRATE_ONLY. Flipping these is Stages
-    D and E — if this test fails after a Stage C-and-below PR, somebody
-    edited the table prematurely."""
+def test_modes_match_current_rollout_state():
+    """Locks the per-language ``_SHADOW_MODES`` state at its current
+    rollout point. Each Stage D/E PR that flips a language updates this
+    test in lockstep — if a flip lands without updating this test, the
+    PR breaks CI immediately, which is the desired tripwire.
+
+    Current state (#399 rollout):
+      - Python: SHADOW_SUBSTRATE (Stage D / 2026-05-19) — walker
+        authoritative, substrate runs silently, divergence logged.
+      - Go, Rust: WALKER_ONLY (Stage D pending observation of Python).
+      - JS/TS, Java, C#: WALKER_ONLY (walker-only forever per Stage A
+        decision — upstream tags.scm gaps make these untouchable).
+      - Elixir: SUBSTRATE_ONLY (no walker; was always this).
+    """
     from code_locator.indexing.symbol_extractor import _SHADOW_MODES, ShadowMode
 
-    assert _SHADOW_MODES["python"] is ShadowMode.WALKER_ONLY
+    assert _SHADOW_MODES["python"] is ShadowMode.SHADOW_SUBSTRATE
     assert _SHADOW_MODES["go"] is ShadowMode.WALKER_ONLY
     assert _SHADOW_MODES["rust"] is ShadowMode.WALKER_ONLY
     assert _SHADOW_MODES["javascript"] is ShadowMode.WALKER_ONLY
@@ -94,12 +103,23 @@ def test_default_modes_match_stage_c_initial_state():
 
 
 def test_walker_only_writes_no_shadow_log(monkeypatch, tmp_path):
-    """Default Python (walker-only) runs without touching the shadow
-    log. Pins the cost-zero property — production indexing of a fully-
-    walker-only workload pays nothing for telemetry."""
+    """Walker-only mode runs without touching the shadow log. Pins the
+    cost-zero property — production indexing of a fully-walker-only
+    workload pays nothing for telemetry.
+
+    Forces Python into WALKER_ONLY for this test even though its
+    current rollout state is SHADOW_SUBSTRATE (Stage D, 2026-05-19) —
+    the property under test is a property of the WALKER_ONLY enum
+    value, not of any specific language."""
     log_path = _reset_shadow_log(monkeypatch, tmp_path)
 
-    from code_locator.indexing.symbol_extractor import extract_symbols_from_content
+    from code_locator.indexing.symbol_extractor import (
+        _SHADOW_MODES,
+        ShadowMode,
+        extract_symbols_from_content,
+    )
+
+    monkeypatch.setitem(_SHADOW_MODES, "python", ShadowMode.WALKER_ONLY)
 
     records = extract_symbols_from_content(_PY_FIXTURE_EQUAL, "python", "fixture.py")
 


### PR DESCRIPTION
## Summary

One-line mode flip: ``_SHADOW_MODES["python"]`` walks from ``WALKER_ONLY`` to ``SHADOW_SUBSTRATE``. The walker stays authoritative — every indexer caller sees identical output. The substrate now runs silently alongside; any `(name, type)` pair the walker emits but the substrate misses lands in `~/.bicameral/m_shadow_divergence.jsonl` as a `substrate-subset` event (the forbidden direction the parity gate is designed to catch).

This kicks off Stage D's observation window for Python per the [#399](https://github.com/BicameralAI/bicameral-mcp/issues/399) rollout plan.

## Observation contract

| Field | Value |
|---|---|
| **Window start** | 2026-05-19 |
| **Window length** | ≥2 weeks of real dev telemetry |
| **Go/no-go signal** | Zero `substrate-subset` events |
| **Revert path** | Single-line revert of this commit; divergence event payload identifies the offending file + symbol |

The pytest parity gate (#400) and M_shadow_parity CI gate (#413) have been green for Python for months — but those measure against fixture corpora. Stage D moves the same comparison from "lab benchmark" to "real user workloads" where edge cases the corpus doesn't cover get a fair shot to surface.

## What changed

- **`code_locator/indexing/symbol_extractor.py`** — one-line table edit, with an inline comment block recording the flip date, the observation contract, the revert protocol, and what to do if the substrate surfaces a real-world gap.
- **`tests/test_shadow_dispatch.py`**:
  - `test_modes_match_current_rollout_state` (renamed from `test_default_modes_match_stage_c_initial_state`) — now pins Python at `SHADOW_SUBSTRATE`. Each subsequent Stage D/E PR updates this test in lockstep. A flip that lands without updating this test breaks CI immediately. Desired tripwire.
  - `test_walker_only_writes_no_shadow_log` — explicitly monkeypatches Python back to `WALKER_ONLY` for the duration of the test, since the cost-zero property is a property of the enum value, not of any specific language.

## What didn't change

| Surface | State |
|---|---|
| Extraction output for Python | Identical — walker authoritative |
| Tags substrate code | Untouched |
| Per-language walker bodies | Untouched |
| Other languages' modes | Untouched (Go/Rust stay at `WALKER_ONLY` pending observation of Python) |
| User-facing behavior | Indistinguishable from pre-flip |

## Verification

```
$ python3 -m pytest tests/test_shadow_dispatch.py \
                   tests/test_m_shadow_divergence_log.py \
                   tests/test_tags_extractor_parity.py \
                   tests/test_phase1_code_locator.py \
                   tests/test_extract_call_sites.py
38 passed, 2 skipped in 8.00s

$ python3 tests/eval_shadow_parity.py --gate-mode hard
  python: 6 files  | equal=5, substrate-superset=1  | subset rate 0.00%
  go:     19 files | equal=18, substrate-superset=1 | subset rate 0.00%
  rust:   25 files | equal=15, substrate-superset=10 | subset rate 0.00%
  Result: PASS

$ python3 -m ruff format + ruff check → clean
```

## Test plan

- [ ] CI green on Linux + Windows matrix
- [ ] M_shadow_parity stays at 0% substrate-subset across all three languages
- [ ] Locked-state test catches accidental future flips

## Stage chain

| Stage | State |
|---|---|
| A — Go type→class mapping (#407) | merged |
| B — Go parity (#409), Rust parity (#411) | merged |
| C — Shadow-mode dispatch + M_shadow_parity (#413) | merged |
| **D — Python flip** | **THIS PR** |
| D — Go flip | Pending ≥2 weeks of Python observation |
| D — Rust flip | Pending ≥2 weeks of Python observation |
| E — Python flip to `shadow-walker` | Pending Stage D Python window |
| E — walker retirement (per language) | Pending Stage E observation |

🤖 Generated with [Claude Code](https://claude.com/claude-code)