### PR TITLE
feat(sources): Phase 1a — Linear active-ingest adapter

### DIFF
--- a/sources/__init__.py
+++ b/sources/__init__.py
@@ -1,0 +1,8 @@
+"""External source adapters (#420 Phase 1+).
+
+Each subpackage (e.g. ``sources.linear``) implements a single external
+system's active-ingest pull and (in later phases) its passive/polling
+loop. Adapters share the ``SourceAdapter`` protocol from
+``sources.protocol`` so the CLI and future UI can register them
+uniformly without per-source branching in the orchestration layer.
+"""

--- a/sources/linear/__init__.py
+++ b/sources/linear/__init__.py
@@ -1,0 +1,15 @@
+"""Linear source adapter (#420 Phase 1a — active ingest).
+
+Public API: ``LinearAdapter`` (the SourceAdapter implementation) and
+``parse_linear_url`` (URL parsing helper, exposed for tests).
+
+Auth: persisted via ``secrets_store`` under ``source_id="linear"``,
+key ``"api_key"``. CLI / setup wizard puts the operator's Linear
+personal API key into the OS keyring; the adapter reads it on each
+fetch (no in-memory caching — keyring revocation propagates within
+one tool call).
+"""
+
+from sources.linear.adapter import LinearAdapter, parse_linear_url
+
+__all__ = ["LinearAdapter", "parse_linear_url"]

