### PR TITLE
feat(sources): Phase 5 — Google Drive / Docs active-ingest adapter

### DIFF
--- a/sources/google_drive/__init__.py
+++ b/sources/google_drive/__init__.py
@@ -1,0 +1,14 @@
+"""Google Drive / Docs source adapter (#337 Phase 5 — active ingest).
+
+Public API: ``GoogleDriveAdapter`` and ``parse_gdrive_url``.
+
+Auth: OAuth credentials persisted in ``secrets_store`` under
+``source_id="google_drive"``, key ``"oauth_token"`` as a JSON blob
+(the output of ``credentials.to_json()``). OAuth handshake itself
+(obtaining the token) is Phase 5b — operator currently uses the
+existing setup_wizard team-backend flow or runs a one-off script.
+"""
+
+from sources.google_drive.adapter import GoogleDriveAdapter, parse_gdrive_url
+
+__all__ = ["GoogleDriveAdapter", "parse_gdrive_url"]

--- a/sources/google_drive/adapter.py
+++ b/sources/google_drive/adapter.py
@@ -1,0 +1,191 @@
+"""Google Drive / Docs source adapter (#337 Phase 5 — active ingest).
+
+Active path: operator pastes a Google Docs URL → adapter fetches the
+document via the Docs API → text extracted from the structured body →
+normalized to an IngestPayload.
+
+URL forms accepted:
+    https://docs.google.com/document/d/<id>/edit
+    https://docs.google.com/document/d/<id>/edit?usp=sharing
+    https://docs.google.com/document/d/<id>
+    https://drive.google.com/file/d/<id>/view
+
+The trailing ``<id>`` is a 25–60-char base64url segment.
+
+Text extraction walks Google's structured-document model:
+- ``body.content[]`` is a list of structural elements.
+- ``paragraph`` elements contain ``paragraph.elements[]`` each with
+  ``textRun.content``.
+- ``table`` elements contain rows × cells × paragraphs.
+- ``sectionBreak`` and other structural elements are skipped.
+
+Decoration: paragraphs that have a ``namedStyleType`` of
+``HEADING_1`` / ``HEADING_2`` / ``HEADING_3`` get markdown decoration
+so the downstream gap-judge chain has topic anchors (mirrors the
+Notion adapter pattern).
+
+Auth model: OAuth token JSON loaded from secrets_store. The Docs API
+``documents.get`` requires the ``https://www.googleapis.com/auth/documents.readonly``
+scope at minimum.
+"""
+
+from __future__ import annotations
+
+import re
+
+_URL_RE = re.compile(
+    r"^https?://(?:docs\.google\.com/document/d/|drive\.google\.com/file/d/)"
+    r"(?P<id>[A-Za-z0-9_-]{25,128})(?:[/?#].*)?$"
+)
+
+
+def parse_gdrive_url(url: str) -> str:
+    """Extract the document ID from a Google Docs/Drive URL.
+
+    Raises:
+        ValueError: URL doesn't match the expected shape.
+    """
+    m = _URL_RE.match(url.strip())
+    if not m:
+        raise ValueError(
+            f"not a recognized Google Docs/Drive URL: {url!r}. "
+            "Expected docs.google.com/document/d/<id> or drive.google.com/file/d/<id>."
+        )
+    return m.group("id")
+
+
+def _extract_text_from_paragraph(para: dict) -> str:
+    """Concatenate textRun content across a paragraph's elements."""
+    pieces: list[str] = []
+    for elem in para.get("elements") or []:
+        run = elem.get("textRun") or {}
+        content = run.get("content") or ""
+        pieces.append(content)
+    return "".join(pieces).strip()
+
+
+def _decorate_paragraph(text: str, named_style: str) -> str:
+    """Markdown-decorate a paragraph based on its namedStyleType."""
+    if not text:
+        return ""
+    if named_style == "HEADING_1":
+        return f"# {text}"
+    if named_style == "HEADING_2":
+        return f"## {text}"
+    if named_style == "HEADING_3":
+        return f"### {text}"
+    if named_style == "HEADING_4":
+        return f"#### {text}"
+    return text
+
+
+def _walk_table(table: dict) -> list[str]:
+    """Flatten table cells into a list of paragraph strings."""
+    out: list[str] = []
+    for row in table.get("tableRows") or []:
+        for cell in row.get("tableCells") or []:
+            for sub_elem in cell.get("content") or []:
+                if "paragraph" in sub_elem:
+                    para = sub_elem["paragraph"]
+                    style = (para.get("paragraphStyle") or {}).get("namedStyleType") or ""
+                    text = _extract_text_from_paragraph(para)
+                    decorated = _decorate_paragraph(text, style)
+                    if decorated:
+                        out.append(decorated)
+    return out
+
+
+def extract_document_text(document: dict) -> str:
+    """Walk the Google Doc structured body and return joined plain text."""
+    blocks: list[str] = []
+    body = document.get("body") or {}
+    for elem in body.get("content") or []:
+        if "paragraph" in elem:
+            para = elem["paragraph"]
+            style = (para.get("paragraphStyle") or {}).get("namedStyleType") or ""
+            text = _extract_text_from_paragraph(para)
+            decorated = _decorate_paragraph(text, style)
+            if decorated:
+                blocks.append(decorated)
+        elif "table" in elem:
+            blocks.extend(_walk_table(elem["table"]))
+        # sectionBreak, tableOfContents, etc. — skipped intentionally.
+    return "\n".join(blocks).strip()
+
+
+def normalize_document_to_payload(document: dict, doc_id: str) -> dict:
+    """Build the ingest payload from a Google Docs document response."""
+    title = document.get("title") or doc_id
+    text = extract_document_text(document)
+    decisions = [{"description": text, "title": title}] if text else []
+    return {
+        "query": title,
+        "source": "google_drive",
+        "title": title,
+        "date": "",  # Docs API documents.get doesn't surface modifiedTime; Drive API does. Phase 5b.
+        "participants": [],  # similarly — Drive API permissions list is Phase 5b.
+        "decisions": decisions,
+    }
+
+
+class GoogleDriveAdapter:
+    """SourceAdapter implementation for Google Drive / Docs (active path)."""
+
+    source_id = "google_drive"
+
+    def can_handle_url(self, url: str) -> bool:
+        return bool(_URL_RE.match(url.strip()))
+
+    def fetch_active(self, url: str) -> dict:
+        doc_id = parse_gdrive_url(url)
+        document = self._fetch_document(doc_id)
+        return normalize_document_to_payload(document, doc_id)
+
+    def _fetch_document(self, doc_id: str) -> dict:
+        """Resolve credentials + Docs service + execute ``documents.get``.
+
+        Split out from ``fetch_active`` so tests can override the whole
+        network path without monkey-patching googleapiclient.discovery.
+        """
+        creds = self._resolve_credentials()
+        service = self._build_docs_service(creds)
+        try:
+            return service.documents().get(documentId=doc_id).execute()
+        except Exception as exc:  # noqa: BLE001 — surface as RuntimeError per SourceAdapter contract
+            raise RuntimeError(f"Google Docs API call failed: {exc}") from exc
+
+    def _resolve_credentials(self):
+        """Build google.oauth2 Credentials from the stored token JSON.
+
+        Raises ``RuntimeError`` when no token is stored — with a hint
+        directing the operator to the (future) OAuth handshake flow.
+        """
+        import json as _json
+
+        from secrets_store import get_secret
+
+        token_json = get_secret(source_id=self.source_id, key="oauth_token")
+        if not token_json:
+            raise RuntimeError(
+                "Google Drive OAuth token not configured. The Phase 5b OAuth "
+                "handshake flow will populate this automatically; for now, "
+                "store the token JSON (output of `credentials.to_json()`) via:\n"
+                '  python -c "from secrets_store import put_secret; '
+                "put_secret(source_id='google_drive', key='oauth_token', value='<json>')\""
+            )
+        try:
+            from google.oauth2.credentials import Credentials  # type: ignore[import-not-found]
+        except ImportError as exc:
+            raise RuntimeError(
+                "google-auth not installed; reinstall bicameral-mcp to pick up the dep"
+            ) from exc
+        info = _json.loads(token_json)
+        return Credentials.from_authorized_user_info(
+            info, scopes=["https://www.googleapis.com/auth/documents.readonly"]
+        )
+
+    def _build_docs_service(self, creds):
+        """Build the Docs API service. Separate method for test override."""
+        from googleapiclient.discovery import build  # type: ignore[import-not-found]
+
+        return build("docs", "v1", credentials=creds, cache_discovery=False)

