### PR TITLE
feat(sources): Phase 3 — GitHub active-ingest adapter

### DIFF
--- a/sources/github/__init__.py
+++ b/sources/github/__init__.py
@@ -1,0 +1,12 @@
+"""GitHub source adapter (#337 Phase 3 — active ingest).
+
+Public API: ``GitHubAdapter`` and ``parse_github_url``.
+
+Auth: persisted via ``secrets_store`` under ``source_id="github"``,
+key ``"api_key"`` (a Personal Access Token with ``repo`` scope, OR a
+GitHub App installation token). Sent as ``Authorization: Bearer <token>``.
+"""
+
+from sources.github.adapter import GitHubAdapter, parse_github_url
+
+__all__ = ["GitHubAdapter", "parse_github_url"]

--- a/sources/github/adapter.py
+++ b/sources/github/adapter.py
@@ -1,0 +1,258 @@
+"""GitHub source adapter (#337 Phase 3 — active ingest).
+
+Handles three URL shapes:
+    https://github.com/<owner>/<repo>/pull/<number>      — PR + reviews + comments
+    https://github.com/<owner>/<repo>/issues/<number>    — issue + comments
+    https://github.com/<owner>/<repo>/commit/<sha>       — commit metadata
+
+PR ingest pulls the PR body + reviews + comments as separate decision
+proposals; downstream gap-judge classifies. Commit ingest produces a
+single decision row from the commit message (useful for the
+``decision:`` commit convention from #337's original capture-pipeline
+sketch).
+"""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+
+_PR_RE = re.compile(
+    r"^https?://github\.com/(?P<owner>[\w.-]+)/(?P<repo>[\w.-]+)/pull/(?P<num>\d+)(?:[/?#].*)?$"
+)
+_ISSUE_RE = re.compile(
+    r"^https?://github\.com/(?P<owner>[\w.-]+)/(?P<repo>[\w.-]+)/issues/(?P<num>\d+)(?:[/?#].*)?$"
+)
+_COMMIT_RE = re.compile(
+    r"^https?://github\.com/(?P<owner>[\w.-]+)/(?P<repo>[\w.-]+)/commit/(?P<sha>[0-9a-fA-F]{7,40})(?:[/?#].*)?$"
+)
+
+
+@dataclass(frozen=True)
+class _ParsedURL:
+    kind: str  # "pull", "issue", or "commit"
+    owner: str
+    repo: str
+    identifier: str  # number for pull/issue, sha for commit
+
+
+def parse_github_url(url: str) -> _ParsedURL:
+    """Parse a GitHub URL into structured parts.
+
+    Raises:
+        ValueError: URL doesn't match any supported GitHub shape.
+    """
+    url = url.strip()
+    for kind, rx, key in (
+        ("pull", _PR_RE, "num"),
+        ("issue", _ISSUE_RE, "num"),
+        ("commit", _COMMIT_RE, "sha"),
+    ):
+        m = rx.match(url)
+        if m:
+            return _ParsedURL(
+                kind=kind,
+                owner=m.group("owner"),
+                repo=m.group("repo"),
+                identifier=m.group(key),
+            )
+    raise ValueError(
+        f"not a recognized GitHub URL: {url!r}. "
+        "Expected github.com/<owner>/<repo>/{pull|issues|commit}/<id>."
+    )
+
+
+def _collect_participants(*sources: list[dict] | dict | None) -> list[str]:
+    """Best-effort participant collection across PR/issue/comment lists.
+
+    Each source is a list of dicts with a ``user`` field, OR a single
+    dict with ``user``. Login is used as identity (email rarely exposed
+    on GitHub's public API).
+    """
+    seen: set[str] = set()
+    out: list[str] = []
+    for src in sources:
+        if src is None:
+            continue
+        items = src if isinstance(src, list) else [src]
+        for item in items:
+            user = item.get("user") or item.get("author") or {}
+            login = user.get("login")
+            if login and login not in seen:
+                seen.add(login)
+                out.append(login)
+    return out
+
+
+def normalize_pr_to_payload(
+    pull: dict,
+    reviews: list[dict],
+    comments: list[dict],
+) -> dict:
+    """Build the ingest payload from a PR + its reviews + its comments."""
+    number = pull.get("number")
+    repo_full = (pull.get("base") or {}).get("repo", {}).get("full_name") or ""
+    title = pull.get("title") or f"PR #{number}"
+    identifier = f"{repo_full}#PR-{number}" if repo_full else f"PR-{number}"
+
+    decisions: list[dict] = []
+    body = (pull.get("body") or "").strip()
+    if body:
+        decisions.append({"description": body, "title": identifier})
+    for review in reviews:
+        review_body = (review.get("body") or "").strip()
+        if not review_body:
+            continue
+        state = review.get("state") or "COMMENTED"
+        decisions.append(
+            {
+                "description": f"[{state}] {review_body}",
+                "title": f"{identifier}#review-{review.get('id')}",
+            }
+        )
+    for comment in comments:
+        comment_body = (comment.get("body") or "").strip()
+        if not comment_body:
+            continue
+        decisions.append(
+            {
+                "description": comment_body,
+                "title": f"{identifier}#comment-{comment.get('id')}",
+            }
+        )
+
+    return {
+        "query": title,
+        "source": "github",
+        "title": identifier,
+        "date": pull.get("merged_at") or pull.get("closed_at") or pull.get("updated_at") or "",
+        "participants": _collect_participants([pull], reviews, comments),
+        "decisions": decisions,
+    }
+
+
+def normalize_issue_to_payload(issue: dict, comments: list[dict]) -> dict:
+    """Build the ingest payload from an issue + its comments."""
+    number = issue.get("number")
+    # The issue object doesn't carry repo info — derive from html_url
+    # if available.
+    html_url = issue.get("html_url") or ""
+    repo_full = ""
+    m = re.match(r"https?://github\.com/([\w.-]+)/([\w.-]+)/", html_url)
+    if m:
+        repo_full = f"{m.group(1)}/{m.group(2)}"
+    title = issue.get("title") or f"issue #{number}"
+    identifier = f"{repo_full}#issue-{number}" if repo_full else f"issue-{number}"
+
+    decisions: list[dict] = []
+    body = (issue.get("body") or "").strip()
+    if body:
+        decisions.append({"description": body, "title": identifier})
+    for comment in comments:
+        comment_body = (comment.get("body") or "").strip()
+        if not comment_body:
+            continue
+        decisions.append(
+            {
+                "description": comment_body,
+                "title": f"{identifier}#comment-{comment.get('id')}",
+            }
+        )
+
+    return {
+        "query": title,
+        "source": "github",
+        "title": identifier,
+        "date": issue.get("closed_at") or issue.get("updated_at") or "",
+        "participants": _collect_participants([issue], comments),
+        "decisions": decisions,
+    }
+
+
+def normalize_commit_to_payload(commit: dict, owner: str, repo: str) -> dict:
+    """Build the ingest payload from a single commit.
+
+    Useful for the ``decision: <text>`` commit-convention path from
+    #337's original capture-pipeline sketch — operator points at the
+    commit, adapter pulls the message into the ledger.
+    """
+    sha = commit.get("sha") or ""
+    commit_info = commit.get("commit") or {}
+    message = (commit_info.get("message") or "").strip()
+    author = (commit_info.get("author") or {}).get("email") or ""
+
+    identifier = f"{owner}/{repo}@{sha[:8]}" if sha else f"{owner}/{repo}@unknown"
+
+    decisions = []
+    if message:
+        decisions.append({"description": message, "title": identifier})
+
+    return {
+        "query": message.splitlines()[0] if message else identifier,
+        "source": "github",
+        "title": identifier,
+        "date": (commit_info.get("author") or {}).get("date") or "",
+        "participants": [author] if author else [],
+        "decisions": decisions,
+    }
+
+
+class GitHubAdapter:
+    """SourceAdapter implementation for GitHub (active path)."""
+
+    source_id = "github"
+
+    def can_handle_url(self, url: str) -> bool:
+        try:
+            parse_github_url(url)
+            return True
+        except ValueError:
+            return False
+
+    def fetch_active(self, url: str) -> dict:
+        parsed = parse_github_url(url)
+        api_key = self._resolve_api_key()
+        from sources.github.client import (
+            get_commit,
+            get_issue,
+            get_issue_comments,
+            get_pull,
+            get_pull_reviews,
+        )
+
+        if parsed.kind == "pull":
+            number = int(parsed.identifier)
+            pull = get_pull(api_key=api_key, owner=parsed.owner, repo=parsed.repo, number=number)
+            reviews = get_pull_reviews(
+                api_key=api_key, owner=parsed.owner, repo=parsed.repo, number=number
+            )
+            comments = get_issue_comments(
+                api_key=api_key, owner=parsed.owner, repo=parsed.repo, number=number
+            )
+            return normalize_pr_to_payload(pull, reviews, comments)
+
+        if parsed.kind == "issue":
+            number = int(parsed.identifier)
+            issue = get_issue(api_key=api_key, owner=parsed.owner, repo=parsed.repo, number=number)
+            comments = get_issue_comments(
+                api_key=api_key, owner=parsed.owner, repo=parsed.repo, number=number
+            )
+            return normalize_issue_to_payload(issue, comments)
+
+        # commit
+        commit = get_commit(
+            api_key=api_key, owner=parsed.owner, repo=parsed.repo, sha=parsed.identifier
+        )
+        return normalize_commit_to_payload(commit, parsed.owner, parsed.repo)
+
+    def _resolve_api_key(self) -> str:
+        from secrets_store import get_secret
+
+        key = get_secret(source_id=self.source_id, key="api_key")
+        if not key:
+            raise RuntimeError(
+                "GitHub API key not configured. Set it via:\n"
+                '  python -c "from secrets_store import put_secret; '
+                "put_secret(source_id='github', key='api_key', value='ghp_...')\""
+            )
+        return key