--- a/sources/linear/adapter.py
+++ b/sources/linear/adapter.py
@@ -1,0 +1,180 @@
+"""Linear source adapter (#420 Phase 1a — active ingest).
+
+URL → GraphQL fetch → normalized ingest payload. Auth pulled from the
+secrets_store under ``source_id="linear"``, key ``"api_key"``.
+
+Linear URL forms accepted (all map to the same ``issue_identifier``,
+e.g. ``"BIC-123"``):
+    https://linear.app/<workspace>/issue/BIC-123
+    https://linear.app/<workspace>/issue/BIC-123/<slug>
+    https://linear.app/<workspace>/issue/BIC-123#comment-abc
+
+Output payload shape (matches the natural-format branch of
+``IngestPayload``):
+    {
+      "query": "<issue title>",
+      "source": "linear",
+      "title": "BIC-123",
+      "date": "<completedAt or updatedAt or empty>",
+      "participants": [<assignee email>, <comment author emails>],
+      "decisions": [
+        {"description": "<issue description>", "title": "BIC-123"},
+        {"description": "<comment body>", "title": "BIC-123#comment-<id>"},
+        ...
+      ],
+    }
+
+Comments are ingested as separate decision proposals — the caller-LLM /
+gap-judge chain downstream decides which are real decisions vs ambient
+chatter. The empty-description case (issue with no body, comment is just
+an emoji) is filtered before payload assembly so handle_ingest doesn't
+silently drop the row.
+"""
+
+from __future__ import annotations
+
+import re
+
+_LINEAR_URL_RE = re.compile(
+    r"^https?://linear\.app/[^/]+/issue/(?P<id>[A-Z][A-Z0-9]*-\d+)(?:[/?#].*)?$",
+    re.IGNORECASE,
+)
+
+_ISSUE_QUERY = """
+query GetIssue($id: String!) {
+  issue(id: $id) {
+    identifier
+    title
+    description
+    completedAt
+    updatedAt
+    state { name }
+    assignee { email name }
+    team { key }
+    comments(first: 100) {
+      nodes {
+        id
+        body
+        createdAt
+        user { email name }
+      }
+    }
+  }
+}
+"""
+
+
+def parse_linear_url(url: str) -> str:
+    """Extract the Linear issue identifier (e.g. ``"BIC-123"``) from a URL.
+
+    Raises:
+        ValueError: URL doesn't match the Linear issue pattern.
+    """
+    m = _LINEAR_URL_RE.match(url.strip())
+    if not m:
+        raise ValueError(
+            f"not a recognized Linear issue URL: {url!r}. "
+            "Expected https://linear.app/<workspace>/issue/<TEAM-NUMBER>[/...]."
+        )
+    return m.group("id").upper()
+
+
+def _normalize_participants(issue: dict) -> list[str]:
+    """Collect emails of meaningful contributors.
+
+    Excludes commenters whose body is empty / whitespace-only — emoji
+    reactions and "+1" comments don't make someone a decision participant
+    for ledger purposes. Assignee is always included regardless of
+    activity (they own the issue).
+    """
+    seen: set[str] = set()
+    out: list[str] = []
+    assignee = (issue.get("assignee") or {}).get("email")
+    if assignee:
+        seen.add(assignee)
+        out.append(assignee)
+    for comment in (issue.get("comments") or {}).get("nodes") or []:
+        body = (comment.get("body") or "").strip()
+        if not body:
+            continue
+        email = (comment.get("user") or {}).get("email")
+        if email and email not in seen:
+            seen.add(email)
+            out.append(email)
+    return out
+
+
+def _normalize_decisions(issue: dict, identifier: str) -> list[dict]:
+    """Build the decisions list. Filter out empty / whitespace-only bodies."""
+    decisions: list[dict] = []
+    description = (issue.get("description") or "").strip()
+    if description:
+        decisions.append({"description": description, "title": identifier})
+    for comment in (issue.get("comments") or {}).get("nodes") or []:
+        body = (comment.get("body") or "").strip()
+        if not body:
+            continue
+        comment_id = comment.get("id") or ""
+        decisions.append(
+            {
+                "description": body,
+                "title": f"{identifier}#comment-{comment_id}" if comment_id else identifier,
+            }
+        )
+    return decisions
+
+
+def normalize_issue_to_payload(issue: dict, identifier: str) -> dict:
+    """Build the ingest payload from a Linear issue response."""
+    return {
+        "query": issue.get("title") or identifier,
+        "source": "linear",
+        "title": identifier,
+        "date": issue.get("completedAt") or issue.get("updatedAt") or "",
+        "participants": _normalize_participants(issue),
+        "decisions": _normalize_decisions(issue, identifier),
+    }
+
+
+class LinearAdapter:
+    """SourceAdapter implementation for Linear (active path)."""
+
+    source_id = "linear"
+
+    def can_handle_url(self, url: str) -> bool:
+        return bool(_LINEAR_URL_RE.match(url.strip()))
+
+    def fetch_active(self, url: str) -> dict:
+        identifier = parse_linear_url(url)
+        api_key = self._resolve_api_key()
+        from sources.linear.client import query as _query
+
+        data = _query(
+            api_key=api_key,
+            document=_ISSUE_QUERY,
+            variables={"id": identifier},
+        )
+        issue = data.get("issue")
+        if not issue:
+            raise RuntimeError(
+                f"Linear returned no issue for identifier {identifier!r}. "
+                "Check the API key has access to this workspace."
+            )
+        return normalize_issue_to_payload(issue, identifier)
+
+    def _resolve_api_key(self) -> str:
+        """Pull the Linear API key from the secrets store.
+
+        Separate method so tests can override without monkey-patching
+        the secrets_store module at import time.
+        """
+        from secrets_store import get_secret
+
+        key = get_secret(source_id=self.source_id, key="api_key")
+        if not key:
+            raise RuntimeError(
+                "Linear API key not configured. Set it via:\n"
+                '  python -c "from secrets_store import put_secret; '
+                "put_secret(source_id='linear', key='api_key', value='lin_...')\""
+            )
+        return key

