### PR TITLE
feat(sources): #420 Phase 2 — Notion active-ingest adapter

### DIFF
--- a/sources/notion/__init__.py
+++ b/sources/notion/__init__.py
@@ -1,0 +1,14 @@
+"""Notion source adapter (#420 Phase 2 — active ingest).
+
+Public API: ``NotionAdapter`` (the SourceAdapter implementation) and
+``parse_notion_url`` (URL parsing helper, exposed for tests).
+
+Auth: persisted via ``secrets_store`` under ``source_id="notion"``,
+key ``"api_key"``. The Notion internal-integration token model means
+the operator creates an integration in Notion's admin UI, shares the
+specific page/database with it, then stores the token here.
+"""
+
+from sources.notion.adapter import NotionAdapter, parse_notion_url
+
+__all__ = ["NotionAdapter", "parse_notion_url"]

--- a/sources/notion/adapter.py
+++ b/sources/notion/adapter.py
@@ -1,0 +1,184 @@
+"""Notion source adapter (#420 Phase 2 — active ingest).
+
+URL → REST fetch → block walk → normalized ingest payload.
+
+Notion URL forms accepted:
+    https://www.notion.so/<workspace>/<slug>-<32hex>
+    https://www.notion.so/<32hex>
+    https://www.notion.so/<workspace>/<32hex>
+
+The trailing 32-hex page ID is the canonical identifier. Notion accepts
+both dashed (``...-...``) and undashed forms in API calls; the adapter
+normalizes to the dashed UUID form before the API call so the response
+is predictable.
+
+Block walker extracts text from common prose block types only:
+    paragraph, heading_1, heading_2, heading_3,
+    bulleted_list_item, numbered_list_item, to_do, quote, callout, code
+
+Other types (image, video, file, embed, child_database, child_page,
+table, divider) are skipped — they're not text-bearing for decision
+extraction purposes. Child pages are not recursed (out-of-scope per
+Phase 2 acceptance — operator passes specific pages).
+"""
+
+from __future__ import annotations
+
+import re
+
+_URL_RE = re.compile(
+    r"^https?://(?:www\.)?notion\.so/(?:[^/]+/)?(?:[^/]+-)?(?P<id>[0-9a-fA-F]{32})(?:[/?#].*)?$"
+)
+
+# Block types we extract text from.
+_PROSE_BLOCK_TYPES = frozenset(
+    {
+        "paragraph",
+        "heading_1",
+        "heading_2",
+        "heading_3",
+        "bulleted_list_item",
+        "numbered_list_item",
+        "to_do",
+        "quote",
+        "callout",
+        "code",
+    }
+)
+
+
+def parse_notion_url(url: str) -> str:
+    """Extract the 32-hex page ID and return the dashed UUID form.
+
+    Raises:
+        ValueError: URL doesn't match any accepted Notion shape.
+    """
+    m = _URL_RE.match(url.strip())
+    if not m:
+        raise ValueError(
+            f"not a recognized Notion URL: {url!r}. "
+            "Expected https://www.notion.so/<workspace>/<slug>-<32hex> or similar."
+        )
+    raw = m.group("id").lower()
+    # Normalize to dashed UUID form (8-4-4-4-12).
+    return f"{raw[0:8]}-{raw[8:12]}-{raw[12:16]}-{raw[16:20]}-{raw[20:32]}"
+
+
+def _extract_rich_text(rich_text: list[dict]) -> str:
+    """Concatenate Notion's rich_text array into a plain string."""
+    return "".join(item.get("plain_text", "") for item in rich_text or [])
+
+
+def _extract_block_text(block: dict) -> str:
+    """Return the plain-text content of a prose block, or empty string."""
+    btype = block.get("type")
+    if btype not in _PROSE_BLOCK_TYPES:
+        return ""
+    body = block.get(btype) or {}
+    rich_text = body.get("rich_text") or body.get("text") or []
+    text = _extract_rich_text(rich_text)
+    # Decorate by type so the ingest sees structural cues — important
+    # for the gap-judge chain that uses headings as topic anchors.
+    if btype == "heading_1":
+        return f"# {text}"
+    if btype == "heading_2":
+        return f"## {text}"
+    if btype == "heading_3":
+        return f"### {text}"
+    if btype == "bulleted_list_item":
+        return f"- {text}"
+    if btype == "numbered_list_item":
+        return f"1. {text}"
+    if btype == "to_do":
+        checked = body.get("checked", False)
+        return f"- [{'x' if checked else ' '}] {text}"
+    if btype == "quote":
+        return f"> {text}"
+    if btype == "callout":
+        return f"📌 {text}"  # Notion's own callout marker convention
+    if btype == "code":
+        lang = body.get("language") or ""
+        return f"```{lang}\n{text}\n```"
+    return text
+
+
+def _extract_page_title(page: dict) -> str:
+    """Pull the page title from properties.
+
+    Notion's property model varies — title lives under a property named
+    ``"title"`` or ``"Name"`` typically. Look for any property whose
+    ``type`` is ``"title"``.
+    """
+    properties = page.get("properties") or {}
+    for prop in properties.values():
+        if prop.get("type") == "title":
+            return _extract_rich_text(prop.get("title", []))
+    return ""
+
+
+def _extract_participants(page: dict) -> list[str]:
+    """Best-effort participant extraction.
+
+    Notion exposes ``created_by`` and ``last_edited_by`` as user objects
+    with at most a name; emails aren't available on the page-properties
+    surface for most workspaces. Returns names where present.
+    """
+    out: list[str] = []
+    seen: set[str] = set()
+    for key in ("created_by", "last_edited_by"):
+        user = page.get(key) or {}
+        name = user.get("name") or user.get("id")
+        if name and name not in seen:
+            seen.add(name)
+            out.append(name)
+    return out
+
+
+def normalize_page_to_payload(page: dict, blocks: list[dict], page_id: str) -> dict:
+    """Build the ingest payload from page metadata + child blocks."""
+    title = _extract_page_title(page) or page_id
+    block_texts = [t for b in blocks if (t := _extract_block_text(b))]
+    full_text = "\n".join(block_texts).strip()
+
+    decisions: list[dict] = []
+    if full_text:
+        decisions.append({"description": full_text, "title": title})
+
+    return {
+        "query": title,
+        "source": "notion",
+        "title": title,
+        "date": page.get("last_edited_time") or page.get("created_time") or "",
+        "participants": _extract_participants(page),
+        "decisions": decisions,
+    }
+
+
+class NotionAdapter:
+    """SourceAdapter implementation for Notion (active path)."""
+
+    source_id = "notion"
+
+    def can_handle_url(self, url: str) -> bool:
+        return bool(_URL_RE.match(url.strip()))
+
+    def fetch_active(self, url: str) -> dict:
+        page_id = parse_notion_url(url)
+        api_key = self._resolve_api_key()
+        from sources.notion.client import get_all_blocks, get_page
+
+        page = get_page(api_key=api_key, page_id=page_id)
+        blocks = get_all_blocks(api_key=api_key, page_id=page_id)
+        return normalize_page_to_payload(page, blocks, page_id)
+
+    def _resolve_api_key(self) -> str:
+        from secrets_store import get_secret
+
+        key = get_secret(source_id=self.source_id, key="api_key")
+        if not key:
+            raise RuntimeError(
+                "Notion API key not configured. Set it via:\n"
+                '  python -c "from secrets_store import put_secret; '
+                "put_secret(source_id='notion', key='api_key', value='secret_...')\""
+            )
+        return key