--- a/tests/test_google_drive_adapter.py
+++ b/tests/test_google_drive_adapter.py
@@ -1,0 +1,225 @@
+"""Tests for the Google Drive / Docs source adapter (#337 Phase 5).
+
+URL parse + document-walker + normalization run unmocked.
+The Google API service builder is patched via the adapter's
+_fetch_document seam — googleapiclient imports defer until first call,
+so tests don't need google-auth installed.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from sources.google_drive.adapter import (
+    GoogleDriveAdapter,
+    extract_document_text,
+    normalize_document_to_payload,
+    parse_gdrive_url,
+)
+
+# ── URL parsing ─────────────────────────────────────────────────────────────
+
+
+@pytest.mark.parametrize(
+    "url,expected_id",
+    [
+        (
+            "https://docs.google.com/document/d/1abcDEF234ghiJKL567mnoPQR890stuVWX/edit",
+            "1abcDEF234ghiJKL567mnoPQR890stuVWX",
+        ),
+        (
+            "https://docs.google.com/document/d/1abcDEF234ghiJKL567mnoPQR890stuVWX/edit?usp=sharing",
+            "1abcDEF234ghiJKL567mnoPQR890stuVWX",
+        ),
+        (
+            "https://docs.google.com/document/d/1abcDEF234ghiJKL567mnoPQR890stuVWX",
+            "1abcDEF234ghiJKL567mnoPQR890stuVWX",
+        ),
+        (
+            "https://drive.google.com/file/d/1abcDEF234ghiJKL567mnoPQR890stuVWX/view",
+            "1abcDEF234ghiJKL567mnoPQR890stuVWX",
+        ),
+    ],
+)
+def test_parse_gdrive_url_accepts_valid(url, expected_id):
+    assert parse_gdrive_url(url) == expected_id
+
+
+@pytest.mark.parametrize(
+    "url",
+    [
+        "https://github.com/foo/bar",
+        "https://docs.google.com/spreadsheets/d/1abc",  # spreadsheets not supported in Phase 5
+        "https://docs.google.com/document/d/short",  # ID too short
+        "https://docs.google.com/document/",
+        "",
+    ],
+)
+def test_parse_gdrive_url_rejects_invalid(url):
+    with pytest.raises(ValueError):
+        parse_gdrive_url(url)
+
+
+# ── Document text extraction ────────────────────────────────────────────────
+
+
+def _para(text: str, style: str = "NORMAL_TEXT") -> dict:
+    return {
+        "paragraph": {
+            "paragraphStyle": {"namedStyleType": style},
+            "elements": [{"textRun": {"content": text}}],
+        }
+    }
+
+
+def test_extract_plain_paragraphs():
+    doc = {"body": {"content": [_para("First line.\n"), _para("Second line.\n")]}}
+    out = extract_document_text(doc)
+    assert "First line." in out
+    assert "Second line." in out
+
+
+def test_extract_decorates_headings():
+    doc = {
+        "body": {
+            "content": [
+                _para("Title", style="HEADING_1"),
+                _para("Subsection", style="HEADING_2"),
+                _para("Sub-subsection", style="HEADING_3"),
+                _para("Normal text", style="NORMAL_TEXT"),
+            ]
+        }
+    }
+    out = extract_document_text(doc)
+    assert "# Title" in out
+    assert "## Subsection" in out
+    assert "### Sub-subsection" in out
+    assert "Normal text" in out
+    assert "# Normal text" not in out  # un-styled paragraphs are NOT decorated
+
+
+def test_extract_flattens_tables():
+    doc = {
+        "body": {
+            "content": [
+                {
+                    "table": {
+                        "tableRows": [
+                            {
+                                "tableCells": [
+                                    {"content": [_para("Cell A1")]},
+                                    {"content": [_para("Cell A2")]},
+                                ]
+                            },
+                            {
+                                "tableCells": [
+                                    {"content": [_para("Cell B1")]},
+                                    {"content": [_para("Cell B2")]},
+                                ]
+                            },
+                        ]
+                    }
+                }
+            ]
+        }
+    }
+    out = extract_document_text(doc)
+    assert "Cell A1" in out
+    assert "Cell B2" in out
+
+
+def test_extract_skips_section_break_and_toc():
+    doc = {
+        "body": {
+            "content": [
+                {"sectionBreak": {}},
+                _para("Real content"),
+                {"tableOfContents": {"content": []}},
+            ]
+        }
+    }
+    out = extract_document_text(doc)
+    assert out == "Real content"
+
+
+def test_extract_handles_empty_paragraphs():
+    """Empty paragraphs (e.g. blank lines) shouldn't pollute the output."""
+    doc = {
+        "body": {
+            "content": [
+                _para(""),
+                _para("Content"),
+                _para("   "),
+            ]
+        }
+    }
+    out = extract_document_text(doc)
+    assert out == "Content"
+
+
+# ── Normalization ───────────────────────────────────────────────────────────
+
+
+def test_normalize_full_shape():
+    doc = {
+        "title": "Architecture Decision Record",
+        "body": {"content": [_para("Context.\n"), _para("Decision.\n")]},
+    }
+    payload = normalize_document_to_payload(doc, "doc-id-123")
+    assert payload["source"] == "google_drive"
+    assert payload["title"] == "Architecture Decision Record"
+    assert payload["query"] == "Architecture Decision Record"
+    assert len(payload["decisions"]) == 1
+    assert "Context." in payload["decisions"][0]["description"]
+
+
+def test_normalize_empty_doc_drops_decision():
+    doc = {"title": "Empty", "body": {"content": []}}
+    payload = normalize_document_to_payload(doc, "doc-id")
+    assert payload["decisions"] == []
+
+
+def test_normalize_falls_back_to_doc_id_when_no_title():
+    doc = {"body": {"content": [_para("x")]}}
+    payload = normalize_document_to_payload(doc, "doc-id-xyz")
+    assert payload["title"] == "doc-id-xyz"
+
+
+# ── Adapter integration ─────────────────────────────────────────────────────
+
+
+def test_adapter_can_handle_url():
+    a = GoogleDriveAdapter()
+    assert a.can_handle_url(
+        "https://docs.google.com/document/d/1abcDEF234ghiJKL567mnoPQR890stuVWX/edit"
+    )
+    assert not a.can_handle_url("https://github.com/foo/bar")
+
+
+def test_adapter_fetch_active_round_trip(monkeypatch):
+    """Override _fetch_document to skip the network entirely — exercises
+    the parse + normalize path end-to-end."""
+    doc_response = {
+        "title": "T",
+        "body": {"content": [_para("Decision body")]},
+    }
+    a = GoogleDriveAdapter()
+    monkeypatch.setattr(a, "_fetch_document", lambda doc_id: doc_response)
+
+    result = a.fetch_active(
+        "https://docs.google.com/document/d/1abcDEF234ghiJKL567mnoPQR890stuVWX/edit"
+    )
+    assert result["source"] == "google_drive"
+    assert result["title"] == "T"
+    assert "Decision body" in result["decisions"][0]["description"]
+
+
+def test_adapter_raises_when_token_missing(monkeypatch):
+    monkeypatch.setenv("BICAMERAL_KEYRING_DISABLE", "1")
+    from secrets_store.store import _reset_for_tests
+
+    _reset_for_tests()
+
+    a = GoogleDriveAdapter()
+    with pytest.raises(RuntimeError, match="OAuth token not configured"):
+        a.fetch_active("https://docs.google.com/document/d/1abcDEF234ghiJKL567mnoPQR890stuVWX/edit")