--- a/sources/linear/client.py
+++ b/sources/linear/client.py
@@ -1,0 +1,89 @@
+"""Thin Linear GraphQL client (#420 Phase 1a).
+
+Uses stdlib ``urllib.request`` rather than adding ``httpx`` or
+``requests`` as deps — matches the precedent set by ``handlers/update.py``.
+Single endpoint (``https://api.linear.app/graphql``) so the surface
+stays tiny; if the adapter family grows to need streaming, retries-with-
+backoff, or multipart upload, swap to ``httpx`` then.
+
+Threat-model notes:
+- API key never appears in URL strings (Authorization header only).
+- Response size capped at 4 MiB (Linear issues with megabytes of
+  comments are a misuse signal; refuse rather than blow out memory).
+- Network timeout fixed at 15s — long enough for slow Linear regions,
+  short enough that an operator-driven active fetch doesn't appear
+  hung.
+"""
+
+from __future__ import annotations
+
+import json
+import urllib.error
+import urllib.request
+
+_API_URL = "https://api.linear.app/graphql"
+_REQUEST_TIMEOUT_SECONDS = 15.0
+_MAX_RESPONSE_BYTES = 4 * 1024 * 1024  # 4 MiB
+
+
+class LinearAPIError(RuntimeError):
+    """Raised for any non-recoverable Linear API failure.
+
+    Subclassed off RuntimeError so the SourceAdapter protocol contract
+    (raises RuntimeError on network/auth failure) is satisfied. Carries
+    ``status_code`` when the failure is HTTP-shaped; ``None`` for
+    network-level failures (DNS, timeout, connection reset).
+    """
+
+    def __init__(self, message: str, *, status_code: int | None = None) -> None:
+        self.status_code = status_code
+        super().__init__(message)
+
+
+def query(*, api_key: str, document: str, variables: dict | None = None) -> dict:
+    """Execute a GraphQL query against Linear's endpoint.
+
+    Returns the ``data`` field of the response on success. Raises
+    ``LinearAPIError`` on any failure — including HTTP non-2xx,
+    GraphQL ``errors`` array present, or response exceeding the
+    size cap.
+
+    The function is intentionally synchronous (urllib). Callers running
+    in an async context should wrap via ``asyncio.to_thread``.
+    """
+    body = json.dumps({"query": document, "variables": variables or {}}).encode("utf-8")
+    headers = {
+        "Authorization": api_key,  # Linear accepts the personal API key directly.
+        "Content-Type": "application/json",
+        "User-Agent": "bicameral-mcp/source-linear",
+    }
+    req = urllib.request.Request(_API_URL, data=body, headers=headers, method="POST")
+    try:
+        with urllib.request.urlopen(req, timeout=_REQUEST_TIMEOUT_SECONDS) as resp:
+            # Read up to cap + 1 byte; if we get the +1 the response is over-cap.
+            raw = resp.read(_MAX_RESPONSE_BYTES + 1)
+            if len(raw) > _MAX_RESPONSE_BYTES:
+                raise LinearAPIError(
+                    f"Linear response exceeded {_MAX_RESPONSE_BYTES} bytes",
+                    status_code=resp.status,
+                )
+    except urllib.error.HTTPError as exc:
+        raise LinearAPIError(
+            f"Linear API HTTP {exc.code}: {exc.reason}",
+            status_code=exc.code,
+        ) from exc
+    except urllib.error.URLError as exc:
+        raise LinearAPIError(f"Linear API network error: {exc.reason}") from exc
+
+    try:
+        parsed = json.loads(raw.decode("utf-8"))
+    except json.JSONDecodeError as exc:
+        raise LinearAPIError(f"Linear API returned non-JSON: {exc}") from exc
+
+    if "errors" in parsed and parsed["errors"]:
+        # GraphQL-level errors arrive as HTTP 200 with an ``errors`` array.
+        first = parsed["errors"][0]
+        msg = first.get("message", "unknown GraphQL error")
+        raise LinearAPIError(f"Linear GraphQL error: {msg}")
+
+    return parsed.get("data") or {}

--- a/sources/protocol.py
+++ b/sources/protocol.py
@@ -1,0 +1,46 @@
+"""Source-adapter protocol (#420 Phase 1).
+
+A ``SourceAdapter`` is the minimal contract every external system
+implements to feed the bicameral ingest pipeline. Phase 1 ships the
+**active** half (fetch on operator demand from a URL); Phase 1b extends
+the same protocol with a passive (poller) half.
+
+Design notes:
+- Adapters return a *normalized ingest payload* — a plain dict that
+  ``handlers.ingest.handle_ingest`` already accepts. No per-source code
+  lives inside ``handlers/`` itself; the dispatch is "user/CLI hands a
+  URL to an adapter, adapter hands the result to handle_ingest."
+- ``source_id`` is the adapter's stable identifier (e.g. ``"linear"``).
+  It flows through to the DLQ, audit log, and per-source secret store.
+  Must match ``[A-Za-z0-9._-]+`` (enforced by ``dlq.store`` and
+  ``secrets_store`` whitelists).
+"""
+
+from __future__ import annotations
+
+from typing import Protocol
+
+
+class SourceAdapter(Protocol):
+    """Minimal adapter surface — Phase 1 (active-only)."""
+
+    source_id: str
+    """Stable identifier, e.g. ``"linear"``. Flows into the DLQ JSONL
+    filename, audit-log source_id field, and keyring service name."""
+
+    def can_handle_url(self, url: str) -> bool:
+        """Return True when ``url`` looks like a resource this adapter
+        knows how to fetch (e.g. for Linear: a ``linear.app`` issue URL).
+        Cheap pattern match — does NOT confirm the URL resolves."""
+        ...
+
+    def fetch_active(self, url: str) -> dict:
+        """Fetch the resource at ``url`` and return a normalized ingest
+        payload (dict suitable for ``handlers.ingest.handle_ingest``).
+
+        Raises:
+            ValueError: malformed URL or unsupported resource shape.
+            RuntimeError: network / auth failure. Caller decides
+                whether to retry or surface to the operator.
+        """
+        ...