--- a/sources/notion/client.py
+++ b/sources/notion/client.py
@@ -1,0 +1,101 @@
+"""Thin Notion REST client (#420 Phase 2 — active ingest).
+
+Uses stdlib ``urllib.request`` for consistency with the Linear client.
+Two endpoints used today:
+    GET /v1/pages/{id}             — page metadata + properties
+    GET /v1/blocks/{id}/children    — paginated block list
+
+Notion requires a ``Notion-Version`` header — pinned to a stable version
+to avoid implicit upgrades silently breaking the block walker.
+
+Threat-model parity with the Linear client:
+- Token in Authorization header (never URL).
+- Response size capped at 4 MiB per call (Notion pages with megabytes of
+  blocks are misuse — operator should narrow the page scope).
+- Per-call 15s timeout.
+"""
+
+from __future__ import annotations
+
+import json
+import urllib.error
+import urllib.parse
+import urllib.request
+
+_API_BASE = "https://api.notion.com/v1"
+_NOTION_VERSION = "2022-06-28"
+_REQUEST_TIMEOUT_SECONDS = 15.0
+_MAX_RESPONSE_BYTES = 4 * 1024 * 1024
+_MAX_PAGINATION_PAGES = 20  # 20 * 100 blocks = 2000 — bounds large-page misuse
+
+
+class NotionAPIError(RuntimeError):
+    """Raised for any non-recoverable Notion API failure."""
+
+    def __init__(self, message: str, *, status_code: int | None = None) -> None:
+        self.status_code = status_code
+        super().__init__(message)
+
+
+def _get(*, api_key: str, path: str, params: dict | None = None) -> dict:
+    """GET ``{_API_BASE}{path}`` with optional query params; return parsed JSON."""
+    url = f"{_API_BASE}{path}"
+    if params:
+        url = url + "?" + urllib.parse.urlencode(params)
+    headers = {
+        "Authorization": f"Bearer {api_key}",
+        "Notion-Version": _NOTION_VERSION,
+        "User-Agent": "bicameral-mcp/source-notion",
+    }
+    req = urllib.request.Request(url, headers=headers, method="GET")
+    try:
+        with urllib.request.urlopen(req, timeout=_REQUEST_TIMEOUT_SECONDS) as resp:
+            raw = resp.read(_MAX_RESPONSE_BYTES + 1)
+            if len(raw) > _MAX_RESPONSE_BYTES:
+                raise NotionAPIError(
+                    f"Notion response exceeded {_MAX_RESPONSE_BYTES} bytes",
+                    status_code=resp.status,
+                )
+    except urllib.error.HTTPError as exc:
+        raise NotionAPIError(
+            f"Notion API HTTP {exc.code}: {exc.reason}",
+            status_code=exc.code,
+        ) from exc
+    except urllib.error.URLError as exc:
+        raise NotionAPIError(f"Notion API network error: {exc.reason}") from exc
+
+    try:
+        return json.loads(raw.decode("utf-8"))
+    except json.JSONDecodeError as exc:
+        raise NotionAPIError(f"Notion API returned non-JSON: {exc}") from exc
+
+
+def get_page(*, api_key: str, page_id: str) -> dict:
+    """Fetch a page's metadata + properties."""
+    return _get(api_key=api_key, path=f"/pages/{page_id}")
+
+
+def get_all_blocks(*, api_key: str, page_id: str) -> list[dict]:
+    """Fetch every child block of ``page_id``, paginating until exhausted
+    or until the per-call page cap fires (misuse bound)."""
+    out: list[dict] = []
+    cursor: str | None = None
+    pages_fetched = 0
+    while True:
+        params: dict[str, str] = {"page_size": "100"}
+        if cursor is not None:
+            params["start_cursor"] = cursor
+        resp = _get(api_key=api_key, path=f"/blocks/{page_id}/children", params=params)
+        out.extend(resp.get("results", []))
+        pages_fetched += 1
+        if not resp.get("has_more"):
+            break
+        if pages_fetched >= _MAX_PAGINATION_PAGES:
+            raise NotionAPIError(
+                f"page has more than {_MAX_PAGINATION_PAGES * 100} blocks — "
+                "narrow the ingest scope to a sub-page"
+            )
+        cursor = resp.get("next_cursor")
+        if not cursor:
+            break
+    return out