--- a/sources/github/client.py
+++ b/sources/github/client.py
@@ -1,0 +1,154 @@
+"""GitHub REST API client (#337 Phase 3 — active ingest).
+
+Mirrors the Linear/Notion clients: stdlib urllib, 15s timeout, 4 MiB
+response cap, Bearer-token Authorization header, never URL.
+
+API base: https://api.github.com. ``Accept: application/vnd.github+json``
+header is preferred per GitHub's recommendation; X-GitHub-Api-Version
+pinned to ``2022-11-28`` so a future GitHub API rev doesn't silently
+reshape responses under us.
+"""
+
+from __future__ import annotations
+
+import json
+import urllib.error
+import urllib.parse
+import urllib.request
+
+_API_BASE = "https://api.github.com"
+_API_VERSION = "2022-11-28"
+_REQUEST_TIMEOUT_SECONDS = 15.0
+_MAX_RESPONSE_BYTES = 4 * 1024 * 1024
+_MAX_PAGINATION_PAGES = 10  # 10 * 100 comments = 1000 — enough for any sensible thread
+
+
+class GitHubAPIError(RuntimeError):
+    """Raised for any non-recoverable GitHub API failure."""
+
+    def __init__(self, message: str, *, status_code: int | None = None) -> None:
+        self.status_code = status_code
+        super().__init__(message)
+
+
+def _get(*, api_key: str, path: str, params: dict | None = None) -> tuple[dict | list, dict]:
+    """GET ``{_API_BASE}{path}`` and return (parsed JSON, response headers).
+
+    Headers are returned so the pagination helper can read ``Link`` for
+    next-page cursors (GitHub uses Link header pagination).
+    """
+    url = f"{_API_BASE}{path}"
+    if params:
+        url = url + "?" + urllib.parse.urlencode(params)
+    headers = {
+        "Authorization": f"Bearer {api_key}",
+        "Accept": "application/vnd.github+json",
+        "X-GitHub-Api-Version": _API_VERSION,
+        "User-Agent": "bicameral-mcp/source-github",
+    }
+    req = urllib.request.Request(url, headers=headers, method="GET")
+    try:
+        with urllib.request.urlopen(req, timeout=_REQUEST_TIMEOUT_SECONDS) as resp:
+            raw = resp.read(_MAX_RESPONSE_BYTES + 1)
+            if len(raw) > _MAX_RESPONSE_BYTES:
+                raise GitHubAPIError(
+                    f"GitHub response exceeded {_MAX_RESPONSE_BYTES} bytes",
+                    status_code=resp.status,
+                )
+            resp_headers = dict(resp.headers.items())
+    except urllib.error.HTTPError as exc:
+        raise GitHubAPIError(
+            f"GitHub API HTTP {exc.code}: {exc.reason}",
+            status_code=exc.code,
+        ) from exc
+    except urllib.error.URLError as exc:
+        raise GitHubAPIError(f"GitHub API network error: {exc.reason}") from exc
+
+    try:
+        return json.loads(raw.decode("utf-8")), resp_headers
+    except json.JSONDecodeError as exc:
+        raise GitHubAPIError(f"GitHub API returned non-JSON: {exc}") from exc
+
+
+def get_pull(*, api_key: str, owner: str, repo: str, number: int) -> dict:
+    """Fetch a single pull request."""
+    data, _ = _get(api_key=api_key, path=f"/repos/{owner}/{repo}/pulls/{number}")
+    if not isinstance(data, dict):
+        raise GitHubAPIError(f"unexpected pull response shape: {type(data).__name__}")
+    return data
+
+
+def get_issue(*, api_key: str, owner: str, repo: str, number: int) -> dict:
+    """Fetch a single issue (or PR; GitHub's issue endpoint covers both)."""
+    data, _ = _get(api_key=api_key, path=f"/repos/{owner}/{repo}/issues/{number}")
+    if not isinstance(data, dict):
+        raise GitHubAPIError(f"unexpected issue response shape: {type(data).__name__}")
+    return data
+
+
+def get_commit(*, api_key: str, owner: str, repo: str, sha: str) -> dict:
+    """Fetch a single commit with stats + file list."""
+    data, _ = _get(api_key=api_key, path=f"/repos/{owner}/{repo}/commits/{sha}")
+    if not isinstance(data, dict):
+        raise GitHubAPIError(f"unexpected commit response shape: {type(data).__name__}")
+    return data
+
+
+def get_issue_comments(*, api_key: str, owner: str, repo: str, number: int) -> list[dict]:
+    """Fetch all issue/PR comments, following Link-header pagination."""
+    return _paginate_list(
+        api_key=api_key,
+        path=f"/repos/{owner}/{repo}/issues/{number}/comments",
+    )
+
+
+def get_pull_reviews(*, api_key: str, owner: str, repo: str, number: int) -> list[dict]:
+    """Fetch PR review records."""
+    return _paginate_list(
+        api_key=api_key,
+        path=f"/repos/{owner}/{repo}/pulls/{number}/reviews",
+    )
+
+
+def _parse_link_next(link_header: str) -> str | None:
+    """Extract the ``rel="next"`` URL from a GitHub Link header, or None."""
+    for chunk in link_header.split(","):
+        if 'rel="next"' in chunk:
+            start = chunk.find("<")
+            end = chunk.find(">")
+            if start >= 0 and end > start:
+                return chunk[start + 1 : end]
+    return None
+
+
+def _paginate_list(*, api_key: str, path: str) -> list[dict]:
+    """Generic paginated GET — accumulates the JSON array across pages.
+
+    Capped at ``_MAX_PAGINATION_PAGES`` * 100 records.
+    """
+    out: list[dict] = []
+    current_path: str | None = path + "?per_page=100"
+    pages = 0
+    while current_path:
+        if current_path.startswith(_API_BASE):
+            url_suffix = current_path[len(_API_BASE) :]
+        else:
+            url_suffix = current_path
+        data, headers = _get(api_key=api_key, path=url_suffix)
+        if not isinstance(data, list):
+            raise GitHubAPIError(f"expected list at {path}, got {type(data).__name__}")
+        out.extend(data)
+        pages += 1
+        if pages >= _MAX_PAGINATION_PAGES:
+            raise GitHubAPIError(
+                f"{path} has more than {_MAX_PAGINATION_PAGES * 100} records — "
+                "narrow the ingest scope"
+            )
+        link = headers.get("Link") or headers.get("link")
+        if not link:
+            break
+        next_url = _parse_link_next(link)
+        if not next_url:
+            break
+        current_path = next_url
+    return out