--- a/tests/test_linear_adapter.py
+++ b/tests/test_linear_adapter.py
@@ -1,0 +1,283 @@
+"""Tests for the Linear source adapter (#420 Phase 1a).
+
+The HTTP boundary (urllib.request.urlopen) is mocked — sociable testing
+doesn't apply to outbound calls to an external SaaS we don't run. Every
+test below mocks at the *narrowest* seam: urlopen → bytes response. The
+URL-parse logic, GraphQL document, normalization, secrets-store
+integration, and error-handling all run end-to-end against the mocks.
+"""
+
+from __future__ import annotations
+
+import io
+import json
+import urllib.error
+from unittest.mock import patch
+
+import pytest
+
+from sources.linear.adapter import (
+    LinearAdapter,
+    normalize_issue_to_payload,
+    parse_linear_url,
+)
+from sources.linear.client import LinearAPIError, query
+
+# ── URL parsing ─────────────────────────────────────────────────────────────
+
+
+@pytest.mark.parametrize(
+    "url,expected",
+    [
+        ("https://linear.app/myworkspace/issue/BIC-123", "BIC-123"),
+        ("https://linear.app/myworkspace/issue/BIC-123/some-slug", "BIC-123"),
+        ("https://linear.app/myworkspace/issue/BIC-123#comment-abc", "BIC-123"),
+        ("https://linear.app/myworkspace/issue/eng-7/blah", "ENG-7"),
+        ("  https://linear.app/myworkspace/issue/ABC-1  ", "ABC-1"),
+    ],
+)
+def test_parse_linear_url_accepts_valid(url, expected):
+    assert parse_linear_url(url) == expected
+
+
+@pytest.mark.parametrize(
+    "url",
+    [
+        "https://github.com/foo/bar",
+        "https://linear.app/myworkspace",
+        "https://linear.app/myworkspace/issue/",
+        "not-a-url",
+        "",
+        "https://linear.app/myworkspace/issue/123-456",  # no team prefix
+    ],
+)
+def test_parse_linear_url_rejects_invalid(url):
+    with pytest.raises(ValueError):
+        parse_linear_url(url)
+
+
+# ── Normalization ───────────────────────────────────────────────────────────
+
+
+def test_normalize_issue_to_payload_full_shape():
+    issue = {
+        "identifier": "BIC-123",
+        "title": "Investigate ingest gates",
+        "description": "We need to refactor the ingest gate posture.",
+        "completedAt": "2026-05-19T20:00:00Z",
+        "updatedAt": "2026-05-18T10:00:00Z",
+        "state": {"name": "Done"},
+        "assignee": {"email": "dev@example.com", "name": "Dev"},
+        "team": {"key": "BIC"},
+        "comments": {
+            "nodes": [
+                {
+                    "id": "c1",
+                    "body": "Agreed — let's go with the WARN posture.",
+                    "createdAt": "2026-05-19T10:00:00Z",
+                    "user": {"email": "pm@example.com", "name": "PM"},
+                },
+                {
+                    "id": "c2",
+                    "body": "",  # empty — must be filtered
+                    "user": {"email": "noisy@example.com"},
+                },
+            ]
+        },
+    }
+
+    payload = normalize_issue_to_payload(issue, "BIC-123")
+
+    assert payload["query"] == "Investigate ingest gates"
+    assert payload["source"] == "linear"
+    assert payload["title"] == "BIC-123"
+    assert payload["date"] == "2026-05-19T20:00:00Z"
+    assert payload["participants"] == ["dev@example.com", "pm@example.com"]
+    assert len(payload["decisions"]) == 2  # description + 1 non-empty comment
+    assert payload["decisions"][0]["description"] == "We need to refactor the ingest gate posture."
+    assert payload["decisions"][0]["title"] == "BIC-123"
+    assert payload["decisions"][1]["title"] == "BIC-123#comment-c1"
+
+
+def test_normalize_skips_empty_description():
+    issue = {
+        "title": "T",
+        "description": "   ",  # whitespace only
+        "updatedAt": "2026-05-19T00:00:00Z",
+        "comments": {"nodes": [{"id": "c1", "body": "real content", "user": {"email": "a@b.com"}}]},
+    }
+    payload = normalize_issue_to_payload(issue, "BIC-1")
+    # Only the comment becomes a decision; the empty description is filtered.
+    assert len(payload["decisions"]) == 1
+    assert payload["decisions"][0]["description"] == "real content"
+
+
+def test_normalize_handles_no_assignee_or_comments():
+    issue = {
+        "title": "Lonely",
+        "description": "Some content",
+        "updatedAt": "2026-05-19T00:00:00Z",
+        "assignee": None,
+        "comments": {"nodes": []},
+    }
+    payload = normalize_issue_to_payload(issue, "BIC-2")
+    assert payload["participants"] == []
+    assert len(payload["decisions"]) == 1
+
+
+def test_normalize_falls_back_to_updated_at_when_completed_at_missing():
+    issue = {
+        "title": "WIP",
+        "description": "x",
+        "completedAt": None,
+        "updatedAt": "2026-05-18T10:00:00Z",
+        "comments": {"nodes": []},
+    }
+    payload = normalize_issue_to_payload(issue, "BIC-3")
+    assert payload["date"] == "2026-05-18T10:00:00Z"
+
+
+# ── GraphQL client error handling ───────────────────────────────────────────
+
+
+def _mock_response(body: dict, status: int = 200):
+    """Build a fake urlopen context manager returning ``body`` as JSON."""
+    raw = json.dumps(body).encode("utf-8")
+    resp = io.BytesIO(raw)
+    resp.status = status  # type: ignore[attr-defined]
+
+    class _Ctx:
+        def __enter__(self):
+            return resp
+
+        def __exit__(self, *args):
+            return False
+
+    return _Ctx()
+
+
+def test_query_returns_data_on_success():
+    payload = {"data": {"issue": {"identifier": "BIC-1", "title": "t"}}}
+    with patch("urllib.request.urlopen", return_value=_mock_response(payload)):
+        data = query(api_key="lin_abc", document="query{}", variables={"id": "BIC-1"})
+    assert data == {"issue": {"identifier": "BIC-1", "title": "t"}}
+
+
+def test_query_raises_on_http_error():
+    err = urllib.error.HTTPError(
+        url="https://api.linear.app/graphql",
+        code=401,
+        msg="Unauthorized",
+        hdrs=None,
+        fp=io.BytesIO(b""),
+    )
+    with patch("urllib.request.urlopen", side_effect=err):
+        with pytest.raises(LinearAPIError) as exc_info:
+            query(api_key="bad", document="query{}")
+    assert exc_info.value.status_code == 401
+
+
+def test_query_raises_on_graphql_errors():
+    payload = {"errors": [{"message": "Issue not found"}], "data": None}
+    with patch("urllib.request.urlopen", return_value=_mock_response(payload)):
+        with pytest.raises(LinearAPIError, match="Issue not found"):
+            query(api_key="lin_abc", document="query{}")
+
+
+def test_query_raises_on_oversized_response():
+    # Build a response that exceeds the 4 MiB cap.
+    big = ("x" * (4 * 1024 * 1024 + 100)).encode("utf-8")
+    resp = io.BytesIO(big)
+    resp.status = 200  # type: ignore[attr-defined]
+
+    class _Ctx:
+        def __enter__(self):
+            return resp
+
+        def __exit__(self, *args):
+            return False
+
+    with patch("urllib.request.urlopen", return_value=_Ctx()):
+        with pytest.raises(LinearAPIError, match="exceeded"):
+            query(api_key="lin_abc", document="query{}")
+
+
+def test_query_raises_on_non_json_response():
+    raw = b"not json at all"
+    resp = io.BytesIO(raw)
+    resp.status = 200  # type: ignore[attr-defined]
+
+    class _Ctx:
+        def __enter__(self):
+            return resp
+
+        def __exit__(self, *args):
+            return False
+
+    with patch("urllib.request.urlopen", return_value=_Ctx()):
+        with pytest.raises(LinearAPIError, match="non-JSON"):
+            query(api_key="lin_abc", document="query{}")
+
+
+# ── Adapter integration ─────────────────────────────────────────────────────
+
+
+def test_adapter_can_handle_url():
+    a = LinearAdapter()
+    assert a.can_handle_url("https://linear.app/foo/issue/BIC-1")
+    assert not a.can_handle_url("https://github.com/foo/bar")
+    assert not a.can_handle_url("totally not a url")
+
+
+def test_adapter_fetch_active_round_trip(monkeypatch):
+    """Patch _resolve_api_key + urlopen; verify the full path returns
+    a well-formed ingest payload."""
+    payload_response = {
+        "data": {
+            "issue": {
+                "identifier": "BIC-1",
+                "title": "t",
+                "description": "Some content",
+                "completedAt": "2026-05-19T00:00:00Z",
+                "updatedAt": "2026-05-19T00:00:00Z",
+                "state": {"name": "Done"},
+                "assignee": {"email": "a@b.com", "name": "A"},
+                "team": {"key": "BIC"},
+                "comments": {"nodes": []},
+            }
+        }
+    }
+    a = LinearAdapter()
+    monkeypatch.setattr(a, "_resolve_api_key", lambda: "lin_test")
+
+    with patch("urllib.request.urlopen", return_value=_mock_response(payload_response)):
+        result = a.fetch_active("https://linear.app/foo/issue/BIC-1")
+
+    assert result["source"] == "linear"
+    assert result["title"] == "BIC-1"
+    assert result["query"] == "t"
+    assert len(result["decisions"]) == 1
+
+
+def test_adapter_raises_when_api_key_missing(monkeypatch):
+    """If secrets_store has no api_key, the adapter must surface the
+    operator-facing setup hint, not a generic null-deref."""
+    monkeypatch.setenv("BICAMERAL_KEYRING_DISABLE", "1")
+    # Ensure the dict fallback is empty for this test.
+    from secrets_store.store import _reset_for_tests
+
+    _reset_for_tests()
+
+    a = LinearAdapter()
+    with pytest.raises(RuntimeError, match="API key not configured"):
+        a.fetch_active("https://linear.app/foo/issue/BIC-1")
+
+
+def test_adapter_raises_when_issue_not_found(monkeypatch):
+    payload_response = {"data": {"issue": None}}
+    a = LinearAdapter()
+    monkeypatch.setattr(a, "_resolve_api_key", lambda: "lin_test")
+
+    with patch("urllib.request.urlopen", return_value=_mock_response(payload_response)):
+        with pytest.raises(RuntimeError, match="no issue"):
+            a.fetch_active("https://linear.app/foo/issue/BIC-999")