--- a/tests/test_notion_adapter.py
+++ b/tests/test_notion_adapter.py
@@ -1,0 +1,261 @@
+"""Tests for the Notion source adapter (#420 Phase 2).
+
+Mirrors the Linear adapter test shape: mock urlopen at the boundary,
+exercise URL parse / block walk / normalization / error paths unmocked.
+"""
+
+from __future__ import annotations
+
+import io
+import json
+import urllib.error
+from unittest.mock import patch
+
+import pytest
+
+from sources.notion.adapter import (
+    NotionAdapter,
+    normalize_page_to_payload,
+    parse_notion_url,
+)
+from sources.notion.client import NotionAPIError, get_all_blocks, get_page
+
+# ── URL parsing ─────────────────────────────────────────────────────────────
+
+
+@pytest.mark.parametrize(
+    "url,expected_id",
+    [
+        (
+            "https://www.notion.so/myws/Decision-Doc-1234567890abcdef1234567890abcdef",
+            "12345678-90ab-cdef-1234-567890abcdef",
+        ),
+        (
+            "https://www.notion.so/1234567890abcdef1234567890abcdef",
+            "12345678-90ab-cdef-1234-567890abcdef",
+        ),
+        (
+            "https://notion.so/myws/1234567890ABCDEF1234567890ABCDEF",
+            "12345678-90ab-cdef-1234-567890abcdef",
+        ),
+        (
+            "https://www.notion.so/myws/some-page-1234567890abcdef1234567890abcdef?v=tab",
+            "12345678-90ab-cdef-1234-567890abcdef",
+        ),
+    ],
+)
+def test_parse_notion_url_accepts_valid(url, expected_id):
+    assert parse_notion_url(url) == expected_id
+
+
+@pytest.mark.parametrize(
+    "url",
+    [
+        "https://github.com/foo/bar",
+        "https://www.notion.so/",
+        "https://www.notion.so/myws/short-id-12345",
+        "",
+        "not-a-url",
+    ],
+)
+def test_parse_notion_url_rejects_invalid(url):
+    with pytest.raises(ValueError):
+        parse_notion_url(url)
+
+
+# ── Block text extraction + normalization ───────────────────────────────────
+
+
+def _block(btype: str, text: str, **extra) -> dict:
+    body = {"rich_text": [{"plain_text": text}]}
+    body.update(extra)
+    return {"type": btype, btype: body}
+
+
+def test_normalize_full_page_with_mixed_blocks():
+    page = {
+        "properties": {
+            "Name": {"type": "title", "title": [{"plain_text": "Decision Doc"}]},
+        },
+        "created_time": "2026-05-01T00:00:00Z",
+        "last_edited_time": "2026-05-19T20:00:00Z",
+        "created_by": {"name": "Alice", "id": "u1"},
+        "last_edited_by": {"name": "Bob", "id": "u2"},
+    }
+    blocks = [
+        _block("heading_1", "Context"),
+        _block("paragraph", "We decided to use the WARN posture."),
+        _block("heading_2", "Rationale"),
+        _block("bulleted_list_item", "Pollers can't fail-fast"),
+        _block("to_do", "Update docs", checked=False),
+        _block("code", "x = 1", language="python"),
+        {"type": "divider", "divider": {}},  # skipped
+        {"type": "image", "image": {}},  # skipped
+    ]
+
+    payload = normalize_page_to_payload(page, blocks, "page-id")
+
+    assert payload["source"] == "notion"
+    assert payload["title"] == "Decision Doc"
+    assert payload["query"] == "Decision Doc"
+    assert payload["date"] == "2026-05-19T20:00:00Z"
+    assert payload["participants"] == ["Alice", "Bob"]
+    assert len(payload["decisions"]) == 1
+    full_text = payload["decisions"][0]["description"]
+    assert "# Context" in full_text
+    assert "## Rationale" in full_text
+    assert "- Pollers can't fail-fast" in full_text
+    assert "- [ ] Update docs" in full_text
+    assert "```python" in full_text
+    # Divider and image are skipped, never appear.
+    assert "image" not in full_text.lower() or "image" not in payload["decisions"][0]["description"]
+
+
+def test_normalize_empty_page_drops_decision():
+    page = {
+        "properties": {"Name": {"type": "title", "title": []}},
+        "created_time": "2026-05-19T00:00:00Z",
+        "last_edited_time": "2026-05-19T00:00:00Z",
+    }
+    blocks = []
+    payload = normalize_page_to_payload(page, blocks, "page-id")
+    # No text → no decision row. Don't push empty decisions through.
+    assert payload["decisions"] == []
+    # But title falls back to the page_id when no title property is set.
+    assert payload["title"] == "page-id"
+
+
+def test_normalize_unchecked_vs_checked_todo():
+    page = {"properties": {}, "created_time": "", "last_edited_time": ""}
+    blocks = [
+        _block("to_do", "Done thing", checked=True),
+        _block("to_do", "Pending thing", checked=False),
+    ]
+    payload = normalize_page_to_payload(page, blocks, "p")
+    desc = payload["decisions"][0]["description"]
+    assert "- [x] Done thing" in desc
+    assert "- [ ] Pending thing" in desc
+
+
+def test_normalize_dedups_participants():
+    page = {
+        "properties": {"Name": {"type": "title", "title": [{"plain_text": "T"}]}},
+        "created_by": {"name": "Same", "id": "u"},
+        "last_edited_by": {"name": "Same", "id": "u"},
+        "created_time": "",
+        "last_edited_time": "",
+    }
+    payload = normalize_page_to_payload(page, [_block("paragraph", "x")], "p")
+    assert payload["participants"] == ["Same"]
+
+
+# ── REST client error handling ──────────────────────────────────────────────
+
+
+def _mock_response(body: dict, status: int = 200):
+    raw = json.dumps(body).encode("utf-8")
+    resp = io.BytesIO(raw)
+    resp.status = status  # type: ignore[attr-defined]
+
+    class _Ctx:
+        def __enter__(self):
+            return resp
+
+        def __exit__(self, *args):
+            return False
+
+    return _Ctx()
+
+
+def test_get_page_success():
+    expected = {"object": "page", "id": "p1"}
+    with patch("urllib.request.urlopen", return_value=_mock_response(expected)):
+        assert get_page(api_key="k", page_id="p1") == expected
+
+
+def test_get_page_raises_on_http_404():
+    err = urllib.error.HTTPError(
+        url="https://api.notion.com/v1/pages/x",
+        code=404,
+        msg="Not Found",
+        hdrs=None,
+        fp=io.BytesIO(b""),
+    )
+    with patch("urllib.request.urlopen", side_effect=err):
+        with pytest.raises(NotionAPIError) as exc_info:
+            get_page(api_key="k", page_id="x")
+    assert exc_info.value.status_code == 404
+
+
+def test_get_all_blocks_paginates_until_has_more_false():
+    page1 = {
+        "results": [_block("paragraph", "first")],
+        "has_more": True,
+        "next_cursor": "cursor-2",
+    }
+    page2 = {"results": [_block("paragraph", "second")], "has_more": False}
+
+    responses = [_mock_response(page1), _mock_response(page2)]
+    with patch("urllib.request.urlopen", side_effect=responses):
+        blocks = get_all_blocks(api_key="k", page_id="p1")
+    assert len(blocks) == 2
+
+
+def test_get_all_blocks_caps_pagination_pages():
+    """A page reporting has_more=True forever must hit the 20-page cap."""
+
+    def _infinite_page(*args, **kwargs):
+        # urlopen returns a context manager — each call needs its own.
+        return _mock_response(
+            {
+                "results": [_block("paragraph", "x")],
+                "has_more": True,
+                "next_cursor": "c",
+            }
+        )
+
+    with patch("urllib.request.urlopen", side_effect=_infinite_page):
+        with pytest.raises(NotionAPIError, match="more than 2000"):
+            get_all_blocks(api_key="k", page_id="p1")
+
+
+# ── Adapter integration ─────────────────────────────────────────────────────
+
+
+def test_adapter_can_handle_url():
+    a = NotionAdapter()
+    assert a.can_handle_url("https://www.notion.so/myws/page-1234567890abcdef1234567890abcdef")
+    assert not a.can_handle_url("https://linear.app/foo/issue/BIC-1")
+
+
+def test_adapter_fetch_active_round_trip(monkeypatch):
+    page_resp = {
+        "properties": {"Name": {"type": "title", "title": [{"plain_text": "T"}]}},
+        "created_time": "2026-05-19T00:00:00Z",
+        "last_edited_time": "2026-05-19T00:00:00Z",
+    }
+    blocks_resp = {
+        "results": [_block("paragraph", "Decision content")],
+        "has_more": False,
+    }
+    a = NotionAdapter()
+    monkeypatch.setattr(a, "_resolve_api_key", lambda: "secret_x")
+
+    responses = [_mock_response(page_resp), _mock_response(blocks_resp)]
+    with patch("urllib.request.urlopen", side_effect=responses):
+        result = a.fetch_active("https://www.notion.so/myws/T-1234567890abcdef1234567890abcdef")
+
+    assert result["source"] == "notion"
+    assert result["title"] == "T"
+    assert "Decision content" in result["decisions"][0]["description"]
+
+
+def test_adapter_raises_when_api_key_missing(monkeypatch):
+    monkeypatch.setenv("BICAMERAL_KEYRING_DISABLE", "1")
+    from secrets_store.store import _reset_for_tests
+
+    _reset_for_tests()
+
+    a = NotionAdapter()
+    with pytest.raises(RuntimeError, match="API key not configured"):
+        a.fetch_active("https://www.notion.so/myws/T-1234567890abcdef1234567890abcdef")