--- a/tests/test_github_adapter.py
+++ b/tests/test_github_adapter.py
@@ -1,0 +1,263 @@
+"""Tests for the GitHub source adapter (#337 Phase 3)."""
+
+from __future__ import annotations
+
+import io
+import json
+from unittest.mock import patch
+
+import pytest
+
+from sources.github.adapter import (
+    GitHubAdapter,
+    _ParsedURL,
+    normalize_commit_to_payload,
+    normalize_issue_to_payload,
+    normalize_pr_to_payload,
+    parse_github_url,
+)
+from sources.github.client import GitHubAPIError, _parse_link_next
+
+# ── URL parsing ─────────────────────────────────────────────────────────────
+
+
+@pytest.mark.parametrize(
+    "url,expected",
+    [
+        (
+            "https://github.com/BicameralAI/bicameral-mcp/pull/337",
+            _ParsedURL(kind="pull", owner="BicameralAI", repo="bicameral-mcp", identifier="337"),
+        ),
+        (
+            "https://github.com/foo/bar/issues/42",
+            _ParsedURL(kind="issue", owner="foo", repo="bar", identifier="42"),
+        ),
+        (
+            "https://github.com/foo/bar/commit/abc1234",
+            _ParsedURL(kind="commit", owner="foo", repo="bar", identifier="abc1234"),
+        ),
+        (
+            "https://github.com/foo/bar/pull/337#issuecomment-123",
+            _ParsedURL(kind="pull", owner="foo", repo="bar", identifier="337"),
+        ),
+    ],
+)
+def test_parse_github_url_accepts_valid(url, expected):
+    assert parse_github_url(url) == expected
+
+
+@pytest.mark.parametrize(
+    "url",
+    [
+        "https://linear.app/foo/issue/BIC-1",
+        "https://github.com/foo",
+        "https://github.com/foo/bar",
+        "https://github.com/foo/bar/wiki",
+        "",
+    ],
+)
+def test_parse_github_url_rejects_invalid(url):
+    with pytest.raises(ValueError):
+        parse_github_url(url)
+
+
+# ── PR normalization ────────────────────────────────────────────────────────
+
+
+def test_normalize_pr_full_shape():
+    pull = {
+        "number": 337,
+        "title": "Unified integrations tracker",
+        "body": "Pulling Linear/Notion/GitHub into one Active/Passive frame.",
+        "merged_at": "2026-05-19T20:00:00Z",
+        "base": {"repo": {"full_name": "BicameralAI/bicameral-mcp"}},
+        "user": {"login": "WulfForge"},
+    }
+    reviews = [
+        {
+            "id": 1001,
+            "state": "APPROVED",
+            "body": "LGTM",
+            "user": {"login": "reviewer1"},
+        },
+        {
+            "id": 1002,
+            "state": "COMMENTED",
+            "body": "",  # empty — filtered
+            "user": {"login": "noisy"},
+        },
+    ]
+    comments = [
+        {
+            "id": 2001,
+            "body": "Should we also handle Jira here?",
+            "user": {"login": "pm-alice"},
+        },
+    ]
+
+    payload = normalize_pr_to_payload(pull, reviews, comments)
+
+    assert payload["source"] == "github"
+    assert payload["title"] == "BicameralAI/bicameral-mcp#PR-337"
+    assert payload["query"] == "Unified integrations tracker"
+    assert payload["date"] == "2026-05-19T20:00:00Z"
+    assert "WulfForge" in payload["participants"]
+    assert "reviewer1" in payload["participants"]
+    assert "pm-alice" in payload["participants"]
+    # 1 PR body + 1 non-empty review + 1 comment = 3 decisions
+    assert len(payload["decisions"]) == 3
+    assert "[APPROVED] LGTM" in payload["decisions"][1]["description"]
+
+
+def test_normalize_pr_empty_body_no_reviews():
+    pull = {"number": 5, "title": "Quick fix", "body": "", "user": {"login": "dev"}}
+    payload = normalize_pr_to_payload(pull, [], [])
+    assert payload["decisions"] == []
+
+
+# ── Issue normalization ─────────────────────────────────────────────────────
+
+
+def test_normalize_issue_extracts_repo_from_html_url():
+    issue = {
+        "number": 42,
+        "title": "Bug report",
+        "body": "Found a bug.",
+        "html_url": "https://github.com/foo/bar/issues/42",
+        "user": {"login": "reporter"},
+        "updated_at": "2026-05-19T00:00:00Z",
+    }
+    payload = normalize_issue_to_payload(issue, [])
+    assert payload["title"] == "foo/bar#issue-42"
+    assert payload["participants"] == ["reporter"]
+
+
+# ── Commit normalization ────────────────────────────────────────────────────
+
+
+def test_normalize_commit():
+    commit = {
+        "sha": "abc12345def",
+        "commit": {
+            "message": "decision: use the WARN posture\n\nMore detail here.",
+            "author": {"email": "dev@example.com", "date": "2026-05-19T00:00:00Z"},
+        },
+    }
+    payload = normalize_commit_to_payload(commit, "foo", "bar")
+    assert payload["title"] == "foo/bar@abc12345"
+    assert payload["query"] == "decision: use the WARN posture"
+    assert payload["participants"] == ["dev@example.com"]
+    assert len(payload["decisions"]) == 1
+
+
+# ── Client error handling + Link parsing ────────────────────────────────────
+
+
+def test_parse_link_next():
+    link = (
+        '<https://api.github.com/repos/x/y/issues/1/comments?page=2>; rel="next", '
+        '<https://api.github.com/repos/x/y/issues/1/comments?page=5>; rel="last"'
+    )
+    assert _parse_link_next(link) == ("https://api.github.com/repos/x/y/issues/1/comments?page=2")
+
+
+def test_parse_link_next_no_next():
+    link = '<https://api.github.com/repos/x/y/issues/1/comments?page=1>; rel="last"'
+    assert _parse_link_next(link) is None
+
+
+# ── Adapter integration ─────────────────────────────────────────────────────
+
+
+def _mock_response(body, status: int = 200, headers: dict | None = None):
+    if isinstance(body, (dict, list)):
+        raw = json.dumps(body).encode("utf-8")
+    else:
+        raw = body
+    resp = io.BytesIO(raw)
+    resp.status = status  # type: ignore[attr-defined]
+
+    class _Headers:
+        def __init__(self, h):
+            self._h = h
+
+        def items(self):
+            return list(self._h.items())
+
+        def get(self, key, default=None):
+            return self._h.get(key, default)
+
+    resp.headers = _Headers(headers or {})  # type: ignore[attr-defined]
+
+    class _Ctx:
+        def __enter__(self):
+            return resp
+
+        def __exit__(self, *args):
+            return False
+
+    return _Ctx()
+
+
+def test_adapter_can_handle_url():
+    a = GitHubAdapter()
+    assert a.can_handle_url("https://github.com/foo/bar/pull/1")
+    assert a.can_handle_url("https://github.com/foo/bar/issues/2")
+    assert a.can_handle_url("https://github.com/foo/bar/commit/abcdef0")
+    assert not a.can_handle_url("https://linear.app/foo/issue/BIC-1")
+
+
+def test_adapter_fetch_active_pull(monkeypatch):
+    pull_resp = {
+        "number": 1,
+        "title": "T",
+        "body": "Body",
+        "merged_at": "2026-01-01T00:00:00Z",
+        "base": {"repo": {"full_name": "foo/bar"}},
+        "user": {"login": "dev"},
+    }
+    reviews_resp = []
+    comments_resp = []
+
+    responses = [
+        _mock_response(pull_resp),
+        _mock_response(reviews_resp),
+        _mock_response(comments_resp),
+    ]
+    a = GitHubAdapter()
+    monkeypatch.setattr(a, "_resolve_api_key", lambda: "ghp_x")
+
+    with patch("urllib.request.urlopen", side_effect=responses):
+        result = a.fetch_active("https://github.com/foo/bar/pull/1")
+
+    assert result["source"] == "github"
+    assert result["title"] == "foo/bar#PR-1"
+
+
+def test_adapter_fetch_active_commit(monkeypatch):
+    commit_resp = {
+        "sha": "abc1234",
+        "commit": {
+            "message": "decision: ship it",
+            "author": {"email": "dev@x.com", "date": "2026-01-01T00:00:00Z"},
+        },
+    }
+    a = GitHubAdapter()
+    monkeypatch.setattr(a, "_resolve_api_key", lambda: "ghp_x")
+
+    with patch("urllib.request.urlopen", return_value=_mock_response(commit_resp)):
+        result = a.fetch_active("https://github.com/foo/bar/commit/abc1234")
+
+    assert result["source"] == "github"
+    assert "decision: ship it" in result["decisions"][0]["description"]
+
+
+def test_adapter_raises_when_api_key_missing(monkeypatch):
+    monkeypatch.setenv("BICAMERAL_KEYRING_DISABLE", "1")
+    from secrets_store.store import _reset_for_tests
+
+    _reset_for_tests()
+
+    a = GitHubAdapter()
+    with pytest.raises(RuntimeError, match="API key not configured"):
+        a.fetch_active("https://github.com/foo/bar/pull/1")


