### PR TITLE
feat(sources): Phase 5c — Google Drive folder polling (passive ingest)

### DIFF
--- a/events/sources/__init__.py
+++ b/events/sources/__init__.py
@@ -20,6 +20,7 @@ from __future__ import annotations
 
 from typing import Protocol, runtime_checkable
 
+from .google_drive import GoogleDriveFolderAdapter
 from .granola import GranolaAdapter, MissingApiKeyError
 from .local_directory import LocalDirectoryAdapter
 
@@ -44,11 +45,13 @@ class SourceAdapter(Protocol):
 ADAPTERS: dict[str, type] = {
     "granola": GranolaAdapter,
     "local_directory": LocalDirectoryAdapter,
+    "google_drive": GoogleDriveFolderAdapter,
 }
 
 
 __all__ = [
     "ADAPTERS",
+    "GoogleDriveFolderAdapter",
     "GranolaAdapter",
     "LocalDirectoryAdapter",
     "MissingApiKeyError",

--- a/events/sources/google_drive.py
+++ b/events/sources/google_drive.py
@@ -1,0 +1,173 @@
+"""Google Drive folder-polling source adapter (#337 Phase 5c).
+
+Pull-based: enumerates new/edited Google Docs in a configured folder,
+fetches each through the Phase 5a active-ingest adapter to extract text,
+and returns a list of ingest-ready payloads. Watermark is the latest
+``modifiedTime`` ingested — two-phase commit via ``confirm_watermark``
+so a failed ingest does not lose the un-ingested items.
+
+Config schema (one entry under ``sources:`` in ``.bicameral/config.yaml``)::
+
+    sources:
+      - type: google_drive
+        folder_id: <Drive folder ID>
+        # Optional: operator-facing label flowing into source_type metadata.
+        source_type_label: design-doc
+
+Auth: OAuth token managed by ``sources.google_drive.auth`` (Phase 5b);
+operator obtains via ``bicameral-mcp source-auth google_drive``. After
+Phase 5c lands, that handshake covers both ``documents.readonly`` (Docs
+body) and ``drive.metadata.readonly`` (folder enumeration).
+
+Watermark file: ``<watermark_dir>/google_drive.json`` with shape
+``{"last_modified": "<RFC 3339>"}``. Corrupt / missing → start from epoch
+(mirrors the Granola + LocalDirectory precedents).
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import sys
+from pathlib import Path
+
+logger = logging.getLogger(__name__)
+
+_WATERMARK_FILENAME = "google_drive.json"
+
+
+class GoogleDriveFolderAdapter:
+    """Source adapter conforming to ``events.sources.SourceAdapter``.
+
+    Registry key (config ``type``) is ``"google_drive"``. ``source_scope``
+    flowing into ``handle_ingest`` therefore matches the active-ingest
+    adapter's ``source_id`` from Phase 5a, so DLQ filenames, audit-log
+    ``source_id`` fields, and the OS-keyring service name are unified
+    across active + passive Drive paths.
+    """
+
+    name = "google_drive"
+
+    def __init__(self) -> None:
+        self._pending_watermark: str | None = None
+        self._watermark_path: Path | None = None
+
+    def pull(self, *, watermark_dir: Path, config: dict) -> list[dict]:
+        """Pull new docs since the last confirmed watermark.
+
+        Returns a list of ingest-ready payloads (one per doc). Empty list
+        when the folder hasn't changed, the folder_id is missing, or any
+        Drive API failure occurs — never raises, matching the
+        ``_run_source`` "never raise to caller" discipline.
+        """
+        watermark_dir = Path(watermark_dir)
+        watermark_dir.mkdir(parents=True, exist_ok=True)
+        self._watermark_path = watermark_dir / _WATERMARK_FILENAME
+
+        folder_id = (config.get("folder_id") or "").strip()
+        if not folder_id:
+            print(
+                "[google_drive] folder_id is required in source config; skipping.",
+                file=sys.stderr,
+            )
+            self._pending_watermark = None
+            return []
+
+        last_watermark = _read_watermark(self._watermark_path)
+
+        try:
+            from sources.google_drive.auth import load_credentials
+            from sources.google_drive.folder import list_docs_in_folder
+
+            creds = load_credentials()
+            docs = list_docs_in_folder(creds, folder_id, modified_after=last_watermark)
+        except Exception as exc:  # noqa: BLE001 — never raise to _run_source
+            print(
+                f"[google_drive] folder enumeration failed: {exc}",
+                file=sys.stderr,
+            )
+            self._pending_watermark = None
+            return []
+
+        if not docs:
+            self._pending_watermark = None
+            return []
+
+        # Build payloads by reusing the Phase 5a active-ingest fetch path.
+        # Each doc fetch issues its own Docs API call — cost is one
+        # request per new/edited doc per pull, bounded by _MAX_PAGES in
+        # folder.py to 2000 per cycle.
+        payloads: list[dict] = []
+        highest_mtime = last_watermark or ""
+        try:
+            from sources.google_drive.adapter import GoogleDriveAdapter
+        except ImportError as exc:
+            print(
+                f"[google_drive] adapter import failed: {exc}",
+                file=sys.stderr,
+            )
+            self._pending_watermark = None
+            return []
+
+        active = GoogleDriveAdapter()
+        for doc in docs:
+            doc_id = doc.get("id")
+            mtime = doc.get("modifiedTime") or ""
+            if not doc_id:
+                continue
+            url = f"https://docs.google.com/document/d/{doc_id}/edit"
+            try:
+                payload = active.fetch_active(url)
+            except Exception as exc:  # noqa: BLE001 — skip individual doc, keep going
+                print(
+                    f"[google_drive] doc {doc_id!r} fetch failed (skipped): {exc}",
+                    file=sys.stderr,
+                )
+                continue
+            # Optional operator-facing label override.
+            label = config.get("source_type_label")
+            if label:
+                payload = {**payload, "source": str(label)}
+            payloads.append(payload)
+            if mtime > highest_mtime:
+                highest_mtime = mtime
+
+        # Stage the watermark advance. Only persisted when the caller
+        # confirms the ingest batch via ``confirm_watermark``.
+        self._pending_watermark = highest_mtime or None
+        return payloads
+
+    def confirm_watermark(self) -> None:
+        """Persist the staged watermark. Called after a successful ingest batch."""
+        if self._watermark_path is None or self._pending_watermark is None:
+            return
+        try:
+            self._watermark_path.write_text(
+                json.dumps({"last_modified": self._pending_watermark}),
+                encoding="utf-8",
+            )
+        except OSError as exc:
+            logger.warning(
+                "[google_drive] watermark persistence failed (will re-pull next run): %s",
+                exc,
+            )
+        self._pending_watermark = None
+
+
+def _read_watermark(path: Path) -> str | None:
+    """Read the last-modified watermark; ``None`` on missing / corrupt."""
+    if not path.exists():
+        return None
+    try:
+        data = json.loads(path.read_text(encoding="utf-8"))
+    except (json.JSONDecodeError, OSError) as exc:
+        logger.warning(
+            "[google_drive] watermark file corrupt at %s, starting from epoch: %s",
+            path,
+            exc,
+        )
+        return None
+    value = data.get("last_modified") if isinstance(data, dict) else None
+    if not value or not isinstance(value, str):
+        return None
+    return value

--- a/sources/google_drive/auth.py
+++ b/sources/google_drive/auth.py
@@ -28,11 +28,24 @@ from __future__ import annotations
 
 import json
 
-# documents.readonly is the minimum scope needed for the
-# ``service.documents().get(documentId=...)`` call in the adapter.
-# drive.readonly (for listing / watching) is deliberately out of scope
-# in Phase 5b — adding scopes later forces a re-consent which is fine.
-INGEST_SCOPE = "https://www.googleapis.com/auth/documents.readonly"
+# Scopes required by the Google Drive / Docs ingest flow.
+# - documents.readonly: read Google Docs body via the Docs API
+#   (used by sources.google_drive.adapter.fetch_active).
+# - drive.metadata.readonly: list files in a configured folder by mtime
+#   (used by events.sources.google_drive.GoogleDriveFolderAdapter,
+#   Phase 5c). Metadata-only — does NOT grant read access to non-Docs
+#   files; doc content still flows through the documents.readonly scope.
+#
+# Operators who consented under Phase 5b (documents.readonly only) must
+# re-run `bicameral-mcp source-auth google_drive` after upgrading; the
+# refresh path can't expand scope on its own.
+INGEST_SCOPES = [
+    "https://www.googleapis.com/auth/documents.readonly",
+    "https://www.googleapis.com/auth/drive.metadata.readonly",
+]
+# Back-compat alias kept until external callers migrate. Renamed in 5c
+# (#337) to reflect the multi-scope reality.
+INGEST_SCOPE = INGEST_SCOPES[0]
 
 _SOURCE_ID = "google_drive"
 _TOKEN_KEY = "oauth_token"
@@ -81,7 +94,7 @@ def run_oauth_handshake() -> None:
     from secrets_store import put_secret
 
     client_config = _bundled_client_config()
-    flow = InstalledAppFlow.from_client_config(client_config, [INGEST_SCOPE])
+    flow = InstalledAppFlow.from_client_config(client_config, INGEST_SCOPES)
     creds = flow.run_local_server(port=0)
     if creds is None:
         raise OAuthFlowAbortedError(
@@ -126,7 +139,7 @@ def load_credentials():
             "Re-run: bicameral-mcp source-auth google_drive"
         ) from exc
 
-    creds = Credentials.from_authorized_user_info(info, scopes=[INGEST_SCOPE])
+    creds = Credentials.from_authorized_user_info(info, scopes=INGEST_SCOPES)
     if creds.valid:
         return creds
     if creds.expired and creds.refresh_token:

--- a/sources/google_drive/folder.py
+++ b/sources/google_drive/folder.py
@@ -1,0 +1,100 @@
+"""Drive folder enumeration for Phase 5c passive ingest (#337).
+
+Uses the Drive API ``files.list`` to enumerate Google Docs in a single
+folder, filtered by ``modifiedTime`` so the polling adapter only fetches
+items that have changed since the last watermark.
+
+Non-recursive: subfolders are ignored. Operator must point the adapter
+at one folder per source-config entry — same discipline as
+``events/sources/local_directory.py`` (per the audit advisories for #344).
+
+MIME-type filter: ``application/vnd.google-apps.document`` only. Other
+shared content (spreadsheets, PDFs, images, etc.) is skipped — Phase 5
+is Docs-only.
+"""
+
+from __future__ import annotations
+
+_DOC_MIME = "application/vnd.google-apps.document"
+_PAGE_SIZE = 100
+_MAX_PAGES = 20  # 20 * 100 = 2000 docs max per pull; misuse bound
+
+
+def list_docs_in_folder(
+    creds,
+    folder_id: str,
+    *,
+    modified_after: str | None = None,
+):
+    """Enumerate Google Docs in ``folder_id`` modified after ``modified_after``.
+
+    Returns a list of dicts with keys ``id``, ``name``, ``modifiedTime``.
+    Result is sorted ascending by ``modifiedTime`` so the caller can
+    watermark on the last item.
+
+    ``modified_after`` is an RFC 3339 timestamp string (the Drive API's
+    native format). ``None`` returns every Doc in the folder, ordered by
+    modifiedTime ascending.
+
+    Raises ``RuntimeError`` on Drive API failures with an operator-facing
+    message; the polling adapter catches and emits a warn-level log
+    without advancing the watermark.
+    """
+    from googleapiclient.discovery import build  # type: ignore[import-not-found]
+    from googleapiclient.errors import HttpError  # type: ignore[import-not-found]
+
+    service = build("drive", "v3", credentials=creds, cache_discovery=False)
+
+    # Compose the q expression. ``parents`` clause restricts to the
+    # configured folder; mime clause filters to Google Docs only;
+    # ``trashed=false`` excludes trash. The ``modifiedTime`` filter uses
+    # ``>`` (strict) so the same RFC 3339 watermark doesn't replay the
+    # last item every pull.
+    q_parts = [
+        f"'{folder_id}' in parents",
+        f"mimeType = '{_DOC_MIME}'",
+        "trashed = false",
+    ]
+    if modified_after:
+        q_parts.append(f"modifiedTime > '{modified_after}'")
+    q = " and ".join(q_parts)
+
+    results: list[dict] = []
+    page_token: str | None = None
+    pages = 0
+    while True:
+        try:
+            resp = (
+                service.files()
+                .list(
+                    q=q,
+                    fields="nextPageToken, files(id, name, modifiedTime)",
+                    pageSize=_PAGE_SIZE,
+                    orderBy="modifiedTime",
+                    pageToken=page_token,
+                )
+                .execute()
+            )
+        except HttpError as exc:
+            raise RuntimeError(
+                f"Google Drive folder list failed for folder_id={folder_id!r}: "
+                f"HTTP {exc.resp.status if hasattr(exc, 'resp') else '?'}"
+            ) from exc
+        except Exception as exc:  # noqa: BLE001 — surface as actionable error
+            raise RuntimeError(
+                f"Google Drive folder list failed for folder_id={folder_id!r}: "
+                f"{type(exc).__name__}: {exc}"
+            ) from exc
+
+        results.extend(resp.get("files") or [])
+        pages += 1
+        page_token = resp.get("nextPageToken")
+        if not page_token:
+            break
+        if pages >= _MAX_PAGES:
+            raise RuntimeError(
+                f"folder {folder_id!r} has more than {_MAX_PAGES * _PAGE_SIZE} "
+                "qualifying docs since the watermark — narrow the watch window "
+                "or split the folder"
+            )
+    return results

--- a/tests/test_google_drive_folder_polling.py
+++ b/tests/test_google_drive_folder_polling.py
@@ -1,0 +1,322 @@
+"""Tests for #337 Phase 5c — Google Drive folder polling adapter.
+
+The Drive `files.list` call is mocked at the boundary (googleapiclient's
+service-builder return value). Watermark persistence runs unmocked over
+``tmp_path``. The active-ingest fetch path (``GoogleDriveAdapter.fetch_active``)
+is also mocked at the seam since it needs a real OAuth token + network.
+"""
+
+from __future__ import annotations
+
+import json
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+
+@pytest.fixture(autouse=True)
+def _disable_keyring(monkeypatch):
+    monkeypatch.setenv("BICAMERAL_KEYRING_DISABLE", "1")
+    from secrets_store.store import _reset_for_tests
+
+    _reset_for_tests()
+    yield
+    _reset_for_tests()
+
+
+# ── folder.list_docs_in_folder ──────────────────────────────────────────────
+
+
+def _fake_list_resp(*docs, next_page=None):
+    return {
+        "files": list(docs),
+        **({"nextPageToken": next_page} if next_page else {}),
+    }
+
+
+def test_list_docs_returns_files_sorted_by_modified_time():
+    from sources.google_drive.folder import list_docs_in_folder
+
+    fake_service = MagicMock()
+    fake_service.files.return_value.list.return_value.execute.return_value = _fake_list_resp(
+        {"id": "a", "name": "A", "modifiedTime": "2026-05-01T00:00:00Z"},
+        {"id": "b", "name": "B", "modifiedTime": "2026-05-02T00:00:00Z"},
+    )
+    with patch("googleapiclient.discovery.build", return_value=fake_service):
+        result = list_docs_in_folder(MagicMock(), "folder1")
+    assert [d["id"] for d in result] == ["a", "b"]
+
+
+def test_list_docs_paginates_until_done():
+    from sources.google_drive.folder import list_docs_in_folder
+
+    fake_service = MagicMock()
+    fake_service.files.return_value.list.return_value.execute.side_effect = [
+        _fake_list_resp(
+            {"id": "a", "name": "A", "modifiedTime": "2026-05-01T00:00:00Z"},
+            next_page="cursor1",
+        ),
+        _fake_list_resp(
+            {"id": "b", "name": "B", "modifiedTime": "2026-05-02T00:00:00Z"},
+        ),
+    ]
+    with patch("googleapiclient.discovery.build", return_value=fake_service):
+        result = list_docs_in_folder(MagicMock(), "folder1")
+    assert len(result) == 2
+
+
+def test_list_docs_applies_modified_after_filter():
+    """The q expression must include `modifiedTime > '<watermark>'` when set."""
+    from sources.google_drive.folder import list_docs_in_folder
+
+    fake_service = MagicMock()
+    fake_service.files.return_value.list.return_value.execute.return_value = _fake_list_resp()
+    with patch("googleapiclient.discovery.build", return_value=fake_service):
+        list_docs_in_folder(MagicMock(), "folder1", modified_after="2026-05-01T00:00:00Z")
+
+    # Inspect the kwargs passed to .list().
+    list_call = fake_service.files.return_value.list.call_args
+    assert "modifiedTime > '2026-05-01T00:00:00Z'" in list_call.kwargs["q"]
+
+
+def test_list_docs_filters_to_google_docs_mime():
+    from sources.google_drive.folder import list_docs_in_folder
+
+    fake_service = MagicMock()
+    fake_service.files.return_value.list.return_value.execute.return_value = _fake_list_resp()
+    with patch("googleapiclient.discovery.build", return_value=fake_service):
+        list_docs_in_folder(MagicMock(), "folder1")
+
+    q = fake_service.files.return_value.list.call_args.kwargs["q"]
+    assert "mimeType = 'application/vnd.google-apps.document'" in q
+    assert "trashed = false" in q
+
+
+def test_list_docs_raises_on_api_error():
+    from googleapiclient.errors import HttpError
+
+    from sources.google_drive.folder import list_docs_in_folder
+
+    err = HttpError(MagicMock(status=403), b"forbidden")
+    fake_service = MagicMock()
+    fake_service.files.return_value.list.return_value.execute.side_effect = err
+    with patch("googleapiclient.discovery.build", return_value=fake_service):
+        with pytest.raises(RuntimeError, match="folder list failed"):
+            list_docs_in_folder(MagicMock(), "folder1")
+
+
+# ── GoogleDriveFolderAdapter.pull ───────────────────────────────────────────
+
+
+def test_pull_returns_payloads_for_new_docs(tmp_path):
+    from events.sources.google_drive import GoogleDriveFolderAdapter
+
+    fake_docs = [
+        {"id": "doc1", "name": "Doc 1", "modifiedTime": "2026-05-01T00:00:00Z"},
+        {"id": "doc2", "name": "Doc 2", "modifiedTime": "2026-05-02T00:00:00Z"},
+    ]
+    fake_payload = {"source": "google_drive", "decisions": [], "title": "x"}
+
+    with (
+        patch(
+            "sources.google_drive.auth.load_credentials",
+            return_value=MagicMock(),
+        ),
+        patch(
+            "sources.google_drive.folder.list_docs_in_folder",
+            return_value=fake_docs,
+        ),
+        patch(
+            "sources.google_drive.adapter.GoogleDriveAdapter.fetch_active",
+            return_value=fake_payload,
+        ),
+    ):
+        adapter = GoogleDriveFolderAdapter()
+        result = adapter.pull(watermark_dir=tmp_path, config={"folder_id": "folder1"})
+
+    assert len(result) == 2
+    # Pending watermark = highest modifiedTime seen.
+    assert adapter._pending_watermark == "2026-05-02T00:00:00Z"
+
+
+def test_pull_returns_empty_when_folder_id_missing(tmp_path, capsys):
+    from events.sources.google_drive import GoogleDriveFolderAdapter
+
+    adapter = GoogleDriveFolderAdapter()
+    result = adapter.pull(watermark_dir=tmp_path, config={})
+    assert result == []
+    err = capsys.readouterr().err
+    assert "folder_id is required" in err
+
+
+def test_pull_returns_empty_when_no_new_docs(tmp_path):
+    from events.sources.google_drive import GoogleDriveFolderAdapter
+
+    with (
+        patch(
+            "sources.google_drive.auth.load_credentials",
+            return_value=MagicMock(),
+        ),
+        patch(
+            "sources.google_drive.folder.list_docs_in_folder",
+            return_value=[],
+        ),
+    ):
+        adapter = GoogleDriveFolderAdapter()
+        result = adapter.pull(watermark_dir=tmp_path, config={"folder_id": "folder1"})
+    assert result == []
+    assert adapter._pending_watermark is None
+
+
+def test_pull_skips_individual_fetch_failures(tmp_path, capsys):
+    """One bad doc shouldn't kill the whole pull."""
+    from events.sources.google_drive import GoogleDriveFolderAdapter
+
+    fake_docs = [
+        {"id": "doc1", "name": "Doc 1", "modifiedTime": "2026-05-01T00:00:00Z"},
+        {"id": "doc2", "name": "Doc 2", "modifiedTime": "2026-05-02T00:00:00Z"},
+    ]
+    call_count = {"n": 0}
+
+    def _flaky_fetch(self, url):
+        call_count["n"] += 1
+        if "doc1" in url:
+            raise RuntimeError("transient API blip")
+        return {"source": "google_drive", "decisions": [], "title": "doc2"}
+
+    with (
+        patch(
+            "sources.google_drive.auth.load_credentials",
+            return_value=MagicMock(),
+        ),
+        patch(
+            "sources.google_drive.folder.list_docs_in_folder",
+            return_value=fake_docs,
+        ),
+        patch(
+            "sources.google_drive.adapter.GoogleDriveAdapter.fetch_active",
+            new=_flaky_fetch,
+        ),
+    ):
+        adapter = GoogleDriveFolderAdapter()
+        result = adapter.pull(watermark_dir=tmp_path, config={"folder_id": "folder1"})
+
+    # doc1 skipped, doc2 succeeded.
+    assert len(result) == 1
+    err = capsys.readouterr().err
+    assert "doc1" in err
+    # Watermark advances to doc2's mtime even though doc1 was skipped —
+    # documented trade-off: skipping individual items doesn't strand the
+    # whole folder behind one bad doc.
+    assert adapter._pending_watermark == "2026-05-02T00:00:00Z"
+
+
+def test_pull_returns_empty_on_oauth_failure(tmp_path, capsys):
+    from events.sources.google_drive import GoogleDriveFolderAdapter
+
+    with patch(
+        "sources.google_drive.auth.load_credentials",
+        side_effect=RuntimeError("token not configured"),
+    ):
+        adapter = GoogleDriveFolderAdapter()
+        result = adapter.pull(watermark_dir=tmp_path, config={"folder_id": "folder1"})
+
+    assert result == []
+    err = capsys.readouterr().err
+    assert "folder enumeration failed" in err
+
+
+def test_pull_passes_last_watermark_to_list(tmp_path):
+    """Watermark on disk should be passed as modified_after to the API."""
+    from events.sources.google_drive import GoogleDriveFolderAdapter
+
+    wm_path = tmp_path / "google_drive.json"
+    wm_path.write_text(json.dumps({"last_modified": "2026-05-01T00:00:00Z"}))
+
+    captured = {}
+
+    def _capture(creds, folder_id, *, modified_after=None):
+        captured["modified_after"] = modified_after
+        return []
+
+    with (
+        patch(
+            "sources.google_drive.auth.load_credentials",
+            return_value=MagicMock(),
+        ),
+        patch(
+            "sources.google_drive.folder.list_docs_in_folder",
+            side_effect=_capture,
+        ),
+    ):
+        adapter = GoogleDriveFolderAdapter()
+        adapter.pull(watermark_dir=tmp_path, config={"folder_id": "folder1"})
+
+    assert captured["modified_after"] == "2026-05-01T00:00:00Z"
+
+
+def test_pull_starts_from_epoch_on_corrupt_watermark(tmp_path, capsys):
+    from events.sources.google_drive import GoogleDriveFolderAdapter
+
+    wm_path = tmp_path / "google_drive.json"
+    wm_path.write_text("not-valid-json{")
+
+    captured = {}
+
+    def _capture(creds, folder_id, *, modified_after=None):
+        captured["modified_after"] = modified_after
+        return []
+
+    with (
+        patch(
+            "sources.google_drive.auth.load_credentials",
+            return_value=MagicMock(),
+        ),
+        patch(
+            "sources.google_drive.folder.list_docs_in_folder",
+            side_effect=_capture,
+        ),
+    ):
+        adapter = GoogleDriveFolderAdapter()
+        adapter.pull(watermark_dir=tmp_path, config={"folder_id": "folder1"})
+
+    assert captured["modified_after"] is None
+
+
+# ── confirm_watermark ───────────────────────────────────────────────────────
+
+
+def test_confirm_watermark_persists_to_disk(tmp_path):
+    from events.sources.google_drive import GoogleDriveFolderAdapter
+
+    adapter = GoogleDriveFolderAdapter()
+    adapter._watermark_path = tmp_path / "google_drive.json"
+    adapter._pending_watermark = "2026-05-19T12:00:00Z"
+    adapter.confirm_watermark()
+
+    data = json.loads((tmp_path / "google_drive.json").read_text())
+    assert data["last_modified"] == "2026-05-19T12:00:00Z"
+    # After confirm, pending is cleared so a re-call is a no-op.
+    assert adapter._pending_watermark is None
+
+
+def test_confirm_watermark_is_noop_when_pending_is_none(tmp_path):
+    """Confirm without a prior pull (or after an empty pull) should not
+    create a watermark file or crash."""
+    from events.sources.google_drive import GoogleDriveFolderAdapter
+
+    adapter = GoogleDriveFolderAdapter()
+    adapter._watermark_path = tmp_path / "google_drive.json"
+    adapter._pending_watermark = None
+    adapter.confirm_watermark()
+    assert not (tmp_path / "google_drive.json").exists()
+
+
+# ── Registry integration ────────────────────────────────────────────────────
+
+
+def test_registered_as_google_drive_in_ADAPTERS():
+    from events.sources import ADAPTERS
+    from events.sources.google_drive import GoogleDriveFolderAdapter
+
+    assert ADAPTERS["google_drive"] is GoogleDriveFolderAdapter


### PR DESCRIPTION
## Summary

Adds Google Drive as a polling source in `events.sources.ADAPTERS`. Enumerates new/edited Docs in a configured folder, fetches each through Phase 5a's active-ingest path, hands payloads to `sync-and-brief` for passive ingest.

### Config

\`\`\`yaml
sources:
  - type: google_drive
    folder_id: <Drive folder ID>
    source_type_label: design-doc  # optional
\`\`\`

### Scope expansion (operator action required)

`INGEST_SCOPES` now includes `drive.metadata.readonly` alongside `documents.readonly`. **Operators who consented under BicameralAI/bicameral-mcp#430 must re-run `bicameral-mcp source-auth google_drive`** — refresh path can't widen scope.

### Failure isolation

- Folder enumeration failure → empty pull, watermark unchanged. Never raises.
- Individual doc fetch failure → that doc skipped, watermark advances past it. (One broken doc shouldn't strand the whole folder.)
- Hard ingest gates (secret/PHI/PAN) still fail-fast via the Phase 0a hard-gate set.

### Tests

15 new tests passing (folder.list_docs_in_folder + adapter + registry). Phase 5a/5b unchanged.

Parent tracker: BicameralAI/bicameral-daemon#3.

🤖 Generated with [Claude Code](https://claude.com/claude-code)