### PR DESCRIPTION
## Summary

Linear active-ingest adapter: operator pastes a Linear issue URL → adapter fetches via Linear GraphQL → normalizes to an `IngestPayload`. Passive/polling path is Phase 1b (out of scope here).

- `sources/protocol.py` — minimal `SourceAdapter` Protocol (`source_id`, `can_handle_url`, `fetch_active`). Every per-source adapter implements this.
- `sources/linear/client.py` — stdlib `urllib.request` GraphQL client (no new HTTP dep — matches `handlers/update.py` precedent). 15s timeout, 4 MiB response cap, Bearer in Authorization header.
- `sources/linear/adapter.py` — URL regex (`linear.app/<ws>/issue/<TEAM-NUMBER>[/...]`), GetIssue GraphQL query with 100 comments, participant + decision normalization.
- Empty/whitespace comment bodies filtered (emoji reactions aren't decisions); their authors are excluded from `participants`.

Auth via `secrets_store` under `source_id="linear"`, key `"api_key"` — no in-memory caching, so keyring revocation propagates within one tool call.

Parent tracker: BicameralAI/bicameral-daemon#3. Note: commit message incorrectly references BicameralAI/bicameral-daemon#11 (which is actually the Notion issue); the real linkage is the parent tracker.

## Dependencies

**Depends on BicameralAI/bicameral-daemon#13 (Phase 0b) being merged first** — imports `from secrets_store import get_secret`. CI will fail on this PR until BicameralAI/bicameral-daemon#13 lands.

## Test plan

- [ ] After BicameralAI/bicameral-daemon#13 merges and this branch rebases, CI green on `tests/test_linear_adapter.py` (24 passing locally).
- [ ] Manual smoke: store a real Linear API key via `secrets_store.put_secret`, point the adapter at a real issue URL, verify the IngestPayload shape.

🤖 Generated with [Claude Code](https://claude.com/claude-code)