### PR DESCRIPTION
## Summary

Active path for the three highest-decision-density GitHub surfaces:

| URL form | Fetched |
|---|---|
| `github.com/<owner>/<repo>/pull/<N>` | PR + reviews + comments |
| `github.com/<owner>/<repo>/issues/<N>` | issue + comments |
| `github.com/<owner>/<repo>/commit/<sha>` | commit message |

PR ingest emits the PR body, each non-empty review (decorated with state — APPROVED / COMMENTED / CHANGES_REQUESTED), and each non-empty comment as separate decision proposals — gap-judge chain downstream sorts decisions from chatter.

Commit ingest unlocks the `decision:` commit-convention path from BicameralAI/bicameral-daemon#3's original capture-pipeline sketch.

- `sources/github/client.py` — stdlib urllib REST client. Pinned `X-GitHub-Api-Version: 2022-11-28`, `Accept: application/vnd.github+json`. Same hardening as Linear/Notion (15s timeout, 4 MiB cap, Bearer in header). `_paginate_list` follows GitHub's `Link` header cursor; cap at 10 pages × 100 records = 1000.
- `sources/github/adapter.py` — three URL regexes routed via a `_ParsedURL` dataclass. `_collect_participants` dedups across PR/review/comment author lists.

Auth via `secrets_store` under `source_id="github"`, key `"api_key"` — PAT with `repo` scope OR GitHub App installation token. Sent as `Authorization: Bearer <token>`.

Parent tracker: BicameralAI/bicameral-daemon#3.

## Dependencies

**Depends on BicameralAI/bicameral-daemon#13 (Phase 0b) being merged first** — imports `from secrets_store import get_secret`. Also depends on `sources/protocol.py` from Phase 1a.

CI will fail on this PR until BicameralAI/bicameral-daemon#13 and Phase 1a both land.

## Test plan

- [ ] After dependencies merge, CI green on `tests/test_github_adapter.py` (19 passing locally).
- [ ] Manual smoke: PR URL → see PR body + reviews + comments as decisions. Issue URL → issue body + comments. Commit URL → commit message.

🤖 Generated with [Claude Code](https://claude.com/claude-code)