### PR DESCRIPTION
## Summary

Mirrors Phase 1a Linear shape: URL → REST fetch → block walk → `IngestPayload`. Active path only; polling/databases/webhooks deferred to Phase 2b.

- `sources/notion/client.py` — stdlib `urllib` REST client. `/v1/pages/{id}` + `/v1/blocks/{id}/children`. Pinned `Notion-Version: 2022-06-28`. Same hardening as Linear client (15s timeout, 4 MiB cap, Bearer in header). Pagination capped at 20 pages × 100 blocks = 2000 (misuse bound).
- `sources/notion/adapter.py` — URL parser accepts dashed/undashed 32-hex IDs across workspace/slug variants; normalizes to dashed UUID. Block walker extracts prose-only types (paragraph, heading_1/2/3, bulleted/numbered_list_item, to_do, quote, callout, code); divider/image/video/embed/child_database/child_page skipped. Structural decoration (`# headings`, `- bullets`, `[x] to_dos`) preserved so the gap-judge chain has topic anchors.

Auth via `secrets_store` under `source_id="notion"`, key `"api_key"`. Notion's internal-integration model — operator creates an integration, shares specific pages with it, stores the token.

Closes BicameralAI/bicameral-daemon#11. Parent tracker: BicameralAI/bicameral-daemon#3.

## Dependencies

**Depends on BicameralAI/bicameral-daemon#13 (Phase 0b) being merged first** — imports `from secrets_store import get_secret`. CI will fail on this PR until BicameralAI/bicameral-daemon#13 lands.

Also depends on `sources/protocol.py` from Phase 1a (#337 stacked). Tree will resolve cleanly once both BicameralAI/bicameral-daemon#13 and the Phase 1a PR merge; until then, this branch will not test in isolation.

## Test plan

- [ ] After BicameralAI/bicameral-daemon#13 + Phase 1a merge, CI green on `tests/test_notion_adapter.py` (20 passing locally).
- [ ] Manual smoke: store a Notion integration token, point at a shared page, verify block walk extracts headings + paragraphs + tables.

🤖 Generated with [Claude Code](https://claude.com/claude-code)