### PR TITLE
feat(sources): Phase 1b — Linear polling adapter (passive ingest)

### DIFF
--- a/events/sources/__init__.py
+++ b/events/sources/__init__.py
@@ -22,6 +22,7 @@ from typing import Protocol, runtime_checkable
 
 from .google_drive import GoogleDriveFolderAdapter
 from .granola import GranolaAdapter, MissingApiKeyError
+from .linear import LinearPollingAdapter
 from .local_directory import LocalDirectoryAdapter
 
 
@@ -46,6 +47,7 @@ ADAPTERS: dict[str, type] = {
     "granola": GranolaAdapter,
     "local_directory": LocalDirectoryAdapter,
     "google_drive": GoogleDriveFolderAdapter,
+    "linear": LinearPollingAdapter,
 }
 
 
@@ -53,6 +55,7 @@ __all__ = [
     "ADAPTERS",
     "GoogleDriveFolderAdapter",
     "GranolaAdapter",
+    "LinearPollingAdapter",
     "LocalDirectoryAdapter",
     "MissingApiKeyError",
     "SourceAdapter",

--- a/events/sources/linear.py
+++ b/events/sources/linear.py
@@ -1,0 +1,148 @@
+"""Linear polling source adapter (#337 Phase 1b).
+
+Pull-based: enumerates Linear issues completed since the last watermark,
+fetches each through Phase 1a's active-ingest adapter to extract decisions
++ comments, returns ingest-ready payloads.
+
+Config schema (one entry under ``sources:`` in ``.bicameral/config.yaml``)::
+
+    sources:
+      - type: linear
+        # Optional: restrict to specific team prefixes (e.g. ["BIC", "ENG"]).
+        team_keys: [BIC]
+        # Optional: operator-facing label override.
+        source_type_label: linear-ticket
+
+Auth: Linear API key persisted via ``secrets_store`` under
+``source_id="linear"``, key ``"api_key"``. Operator stores it once via:
+    python -c "from secrets_store import put_secret; \\
+               put_secret(source_id='linear', key='api_key', value='lin_...')"
+
+Watermark: ``<watermark_dir>/linear.json`` with
+``{"last_completed_at": "<RFC3339>"}``. Corrupt / missing → epoch.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import sys
+from pathlib import Path
+
+logger = logging.getLogger(__name__)
+
+_WATERMARK_FILENAME = "linear.json"
+
+
+class LinearPollingAdapter:
+    """Source adapter conforming to ``events.sources.SourceAdapter``."""
+
+    name = "linear"
+
+    def __init__(self) -> None:
+        self._pending_watermark: str | None = None
+        self._watermark_path: Path | None = None
+
+    def pull(self, *, watermark_dir: Path, config: dict) -> list[dict]:
+        watermark_dir = Path(watermark_dir)
+        watermark_dir.mkdir(parents=True, exist_ok=True)
+        self._watermark_path = watermark_dir / _WATERMARK_FILENAME
+
+        team_keys_raw = config.get("team_keys") or []
+        team_keys: list[str] | None = [str(k) for k in team_keys_raw] if team_keys_raw else None
+
+        last_watermark = _read_watermark(self._watermark_path)
+
+        try:
+            from secrets_store import get_secret
+            from sources.linear.poller import list_completed_issues
+
+            api_key = get_secret(source_id="linear", key="api_key")
+            if not api_key:
+                print(
+                    "[linear] api_key not configured (secrets_store source_id=linear, key=api_key); "
+                    "skipping.",
+                    file=sys.stderr,
+                )
+                self._pending_watermark = None
+                return []
+            issues = list_completed_issues(
+                api_key=api_key,
+                completed_after=last_watermark,
+                team_keys=team_keys,
+            )
+        except Exception as exc:  # noqa: BLE001 — never raise to _run_source
+            print(f"[linear] issue listing failed: {exc}", file=sys.stderr)
+            self._pending_watermark = None
+            return []
+
+        if not issues:
+            self._pending_watermark = None
+            return []
+
+        try:
+            from sources.linear.adapter import LinearAdapter
+        except ImportError as exc:
+            print(f"[linear] adapter import failed: {exc}", file=sys.stderr)
+            self._pending_watermark = None
+            return []
+
+        active = LinearAdapter()
+        payloads: list[dict] = []
+        highest_completed = last_watermark or ""
+        for issue in issues:
+            url = issue.get("url") or ""
+            completed_at = issue.get("completedAt") or ""
+            if not url:
+                continue
+            try:
+                payload = active.fetch_active(url)
+            except Exception as exc:  # noqa: BLE001 — skip individual
+                identifier = issue.get("identifier", "?")
+                print(
+                    f"[linear] issue {identifier!r} fetch failed (skipped): {exc}",
+                    file=sys.stderr,
+                )
+                continue
+            label = config.get("source_type_label")
+            if label:
+                payload = {**payload, "source": str(label)}
+            payloads.append(payload)
+            if completed_at > highest_completed:
+                highest_completed = completed_at
+
+        self._pending_watermark = highest_completed or None
+        return payloads
+
+    def confirm_watermark(self) -> None:
+        if self._watermark_path is None or self._pending_watermark is None:
+            return
+        try:
+            self._watermark_path.write_text(
+                json.dumps({"last_completed_at": self._pending_watermark}),
+                encoding="utf-8",
+            )
+        except OSError as exc:
+            logger.warning(
+                "[linear] watermark persistence failed (will re-pull next run): %s",
+                exc,
+            )
+        self._pending_watermark = None
+
+
+def _read_watermark(path: Path) -> str | None:
+    if not path.exists():
+        return None
+    try:
+        data = json.loads(path.read_text(encoding="utf-8"))
+    except (json.JSONDecodeError, OSError) as exc:
+        logger.warning(
+            "[linear] watermark file corrupt at %s, starting from epoch: %s",
+            path,
+            exc,
+        )
+        return None
+    value = data.get("last_completed_at") if isinstance(data, dict) else None
+    if not value or not isinstance(value, str):
+        return None
+    return value

--- a/sources/linear/poller.py
+++ b/sources/linear/poller.py
@@ -1,0 +1,102 @@
+"""Linear polling helper for Phase 1b passive ingest (#337).
+
+Wraps the Phase 1a GraphQL client with a `completedAt`-ordered query
+that returns issues completed strictly after the watermark.
+
+Pagination uses Linear's `first` + `after` connection model. Cap at 10
+pages × 50 issues = 500 per pull — large team backlogs that exceed this
+should narrow the team filter or split the source config.
+"""
+
+from __future__ import annotations
+
+_PAGE_SIZE = 50
+_MAX_PAGES = 10
+
+_LIST_ISSUES_QUERY = """
+query ListCompletedIssues(
+  $first: Int!
+  $after: String
+  $filter: IssueFilter
+) {
+  issues(first: $first, after: $after, filter: $filter, orderBy: updatedAt) {
+    pageInfo { hasNextPage endCursor }
+    nodes {
+      identifier
+      url
+      completedAt
+      updatedAt
+    }
+  }
+}
+"""
+
+
+def list_completed_issues(
+    *,
+    api_key: str,
+    completed_after: str | None = None,
+    team_keys: list[str] | None = None,
+):
+    """Return issues with ``completedAt > completed_after``.
+
+    Each result dict has ``identifier``, ``url``, ``completedAt``,
+    ``updatedAt``. Sorted ascending by ``updatedAt`` (Linear's orderBy
+    keys are limited; we re-sort by ``completedAt`` client-side below
+    for the watermark advance).
+
+    ``team_keys`` (e.g. ``["BIC", "ENG"]``) restricts results via
+    ``filter: {team: {key: {in: ...}}}``. ``None`` returns issues
+    across all teams the API key can see.
+
+    Raises ``RuntimeError`` on Linear GraphQL failure with a message the
+    polling adapter logs without advancing the watermark.
+    """
+    from sources.linear.client import LinearAPIError, query
+
+    issue_filter: dict = {"completedAt": {"null": False}}
+    if completed_after:
+        issue_filter["completedAt"] = {"gt": completed_after}
+    if team_keys:
+        issue_filter["team"] = {"key": {"in": list(team_keys)}}
+
+    results: list[dict] = []
+    after: str | None = None
+    pages = 0
+    while True:
+        variables = {"first": _PAGE_SIZE, "after": after, "filter": issue_filter}
+        try:
+            data = query(
+                api_key=api_key,
+                document=_LIST_ISSUES_QUERY,
+                variables=variables,
+            )
+        except LinearAPIError as exc:
+            raise RuntimeError(f"Linear issue listing failed: {exc}") from exc
+
+        issues_conn = data.get("issues") or {}
+        for node in issues_conn.get("nodes") or []:
+            # Filter out issues without completedAt — the GraphQL filter
+            # above should already exclude these, but belt-and-suspenders
+            # for the watermark math.
+            if not node.get("completedAt"):
+                continue
+            results.append(node)
+        pages += 1
+        page_info = issues_conn.get("pageInfo") or {}
+        if not page_info.get("hasNextPage"):
+            break
+        after = page_info.get("endCursor")
+        if not after:
+            break
+        if pages >= _MAX_PAGES:
+            raise RuntimeError(
+                f"Linear returned more than {_MAX_PAGES * _PAGE_SIZE} issues "
+                "since the watermark — narrow team_keys or shorten the watch "
+                "window"
+            )
+
+    # Sort by completedAt ascending so the polling adapter can watermark
+    # on the last item it ingests.
+    results.sort(key=lambda d: d.get("completedAt") or "")
+    return results

--- a/tests/test_linear_polling.py
+++ b/tests/test_linear_polling.py
@@ -1,0 +1,280 @@
+"""Tests for #337 Phase 1b — Linear polling adapter.
+
+Mocks at the narrowest seams: ``sources.linear.client.query`` for the
+GraphQL boundary; ``sources.linear.adapter.LinearAdapter.fetch_active``
+for the per-issue payload build. Watermark file I/O runs unmocked.
+"""
+
+from __future__ import annotations
+
+import json
+from unittest.mock import patch
+
+import pytest
+
+
+@pytest.fixture(autouse=True)
+def _disable_keyring(monkeypatch):
+    monkeypatch.setenv("BICAMERAL_KEYRING_DISABLE", "1")
+    from secrets_store.store import _reset_for_tests
+
+    _reset_for_tests()
+    yield
+    _reset_for_tests()
+
+
+# ── poller.list_completed_issues ────────────────────────────────────────────
+
+
+def _conn(*nodes, has_next=False, cursor=None):
+    return {
+        "issues": {
+            "pageInfo": {"hasNextPage": has_next, "endCursor": cursor},
+            "nodes": list(nodes),
+        }
+    }
+
+
+def test_list_completed_filters_to_non_null_completed_at():
+    """The poller must drop nodes without completedAt even if the API
+    leaks one (defense in depth — GraphQL filter should already exclude)."""
+    from sources.linear.poller import list_completed_issues
+
+    nodes = [
+        {"identifier": "BIC-1", "url": "u1", "completedAt": "2026-05-01T00:00:00Z"},
+        {"identifier": "BIC-2", "url": "u2", "completedAt": None},
+        {"identifier": "BIC-3", "url": "u3", "completedAt": "2026-05-02T00:00:00Z"},
+    ]
+    with patch("sources.linear.client.query", return_value=_conn(*nodes)):
+        result = list_completed_issues(api_key="k")
+    assert [n["identifier"] for n in result] == ["BIC-1", "BIC-3"]
+
+
+def test_list_completed_sorts_by_completed_at_ascending():
+    from sources.linear.poller import list_completed_issues
+
+    nodes = [
+        {"identifier": "B", "url": "ub", "completedAt": "2026-05-02T00:00:00Z"},
+        {"identifier": "A", "url": "ua", "completedAt": "2026-05-01T00:00:00Z"},
+    ]
+    with patch("sources.linear.client.query", return_value=_conn(*nodes)):
+        result = list_completed_issues(api_key="k")
+    assert [n["identifier"] for n in result] == ["A", "B"]
+
+
+def test_list_completed_includes_filter_in_variables():
+    from sources.linear.poller import list_completed_issues
+
+    captured = {}
+
+    def _capture(*, api_key, document, variables):
+        captured.update(variables)
+        return _conn()
+
+    with patch("sources.linear.client.query", side_effect=_capture):
+        list_completed_issues(
+            api_key="k",
+            completed_after="2026-05-01T00:00:00Z",
+            team_keys=["BIC", "ENG"],
+        )
+
+    f = captured["filter"]
+    assert f["completedAt"]["gt"] == "2026-05-01T00:00:00Z"
+    assert f["team"] == {"key": {"in": ["BIC", "ENG"]}}
+
+
+def test_list_completed_paginates():
+    from sources.linear.poller import list_completed_issues
+
+    page1 = _conn(
+        {"identifier": "A", "url": "ua", "completedAt": "2026-05-01T00:00:00Z"},
+        has_next=True,
+        cursor="c1",
+    )
+    page2 = _conn(
+        {"identifier": "B", "url": "ub", "completedAt": "2026-05-02T00:00:00Z"},
+    )
+    with patch("sources.linear.client.query", side_effect=[page1, page2]):
+        result = list_completed_issues(api_key="k")
+    assert len(result) == 2
+
+
+def test_list_completed_raises_on_api_error():
+    from sources.linear.client import LinearAPIError
+    from sources.linear.poller import list_completed_issues
+
+    with patch(
+        "sources.linear.client.query",
+        side_effect=LinearAPIError("bad", status_code=401),
+    ):
+        with pytest.raises(RuntimeError, match="issue listing failed"):
+            list_completed_issues(api_key="k")
+
+
+# ── LinearPollingAdapter.pull ───────────────────────────────────────────────
+
+
+def test_pull_returns_payloads_for_new_issues(tmp_path):
+    from events.sources.linear import LinearPollingAdapter
+    from secrets_store import put_secret
+
+    put_secret(source_id="linear", key="api_key", value="lin_test")
+
+    fake_issues = [
+        {
+            "identifier": "BIC-1",
+            "url": "https://linear.app/x/issue/BIC-1",
+            "completedAt": "2026-05-01T00:00:00Z",
+        },
+        {
+            "identifier": "BIC-2",
+            "url": "https://linear.app/x/issue/BIC-2",
+            "completedAt": "2026-05-02T00:00:00Z",
+        },
+    ]
+    fake_payload = {"source": "linear", "decisions": [], "title": "x"}
+
+    with (
+        patch(
+            "sources.linear.poller.list_completed_issues",
+            return_value=fake_issues,
+        ),
+        patch(
+            "sources.linear.adapter.LinearAdapter.fetch_active",
+            return_value=fake_payload,
+        ),
+    ):
+        adapter = LinearPollingAdapter()
+        result = adapter.pull(watermark_dir=tmp_path, config={})
+
+    assert len(result) == 2
+    assert adapter._pending_watermark == "2026-05-02T00:00:00Z"
+
+
+def test_pull_returns_empty_when_api_key_missing(tmp_path, capsys):
+    from events.sources.linear import LinearPollingAdapter
+
+    # No put_secret call → no api_key stored.
+    adapter = LinearPollingAdapter()
+    result = adapter.pull(watermark_dir=tmp_path, config={})
+    assert result == []
+    err = capsys.readouterr().err
+    assert "api_key not configured" in err
+
+
+def test_pull_skips_individual_fetch_failures(tmp_path, capsys):
+    from events.sources.linear import LinearPollingAdapter
+    from secrets_store import put_secret
+
+    put_secret(source_id="linear", key="api_key", value="lin_test")
+
+    fake_issues = [
+        {
+            "identifier": "BIC-1",
+            "url": "https://linear.app/x/issue/BIC-1",
+            "completedAt": "2026-05-01T00:00:00Z",
+        },
+        {
+            "identifier": "BIC-2",
+            "url": "https://linear.app/x/issue/BIC-2",
+            "completedAt": "2026-05-02T00:00:00Z",
+        },
+    ]
+
+    def _flaky(self, url):
+        if "BIC-1" in url:
+            raise RuntimeError("transient")
+        return {"source": "linear", "decisions": [], "title": "BIC-2"}
+
+    with (
+        patch(
+            "sources.linear.poller.list_completed_issues",
+            return_value=fake_issues,
+        ),
+        patch(
+            "sources.linear.adapter.LinearAdapter.fetch_active",
+            new=_flaky,
+        ),
+    ):
+        adapter = LinearPollingAdapter()
+        result = adapter.pull(watermark_dir=tmp_path, config={})
+
+    assert len(result) == 1
+    assert "BIC-1" in capsys.readouterr().err
+    assert adapter._pending_watermark == "2026-05-02T00:00:00Z"
+
+
+def test_pull_passes_watermark_to_poller(tmp_path):
+    from events.sources.linear import LinearPollingAdapter
+    from secrets_store import put_secret
+
+    put_secret(source_id="linear", key="api_key", value="lin_test")
+    (tmp_path / "linear.json").write_text(json.dumps({"last_completed_at": "2026-05-01T00:00:00Z"}))
+
+    captured = {}
+
+    def _capture(*, api_key, completed_after, team_keys=None):
+        captured["completed_after"] = completed_after
+        captured["team_keys"] = team_keys
+        return []
+
+    with patch(
+        "sources.linear.poller.list_completed_issues",
+        side_effect=_capture,
+    ):
+        adapter = LinearPollingAdapter()
+        adapter.pull(watermark_dir=tmp_path, config={"team_keys": ["BIC"]})
+
+    assert captured["completed_after"] == "2026-05-01T00:00:00Z"
+    assert captured["team_keys"] == ["BIC"]
+
+
+def test_pull_starts_from_epoch_on_corrupt_watermark(tmp_path):
+    from events.sources.linear import LinearPollingAdapter
+    from secrets_store import put_secret
+
+    put_secret(source_id="linear", key="api_key", value="lin_test")
+    (tmp_path / "linear.json").write_text("not-json{")
+
+    captured = {}
+
+    def _capture(*, api_key, completed_after, team_keys=None):
+        captured["completed_after"] = completed_after
+        return []
+
+    with patch(
+        "sources.linear.poller.list_completed_issues",
+        side_effect=_capture,
+    ):
+        adapter = LinearPollingAdapter()
+        adapter.pull(watermark_dir=tmp_path, config={})
+
+    assert captured["completed_after"] is None
+
+
+def test_confirm_watermark_persists(tmp_path):
+    from events.sources.linear import LinearPollingAdapter
+
+    adapter = LinearPollingAdapter()
+    adapter._watermark_path = tmp_path / "linear.json"
+    adapter._pending_watermark = "2026-05-19T00:00:00Z"
+    adapter.confirm_watermark()
+    data = json.loads((tmp_path / "linear.json").read_text())
+    assert data["last_completed_at"] == "2026-05-19T00:00:00Z"
+
+
+def test_confirm_watermark_noop_when_pending_none(tmp_path):
+    from events.sources.linear import LinearPollingAdapter
+
+    adapter = LinearPollingAdapter()
+    adapter._watermark_path = tmp_path / "linear.json"
+    adapter._pending_watermark = None
+    adapter.confirm_watermark()
+    assert not (tmp_path / "linear.json").exists()
+
+
+def test_registered_in_ADAPTERS():
+    from events.sources import ADAPTERS
+    from events.sources.linear import LinearPollingAdapter
+
+    assert ADAPTERS["linear"] is LinearPollingAdapter


### PR DESCRIPTION
## Summary

Adds Linear as a polling source in `events.sources.ADAPTERS`. Enumerates issues with `completedAt > watermark` via GraphQL, fetches each through Phase 1a's active-ingest adapter, hands payloads to `sync-and-brief`.

### Config

\`\`\`yaml
sources:
  - type: linear
    team_keys: [BIC, ENG]          # optional team-prefix filter
    source_type_label: linear-ticket  # optional
\`\`\`

### Auth

Reuses Phase 1a's `secrets_store source_id="linear", key="api_key"` — no re-handshake. Operator's existing static token works for both active + passive paths.

### Failure isolation

- GraphQL listing failure → empty pull, watermark unchanged. Never raises.
- Individual `fetch_active` failure → skip that issue, advance watermark past it.

### Conflict note

Touches `events/sources/__init__.py` in the same place as Phase 5c (#432). When 5c lands first, this PR will need a trivial rebase to combine the two registry additions.

Tests: 13 new + 24 Phase 1a unchanged = 37 passing.

Parent tracker: BicameralAI/bicameral-daemon#3.

🤖 Generated with [Claude Code](https://claude.com/claude-code)