### PR DESCRIPTION
## Summary

Active path: operator pastes a Google Docs URL → adapter fetches via Docs API → structured body walked into plain text → `IngestPayload`. OAuth handshake (token acquisition) deferred to Phase 5b; this PR ships the read path.

- `sources/google_drive/adapter.py` — URL parser accepts `docs.google.com/document/d/<id>` and `drive.google.com/file/d/<id>` forms with 25–128-char base64url IDs. Document walker handles paragraph elements (with HEADING_1/2/3/4 markdown decoration mirroring the Notion adapter), table elements (cells → flattened paragraph list). `sectionBreak` / `tableOfContents` / other structural elements skipped.

Auth: OAuth token JSON (output of `credentials.to_json()`) stored in `secrets_store` under `source_id="google_drive"`, key `"oauth_token"`. Scope: `documents.readonly`. Reuses `google-auth` + `google-api-python-client` already in `pyproject.toml` (used by the existing team-backend Drive flow).

**Phase 4 (Slack ingest) intentionally deferred** per parent tracker — gated on BicameralAI/bicameral-daemon#4 outbound ChannelAdapter landing first to share auth scaffolding.

Parent tracker: BicameralAI/bicameral-daemon#3.

## Dependencies

**Depends on BicameralAI/bicameral-daemon#13 (Phase 0b) being merged first** — imports `from secrets_store import get_secret`. Also depends on `sources/protocol.py` from Phase 1a.

CI will fail on this PR until BicameralAI/bicameral-daemon#13 and Phase 1a both land.

## Test plan

- [ ] After dependencies merge, CI green on `tests/test_google_drive_adapter.py` (20 passing locally).
- [ ] Manual smoke: store an OAuth token JSON, point at a shared Google Doc, verify the body extraction (headings, paragraphs, tables).
- [ ] Phase 5b follow-up: build the OAuth handshake flow so operators don't manually populate the token.

🤖 Generated with [Claude Code](https://claude.com/claude-code)