### PR TITLE
feat(audit+secrets): #419 Phase 0b — SOURCE_INGEST_* events + keyring store

### DIFF
--- a/audit_log.py
+++ b/audit_log.py
@@ -79,6 +79,14 @@ class AuditEventType(enum.StrEnum):
     # than blocked replay. The diagnose pipeline picks this up and surfaces
     # the upgrade hint.
     EVENT_REPLAY_SCHEMA_VIOLATION = "event_replay_schema_violation"
+    # #419 Phase 0b — per-source ingest + auth lifecycle. Emit sites are
+    # added by the per-source adapter phases (Phase 1 Linear onward); the
+    # vocabulary ships here so future PRs have a stable target.
+    SOURCE_INGEST_ATTEMPT = "source_ingest_attempt"
+    SOURCE_INGEST_ACCEPTED = "source_ingest_accepted"
+    SOURCE_INGEST_REFUSED = "source_ingest_refused"
+    SOURCE_AUTH_GRANTED = "source_auth_granted"
+    SOURCE_AUTH_REVOKED = "source_auth_revoked"
 
 
 _LEVEL_BY_EVENT: dict[AuditEventType, str] = {
@@ -94,6 +102,14 @@ _LEVEL_BY_EVENT: dict[AuditEventType, str] = {
     AuditEventType.LEDGER_VERSION_DRIFT: "warn",
     AuditEventType.SCHEMA_DEFINE_SKIPPED: "warn",
     AuditEventType.EVENT_REPLAY_SCHEMA_VIOLATION: "error",
+    # #419 Phase 0b — per-source ingest is high-volume / info-class.
+    # Refusals + auth lifecycle are warn-class (security-relevant or
+    # operator-actionable).
+    AuditEventType.SOURCE_INGEST_ATTEMPT: "info",
+    AuditEventType.SOURCE_INGEST_ACCEPTED: "info",
+    AuditEventType.SOURCE_INGEST_REFUSED: "warn",
+    AuditEventType.SOURCE_AUTH_GRANTED: "warn",
+    AuditEventType.SOURCE_AUTH_REVOKED: "warn",
 }
 
 _LEVEL_RANK = {"info": 10, "warn": 20, "error": 30}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -58,6 +58,11 @@ dependencies = [
   # Google Drive backend for team-mode replication (#277).
   "google-auth-oauthlib>=1.2",
   "google-api-python-client>=2.100",
+  # #419 Phase 0b — OS-native secret storage for per-source OAuth tokens
+  # and API keys. Linux Secret Service / macOS Keychain / Windows
+  # Credential Locker. `keyrings.alt` is intentionally NOT added — its
+  # plaintext-file backend would defeat the security posture.
+  "keyring>=24.0",
 ]
 
 [project.optional-dependencies]

--- a/secrets_store/__init__.py
+++ b/secrets_store/__init__.py
@@ -1,0 +1,19 @@
+"""Secret store wrapper (#419 Phase 0b).
+
+Public API re-exports. Backed by the OS keyring (Linux Secret Service,
+macOS Keychain, Windows Credential Locker) via the ``keyring`` package.
+Falls back to an in-process dict with a loud audit-log warning when no
+keyring backend is available — never silently to plaintext-on-disk.
+
+Module name is ``secrets_store`` (not ``secrets``) because Python's
+standard library claims ``secrets`` for ``secrets.token_bytes`` etc.
+"""
+
+from secrets_store.store import (
+    delete_secret,
+    get_secret,
+    list_keys,
+    put_secret,
+)
+
+__all__ = ["put_secret", "get_secret", "delete_secret", "list_keys"]

--- a/secrets_store/store.py
+++ b/secrets_store/store.py
@@ -1,0 +1,226 @@
+"""OS-keyring-backed secret storage for per-source credentials (#419 Phase 0b).
+
+Used by future Phase 1+ source adapters (Linear, Notion, GitHub, Slack,
+Google Drive) to persist OAuth tokens / API keys without ever writing them
+to ``.bicameral/config.yaml`` in plaintext.
+
+Backend selection:
+- Linux: Secret Service (gnome-keyring, kwallet, ...)
+- macOS: Keychain
+- Windows: Credential Locker
+- Fallback: in-process dict + warn-level audit event so the operator
+  sees that secrets are NOT persisted across server restart.
+
+Service-name convention: ``bicameral-mcp::<source_id>``. An operator can
+manually inspect or wipe via the OS-native keyring tool:
+    keyring del bicameral-mcp::linear api_key
+
+Hardening:
+- ``source_id`` and ``key`` whitelisted to ``[A-Za-z0-9._-]+`` (no traversal,
+  no spaces, no path separators).
+- ``value`` length-capped at 8 KiB — no legitimate OAuth token is bigger,
+  and the cap bounds memory misuse if a confused caller passes a payload.
+- ``BICAMERAL_KEYRING_DISABLE=1`` short-circuits to the dict backend
+  deterministically — required for CI sandboxes where no keyring daemon
+  is running.
+
+Audit-log emission:
+- ``put_secret`` emits ``SOURCE_AUTH_GRANTED`` (warn) with no value.
+- ``delete_secret`` emits ``SOURCE_AUTH_REVOKED`` (warn) with no value.
+- Backend-degraded path emits ``GATE_FIRED`` (warn) once per process to
+  notify the operator that secrets are not persisted.
+
+The forbid-list discipline in ``audit_log._strip_forbidden`` already
+catches accidental ``value`` / ``content`` / ``payload`` keys — the
+``put_secret`` emit deliberately passes only ``source_id`` + ``key`` so
+the value cannot leak via misuse.
+"""
+
+from __future__ import annotations
+
+import os
+import re
+import threading
+from typing import Any
+
+_SERVICE_NAME_RE = re.compile(r"^[A-Za-z0-9._-]+$")
+_VALUE_MAX_BYTES = 8 * 1024  # 8 KiB — bigger than any legitimate OAuth token
+
+_DICT_FALLBACK: dict[tuple[str, str], str] = {}
+_DICT_FALLBACK_LOCK = threading.Lock()
+_BACKEND_NOTICE_FIRED = False
+_BACKEND_NOTICE_LOCK = threading.Lock()
+
+
+def _validate_identifier(name: str, field_label: str) -> None:
+    if not name or not _SERVICE_NAME_RE.match(name):
+        raise ValueError(
+            f"{field_label} must match [A-Za-z0-9._-]+ (got {name!r}). "
+            "Path-traversal characters and spaces are rejected to prevent "
+            "keyring-service-name attacks."
+        )
+
+
+def _service_for(source_id: str) -> str:
+    """Build the keyring service name from a validated source_id."""
+    return f"bicameral-mcp::{source_id}"
+
+
+def _keyring_disabled() -> bool:
+    return os.getenv("BICAMERAL_KEYRING_DISABLE", "").strip().lower() in {
+        "1",
+        "true",
+        "yes",
+        "on",
+    }
+
+
+def _get_backend() -> Any | None:
+    """Return the live keyring module, or None when unavailable / disabled.
+
+    The first call when no backend is available emits one warn-level
+    audit event so the operator sees that secrets are not persisted.
+    Subsequent calls are silent to avoid log spam.
+    """
+    if _keyring_disabled():
+        return None
+    try:
+        import keyring  # type: ignore[import-not-found]
+        from keyring.errors import NoKeyringError  # type: ignore[import-not-found]
+    except ImportError:
+        _emit_degraded_once(reason="keyring package not installed")
+        return None
+    # Probe the backend — `keyring.get_keyring()` returns even when no
+    # functional backend exists (it returns a fail-keyring). Check for
+    # the fail-keyring shape by exercising a no-op read; NoKeyringError
+    # is the typed signal.
+    try:
+        keyring.get_password("bicameral-mcp::__probe__", "__probe__")
+    except NoKeyringError:
+        _emit_degraded_once(reason="no functional keyring backend available")
+        return None
+    except Exception:  # noqa: BLE001 — defensive; treat any backend hiccup as no-backend
+        _emit_degraded_once(reason="keyring backend raised during probe")
+        return None
+    return keyring
+
+
+def _emit_degraded_once(*, reason: str) -> None:
+    """Fire the backend-degraded notice exactly once per process."""
+    global _BACKEND_NOTICE_FIRED
+    with _BACKEND_NOTICE_LOCK:
+        if _BACKEND_NOTICE_FIRED:
+            return
+        _BACKEND_NOTICE_FIRED = True
+    try:
+        from audit_log import AuditEventType
+        from audit_log import emit as audit_emit
+
+        audit_emit(
+            AuditEventType.GATE_FIRED,
+            message="secrets_store backend unavailable — falling back to in-process dict",
+            reason=reason,
+            persisted=False,
+        )
+    except Exception:  # noqa: BLE001 — audit failure must not block secret access
+        pass
+
+
+def _audit_lifecycle(event_type_name: str, *, source_id: str, key: str) -> None:
+    """Emit a SOURCE_AUTH_* event without ever logging the value."""
+    try:
+        from audit_log import AuditEventType
+        from audit_log import emit as audit_emit
+
+        audit_emit(
+            AuditEventType(event_type_name),
+            source_id=source_id,
+            secret_key=key,
+        )
+    except Exception:  # noqa: BLE001 — lifecycle emit must not block ops
+        pass
+
+
+def put_secret(*, source_id: str, key: str, value: str) -> None:
+    """Persist ``value`` under ``(source_id, key)``.
+
+    Raises ``ValueError`` on whitelist violation or oversized value.
+    Emits ``SOURCE_AUTH_GRANTED`` on success (or on fallback-dict write).
+    """
+    _validate_identifier(source_id, "source_id")
+    _validate_identifier(key, "key")
+    encoded_size = len(value.encode("utf-8"))
+    if encoded_size > _VALUE_MAX_BYTES:
+        raise ValueError(
+            f"value too large: {encoded_size} bytes > {_VALUE_MAX_BYTES} cap. "
+            "Tokens are kilobyte-class at most."
+        )
+
+    backend = _get_backend()
+    if backend is None:
+        with _DICT_FALLBACK_LOCK:
+            _DICT_FALLBACK[(source_id, key)] = value
+    else:
+        backend.set_password(_service_for(source_id), key, value)
+
+    _audit_lifecycle("source_auth_granted", source_id=source_id, key=key)
+
+
+def get_secret(*, source_id: str, key: str) -> str | None:
+    """Return the persisted value, or None if not set.
+
+    No audit emit on read — read traffic would dominate the audit-log
+    surface; readers should rely on the granted/revoked lifecycle for
+    state-of-the-world reconstruction.
+    """
+    _validate_identifier(source_id, "source_id")
+    _validate_identifier(key, "key")
+    backend = _get_backend()
+    if backend is None:
+        with _DICT_FALLBACK_LOCK:
+            return _DICT_FALLBACK.get((source_id, key))
+    return backend.get_password(_service_for(source_id), key)
+
+
+def delete_secret(*, source_id: str, key: str) -> None:
+    """Remove the persisted value. Idempotent — no-op if not present.
+
+    Emits ``SOURCE_AUTH_REVOKED`` whether or not the key existed; the
+    revocation signal is operator-visible regardless of prior state.
+    """
+    _validate_identifier(source_id, "source_id")
+    _validate_identifier(key, "key")
+    backend = _get_backend()
+    if backend is None:
+        with _DICT_FALLBACK_LOCK:
+            _DICT_FALLBACK.pop((source_id, key), None)
+    else:
+        try:
+            backend.delete_password(_service_for(source_id), key)
+        except Exception:  # noqa: BLE001 — keyring raises PasswordDeleteError on missing key
+            pass
+    _audit_lifecycle("source_auth_revoked", source_id=source_id, key=key)
+
+
+def list_keys(*, source_id: str) -> list[str]:
+    """Return the list of keys currently set under ``source_id``.
+
+    Keyring does not expose a portable "list" primitive — Secret Service
+    supports it, Windows Credential Locker does not. Phase 0b returns
+    only the dict-backend keys reliably; backend-backed installs require
+    the OS-native tool (``keyring`` CLI) to enumerate. Documented gap;
+    the per-source adapters track their own key inventories via the
+    ledger anyway.
+    """
+    _validate_identifier(source_id, "source_id")
+    with _DICT_FALLBACK_LOCK:
+        return [k for (sid, k) in _DICT_FALLBACK.keys() if sid == source_id]
+
+
+def _reset_for_tests() -> None:
+    """Clear the dict fallback + reset the one-shot notice. Test-only."""
+    global _BACKEND_NOTICE_FIRED
+    with _DICT_FALLBACK_LOCK:
+        _DICT_FALLBACK.clear()
+    with _BACKEND_NOTICE_LOCK:
+        _BACKEND_NOTICE_FIRED = False

--- a/tests/test_audit_log_source_events.py
+++ b/tests/test_audit_log_source_events.py
@@ -1,0 +1,52 @@
+"""Tests for #419 Phase 0b — new AuditEventType members + level mapping.
+
+Phase 0b ships the vocabulary; per-source adapters (Phase 1+) add the
+emit sites. These tests assert the enum + level mapping is wired so a
+future PR can rely on it without fragile string-comparison checks.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from audit_log import _LEVEL_BY_EVENT, AuditEventType
+
+_SOURCE_EVENTS = [
+    AuditEventType.SOURCE_INGEST_ATTEMPT,
+    AuditEventType.SOURCE_INGEST_ACCEPTED,
+    AuditEventType.SOURCE_INGEST_REFUSED,
+    AuditEventType.SOURCE_AUTH_GRANTED,
+    AuditEventType.SOURCE_AUTH_REVOKED,
+]
+
+
+@pytest.mark.parametrize("ev", _SOURCE_EVENTS)
+def test_source_event_has_level_mapping(ev):
+    assert ev in _LEVEL_BY_EVENT, f"{ev} missing from _LEVEL_BY_EVENT"
+    level = _LEVEL_BY_EVENT[ev]
+    assert level in {"info", "warn", "error"}
+
+
+def test_attempt_and_accepted_are_info():
+    """High-volume routine events stay at info — operators filtering on
+    warn shouldn't drown in ingest attempt logs."""
+    assert _LEVEL_BY_EVENT[AuditEventType.SOURCE_INGEST_ATTEMPT] == "info"
+    assert _LEVEL_BY_EVENT[AuditEventType.SOURCE_INGEST_ACCEPTED] == "info"
+
+
+def test_refusal_and_auth_lifecycle_are_warn():
+    """Operator-actionable events surface at warn — refusals indicate
+    problems, auth grants/revokes are security-relevant."""
+    assert _LEVEL_BY_EVENT[AuditEventType.SOURCE_INGEST_REFUSED] == "warn"
+    assert _LEVEL_BY_EVENT[AuditEventType.SOURCE_AUTH_GRANTED] == "warn"
+    assert _LEVEL_BY_EVENT[AuditEventType.SOURCE_AUTH_REVOKED] == "warn"
+
+
+def test_string_values_are_stable():
+    """Enum string values are part of the operator-facing audit-log
+    schema — assert them explicitly so a rename triggers a test failure."""
+    assert AuditEventType.SOURCE_INGEST_ATTEMPT.value == "source_ingest_attempt"
+    assert AuditEventType.SOURCE_INGEST_ACCEPTED.value == "source_ingest_accepted"
+    assert AuditEventType.SOURCE_INGEST_REFUSED.value == "source_ingest_refused"
+    assert AuditEventType.SOURCE_AUTH_GRANTED.value == "source_auth_granted"
+    assert AuditEventType.SOURCE_AUTH_REVOKED.value == "source_auth_revoked"

--- a/tests/test_secrets_store.py
+++ b/tests/test_secrets_store.py
@@ -1,0 +1,189 @@
+"""Tests for #419 Phase 0b — secrets_store wrapper.
+
+Sociable where it matters: when ``BICAMERAL_KEYRING_DISABLE=1`` is set the
+dict fallback IS the real backend, and the audit-log emit goes through
+the real ``audit_log.emit`` channel. We don't mock either of those.
+
+For backend-present platforms, the OS keyring is exercised in a separate
+manual-run job (CI sandboxes don't reliably ship a Secret Service /
+Keychain daemon). The dict-fallback path covers the API surface contract.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import patch
+
+import pytest
+
+import audit_log
+from audit_log import AuditEventType
+from secrets_store import store as secrets_store_module
+from secrets_store.store import (
+    _reset_for_tests,
+    delete_secret,
+    get_secret,
+    list_keys,
+    put_secret,
+)
+
+
+@pytest.fixture(autouse=True)
+def _disable_keyring_and_reset(monkeypatch):
+    """Force dict-fallback path + reset module state for each test."""
+    monkeypatch.setenv("BICAMERAL_KEYRING_DISABLE", "1")
+    _reset_for_tests()
+    yield
+    _reset_for_tests()
+
+
+# ── round-trip ──────────────────────────────────────────────────────────────
+
+
+def test_put_get_delete_round_trip():
+    put_secret(source_id="linear", key="api_key", value="lin_abc123")
+    assert get_secret(source_id="linear", key="api_key") == "lin_abc123"
+    delete_secret(source_id="linear", key="api_key")
+    assert get_secret(source_id="linear", key="api_key") is None
+
+
+def test_get_returns_none_for_unset():
+    assert get_secret(source_id="notion", key="missing") is None
+
+
+def test_delete_is_idempotent():
+    # Should not raise on a key that was never set.
+    delete_secret(source_id="github", key="never_existed")
+
+
+def test_list_keys_isolates_by_source():
+    put_secret(source_id="linear", key="api_key", value="x")
+    put_secret(source_id="linear", key="refresh_token", value="y")
+    put_secret(source_id="notion", key="api_key", value="z")
+    linear_keys = set(list_keys(source_id="linear"))
+    notion_keys = set(list_keys(source_id="notion"))
+    assert linear_keys == {"api_key", "refresh_token"}
+    assert notion_keys == {"api_key"}
+
+
+# ── validation: service-name + key whitelist ────────────────────────────────
+
+
+@pytest.mark.parametrize(
+    "bad_source",
+    [
+        "../../etc/foo",
+        "linear/../notion",
+        "with space",
+        "with\\backslash",
+        "with/slash",
+        "with\x00null",
+        "",
+    ],
+)
+def test_put_rejects_traversal_source_id(bad_source):
+    with pytest.raises(ValueError, match="source_id"):
+        put_secret(source_id=bad_source, key="api_key", value="x")
+
+
+@pytest.mark.parametrize(
+    "bad_key",
+    [
+        "../password",
+        "key with space",
+        "",
+        "key/with/slash",
+    ],
+)
+def test_put_rejects_bad_key(bad_key):
+    with pytest.raises(ValueError, match="key"):
+        put_secret(source_id="linear", key=bad_key, value="x")
+
+
+def test_get_validates_same_whitelist():
+    with pytest.raises(ValueError):
+        get_secret(source_id="../etc", key="api_key")
+
+
+def test_delete_validates_same_whitelist():
+    with pytest.raises(ValueError):
+        delete_secret(source_id="../etc", key="api_key")
+
+
+# ── value size cap ──────────────────────────────────────────────────────────
+
+
+def test_put_rejects_oversized_value():
+    big = "x" * (8 * 1024 + 1)
+    with pytest.raises(ValueError, match="too large"):
+        put_secret(source_id="linear", key="api_key", value=big)
+
+
+def test_put_accepts_value_at_cap():
+    # Exactly 8 KiB is allowed; the gate is `> max`.
+    at_cap = "x" * (8 * 1024)
+    put_secret(source_id="linear", key="api_key", value=at_cap)
+    assert get_secret(source_id="linear", key="api_key") == at_cap
+
+
+# ── audit lifecycle ─────────────────────────────────────────────────────────
+
+
+def test_put_emits_source_auth_granted():
+    with patch.object(audit_log, "emit", wraps=audit_log.emit) as emit_spy:
+        put_secret(source_id="linear", key="api_key", value="x")
+
+    granted_calls = [
+        c
+        for c in emit_spy.call_args_list
+        if c.args and c.args[0] == AuditEventType.SOURCE_AUTH_GRANTED
+    ]
+    assert len(granted_calls) == 1
+    # Audit event must carry source_id + secret_key, NEVER the value.
+    kwargs = granted_calls[0].kwargs
+    assert kwargs["source_id"] == "linear"
+    assert kwargs["secret_key"] == "api_key"
+    assert "value" not in kwargs
+    assert "x" not in str(kwargs)  # belt-and-suspenders
+
+
+def test_delete_emits_source_auth_revoked():
+    put_secret(source_id="linear", key="api_key", value="x")
+
+    with patch.object(audit_log, "emit", wraps=audit_log.emit) as emit_spy:
+        delete_secret(source_id="linear", key="api_key")
+
+    revoked_calls = [
+        c
+        for c in emit_spy.call_args_list
+        if c.args and c.args[0] == AuditEventType.SOURCE_AUTH_REVOKED
+    ]
+    assert len(revoked_calls) == 1
+
+
+def test_delete_emits_revoked_even_when_key_missing():
+    """Revocation signal must be operator-visible regardless of prior state."""
+    with patch.object(audit_log, "emit", wraps=audit_log.emit) as emit_spy:
+        delete_secret(source_id="linear", key="never_existed")
+
+    revoked_calls = [
+        c
+        for c in emit_spy.call_args_list
+        if c.args and c.args[0] == AuditEventType.SOURCE_AUTH_REVOKED
+    ]
+    assert len(revoked_calls) == 1
+
+
+def test_get_does_not_emit():
+    """Reads must not flood the audit log — granted/revoked carry state."""
+    put_secret(source_id="linear", key="api_key", value="x")
+
+    with patch.object(audit_log, "emit", wraps=audit_log.emit) as emit_spy:
+        get_secret(source_id="linear", key="api_key")
+
+    # No SOURCE_* event from a read.
+    source_events = [
+        c
+        for c in emit_spy.call_args_list
+        if c.args and str(c.args[0]).startswith("AuditEventType.SOURCE_")
+    ]
+    assert source_events == []


### PR DESCRIPTION
## Summary

**Part A — audit-log extension**
- `AuditEventType` gains `SOURCE_INGEST_ATTEMPT` / `_ACCEPTED` / `_REFUSED` (info / info / warn) and `SOURCE_AUTH_GRANTED` / `_REVOKED` (warn / warn).
- No callers added in this PR — vocabulary ships so Phase 1+ adapters have a stable target.

**Part B — `secrets_store` module**
- `put_secret` / `get_secret` / `delete_secret` / `list_keys` backed by the OS keyring (Linux Secret Service, macOS Keychain, Windows Credential Locker) via the `keyring` package.
- Service-name convention: `bicameral-mcp::<source_id>`.
- `source_id` + `key` whitelisted to `[A-Za-z0-9._-]+` (rejects path traversal, null bytes, spaces, separators). Same discipline as BicameralAI/bicameral-daemon#12's DLQ store.
- Value capped at 8 KiB.
- `BICAMERAL_KEYRING_DISABLE=1` short-circuits to in-process dict for CI sandboxes.
- Backend-degraded fallback fires `GATE_FIRED` audit event once per process — operator sees secrets are not persisted.
- `put_secret`/`delete_secret` emit `SOURCE_AUTH_GRANTED`/`_REVOKED` with `source_id` + `secret_key` only — never the value. Reads do not emit.

**Part C — dependency**
- `keyring>=24.0` added to `pyproject.toml`. `keyrings.alt` deliberately excluded (its plaintext file backend defeats the security posture).

Closes BicameralAI/bicameral-daemon#13. Parent tracker: BicameralAI/bicameral-daemon#3.

**Independent of all other phases in this stack — can merge first or in parallel with Phase 0a (#418).**

## Test plan

- [ ] CI green on `tests/test_secrets_store.py` (23) and `tests/test_audit_log_source_events.py` (8) — 31 passing locally.
- [ ] Manual: confirm `keyring` install works on Linux/macOS/Windows CI runners.
- [ ] Spot-check: existing audit-log consumers don't break (additive enum extension).

🤖 Generated with [Claude Code](https://claude.com/claude-code)