### PR TITLE
feat(sources): Phase 5b — Google Drive OAuth handshake + auto-refresh

### DIFF
--- a/cli/source_auth_cli.py
+++ b/cli/source_auth_cli.py
@@ -1,0 +1,79 @@
+"""CLI: ``bicameral-mcp source-auth <source>`` — run the OAuth handshake (Phase 5b).
+
+Currently dispatches to:
+    google_drive → sources.google_drive.auth.run_oauth_handshake()
+
+Future sources (Linear PAT-OAuth, Notion OAuth, GitHub App install,
+Slack OAuth) will register here when their auth flows ship.
+"""
+
+from __future__ import annotations
+
+import argparse
+import sys
+
+_KNOWN_SOURCES = ("google_drive",)
+
+
+def _build_argparser(subparser: argparse.ArgumentParser) -> None:
+    """Wire the subcommand's args. Called from ``server.py``'s argparse."""
+    subparser.add_argument(
+        "source",
+        choices=list(_KNOWN_SOURCES),
+        help=(
+            "Source to authenticate. Currently only google_drive — the Linear "
+            "/ Notion / GitHub adapters use static API keys stored via "
+            "`secrets_store.put_secret`."
+        ),
+    )
+
+
+def main(args: argparse.Namespace) -> int:
+    """Entry point invoked from ``server.py``'s ``_dispatch``.
+
+    Returns 0 on successful handshake, 1 on flow abort, 2 on bundled-client
+    misconfiguration, 3 on unexpected exception. Non-zero exits print a
+    one-line operator-facing hint to stderr.
+    """
+    if args.source == "google_drive":
+        return _run_google_drive()
+    # argparse choices=... blocks unknown sources before we get here, but
+    # belt-and-suspenders in case the choices list and the dispatch table
+    # drift.
+    print(f"[source-auth] unknown source: {args.source}", file=sys.stderr)
+    return 2
+
+
+def _run_google_drive() -> int:
+    from sources.google_drive.auth import OAuthFlowAbortedError, run_oauth_handshake
+
+    print("[source-auth] starting Google Drive OAuth handshake...")
+    print("[source-auth] your browser should open shortly. Sign in and consent.")
+    try:
+        run_oauth_handshake()
+    except OAuthFlowAbortedError as exc:
+        print(f"[source-auth] flow aborted: {exc}", file=sys.stderr)
+        return 1
+    except ImportError as exc:
+        print(
+            f"[source-auth] missing OAuth dependency ({exc}). "
+            "Reinstall bicameral-mcp to pick up `google-auth-oauthlib`.",
+            file=sys.stderr,
+        )
+        return 2
+    except RuntimeError as exc:
+        # OAuthClientNotProvisionedError from events.backends.google_drive lands here.
+        print(f"[source-auth] {exc}", file=sys.stderr)
+        return 2
+    except Exception as exc:  # noqa: BLE001 — CLI must never re-raise to user
+        print(
+            f"[source-auth] unexpected error ({type(exc).__name__}): {exc}",
+            file=sys.stderr,
+        )
+        return 3
+    print(
+        "[source-auth] success — token stored in OS keyring under "
+        "service `bicameral-mcp::google_drive`, key `oauth_token`. "
+        "The Google Drive ingest adapter is now ready."
+    )
+    return 0

--- a/server.py
+++ b/server.py
@@ -1508,6 +1508,13 @@ def _register_subparsers(parser: ArgumentParser, subparsers: Any) -> None:
     from cli.sync_and_brief_cli import _build_argparser as _sb_build
 
     _sb_build(sync_and_brief)
