### PR TITLE
feat(sources): Phase 2b — Notion polling adapter (passive ingest)

### DIFF
--- a/events/sources/__init__.py
+++ b/events/sources/__init__.py
@@ -24,6 +24,7 @@ from .google_drive import GoogleDriveFolderAdapter
 from .granola import GranolaAdapter, MissingApiKeyError
 from .linear import LinearPollingAdapter
 from .local_directory import LocalDirectoryAdapter
+from .notion import NotionPollingAdapter
 
 
 @runtime_checkable
@@ -48,6 +49,7 @@ ADAPTERS: dict[str, type] = {
     "local_directory": LocalDirectoryAdapter,
     "google_drive": GoogleDriveFolderAdapter,
     "linear": LinearPollingAdapter,
+    "notion": NotionPollingAdapter,
 }
 
 
@@ -58,5 +60,6 @@ __all__ = [
     "LinearPollingAdapter",
     "LocalDirectoryAdapter",
     "MissingApiKeyError",
+    "NotionPollingAdapter",
     "SourceAdapter",
 ]

--- a/events/sources/notion.py
+++ b/events/sources/notion.py
@@ -1,0 +1,152 @@
+"""Notion polling source adapter (#337 Phase 2b).
+
+Pull-based: enumerates pages in a Notion database that were last edited
+after the watermark, fetches each through Phase 2's active-ingest adapter
+for property + block-walk normalization, returns ingest-ready payloads.
+
+Config schema::
+
+    sources:
+      - type: notion
+        database_id: <Notion database ID>
+        source_type_label: decision-doc  # optional
+
+Auth: ``secrets_store source_id="notion", key="api_key"``. Operator
+stores the Notion integration token there; the integration must be
+shared with each database the adapter polls (Notion's share-per-database
+permission model — see plan-2-notion-active for caveats).
+
+Watermark: ``<watermark_dir>/notion.json`` with
+``{"last_edited_time": "<ISO8601>"}``. Corrupt / missing → epoch.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import sys
+from pathlib import Path
+
+logger = logging.getLogger(__name__)
+
+_WATERMARK_FILENAME = "notion.json"
+
+
+class NotionPollingAdapter:
+    """Source adapter conforming to ``events.sources.SourceAdapter``."""
+
+    name = "notion"
+
+    def __init__(self) -> None:
+        self._pending_watermark: str | None = None
+        self._watermark_path: Path | None = None
+
+    def pull(self, *, watermark_dir: Path, config: dict) -> list[dict]:
+        watermark_dir = Path(watermark_dir)
+        watermark_dir.mkdir(parents=True, exist_ok=True)
+        self._watermark_path = watermark_dir / _WATERMARK_FILENAME
+
+        database_id = (config.get("database_id") or "").strip()
+        if not database_id:
+            print(
+                "[notion] database_id is required in source config; skipping.",
+                file=sys.stderr,
+            )
+            self._pending_watermark = None
+            return []
+
+        last_watermark = _read_watermark(self._watermark_path)
+
+        try:
+            from secrets_store import get_secret
+            from sources.notion.poller import list_recently_edited_pages
+
+            api_key = get_secret(source_id="notion", key="api_key")
+            if not api_key:
+                print(
+                    "[notion] api_key not configured (secrets_store source_id=notion, "
+                    "key=api_key); skipping.",
+                    file=sys.stderr,
+                )
+                self._pending_watermark = None
+                return []
+            pages = list_recently_edited_pages(
+                api_key=api_key,
+                database_id=database_id,
+                edited_after=last_watermark,
+            )
+        except Exception as exc:  # noqa: BLE001 — never raise to _run_source
+            print(f"[notion] database query failed: {exc}", file=sys.stderr)
+            self._pending_watermark = None
+            return []
+
+        if not pages:
+            self._pending_watermark = None
+            return []
+
+        try:
+            from sources.notion.adapter import NotionAdapter
+        except ImportError as exc:
+            print(f"[notion] adapter import failed: {exc}", file=sys.stderr)
+            self._pending_watermark = None
+            return []
+
+        active = NotionAdapter()
+        payloads: list[dict] = []
+        highest_edited = last_watermark or ""
+        for page in pages:
+            page_id = page.get("id") or ""
+            edited = page.get("last_edited_time") or ""
+            url = page.get("url") or ""
+            if not page_id or not url:
+                continue
+            try:
+                payload = active.fetch_active(url)
+            except Exception as exc:  # noqa: BLE001
+                print(
+                    f"[notion] page {page_id!r} fetch failed (skipped): {exc}",
+                    file=sys.stderr,
+                )
+                continue
+            label = config.get("source_type_label")
+            if label:
+                payload = {**payload, "source": str(label)}
+            payloads.append(payload)
+            if edited > highest_edited:
+                highest_edited = edited
+
+        self._pending_watermark = highest_edited or None
+        return payloads
+
+    def confirm_watermark(self) -> None:
+        if self._watermark_path is None or self._pending_watermark is None:
+            return
+        try:
+            self._watermark_path.write_text(
+                json.dumps({"last_edited_time": self._pending_watermark}),
+                encoding="utf-8",
+            )
+        except OSError as exc:
+            logger.warning(
+                "[notion] watermark persistence failed (will re-pull next run): %s",
+                exc,
+            )
+        self._pending_watermark = None
+
+
+def _read_watermark(path: Path) -> str | None:
+    if not path.exists():
+        return None
+    try:
+        data = json.loads(path.read_text(encoding="utf-8"))
+    except (json.JSONDecodeError, OSError) as exc:
+        logger.warning(
+            "[notion] watermark file corrupt at %s, starting from epoch: %s",
+            path,
+            exc,
+        )
+        return None
+    value = data.get("last_edited_time") if isinstance(data, dict) else None
+    if not value or not isinstance(value, str):
+        return None
+    return value

--- a/sources/notion/poller.py
+++ b/sources/notion/poller.py
@@ -1,0 +1,116 @@
+"""Notion polling helper for Phase 2b passive ingest (#337).
+
+Wraps the Phase 2 REST client with a database query that returns pages
+edited strictly after the watermark. Notion has no webhook story for
+shared workspaces, so polling is the only viable passive path.
+
+Pagination cap: 20 pages × 100 results = 2000 pages per pull. Mirrors
+the Phase 2 blocks pagination cap.
+"""
+
+from __future__ import annotations
+
+_PAGE_SIZE = 100
+_MAX_PAGES = 20
+
+
+def list_recently_edited_pages(
+    *,
+    api_key: str,
+    database_id: str,
+    edited_after: str | None = None,
+):
+    """Return database pages with ``last_edited_time > edited_after``.
+
+    Each result dict carries the full Notion page object (the polling
+    adapter pulls ``id``, ``last_edited_time``, and the URL from it).
+
+    Sorted ascending by ``last_edited_time`` via the Notion sort spec.
+
+    ``edited_after`` is an ISO 8601 timestamp string. ``None`` returns
+    every page in the database, oldest-edit first.
+
+    Raises ``RuntimeError`` on Notion API failure with a message the
+    polling adapter logs without advancing the watermark.
+    """
+    import json
+    import urllib.error
+    import urllib.request
+
+    from sources.notion.client import (
+        _API_BASE,
+        _MAX_RESPONSE_BYTES,
+        _NOTION_VERSION,
+        _REQUEST_TIMEOUT_SECONDS,
+        NotionAPIError,
+    )
+
+    headers = {
+        "Authorization": f"Bearer {api_key}",
+        "Notion-Version": _NOTION_VERSION,
+        "Content-Type": "application/json",
+        "User-Agent": "bicameral-mcp/source-notion-polling",
+    }
+
+    body: dict = {
+        "page_size": _PAGE_SIZE,
+        "sorts": [{"timestamp": "last_edited_time", "direction": "ascending"}],
+    }
+    if edited_after:
+        body["filter"] = {
+            "timestamp": "last_edited_time",
+            "last_edited_time": {"after": edited_after},
+        }
+
+    results: list[dict] = []
+    cursor: str | None = None
+    pages = 0
+    while True:
+        if cursor is not None:
+            body["start_cursor"] = cursor
+        elif "start_cursor" in body:
+            del body["start_cursor"]
+        req = urllib.request.Request(
+            f"{_API_BASE}/databases/{database_id}/query",
+            data=json.dumps(body).encode("utf-8"),
+            headers=headers,
+            method="POST",
+        )
+        try:
+            with urllib.request.urlopen(req, timeout=_REQUEST_TIMEOUT_SECONDS) as resp:
+                raw = resp.read(_MAX_RESPONSE_BYTES + 1)
+                if len(raw) > _MAX_RESPONSE_BYTES:
+                    raise NotionAPIError(
+                        f"Notion response exceeded {_MAX_RESPONSE_BYTES} bytes",
+                        status_code=resp.status,
+                    )
+        except urllib.error.HTTPError as exc:
+            raise RuntimeError(
+                f"Notion database query failed for database_id={database_id!r}: "
+                f"HTTP {exc.code} {exc.reason}"
+            ) from exc
+        except urllib.error.URLError as exc:
+            raise RuntimeError(f"Notion database query network error: {exc.reason}") from exc
+        except NotionAPIError as exc:
+            raise RuntimeError(f"Notion database query failed: {exc}") from exc
+
+        try:
+            data = json.loads(raw.decode("utf-8"))
+        except json.JSONDecodeError as exc:
+            raise RuntimeError(f"Notion database query returned non-JSON: {exc}") from exc
+
+        results.extend(data.get("results") or [])
+        pages += 1
+        if not data.get("has_more"):
+            break
+        cursor = data.get("next_cursor")
+        if not cursor:
+            break
+        if pages >= _MAX_PAGES:
+            raise RuntimeError(
+                f"Notion database {database_id!r} has more than "
+                f"{_MAX_PAGES * _PAGE_SIZE} edited pages since the watermark — "
+                "narrow the database or split the source config"
+            )
+
+    return results

--- a/tests/test_notion_polling.py
+++ b/tests/test_notion_polling.py
@@ -1,0 +1,230 @@
+"""Tests for #337 Phase 2b — Notion polling adapter."""
+
+from __future__ import annotations
+
+import io
+import json
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+
+@pytest.fixture(autouse=True)
+def _disable_keyring(monkeypatch):
+    monkeypatch.setenv("BICAMERAL_KEYRING_DISABLE", "1")
+    from secrets_store.store import _reset_for_tests
+
+    _reset_for_tests()
+    yield
+    _reset_for_tests()
+
+
+def _mock_response(body: dict):
+    raw = json.dumps(body).encode("utf-8")
+    resp = io.BytesIO(raw)
+    resp.status = 200
+
+    class _Ctx:
+        def __enter__(self):
+            return resp
+
+        def __exit__(self, *args):
+            return False
+
+    return _Ctx()
+
+
+# ── poller.list_recently_edited_pages ───────────────────────────────────────
+
+
+def test_list_recently_edited_returns_results():
+    from sources.notion.poller import list_recently_edited_pages
+
+    pages = [
+        {"id": "p1", "last_edited_time": "2026-05-01T00:00:00Z", "url": "u1"},
+        {"id": "p2", "last_edited_time": "2026-05-02T00:00:00Z", "url": "u2"},
+    ]
+    with patch(
+        "urllib.request.urlopen",
+        return_value=_mock_response({"results": pages, "has_more": False}),
+    ):
+        result = list_recently_edited_pages(api_key="k", database_id="db1")
+    assert [p["id"] for p in result] == ["p1", "p2"]
+
+
+def test_list_recently_edited_paginates():
+    from sources.notion.poller import list_recently_edited_pages
+
+    page1 = {
+        "results": [{"id": "p1", "last_edited_time": "2026-05-01T00:00:00Z", "url": "u1"}],
+        "has_more": True,
+        "next_cursor": "c1",
+    }
+    page2 = {
+        "results": [{"id": "p2", "last_edited_time": "2026-05-02T00:00:00Z", "url": "u2"}],
+        "has_more": False,
+    }
+    with patch(
+        "urllib.request.urlopen",
+        side_effect=[_mock_response(page1), _mock_response(page2)],
+    ):
+        result = list_recently_edited_pages(api_key="k", database_id="db1")
+    assert len(result) == 2
+
+
+def test_list_recently_edited_includes_filter():
+    from sources.notion.poller import list_recently_edited_pages
+
+    captured: dict = {}
+
+    def _capture_request(req, timeout):
+        captured["body"] = json.loads(req.data.decode("utf-8"))
+        return _mock_response({"results": [], "has_more": False})
+
+    with patch("urllib.request.urlopen", side_effect=_capture_request):
+        list_recently_edited_pages(
+            api_key="k", database_id="db1", edited_after="2026-05-01T00:00:00Z"
+        )
+
+    assert captured["body"]["filter"]["last_edited_time"]["after"] == "2026-05-01T00:00:00Z"
+
+
+def test_list_recently_edited_raises_on_http_error():
+    import urllib.error
+
+    from sources.notion.poller import list_recently_edited_pages
+
+    err = urllib.error.HTTPError(
+        url="https://api.notion.com/v1/databases/db1/query",
+        code=403,
+        msg="Forbidden",
+        hdrs=None,
+        fp=io.BytesIO(b""),
+    )
+    with patch("urllib.request.urlopen", side_effect=err):
+        with pytest.raises(RuntimeError, match="database query failed"):
+            list_recently_edited_pages(api_key="k", database_id="db1")
+
+
+# ── NotionPollingAdapter.pull ───────────────────────────────────────────────
+
+
+def test_pull_returns_payloads_for_new_pages(tmp_path):
+    from events.sources.notion import NotionPollingAdapter
+    from secrets_store import put_secret
+
+    put_secret(source_id="notion", key="api_key", value="secret_x")
+
+    fake_pages = [
+        {"id": "p1", "url": "https://www.notion.so/p1", "last_edited_time": "2026-05-01T00:00:00Z"},
+        {"id": "p2", "url": "https://www.notion.so/p2", "last_edited_time": "2026-05-02T00:00:00Z"},
+    ]
+    fake_payload = {"source": "notion", "decisions": [], "title": "x"}
+
+    with (
+        patch(
+            "sources.notion.poller.list_recently_edited_pages",
+            return_value=fake_pages,
+        ),
+        patch(
+            "sources.notion.adapter.NotionAdapter.fetch_active",
+            return_value=fake_payload,
+        ),
+    ):
+        adapter = NotionPollingAdapter()
+        result = adapter.pull(watermark_dir=tmp_path, config={"database_id": "db1"})
+
+    assert len(result) == 2
+    assert adapter._pending_watermark == "2026-05-02T00:00:00Z"
+
+
+def test_pull_returns_empty_when_database_id_missing(tmp_path, capsys):
+    from events.sources.notion import NotionPollingAdapter
+
+    adapter = NotionPollingAdapter()
+    result = adapter.pull(watermark_dir=tmp_path, config={})
+    assert result == []
+    assert "database_id is required" in capsys.readouterr().err
+
+
+def test_pull_returns_empty_when_api_key_missing(tmp_path, capsys):
+    from events.sources.notion import NotionPollingAdapter
+
+    adapter = NotionPollingAdapter()
+    result = adapter.pull(watermark_dir=tmp_path, config={"database_id": "db1"})
+    assert result == []
+    assert "api_key not configured" in capsys.readouterr().err
+
+
+def test_pull_skips_individual_fetch_failures(tmp_path, capsys):
+    from events.sources.notion import NotionPollingAdapter
+    from secrets_store import put_secret
+
+    put_secret(source_id="notion", key="api_key", value="secret_x")
+    fake_pages = [
+        {"id": "p1", "url": "https://www.notion.so/p1", "last_edited_time": "2026-05-01T00:00:00Z"},
+        {"id": "p2", "url": "https://www.notion.so/p2", "last_edited_time": "2026-05-02T00:00:00Z"},
+    ]
+
+    def _flaky(self, url):
+        if "p1" in url:
+            raise RuntimeError("transient")
+        return {"source": "notion", "decisions": [], "title": "p2"}
+
+    with (
+        patch(
+            "sources.notion.poller.list_recently_edited_pages",
+            return_value=fake_pages,
+        ),
+        patch(
+            "sources.notion.adapter.NotionAdapter.fetch_active",
+            new=_flaky,
+        ),
+    ):
+        adapter = NotionPollingAdapter()
+        result = adapter.pull(watermark_dir=tmp_path, config={"database_id": "db1"})
+
+    assert len(result) == 1
+    assert "p1" in capsys.readouterr().err
+    assert adapter._pending_watermark == "2026-05-02T00:00:00Z"
+
+
+def test_pull_passes_watermark_to_poller(tmp_path):
+    from events.sources.notion import NotionPollingAdapter
+    from secrets_store import put_secret
+
+    put_secret(source_id="notion", key="api_key", value="secret_x")
+    (tmp_path / "notion.json").write_text(json.dumps({"last_edited_time": "2026-05-01T00:00:00Z"}))
+
+    captured: dict = {}
+
+    def _capture(*, api_key, database_id, edited_after=None):
+        captured["edited_after"] = edited_after
+        return []
+
+    with patch(
+        "sources.notion.poller.list_recently_edited_pages",
+        side_effect=_capture,
+    ):
+        adapter = NotionPollingAdapter()
+        adapter.pull(watermark_dir=tmp_path, config={"database_id": "db1"})
+
+    assert captured["edited_after"] == "2026-05-01T00:00:00Z"
+
+
+def test_confirm_watermark_persists(tmp_path):
+    from events.sources.notion import NotionPollingAdapter
+
+    adapter = NotionPollingAdapter()
+    adapter._watermark_path = tmp_path / "notion.json"
+    adapter._pending_watermark = "2026-05-19T00:00:00Z"
+    adapter.confirm_watermark()
+    data = json.loads((tmp_path / "notion.json").read_text())
+    assert data["last_edited_time"] == "2026-05-19T00:00:00Z"
+
+
+def test_registered_in_ADAPTERS():
+    from events.sources import ADAPTERS
+    from events.sources.notion import NotionPollingAdapter
+
+    assert ADAPTERS["notion"] is NotionPollingAdapter


### PR DESCRIPTION
## Summary

Adds Notion as a polling source. Database pages with `last_edited_time > watermark` are enumerated via Notion's REST `databases/{id}/query` endpoint and fed through Phase 2's active-ingest adapter for block-walk normalization.

### Config

\`\`\`yaml
sources:
  - type: notion
    database_id: <Notion database ID>
    source_type_label: decision-doc  # optional
\`\`\`

### Auth

Reuses Phase 2's `secrets_store source_id="notion", key="api_key"`. No re-handshake.

### Conflict note

Touches `events/sources/__init__.py` alongside BicameralAI/bicameral-mcp#432 (5c) and BicameralAI/bicameral-mcp#433 (1b). Whoever merges last needs a trivial rebase combining the three registry additions.

Tests: 11 new passing.

Parent tracker: BicameralAI/bicameral-daemon#3.

🤖 Generated with [Claude Code](https://claude.com/claude-code)