### PR TITLE
feat(ingest): #418 Phase 0a — passive ingest_mode + DLQ + disposition

### DIFF
--- a/cli/sync_and_brief_cli.py
+++ b/cli/sync_and_brief_cli.py
@@ -204,7 +204,17 @@ async def _run_source(ctx: Any, source: dict, *, watermark_dir: Path) -> None:
 
     try:
         for payload in payloads:
-            await handle_ingest(ctx, payload, source_scope=source_type, cursor=adapter.name)
+            # #418 Phase 0a: passive caller — soft gates WARN+DLQ+continue so
+            # a single bad item from the source doesn't halt the poller. Hard
+            # gates (secret/PHI/PAN/malformed) still raise; the except below
+            # catches them and refuses to advance the watermark.
+            await handle_ingest(
+                ctx,
+                payload,
+                source_scope=source_type,
+                cursor=adapter.name,
+                ingest_mode="passive",
+            )
     except Exception as exc:  # noqa: BLE001
         # Ingest failure: do NOT advance watermark.
         print(

--- a/contracts.py
+++ b/contracts.py
@@ -564,6 +564,15 @@ class IngestStats(BaseModel):
     grounded_pct: float = 0.0
     grounding_deferred: int = 0
     cache_hits: int = 0
+    # #418 Phase 0a: passive-mode soft-gate refusals routed to the DLQ
+    # rather than raised. Empty dict on every active-mode call and on
+    # successful passive calls. Populated only when ``ingest_mode="passive"``
+    # and a soft gate (``size_limit_exceeded`` / ``rate_limit_exceeded`` /
+    # ``injection_canary_match``) fires — keyed by the gate's refusal reason,
+    # value is the count routed to DLQ in this call (currently always 1
+    # since handle_ingest takes a single payload; dict shape is forward-
+    # compatible with future batched ingest).
+    dlqd_count: dict[str, int] = {}
 
 
 class ContextForCandidate(BaseModel):

--- a/dlq/__init__.py
+++ b/dlq/__init__.py
@@ -1,0 +1,8 @@
+"""Dead-letter queue for passive-ingest refusals (#418 Phase 0a).
+
+Public API re-exports for callers (`from dlq import write_dlq_entry`).
+"""
+
+from dlq.store import write_dlq_entry
+
+__all__ = ["write_dlq_entry"]

--- a/dlq/store.py
+++ b/dlq/store.py
@@ -1,0 +1,159 @@
+"""Dead-letter queue store for passive-ingest refusals (#418 Phase 0a).
+
+Writes one JSONL row + one raw-content sidecar per item rejected by a
+soft gate (`size_limit_exceeded`, `rate_limit_exceeded`, `injection_canary_match`)
+in passive ingest mode. Hard-gate refusals (`sensitive_data:*`,
+`malformed_payload`) never reach DLQ — they fail-fast in both modes so the
+operator MUST intervene (credential rotation, regulated-data response,
+caller bug fix).
+
+Layout:
+    <root>/dlq/<source_id>.jsonl      append-mode JSONL index
+    <root>/dlq/raw/<dlq_id>.bin       raw payload, mode 0600
+
+Root selection: ``$BICAMERAL_DATA_PATH`` if set, else ``~/.bicameral``.
+
+JSONL row schema (one per refused item):
+    {
+      "dlq_id": "<uuid4-hex>",
+      "source_id": "linear",
+      "source_ref": "LIN-123#comment-456",
+      "received_at": "2026-05-19T19:45:12.123456+00:00",
+      "reason": "size_limit_exceeded",
+      "byte_size": 2097153,
+      "content_hash": "sha256:...",
+      "raw_content_path": "<absolute-path-to-sidecar>"
+    }
+
+Retention: this module ships storage only. Rotation / cap enforcement is
+out of scope for Phase 0a; the gap is documented in the parent plan.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import re
+import sys
+import uuid
+from datetime import UTC, datetime
+from pathlib import Path
+
+_JSONL_MODE = 0o600
+_DIR_MODE = 0o700
+
+# Whitelist for ``source_id`` — strict subset that's safe as a filename on
+# every platform and impossible to use for traversal. Anything else is
+# normalized to ``"unknown"`` so the JSONL still records what the gate saw
+# without letting a hostile ``source_scope`` write outside the DLQ root
+# (e.g. ``"../../etc/something"``).
+_SOURCE_ID_RE = re.compile(r"^[A-Za-z0-9._-]+$")
+_SOURCE_REF_MAX_LEN = 512
+
+
+def _sanitize_source_id(raw: str) -> str:
+    """Return ``raw`` if it matches the safe-filename whitelist; else ``"unknown"``."""
+    if not raw or not _SOURCE_ID_RE.match(raw):
+        return "unknown"
+    # Belt-and-suspenders: even within the whitelist, a leading ``.`` could
+    # produce a hidden file. Allow it (the whitelist permits ``.``) but cap
+    # length so an operator typo doesn't blow filesystem name limits.
+    return raw[:64]
+
+
+def _resolve_dlq_root() -> Path:
+    """Return the DLQ root directory (created if missing).
+
+    Honors ``BICAMERAL_DATA_PATH`` for parity with the rest of the
+    persistence layer. Default ``~/.bicameral/``. The ``dlq`` subdirectory
+    and the ``dlq/raw`` sidecar directory are created with mode 0700 on
+    first call so the raw payloads never have group/world read bits.
+    """
+    base = os.getenv("BICAMERAL_DATA_PATH")
+    root = Path(base) if base else Path.home() / ".bicameral"
+    dlq_root = root / "dlq"
+    raw_root = dlq_root / "raw"
+    # exist_ok=True is fine — mkdir doesn't relax existing permissions, and
+    # any pre-existing dir is operator-controlled.
+    dlq_root.mkdir(mode=_DIR_MODE, parents=True, exist_ok=True)
+    raw_root.mkdir(mode=_DIR_MODE, parents=True, exist_ok=True)
+    return dlq_root
+
+
+def write_dlq_entry(
+    *,
+    source_id: str,
+    source_ref: str,
+    reason: str,
+    byte_size: int,
+    content_hash: str,
+    raw_content: bytes,
+) -> str:
+    """Persist one DLQ row + raw sidecar. Returns the dlq_id.
+
+    Caller is responsible for hashing the raw content (so the same hash
+    function flows through audit-log emit + DLQ row + sidecar lookup).
+    ``raw_content`` should be the exact bytes that failed the gate — for
+    JSON payloads, callers pass ``json.dumps(payload, default=str).encode("utf-8")``.
+
+    Failure modes:
+    - Sidecar creation collision (uuid4 reuse) is treated as fatal and
+      raises ``FileExistsError``. The retry policy is caller-side.
+    - JSONL append failure raises ``OSError``. The caller's audit emit
+      already fired BEFORE this function ran, so even a DLQ write failure
+      doesn't lose observability of the refusal.
+    """
+    # #418 audit finding: source_id flows from MCP `source_scope` argument,
+    # which a malicious / buggy caller could set to `"../../../etc/foo"`.
+    # Normalize through the whitelist BEFORE it touches Path arithmetic.
+    safe_source_id = _sanitize_source_id(source_id)
+    # source_ref lands inside the JSON row (so traversal there is inert),
+    # but cap length so a runaway payload can't bloat the JSONL index.
+    if len(source_ref) > _SOURCE_REF_MAX_LEN:
+        source_ref = source_ref[:_SOURCE_REF_MAX_LEN] + "...[truncated]"
+
+    dlq_root = _resolve_dlq_root()
+    raw_root = dlq_root / "raw"
+    dlq_id = uuid.uuid4().hex
+
+    sidecar = raw_root / f"{dlq_id}.bin"
+    # O_EXCL: atomic create-or-fail (no TOCTOU race).
+    # 0o600 from the umask-bypassing os.open path: sidecar is operator-
+    # readable only from the first byte. On Windows os.open honors the
+    # mode bits via ACL translation but the precise mapping is
+    # platform-dependent — POSIX-strict semantics are POSIX-only.
+    fd = os.open(str(sidecar), os.O_WRONLY | os.O_CREAT | os.O_EXCL, _JSONL_MODE)
+    try:
+        os.write(fd, raw_content)
+    finally:
+        os.close(fd)
+
+    row = {
+        "dlq_id": dlq_id,
+        "source_id": safe_source_id,
+        "source_id_raw": source_id if source_id != safe_source_id else None,
+        "source_ref": source_ref,
+        "received_at": datetime.now(UTC).isoformat(),
+        "reason": reason,
+        "byte_size": byte_size,
+        "content_hash": content_hash,
+        "raw_content_path": str(sidecar.resolve()),
+    }
+    # Drop the None when the source_id was clean so the row stays compact.
+    if row["source_id_raw"] is None:
+        del row["source_id_raw"]
+
+    jsonl_path = dlq_root / f"{safe_source_id}.jsonl"
+    is_new = not jsonl_path.exists()
+    # Append-mode write; one JSON record per line.
+    with jsonl_path.open("a", encoding="utf-8") as f:
+        f.write(json.dumps(row, sort_keys=True) + "\n")
+    if is_new and sys.platform != "win32":
+        # First-create chmod: append-mode `open` doesn't bypass umask the
+        # way `os.open(..., 0o600)` does, so a freshly-created JSONL may
+        # carry group/world bits. Tighten to 0o600 on POSIX. Windows ACL
+        # model doesn't map cleanly here — skip; the parent dir is 0700
+        # which is the structural protection that matters.
+        os.chmod(jsonl_path, _JSONL_MODE)
+
+    return dlq_id

--- a/handlers/ingest.py
+++ b/handlers/ingest.py
@@ -19,12 +19,14 @@ Limitations — aggregate-rate worst case (#230 Finding 2):
 
 from __future__ import annotations
 
+import hashlib
 import json
 import logging
 import os
 import threading
 import time
 from datetime import UTC
+from typing import Literal
 
 import preflight_telemetry
 
@@ -64,7 +66,37 @@ class _IngestRefused(Exception):
         super().__init__(f"{reason}: {detail}" if detail else reason)
 
 
-def _emit_ingest_refusal_telemetry(reason: str, session_id: str) -> None:
+# #418 Phase 0a: gate classification. Hard gates raise unconditionally in
+# both active and passive ingest modes — operator MUST intervene (rotate
+# credential, handle regulated data out-of-band, fix caller serialization
+# bug). Soft gates fail-fast in active mode (today's behavior) but
+# WARN+DLQ+continue in passive mode (poller resilience).
+#
+# Classification is principled, not arbitrary:
+#   - ``sensitive_data:*`` — credential/PHI/PAN leak; skipping the item is
+#     not safe (the data is already in the agent's context window).
+#   - ``malformed_payload`` — caller bug; the payload isn't even JSON-
+#     serializable, so we couldn't write the DLQ sidecar even if we wanted to.
+#   - ``size_limit_exceeded``, ``rate_limit_exceeded``,
+#     ``injection_canary_match`` — recoverable by skipping the item;
+#     operator reviews the DLQ.
+_HARD_GATE_PREFIXES = ("sensitive_data:",)
+_HARD_GATE_REASONS = frozenset({"malformed_payload"})
+
+
+def _is_hard_gate(reason: str) -> bool:
+    """Return True when a refusal must fail-fast in both ingest modes."""
+    if reason in _HARD_GATE_REASONS:
+        return True
+    return any(reason.startswith(p) for p in _HARD_GATE_PREFIXES)
+
+
+def _emit_ingest_refusal_telemetry(
+    reason: str,
+    session_id: str,
+    *,
+    disposition: str = "rejected",
+) -> None:
     """Dual-write the refusal event to JSONL telemetry + audit log.
 
     Side-effect-only helper invoked by ``handle_ingest`` after a guard
@@ -78,6 +110,12 @@ def _emit_ingest_refusal_telemetry(reason: str, session_id: str) -> None:
     to raise, but the explicit ``try/except`` formalizes that trust at
     the helper level and is required for the bidirectional-independence
     test contract (#227 Phase 2).
+
+    ``disposition`` (#418 Phase 0a): one of ``"rejected"`` (default,
+    hard-gate OR active-mode soft-gate refusal) or ``"warned_and_dlqd"``
+    (passive-mode soft-gate refusal — item routed to the DLQ store and
+    the caller continues). Additive on the audit event; existing
+    consumers see the field appear without schema migration.
     """
     from audit_log import AuditEventType
     from audit_log import emit as audit_emit
@@ -87,7 +125,12 @@ def _emit_ingest_refusal_telemetry(reason: str, session_id: str) -> None:
     except Exception:  # noqa: BLE001 — audit-log surface must not be blocked
         pass
     try:
-        audit_emit(AuditEventType.INGEST_REFUSAL, session_id=session_id, reason=reason)
+        audit_emit(
+            AuditEventType.INGEST_REFUSAL,
+            session_id=session_id,
+            reason=reason,
+            disposition=disposition,
+        )
     except Exception:  # noqa: BLE001 — refusal flow must not be broken by emit
         pass
 
@@ -461,6 +504,8 @@ async def handle_ingest(
     payload: dict,
     source_scope: str = "",
     cursor: str = "",
+    *,
+    ingest_mode: Literal["active", "passive"] = "active",
 ) -> IngestResponse:
     # #216: enforce entry-time guardrails BEFORE any ledger work, including
     # the SurrealDB connection handshake. A refused payload should cost zero
@@ -485,6 +530,16 @@ async def handle_ingest(
     # Canary first because injection is upstream of leakage — block the
     # manipulation attempt before scanning for leaks. #212 LLM-01,
     # #213 LLM-04 + HIPAA-01 + PCI-01 fold.
+    #
+    # #418 Phase 0a: ``ingest_mode`` splits soft-gate posture by transport.
+    # ``ingest_mode="active"`` (default, MCP tool surface) keeps fail-fast
+    # behavior — the caller-LLM sees the refusal, fixes the payload,
+    # retries. ``ingest_mode="passive"`` (pollers, webhook receivers, the
+    # sync-and-brief CLI) WARNs + DLQs + continues for soft gates so a
+    # single bad item can't halt the whole poller. Hard gates
+    # (``sensitive_data:*``, ``malformed_payload``) fail-fast in BOTH modes —
+    # the failure is not safely recoverable by skipping.
+    dlqd_count: dict[str, int] = {}
     try:
         _check_payload_size(payload, ctx.ingest_max_bytes)
         _check_rate_limit(
@@ -495,7 +550,65 @@ async def handle_ingest(
         _check_canary(payload)
         _check_sensitive(payload)
     except _IngestRefused as exc:
-        _emit_ingest_refusal_telemetry(exc.reason, getattr(ctx, "session_id", ""))
+        session_id_for_emit = getattr(ctx, "session_id", "")
+        if ingest_mode == "passive" and not _is_hard_gate(exc.reason):
+            # Soft gate + passive caller: route to DLQ, emit refusal with
+            # warned_and_dlqd disposition, return an empty stats-only
+            # IngestResponse so the poller continues with the next item.
+            try:
+                from dlq.store import write_dlq_entry
+
+                try:
+                    serialized = json.dumps(payload, default=str).encode("utf-8")
+                except Exception:  # noqa: BLE001 — should be impossible (malformed is hard-gate)
+                    serialized = repr(payload).encode("utf-8", errors="replace")
+                content_hash = "sha256:" + hashlib.sha256(serialized).hexdigest()
+                derived_source_ref = _derive_last_source_ref(payload) or str(
+                    payload.get("title") or ""
+                )
+                write_dlq_entry(
+                    source_id=source_scope or "unknown",
+                    source_ref=derived_source_ref or "<unknown>",
+                    reason=exc.reason,
+                    byte_size=len(serialized),
+                    content_hash=content_hash,
+                    raw_content=serialized,
+                )
+            except Exception as dlq_exc:  # noqa: BLE001 — audit emit must still fire
+                logger.warning(
+                    "[ingest] DLQ write failed for reason=%s: %s",
+                    exc.reason,
+                    dlq_exc,
+                )
+            _emit_ingest_refusal_telemetry(
+                exc.reason,
+                session_id_for_emit,
+                disposition="warned_and_dlqd",
+            )
+            dlqd_count[exc.reason] = dlqd_count.get(exc.reason, 0) + 1
+            return IngestResponse(
+                ingested=False,
+                repo=str(payload.get("repo") or getattr(ctx, "repo_path", "")),
+                query=str(payload.get("query", "")),
+                source_refs=[],
+                stats=IngestStats(
+                    intents_created=0,
+                    symbols_mapped=0,
+                    regions_linked=0,
+                    ungrounded=0,
+                    grounded=0,
+                    grounded_pct=0.0,
+                    grounding_deferred=0,
+                    dlqd_count=dlqd_count,
+                ),
+                created_decisions=[],
+            )
+        # Hard gate OR active-mode soft gate: today's fail-fast path.
+        _emit_ingest_refusal_telemetry(
+            exc.reason,
+            session_id_for_emit,
+            disposition="rejected",
+        )
         raise
 
     ledger = ctx.ledger
@@ -687,6 +800,7 @@ async def handle_ingest(
             grounded=grounded_count,
             grounded_pct=grounded_pct,
             grounding_deferred=0,
+            dlqd_count=dlqd_count,
         ),
         created_decisions=[
             CreatedDecision(

--- a/tests/test_ingest_passive_dlq.py
+++ b/tests/test_ingest_passive_dlq.py
@@ -1,0 +1,311 @@
+"""Sociable tests for #418 Phase 0a — passive ingest_mode + DLQ routing.
+
+Per ``CLAUDE.md`` § Sociable Testing for UX Paths: handler tests must use a
+real ``SurrealDBLedgerAdapter`` over ``memory://`` and ``SimpleNamespace``
+for ``ctx``. The previous solitary pattern (``MagicMock`` ctx + ``AsyncMock``
+ledger) is what let production bugs sit invisibly under green coverage; new
+handler tests intentionally do not follow that pattern.
+
+Scope:
+- soft-gate behavior split by ``ingest_mode``
+- hard-gate fail-fast preserved in BOTH modes
+- DLQ file permissions (POSIX-only — Windows ACL model doesn't map cleanly)
+- audit-event ``disposition`` field flows through both arms
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import sys
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import patch
+
+import pytest
+
+from handlers.ingest import _IngestRefused, handle_ingest
+from ledger.adapter import SurrealDBLedgerAdapter
+from ledger.client import LedgerClient
+from ledger.schema import init_schema, migrate
+
+# ── Sociable substrate: real ledger over memory:// ──────────────────────────
+
+_NS_COUNTER = 0
+
+
+async def _make_real_adapter() -> SurrealDBLedgerAdapter:
+    """Spin up an isolated SurrealDB memory backend for one test.
+
+    Mirrors ``tests/test_sync_middleware.py::_make_real_adapter`` and
+    ``tests/test_codegenome_continuity_service.py::_fresh_adapter``.
+    """
+    global _NS_COUNTER
+    _NS_COUNTER += 1
+    client = LedgerClient(url="memory://", ns=f"dlq_test_{_NS_COUNTER}", db="ledger_test")
+    await client.connect()
+    await init_schema(client)
+    await migrate(client, allow_destructive=True)
+    adapter = SurrealDBLedgerAdapter(url="memory://")
+    adapter._client = client
+    adapter._connected = True
+    return adapter
+
+
+def _make_ctx(adapter, repo_path: str, *, max_bytes: int = 1_000_000) -> SimpleNamespace:
+    """Build a SimpleNamespace ctx with only the fields handle_ingest reads
+    before normalization. SimpleNamespace (not MagicMock) so missing fields
+    raise AttributeError rather than silently inventing themselves."""
+    return SimpleNamespace(
+        repo_path=repo_path,
+        head_sha="0" * 40,
+        authoritative_ref="main",
+        authoritative_sha="0" * 40,
+        ledger=adapter,
+        code_graph=SimpleNamespace(resolve_symbols=lambda p: p),
+        session_id="test-session-418",
+        signer_email_fallback="local-part-only",
+        render_source_attribution="redacted",
+        ingest_max_bytes=max_bytes,
+        ingest_rate_limit_burst=10_000,  # generous, so rate gate doesn't fire
+        ingest_rate_limit_refill_per_sec=1_000.0,
+        query_timeout_read_seconds=5.0,
+        query_timeout_drift_seconds=30.0,
+    )
+
+
+@pytest.fixture
+def isolated_dlq_root(tmp_path, monkeypatch) -> Path:
+    """Point the DLQ store at a tmp dir for this test."""
+    monkeypatch.setenv("BICAMERAL_DATA_PATH", str(tmp_path))
+    return tmp_path / "dlq"
+
+
+# ── 1. active-mode soft-gate fail-fast (unchanged from today) ───────────────
+
+
+@pytest.mark.asyncio
+async def test_active_size_overflow_still_raises(tmp_path, isolated_dlq_root):
+    adapter = await _make_real_adapter()
+    ctx = _make_ctx(adapter, str(tmp_path), max_bytes=100)
+    payload = {"query": "x", "title": "t", "decisions": [{"description": "y" * 500}]}
+
+    with pytest.raises(_IngestRefused) as exc:
+        await handle_ingest(ctx, payload, source_scope="linear", ingest_mode="active")
+
+    assert exc.value.reason == "size_limit_exceeded"
+    # No DLQ row written for active-mode refusal.
+    assert not isolated_dlq_root.exists() or not any(isolated_dlq_root.glob("*.jsonl"))
+
+
+# ── 2. passive-mode soft-gate WARN + DLQ + continue ─────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_passive_size_overflow_writes_dlq_and_returns(tmp_path, isolated_dlq_root):
+    adapter = await _make_real_adapter()
+    ctx = _make_ctx(adapter, str(tmp_path), max_bytes=100)
+    payload = {"query": "x", "title": "t", "decisions": [{"description": "y" * 500}]}
+
+    result = await handle_ingest(ctx, payload, source_scope="linear", ingest_mode="passive")
+
+    # Returned normally — no raise.
+    assert result.ingested is False
+    assert result.stats.dlqd_count == {"size_limit_exceeded": 1}
+    assert result.stats.intents_created == 0
+
+    # DLQ JSONL row written for the "linear" source.
+    jsonl_path = isolated_dlq_root / "linear.jsonl"
+    assert jsonl_path.exists(), "DLQ JSONL was not created"
+    rows = [json.loads(line) for line in jsonl_path.read_text().splitlines() if line]
+    assert len(rows) == 1
+    row = rows[0]
+    assert row["reason"] == "size_limit_exceeded"
+    assert row["source_id"] == "linear"
+    assert row["content_hash"].startswith("sha256:")
+    assert row["byte_size"] > 100
+
+    # Sidecar exists and has the right content.
+    sidecar = Path(row["raw_content_path"])
+    assert sidecar.exists()
+    assert sidecar.read_bytes() == json.dumps(payload, default=str).encode("utf-8")
+
+
+@pytest.mark.skipif(sys.platform == "win32", reason="POSIX-only file-mode semantics")
+@pytest.mark.asyncio
+async def test_passive_dlq_sidecar_is_mode_0600(tmp_path, isolated_dlq_root):
+    adapter = await _make_real_adapter()
+    ctx = _make_ctx(adapter, str(tmp_path), max_bytes=100)
+    payload = {"query": "x", "decisions": [{"description": "y" * 500}]}
+
+    result = await handle_ingest(ctx, payload, source_scope="notion", ingest_mode="passive")
+    assert result.stats.dlqd_count == {"size_limit_exceeded": 1}
+
+    sidecar = next((isolated_dlq_root / "raw").glob("*.bin"))
+    mode = sidecar.stat().st_mode & 0o777
+    assert mode == 0o600, f"sidecar mode is 0o{mode:o}, expected 0o600"
+
+    dir_mode = (isolated_dlq_root / "raw").stat().st_mode & 0o777
+    assert dir_mode == 0o700, f"raw dir mode is 0o{dir_mode:o}, expected 0o700"
+
+
+# ── 3. hard-gate fail-fast preserved in BOTH modes ──────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_passive_secret_still_raises(tmp_path, isolated_dlq_root):
+    """Hard gate: sensitive_data:secret must fail-fast even in passive mode."""
+    adapter = await _make_real_adapter()
+    ctx = _make_ctx(adapter, str(tmp_path))
+    # AWS access key pattern — well-known credential shape detected by
+    # the sensitive-data gate. Bypass the canary gate (cheaper) by keeping
+    # the rest of the payload benign.
+    payload = {
+        "query": "deploy plan",
+        "decisions": [{"description": "use key AKIAIOSFODNN7EXAMPLE for upload"}],
+    }
+
+    with pytest.raises(_IngestRefused) as exc:
+        await handle_ingest(ctx, payload, source_scope="linear", ingest_mode="passive")
+
+    assert exc.value.reason.startswith("sensitive_data:")
+    # No DLQ row — hard gates never reach DLQ.
+    assert not (isolated_dlq_root / "linear.jsonl").exists()
+
+
+@pytest.mark.asyncio
+async def test_passive_malformed_still_raises(tmp_path, isolated_dlq_root):
+    """Hard gate: malformed_payload (non-JSON-serializable) must fail-fast
+    even in passive mode — there's nothing serializable to write to DLQ.
+
+    Trigger: a ``set()`` is not JSON-serializable and ``default=str`` will
+    serialize it as the literal string ``"{...}"`` — which means we need an
+    object that ``default=str`` cannot resolve. ``object()`` works because
+    ``str(object())`` produces a stable repr but the json encoder still
+    fails before ``default`` is consulted for nested non-serializable types.
+    The cleanest trigger is a self-referencing dict (RecursionError caught).
+    """
+    adapter = await _make_real_adapter()
+    ctx = _make_ctx(adapter, str(tmp_path))
+
+    # Self-referencing structure: json.dumps recurses and raises
+    # ValueError("Circular reference detected") — one of the caught types
+    # in _check_payload_size's translation block.
+    payload: dict = {"query": "x"}
+    payload["self"] = payload
+
+    with pytest.raises(_IngestRefused) as exc:
+        await handle_ingest(ctx, payload, source_scope="linear", ingest_mode="passive")
+
+    assert exc.value.reason == "malformed_payload"
+    assert not (isolated_dlq_root / "linear.jsonl").exists()
+
+
+# ── 3b. path-traversal defense in source_id ─────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_passive_dlq_rejects_traversal_source_scope(tmp_path, isolated_dlq_root):
+    """A malicious / buggy caller passing ``source_scope="../../etc/foo"``
+    must NOT write the JSONL outside the DLQ root. The store sanitizes
+    the value to ``"unknown"`` and records the original under
+    ``source_id_raw`` for audit.
+    """
+    adapter = await _make_real_adapter()
+    ctx = _make_ctx(adapter, str(tmp_path), max_bytes=100)
+    payload = {"query": "x", "decisions": [{"description": "y" * 500}]}
+
+    result = await handle_ingest(ctx, payload, source_scope="../../etc/evil", ingest_mode="passive")
+
+    assert result.stats.dlqd_count == {"size_limit_exceeded": 1}
+
+    # JSONL landed under "unknown.jsonl" inside the DLQ root, not at
+    # ../../etc/evil.jsonl outside it.
+    assert (isolated_dlq_root / "unknown.jsonl").exists()
+    # Confirm nothing slipped outside the dlq root.
+    parent_of_root = isolated_dlq_root.parent
+    suspect = parent_of_root / "etc"
+    assert not suspect.exists(), "traversal escaped the DLQ root"
+
+    row = json.loads((isolated_dlq_root / "unknown.jsonl").read_text().splitlines()[0])
+    assert row["source_id"] == "unknown"
+    assert row["source_id_raw"] == "../../etc/evil"  # original preserved for audit
+
+
+@pytest.mark.asyncio
+async def test_active_secret_still_raises(tmp_path, isolated_dlq_root):
+    """Symmetric check: hard gate behavior is identical across modes."""
+    adapter = await _make_real_adapter()
+    ctx = _make_ctx(adapter, str(tmp_path))
+    payload = {
+        "query": "deploy plan",
+        "decisions": [{"description": "use key AKIAIOSFODNN7EXAMPLE for upload"}],
+    }
+
+    with pytest.raises(_IngestRefused) as exc:
+        await handle_ingest(ctx, payload, source_scope="linear", ingest_mode="active")
+
+    assert exc.value.reason.startswith("sensitive_data:")
+
+
+# ── 4. audit event disposition field ────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_audit_event_carries_disposition_warned_and_dlqd(tmp_path, isolated_dlq_root):
+    adapter = await _make_real_adapter()
+    ctx = _make_ctx(adapter, str(tmp_path), max_bytes=100)
+    payload = {"query": "x", "decisions": [{"description": "y" * 500}]}
+
+    with patch("audit_log.emit") as emit:
+        await handle_ingest(ctx, payload, source_scope="linear", ingest_mode="passive")
+
+    refusal_calls = [c for c in emit.call_args_list if "INGEST_REFUSAL" in str(c)]
+    # Find the call carrying disposition. The helper emits one INGEST_REFUSAL
+    # per refused payload; assert the disposition kwarg was warned_and_dlqd.
+    disposed = [c for c in refusal_calls if c.kwargs.get("disposition") == "warned_and_dlqd"]
+    assert len(disposed) == 1, (
+        f"expected one warned_and_dlqd refusal emit, got {len(disposed)} from {refusal_calls!r}"
+    )
+
+
+@pytest.mark.asyncio
+async def test_audit_event_carries_disposition_rejected_on_active(tmp_path, isolated_dlq_root):
+    adapter = await _make_real_adapter()
+    ctx = _make_ctx(adapter, str(tmp_path), max_bytes=100)
+    payload = {"query": "x", "decisions": [{"description": "y" * 500}]}
+
+    with patch("audit_log.emit") as emit:
+        with pytest.raises(_IngestRefused):
+            await handle_ingest(ctx, payload, source_scope="linear", ingest_mode="active")
+
+    refusal_calls = [c for c in emit.call_args_list if "INGEST_REFUSAL" in str(c)]
+    disposed = [c for c in refusal_calls if c.kwargs.get("disposition") == "rejected"]
+    assert len(disposed) == 1, (
+        f"expected one rejected refusal emit, got {len(disposed)} from {refusal_calls!r}"
+    )
+
+
+# ── 5. hard-gate emit still carries disposition=rejected in passive mode ────
+
+
+@pytest.mark.asyncio
+async def test_hard_gate_disposition_rejected_in_passive(tmp_path, isolated_dlq_root):
+    """The disposition field must report 'rejected' for hard gates regardless
+    of mode — observability of the security floor must be uniform."""
+    adapter = await _make_real_adapter()
+    ctx = _make_ctx(adapter, str(tmp_path))
+    payload = {
+        "query": "x",
+        "decisions": [{"description": "use AKIAIOSFODNN7EXAMPLE secret"}],
+    }
+
+    with patch("audit_log.emit") as emit:
+        with pytest.raises(_IngestRefused):
+            await handle_ingest(ctx, payload, source_scope="linear", ingest_mode="passive")
+
+    refusal_calls = [c for c in emit.call_args_list if "INGEST_REFUSAL" in str(c)]
+    rejected_calls = [c for c in refusal_calls if c.kwargs.get("disposition") == "rejected"]
+    warned_calls = [c for c in refusal_calls if c.kwargs.get("disposition") == "warned_and_dlqd"]
+    assert len(rejected_calls) == 1
+    assert len(warned_calls) == 0


### PR DESCRIPTION
## Summary

- Add `ingest_mode: Literal["active", "passive"]` kwarg to `handle_ingest` (default `"active"` — backwards-compatible).
- Passive mode: soft gates (size/rate/canary) write to `~/.bicameral/dlq/<source_id>.jsonl` + mode-0600 raw sidecar and return a stats-only `IngestResponse` with `dlqd_count` populated — a single bad item can no longer halt a passive poller.
- Hard gates (`sensitive_data:*`, `malformed_payload`) fail-fast uniformly in both modes — explicit classification via `_HARD_GATE_PREFIXES` + `_HARD_GATE_REASONS`, no bypass via mode flag.
- Audit-log `INGEST_REFUSAL` events gain a `disposition` field (`"rejected"` | `"warned_and_dlqd"`). Additive; no consumer migration.
- `source_id` whitelist-sanitized to `[A-Za-z0-9._-]+` before filesystem use (defense against path traversal via MCP `source_scope` argument).

Closes BicameralAI/bicameral-daemon#12. Parent tracker: BicameralAI/bicameral-daemon#3.

Independent of all other phases in this stack — can merge first.

## Test plan

- [ ] CI green on `tests/test_ingest_passive_dlq.py` (9 passing + 1 platform-skipped).
- [ ] No regression in existing `test_ingest_*` suite.
- [ ] Spot-check: an active `bicameral.ingest` call with an oversized payload still raises and surfaces as a refusal TextContent at the MCP boundary (existing behavior preserved).

🤖 Generated with [Claude Code](https://claude.com/claude-code)