+    source_auth = subparsers.add_parser(
+        "source-auth",
+        help="run the OAuth handshake for an ingest source and persist the token (#337 Phase 5b)",
+    )
+    from cli.source_auth_cli import _build_argparser as _sa_build
+
+    _sa_build(source_auth)
     subparsers.add_parser(
         "ledger-export",
         help="export the full ledger as JSON-Lines to stdout (#252 Layer 4)",
@@ -1586,6 +1593,10 @@ def _dispatch(args: Any) -> int:
         from cli.sync_and_brief_cli import main as sync_and_brief_main
 
         return sync_and_brief_main(args)
+    if args.command == "source-auth":
+        from cli.source_auth_cli import main as source_auth_main
+
+        return source_auth_main(args)
     if args.command == "ledger-export":
         from cli.ledger_export_cli import main as export_main
 

--- a/sources/google_drive/adapter.py
+++ b/sources/google_drive/adapter.py
@@ -155,34 +155,18 @@ class GoogleDriveAdapter:
             raise RuntimeError(f"Google Docs API call failed: {exc}") from exc
 
     def _resolve_credentials(self):
-        """Build google.oauth2 Credentials from the stored token JSON.
+        """Return live OAuth credentials for the Docs API call.
 
-        Raises ``RuntimeError`` when no token is stored — with a hint
-        directing the operator to the (future) OAuth handshake flow.
+        Phase 5b (#337): delegates to ``sources.google_drive.auth.load_credentials``
+        which adds the auto-refresh path — expired tokens get a new access
+        token via the refresh token without operator re-consent, and the
+        rotated JSON is re-persisted so the next fetch sees it. Missing /
+        unrefreshable tokens raise ``RuntimeError`` pointing at the
+        ``bicameral-mcp source-auth google_drive`` command.
         """
-        import json as _json
+        from sources.google_drive.auth import load_credentials
 
-        from secrets_store import get_secret
-
-        token_json = get_secret(source_id=self.source_id, key="oauth_token")
-        if not token_json:
-            raise RuntimeError(
-                "Google Drive OAuth token not configured. The Phase 5b OAuth "
-                "handshake flow will populate this automatically; for now, "
-                "store the token JSON (output of `credentials.to_json()`) via:\n"
-                '  python -c "from secrets_store import put_secret; '
-                "put_secret(source_id='google_drive', key='oauth_token', value='<json>')\""
-            )
-        try:
-            from google.oauth2.credentials import Credentials  # type: ignore[import-not-found]
-        except ImportError as exc:
-            raise RuntimeError(
-                "google-auth not installed; reinstall bicameral-mcp to pick up the dep"
-            ) from exc
-        info = _json.loads(token_json)
-        return Credentials.from_authorized_user_info(
-            info, scopes=["https://www.googleapis.com/auth/documents.readonly"]
-        )
+        return load_credentials()
 
     def _build_docs_service(self, creds):
         """Build the Docs API service. Separate method for test override."""

--- a/sources/google_drive/auth.py
+++ b/sources/google_drive/auth.py
@@ -1,0 +1,154 @@
+"""OAuth handshake flow for the Google Drive / Docs ingest adapter (Phase 5b).
+
+Phase 5a (#427) shipped the read path against an already-stored token JSON;
+this module ships the actual acquisition flow. Operator runs
+``bicameral-mcp source-auth google_drive``, the local-loopback OAuth flow
+opens the browser, Google issues a token with ``documents.readonly`` scope,
+the result is persisted via ``secrets_store`` under
+``source_id="google_drive"``, key ``"oauth_token"``.
+
+Refresh handling: the adapter calls :func:`load_credentials` on every
+fetch. When the stored token is expired but has a refresh token, the new
+access token is silently minted and re-persisted. When the refresh token
+itself is gone (revoked, replaced) the function raises a clear error so
+the operator re-runs the handshake.
+
+Threat model parity with ``events/backends/google_drive.py``:
+- Same bundled OAuth client (one consent screen entry for the
+  ``bicameral-mcp`` product, not two).
+- Documents-only scope: ``documents.readonly`` — we cannot enumerate
+  Drive, list folders, or touch any non-Docs MIME type. Operator passes
+  individual doc URLs to the adapter.
+- Token never leaves the OS keyring (via ``secrets_store``). Falls back
+  to the in-process dict + warn-level audit event when no backend is
+  available, same as every other secret in the project.
+"""
+
+from __future__ import annotations
+
+import json
+
+# documents.readonly is the minimum scope needed for the
+# ``service.documents().get(documentId=...)`` call in the adapter.
+# drive.readonly (for listing / watching) is deliberately out of scope
+# in Phase 5b — adding scopes later forces a re-consent which is fine.
+INGEST_SCOPE = "https://www.googleapis.com/auth/documents.readonly"
+
+_SOURCE_ID = "google_drive"
+_TOKEN_KEY = "oauth_token"
+
+
+class OAuthFlowAbortedError(RuntimeError):
+    """Raised when the local-loopback OAuth flow ends without credentials.
+
+    The most common cause is the operator closing the browser tab before
+    completing consent. The CLI surfaces this with a retry hint.
+    """
+
+
+def _bundled_client_config() -> dict:
+    """Delegate to the existing team-backend config helper.
+
+    Shared single source of truth for the bundled OAuth client identity
+    — both the team-backend Drive flow and this ingest flow show up as
+    the same ``bicameral-mcp`` app on the operator's consent screen.
+    """
+    from events.backends.google_drive import _bundled_client_config as _cfg
+
+    return _cfg()
+
+
+def run_oauth_handshake() -> None:
+    """Run the local-loopback OAuth flow and persist the result.
+
+    Blocks until the operator completes consent in the browser (or aborts
+    by closing the tab). On success, the token JSON is stored in
+    ``secrets_store``; ``put_secret`` emits ``SOURCE_AUTH_GRANTED`` so
+    the operator's audit log records the grant without ever logging
+    the token value.
+
+    Re-running the handshake when a token is already stored is fine — the
+    new token overwrites the old, and ``put_secret`` emits a fresh
+    ``SOURCE_AUTH_GRANTED`` event.
+
+    Raises:
+        OAuthFlowAbortedError: flow completed without producing credentials.
+        RuntimeError: any other OAuth failure (network, bundled-client
+            misconfiguration, etc.). The CLI translates to an exit code.
+    """
+    from google_auth_oauthlib.flow import InstalledAppFlow  # type: ignore[import-not-found]
+
+    from secrets_store import put_secret
+
+    client_config = _bundled_client_config()
+    flow = InstalledAppFlow.from_client_config(client_config, [INGEST_SCOPE])
+    creds = flow.run_local_server(port=0)
+    if creds is None:
+        raise OAuthFlowAbortedError(
+            "OAuth flow did not produce credentials. "
+            "Common cause: browser tab closed before consent. Re-run the command."
+        )
+    put_secret(source_id=_SOURCE_ID, key=_TOKEN_KEY, value=creds.to_json())
+
+
+def load_credentials():
+    """Return live ``google.oauth2.credentials.Credentials`` for the adapter.
+
+    Resolution path:
+    1. Read the persisted token JSON from ``secrets_store``.
+    2. Build a ``Credentials`` object scoped to ``documents.readonly``.
+    3. If the access token is expired, refresh using the refresh token;
+       re-persist the rotated JSON so subsequent calls see the new
+       access token.
+    4. If no token is stored OR refresh fails, raise ``RuntimeError`` with
+       an operator-facing hint pointing at the handshake command.
+
+    Phase 5a's adapter currently builds Credentials directly from
+    ``from_authorized_user_info``; Phase 5b's adapter is updated to call
+    this function instead so the refresh path is exercised on every fetch.
+    """
+    from google.auth.transport.requests import Request  # type: ignore[import-not-found]
+    from google.oauth2.credentials import Credentials  # type: ignore[import-not-found]
+
+    from secrets_store import get_secret, put_secret
+
+    token_json = get_secret(source_id=_SOURCE_ID, key=_TOKEN_KEY)
+    if not token_json:
+        raise RuntimeError(
+            "Google Drive OAuth token not configured. Run:\n"
+            "  bicameral-mcp source-auth google_drive"
+        )
+    try:
+        info = json.loads(token_json)
+    except json.JSONDecodeError as exc:
+        raise RuntimeError(
+            "Stored Google Drive OAuth token is not valid JSON. "
+            "Re-run: bicameral-mcp source-auth google_drive"
+        ) from exc
+
+    creds = Credentials.from_authorized_user_info(info, scopes=[INGEST_SCOPE])
+    if creds.valid:
+        return creds
+    if creds.expired and creds.refresh_token:
+        try:
+            creds.refresh(Request())
+        except Exception as exc:  # noqa: BLE001 — surface as actionable RuntimeError
+            raise RuntimeError(
+                "Failed to refresh Google Drive OAuth token "
+                f"({type(exc).__name__}: {exc}). The refresh token may have been "
+                "revoked. Re-run: bicameral-mcp source-auth google_drive"
+            ) from exc
+        # Re-persist with the rotated access_token + token_expiry so subsequent
+        # calls don't trigger another refresh round-trip. put_secret emits
+        # SOURCE_AUTH_GRANTED again, which is correct — the access token IS
+        # a new grant even though the underlying consent is unchanged.
+        put_secret(source_id=_SOURCE_ID, key=_TOKEN_KEY, value=creds.to_json())
+        return creds
+
+    # No refresh path available — either no refresh_token was returned at
+    # initial consent (Google sometimes omits it on re-grant for the same
+    # client) or the token shape is malformed.
+    raise RuntimeError(
+        "Google Drive OAuth credentials are not valid and cannot be refreshed. "
+        "Re-run: bicameral-mcp source-auth google_drive"
+    )

--- a/tests/test_google_drive_auth.py
+++ b/tests/test_google_drive_auth.py
@@ -1,0 +1,361 @@
+"""Tests for #337 Phase 5b — Google Drive OAuth handshake + refresh.
+
+The OAuth flow itself (``InstalledAppFlow.run_local_server``) opens a real
+browser and cannot run unattended — every test patches it at the narrowest
+seam (the ``InstalledAppFlow.from_client_config`` factory's return value).
+The secrets_store integration runs unmocked under
+``BICAMERAL_KEYRING_DISABLE=1`` so the dict-backed fallback is the actual
+substrate.
+"""
+
+from __future__ import annotations
+
+import json
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+import audit_log
+from audit_log import AuditEventType
+from secrets_store import get_secret, put_secret
+from secrets_store.store import _reset_for_tests as _reset_secrets
+
+
+@pytest.fixture(autouse=True)
+def _disable_keyring_and_reset(monkeypatch):
+    monkeypatch.setenv("BICAMERAL_KEYRING_DISABLE", "1")
+    _reset_secrets()
+    yield
+    _reset_secrets()
+
+
+def _fake_creds(*, valid=True, expired=False, has_refresh=True, json_payload=None):
+    """Build a stand-in for google.oauth2.credentials.Credentials."""
+    creds = MagicMock()
+    creds.valid = valid
+    creds.expired = expired
+    creds.refresh_token = "refresh_xyz" if has_refresh else None
+    creds.to_json = MagicMock(
+        return_value=json.dumps(
+            json_payload
+            or {
+                "token": "access_abc",
+                "refresh_token": "refresh_xyz",
+                "client_id": "fake",
+                "client_secret": "fake",
+                "scopes": ["https://www.googleapis.com/auth/documents.readonly"],
+            }
+        )
+    )
+    return creds
+
+
+# ── run_oauth_handshake ─────────────────────────────────────────────────────
+
+
+def test_handshake_persists_token_and_emits_granted_event():
+    fake_creds = _fake_creds(valid=True)
+    fake_flow = MagicMock()
+    fake_flow.run_local_server = MagicMock(return_value=fake_creds)
+
+    with (
+        patch(
+            "google_auth_oauthlib.flow.InstalledAppFlow.from_client_config",
+            return_value=fake_flow,
+        ),
+        patch(
+            "sources.google_drive.auth._bundled_client_config",
+            return_value={"installed": {"client_id": "x", "client_secret": "y"}},
+        ),
+        patch.object(audit_log, "emit", wraps=audit_log.emit) as emit_spy,
+    ):
+        from sources.google_drive.auth import run_oauth_handshake
+
+        run_oauth_handshake()
+
+    # Token landed in secrets_store.
+    stored = get_secret(source_id="google_drive", key="oauth_token")
+    assert stored is not None
+    assert "access_abc" in stored
+
+    # SOURCE_AUTH_GRANTED emitted, no token value in audit fields.
+    granted = [
+        c
+        for c in emit_spy.call_args_list
+        if c.args and c.args[0] == AuditEventType.SOURCE_AUTH_GRANTED
+    ]
+    assert len(granted) == 1
+    assert "access_abc" not in str(granted[0].kwargs)
+
+
+def test_handshake_raises_when_flow_returns_none():
+    fake_flow = MagicMock()
+    fake_flow.run_local_server = MagicMock(return_value=None)
+
+    with (
+        patch(
+            "google_auth_oauthlib.flow.InstalledAppFlow.from_client_config",
+            return_value=fake_flow,
+        ),
+        patch(
+            "sources.google_drive.auth._bundled_client_config",
+            return_value={"installed": {"client_id": "x", "client_secret": "y"}},
+        ),
+    ):
+        from sources.google_drive.auth import OAuthFlowAbortedError, run_oauth_handshake
+
+        with pytest.raises(OAuthFlowAbortedError):
+            run_oauth_handshake()
+
+    # No token persisted on abort.
+    assert get_secret(source_id="google_drive", key="oauth_token") is None
+
+
+def test_handshake_overwrites_existing_token():
+    """Re-running the handshake should replace the stored token cleanly."""
+    put_secret(source_id="google_drive", key="oauth_token", value='{"token":"old"}')
+
+    fake_creds = _fake_creds(
+        valid=True,
+        json_payload={
+            "token": "fresh",
+            "refresh_token": "r",
+            "client_id": "x",
+            "client_secret": "y",
+            "scopes": ["https://www.googleapis.com/auth/documents.readonly"],
+        },
+    )
+    fake_flow = MagicMock()
+    fake_flow.run_local_server = MagicMock(return_value=fake_creds)
+
+    with (
+        patch(
+            "google_auth_oauthlib.flow.InstalledAppFlow.from_client_config",
+            return_value=fake_flow,
+        ),
+        patch(
+            "sources.google_drive.auth._bundled_client_config",
+            return_value={"installed": {"client_id": "x", "client_secret": "y"}},
+        ),
+    ):
+        from sources.google_drive.auth import run_oauth_handshake
+
+        run_oauth_handshake()
+
+    stored = get_secret(source_id="google_drive", key="oauth_token")
+    assert "fresh" in stored
+    assert "old" not in stored
+
+
+# ── load_credentials ────────────────────────────────────────────────────────
+
+
+def test_load_raises_when_no_token_stored():
+    from sources.google_drive.auth import load_credentials
+
+    with pytest.raises(RuntimeError, match="not configured"):
+        load_credentials()
+
+
+def test_load_raises_when_stored_token_is_not_json():
+    put_secret(source_id="google_drive", key="oauth_token", value="not-json{")
+    from sources.google_drive.auth import load_credentials
+
+    with pytest.raises(RuntimeError, match="not valid JSON"):
+        load_credentials()
+
+
+def test_load_returns_credentials_when_valid():
+    """Valid (non-expired) token → returns the Credentials object directly,
+    no refresh attempted."""
+    put_secret(
+        source_id="google_drive",
+        key="oauth_token",
+        value=json.dumps(
+            {
+                "token": "access_abc",
+                "refresh_token": "r",
+                "client_id": "x",
+                "client_secret": "y",
+                "scopes": ["https://www.googleapis.com/auth/documents.readonly"],
+            }
+        ),
+    )
+    fake_creds = _fake_creds(valid=True, expired=False)
+    with patch(
+        "google.oauth2.credentials.Credentials.from_authorized_user_info",
+        return_value=fake_creds,
+    ):
+        from sources.google_drive.auth import load_credentials
+
+        result = load_credentials()
+    assert result is fake_creds
+    fake_creds.refresh.assert_not_called()
+
+
+def test_load_refreshes_and_repersists_expired_token():
+    """Expired token + refresh_token present → refresh path runs, new JSON
+    is persisted, returned creds are the refreshed object."""
+    original_json = json.dumps(
+        {
+            "token": "old_access",
+            "refresh_token": "r",
+            "client_id": "x",
+            "client_secret": "y",
+            "scopes": ["https://www.googleapis.com/auth/documents.readonly"],
+        }
+    )
+    put_secret(source_id="google_drive", key="oauth_token", value=original_json)
+
+    # Refreshed creds expose a different to_json payload so we can verify
+    # re-persistence happened with the new value.
+    fake_creds = _fake_creds(
+        valid=False,
+        expired=True,
+        has_refresh=True,
+        json_payload={
+            "token": "new_access",
+            "refresh_token": "r",
+            "client_id": "x",
+            "client_secret": "y",
+            "scopes": ["https://www.googleapis.com/auth/documents.readonly"],
+        },
+    )
+
+    with patch(
+        "google.oauth2.credentials.Credentials.from_authorized_user_info",
+        return_value=fake_creds,
+    ):
+        from sources.google_drive.auth import load_credentials
+
+        result = load_credentials()
+
+    fake_creds.refresh.assert_called_once()
+    assert result is fake_creds
+    # New token persisted, old one overwritten.
+    stored = get_secret(source_id="google_drive", key="oauth_token")
+    assert "new_access" in stored
+
+
+def test_load_raises_when_refresh_fails():
+    put_secret(
+        source_id="google_drive",
+        key="oauth_token",
+        value=json.dumps(
+            {
+                "token": "x",
+                "refresh_token": "r",
+                "client_id": "x",
+                "client_secret": "y",
+                "scopes": ["https://www.googleapis.com/auth/documents.readonly"],
+            }
+        ),
+    )
+    fake_creds = _fake_creds(valid=False, expired=True, has_refresh=True)
+    fake_creds.refresh.side_effect = Exception("Token revoked by user")
+
+    with patch(
+        "google.oauth2.credentials.Credentials.from_authorized_user_info",
+        return_value=fake_creds,
+    ):
+        from sources.google_drive.auth import load_credentials
+
+        with pytest.raises(RuntimeError, match="Failed to refresh"):
+            load_credentials()
+
+
+def test_load_raises_when_no_refresh_token_and_token_invalid():
+    """Stored token is invalid and has no refresh_token — operator must
+    re-run the handshake."""
+    put_secret(
+        source_id="google_drive",
+        key="oauth_token",
+        value=json.dumps(
+            {
+                "token": "x",
+                "client_id": "x",
+                "client_secret": "y",
+                "scopes": ["https://www.googleapis.com/auth/documents.readonly"],
+            }
+        ),
+    )
+    fake_creds = _fake_creds(valid=False, expired=True, has_refresh=False)
+
+    with patch(
+        "google.oauth2.credentials.Credentials.from_authorized_user_info",
+        return_value=fake_creds,
+    ):
+        from sources.google_drive.auth import load_credentials
+
+        with pytest.raises(RuntimeError, match="not valid and cannot be refreshed"):
+            load_credentials()
+
+
+# ── CLI integration ─────────────────────────────────────────────────────────
+
+
+def test_cli_main_success(capsys):
+    fake_creds = _fake_creds(valid=True)
+    fake_flow = MagicMock()
+    fake_flow.run_local_server = MagicMock(return_value=fake_creds)
+
+    with (
+        patch(
+            "google_auth_oauthlib.flow.InstalledAppFlow.from_client_config",
+            return_value=fake_flow,
+        ),
+        patch(
+            "sources.google_drive.auth._bundled_client_config",
+            return_value={"installed": {"client_id": "x", "client_secret": "y"}},
+        ),
+    ):
+        from cli.source_auth_cli import main
+
+        exit_code = main(SimpleNamespace(source="google_drive"))
+
+    assert exit_code == 0
+    out = capsys.readouterr().out
+    assert "success" in out.lower()
+    assert get_secret(source_id="google_drive", key="oauth_token") is not None
+
+
+def test_cli_main_returns_1_on_abort(capsys):
+    fake_flow = MagicMock()
+    fake_flow.run_local_server = MagicMock(return_value=None)
+
+    with (
+        patch(
+            "google_auth_oauthlib.flow.InstalledAppFlow.from_client_config",
+            return_value=fake_flow,
+        ),
+        patch(
+            "sources.google_drive.auth._bundled_client_config",
+            return_value={"installed": {"client_id": "x", "client_secret": "y"}},
+        ),
+    ):
+        from cli.source_auth_cli import main
+
+        exit_code = main(SimpleNamespace(source="google_drive"))
+
+    assert exit_code == 1
+    err = capsys.readouterr().err
+    assert "aborted" in err.lower()
+
+
+def test_cli_main_returns_2_on_client_not_provisioned(capsys, monkeypatch):
+    """Bundled OAuth client placeholders raise OAuthClientNotProvisionedError
+    (which is a RuntimeError subclass) → CLI should exit 2."""
+    from events.backends.google_drive import OAuthClientNotProvisionedError
+
+    def _raise(*a, **kw):
+        raise OAuthClientNotProvisionedError("not provisioned")
+
+    monkeypatch.setattr("sources.google_drive.auth._bundled_client_config", _raise)
+
+    from cli.source_auth_cli import main
+
+    exit_code = main(SimpleNamespace(source="google_drive"))
+    assert exit_code == 2
+    err = capsys.readouterr().err
+    assert "not provisioned" in err.lower()


### PR DESCRIPTION
## Summary

Closes the credential-acquisition gap from Phase 5a (#427).

Before this PR: operator had to manually run a script to obtain a Google Docs OAuth token and paste its JSON into \`secrets_store\` via \`put_secret(source_id='google_drive', key='oauth_token', value='<json>')\`.

After this PR: operator runs \`bicameral-mcp source-auth google_drive\`, browser opens, Google consent screen appears, token is persisted to the OS keyring. The Phase 5a adapter now auto-refreshes the token on every fetch when expired (using the refresh_token) and re-persists the rotated JSON so subsequent fetches skip the refresh round-trip.

### New surfaces

- \`sources/google_drive/auth.py\`
  - \`run_oauth_handshake()\` — InstalledAppFlow.run_local_server, \`documents.readonly\` scope only (minimum-scope principle), persists via \`secrets_store.put_secret\` which emits \`SOURCE_AUTH_GRANTED\`.
  - \`load_credentials()\` — adapter-side resolver with auto-refresh + re-persist.
  - \`OAuthFlowAbortedError\` — raised when the operator closes the browser tab before consent; CLI surfaces as exit 1.
- \`cli/source_auth_cli.py\` + \`server.py\` — \`bicameral-mcp source-auth google_drive\` subcommand. Exit codes: 0 success / 1 abort / 2 client-not-provisioned / 3 unexpected.

### Modified

- \`sources/google_drive/adapter.py::_resolve_credentials\` — delegates to \`auth.load_credentials\` so the refresh path runs on every fetch. The inline put_secret hint in the missing-token error is replaced with a pointer to the CLI command.

### Reuse

Bundled OAuth client identity is shared with \`events/backends/google_drive.py\` (via \`_bundled_client_config()\`) so both the team-backend flow and this ingest flow show up as the same \`bicameral-mcp\` app on the operator's consent screen — one entry to manage, one entry to revoke.

## Threat model

- Token never leaves the OS keyring (or in-process dict fallback when no keyring backend, with a one-time \`GATE_FIRED\` warn so the operator knows persistence is degraded — inherits from BicameralAI/bicameral-mcp#423).
- \`SOURCE_AUTH_GRANTED\` audit event fires on both initial grant AND every refresh — semantically correct, each refreshed access token is a new grant.
- \`run_local_server\` uses 127.0.0.1 loopback redirect per RFC 8252 desktop-app pattern. No state through external services.
- Minimum scope (\`documents.readonly\`). Adding \`drive.readonly\` later (Phase 5c for listing/watching) is intentional friction — operator should see exactly which permissions Bicameral requests.

## Test plan

- [ ] CI green on \`tests/test_google_drive_auth.py\` (12 passing locally with \`google-auth\` installed) + no regression in \`tests/test_google_drive_adapter.py\` (20 passing).
- [ ] Manual smoke: run \`bicameral-mcp source-auth google_drive\` on a desktop, complete consent, verify a Phase 5a fetch then works without re-prompting.
- [ ] Follow-up: Phase 5c will add \`drive.readonly\` + folder-watching for passive ingest.

Parent tracker: BicameralAI/bicameral-daemon#3.

🤖 Generated with [Claude Code](https://claude.com/claude-code)