### PR TITLE
feat(sources): Phase 3b — GitHub polling adapter (passive ingest)

### DIFF
--- a/events/sources/__init__.py
+++ b/events/sources/__init__.py
@@ -20,6 +20,7 @@ from __future__ import annotations
 
 from typing import Protocol, runtime_checkable
 
+from .github import GitHubPollingAdapter
 from .google_drive import GoogleDriveFolderAdapter
 from .granola import GranolaAdapter, MissingApiKeyError
 from .linear import LinearPollingAdapter
@@ -50,11 +51,13 @@ ADAPTERS: dict[str, type] = {
     "google_drive": GoogleDriveFolderAdapter,
     "linear": LinearPollingAdapter,
     "notion": NotionPollingAdapter,
+    "github": GitHubPollingAdapter,
 }
 
 
 __all__ = [
     "ADAPTERS",
+    "GitHubPollingAdapter",
     "GoogleDriveFolderAdapter",
     "GranolaAdapter",
     "LinearPollingAdapter",

--- a/events/sources/github.py
+++ b/events/sources/github.py
@@ -1,0 +1,174 @@
+"""GitHub polling source adapter (#337 Phase 3b).
+
+Pull-based: enumerates merged PRs in configured repos since the last
+watermark via the REST `pulls?state=closed&sort=updated&since=...`
+endpoint, fetches each through Phase 3's active-ingest adapter for
+PR + reviews + comments normalization, returns ingest-ready payloads.
+
+Config schema::
+
+    sources:
+      - type: github
+        repos: ["owner/repo", "owner/other-repo"]
+        source_type_label: pr-review  # optional
+
+Auth: ``secrets_store source_id="github", key="api_key"`` (PAT with
+``repo`` scope OR GitHub App installation token).
+
+Watermark: per-repo. ``<watermark_dir>/github.json`` stores a dict
+keyed by ``owner/repo`` → ``last_updated_at`` so a slow repo doesn't
+re-pull every PR after a fast repo advances. Corrupt / missing → epoch.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import sys
+from pathlib import Path
+
+logger = logging.getLogger(__name__)
+
+_WATERMARK_FILENAME = "github.json"
+
+
+class GitHubPollingAdapter:
+    """Source adapter conforming to ``events.sources.SourceAdapter``."""
+
+    name = "github"
+
+    def __init__(self) -> None:
+        self._pending_watermarks: dict[str, str] = {}
+        self._watermark_path: Path | None = None
+
+    def pull(self, *, watermark_dir: Path, config: dict) -> list[dict]:
+        watermark_dir = Path(watermark_dir)
+        watermark_dir.mkdir(parents=True, exist_ok=True)
+        self._watermark_path = watermark_dir / _WATERMARK_FILENAME
+
+        repos_raw = config.get("repos") or []
+        repos = [str(r) for r in repos_raw if "/" in str(r)]
+        if not repos:
+            print(
+                "[github] at least one 'owner/repo' entry is required in source.repos; skipping.",
+                file=sys.stderr,
+            )
+            self._pending_watermarks = {}
+            return []
+
+        all_watermarks = _read_watermarks(self._watermark_path)
+
+        try:
+            from secrets_store import get_secret
+
+            api_key = get_secret(source_id="github", key="api_key")
+            if not api_key:
+                print(
+                    "[github] api_key not configured (secrets_store source_id=github, "
+                    "key=api_key); skipping.",
+                    file=sys.stderr,
+                )
+                self._pending_watermarks = {}
+                return []
+        except Exception as exc:  # noqa: BLE001
+            print(f"[github] secret lookup failed: {exc}", file=sys.stderr)
+            self._pending_watermarks = {}
+            return []
+
+        try:
+            from sources.github.adapter import GitHubAdapter
+        except ImportError as exc:
+            print(f"[github] adapter import failed: {exc}", file=sys.stderr)
+            self._pending_watermarks = {}
+            return []
+
+        active = GitHubAdapter()
+        payloads: list[dict] = []
+        new_watermarks: dict[str, str] = dict(all_watermarks)
+
+        for owner_repo in repos:
+            try:
+                owner, repo = owner_repo.split("/", 1)
+            except ValueError:
+                print(
+                    f"[github] malformed repo entry {owner_repo!r}; expected 'owner/repo'.",
+                    file=sys.stderr,
+                )
+                continue
+            last_updated = all_watermarks.get(owner_repo)
+            try:
+                from sources.github.poller import list_merged_pulls_since
+
+                pulls = list_merged_pulls_since(
+                    api_key=api_key,
+                    owner=owner,
+                    repo=repo,
+                    updated_after=last_updated,
+                )
+            except Exception as exc:  # noqa: BLE001
+                print(
+                    f"[github] {owner_repo} pull listing failed: {exc}",
+                    file=sys.stderr,
+                )
+                continue
+
+            highest_updated = last_updated or ""
+            for pr in pulls:
+                url = pr.get("html_url") or ""
+                updated_at = pr.get("updated_at") or ""
+                if not url:
+                    continue
+                try:
+                    payload = active.fetch_active(url)
+                except Exception as exc:  # noqa: BLE001
+                    pr_number = pr.get("number", "?")
+                    print(
+                        f"[github] {owner_repo}#{pr_number} fetch failed (skipped): {exc}",
+                        file=sys.stderr,
+                    )
+                    continue
+                label = config.get("source_type_label")
+                if label:
+                    payload = {**payload, "source": str(label)}
+                payloads.append(payload)
+                if updated_at > highest_updated:
+                    highest_updated = updated_at
+
+            if highest_updated:
+                new_watermarks[owner_repo] = highest_updated
+
+        # Stage the per-repo watermark advance.
+        self._pending_watermarks = new_watermarks
+        return payloads
+
+    def confirm_watermark(self) -> None:
+        if self._watermark_path is None or not self._pending_watermarks:
+            return
+        try:
+            self._watermark_path.write_text(
+                json.dumps(self._pending_watermarks),
+                encoding="utf-8",
+            )
+        except OSError as exc:
+            logger.warning(
+                "[github] watermark persistence failed (will re-pull next run): %s",
+                exc,
+            )
+        self._pending_watermarks = {}
+
+
+def _read_watermarks(path: Path) -> dict[str, str]:
+    if not path.exists():
+        return {}
+    try:
+        data = json.loads(path.read_text(encoding="utf-8"))
+    except (json.JSONDecodeError, OSError) as exc:
+        logger.warning(
+            "[github] watermark file corrupt at %s, starting from epoch: %s",
+            path,
+            exc,
+        )
+        return {}
+    if not isinstance(data, dict):
+        return {}
+    return {str(k): str(v) for k, v in data.items() if isinstance(v, str)}

--- a/sources/github/poller.py
+++ b/sources/github/poller.py
@@ -1,0 +1,96 @@
+"""GitHub polling helper for Phase 3b passive ingest (#337).
+
+Enumerates pull requests in a configured repo that were updated after
+the watermark and have ``merged_at`` set (i.e. actually merged, not just
+closed without merge).
+
+Uses the existing Phase 3 GitHub REST client's pagination helper
+(``_paginate_list``) so the rate-limit handling, response cap, and
+Link-header cursor are shared with the active-ingest path.
+
+Pagination cap is the same as the active-ingest path: 10 pages × 100
+PRs = 1000 per cycle.
+"""
+
+from __future__ import annotations
+
+
+def list_merged_pulls_since(
+    *,
+    api_key: str,
+    owner: str,
+    repo: str,
+    updated_after: str | None = None,
+):
+    """Return PRs in ``owner/repo`` updated after ``updated_after``, filtered
+    to those with ``merged_at`` set.
+
+    Each result is the raw GitHub PR object (the polling adapter pulls
+    ``html_url`` and ``merged_at`` from it).
+
+    Sorted ascending by ``updated_at`` (GitHub's native ordering when
+    sort=updated + direction=asc).
+
+    ``updated_after`` is an ISO 8601 timestamp string. GitHub's
+    ``pulls?since=<ts>`` filter is applied via _paginate_list with a
+    custom path.
+
+    Raises ``RuntimeError`` on API failure with a message the polling
+    adapter logs without advancing the watermark.
+    """
+    from sources.github.client import GitHubAPIError
+
+    base_path = f"/repos/{owner}/{repo}/pulls"
+    # _paginate_list always appends `?per_page=100`; pass our other params
+    # via `params=` so the helper composes the query string correctly.
+    params: dict[str, str] = {"state": "closed", "sort": "updated", "direction": "asc"}
+    if updated_after:
+        params["since"] = updated_after
+
+    try:
+        pulls = _list_pulls_manual(api_key=api_key, base_path=base_path, params=params)
+    except GitHubAPIError as exc:
+        raise RuntimeError(f"GitHub pulls listing failed: {exc}") from exc
+
+    # GitHub state=closed includes both merged and abandoned; filter to
+    # actually-merged.
+    return [p for p in pulls if p.get("merged_at")]
+
+
+def _list_pulls_manual(*, api_key: str, base_path: str, params: dict) -> list[dict]:
+    """Paginated GET keeping our query params alongside Link-header pagination."""
+    import urllib.parse
+
+    from sources.github.client import _MAX_PAGINATION_PAGES, GitHubAPIError, _get, _parse_link_next
+
+    full_params = {**params, "per_page": "100"}
+    url_suffix = base_path + "?" + urllib.parse.urlencode(full_params)
+    out: list[dict] = []
+    pages = 0
+    while True:
+        data, headers = _get(api_key=api_key, path=url_suffix)
+        if not isinstance(data, list):
+            raise GitHubAPIError(f"expected list at {base_path}, got {type(data).__name__}")
+        out.extend(data)
+        pages += 1
+        if pages >= _MAX_PAGINATION_PAGES:
+            raise GitHubAPIError(
+                f"{base_path} has more than {_MAX_PAGINATION_PAGES * 100} PRs "
+                "since the watermark — narrow the repo or shorten the watch window"
+            )
+        link = headers.get("Link") or headers.get("link")
+        if not link:
+            break
+        next_url = _parse_link_next(link)
+        if not next_url:
+            break
+        # _get re-prepends _API_BASE if the path starts with /; strip the
+        # base from the absolute URL the Link header returned so _get
+        # builds the correct request.
+        from sources.github.client import _API_BASE
+
+        if next_url.startswith(_API_BASE):
+            url_suffix = next_url[len(_API_BASE) :]
+        else:
+            url_suffix = next_url
+    return out

--- a/tests/test_github_polling.py
+++ b/tests/test_github_polling.py
@@ -1,0 +1,294 @@
+"""Tests for #337 Phase 3b — GitHub polling adapter."""
+
+from __future__ import annotations
+
+import io
+import json
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+
+@pytest.fixture(autouse=True)
+def _disable_keyring(monkeypatch):
+    monkeypatch.setenv("BICAMERAL_KEYRING_DISABLE", "1")
+    from secrets_store.store import _reset_for_tests
+
+    _reset_for_tests()
+    yield
+    _reset_for_tests()
+
+
+def _mock_response(body, headers=None):
+    raw = json.dumps(body).encode("utf-8")
+    resp = io.BytesIO(raw)
+    resp.status = 200  # type: ignore[attr-defined]
+
+    class _Headers:
+        def __init__(self, h):
+            self._h = h
+
+        def items(self):
+            return list(self._h.items())
+
+        def get(self, key, default=None):
+            return self._h.get(key, default)
+
+    resp.headers = _Headers(headers or {})  # type: ignore[attr-defined]
+
+    class _Ctx:
+        def __enter__(self):
+            return resp
+
+        def __exit__(self, *args):
+            return False
+
+    return _Ctx()
+
+
+# ── poller.list_merged_pulls_since ──────────────────────────────────────────
+
+
+def test_list_merged_filters_to_actually_merged():
+    """state=closed returns both merged + abandoned; we keep only merged."""
+    from sources.github.poller import list_merged_pulls_since
+
+    pulls = [
+        {
+            "number": 1,
+            "html_url": "u1",
+            "updated_at": "2026-05-01T00:00:00Z",
+            "merged_at": "2026-05-01T01:00:00Z",
+        },
+        {"number": 2, "html_url": "u2", "updated_at": "2026-05-02T00:00:00Z", "merged_at": None},
+        {
+            "number": 3,
+            "html_url": "u3",
+            "updated_at": "2026-05-03T00:00:00Z",
+            "merged_at": "2026-05-03T01:00:00Z",
+        },
+    ]
+    with patch("urllib.request.urlopen", return_value=_mock_response(pulls)):
+        result = list_merged_pulls_since(api_key="ghp_x", owner="foo", repo="bar")
+    assert [p["number"] for p in result] == [1, 3]
+
+
+def test_list_merged_paginates_via_link_header():
+    from sources.github.poller import list_merged_pulls_since
+
+    page1_pulls = [
+        {
+            "number": 1,
+            "html_url": "u1",
+            "updated_at": "2026-05-01T00:00:00Z",
+            "merged_at": "2026-05-01T01:00:00Z",
+        },
+    ]
+    page2_pulls = [
+        {
+            "number": 2,
+            "html_url": "u2",
+            "updated_at": "2026-05-02T00:00:00Z",
+            "merged_at": "2026-05-02T01:00:00Z",
+        },
+    ]
+    page1 = _mock_response(
+        page1_pulls,
+        headers={"Link": ('<https://api.github.com/repos/foo/bar/pulls?page=2>; rel="next"')},
+    )
+    page2 = _mock_response(page2_pulls)
+    with patch("urllib.request.urlopen", side_effect=[page1, page2]):
+        result = list_merged_pulls_since(api_key="ghp_x", owner="foo", repo="bar")
+    assert len(result) == 2
+
+
+def test_list_merged_raises_on_api_error():
+    import urllib.error
+
+    from sources.github.poller import list_merged_pulls_since
+
+    err = urllib.error.HTTPError(
+        url="https://api.github.com/repos/foo/bar/pulls",
+        code=403,
+        msg="forbidden",
+        hdrs=None,
+        fp=io.BytesIO(b""),
+    )
+    with patch("urllib.request.urlopen", side_effect=err):
+        with pytest.raises(RuntimeError, match="pulls listing failed"):
+            list_merged_pulls_since(api_key="ghp_x", owner="foo", repo="bar")
+
+
+# ── GitHubPollingAdapter.pull ───────────────────────────────────────────────
+
+
+def test_pull_returns_payloads_for_new_prs(tmp_path):
+    from events.sources.github import GitHubPollingAdapter
+    from secrets_store import put_secret
+
+    put_secret(source_id="github", key="api_key", value="ghp_x")
+
+    fake_pulls = [
+        {
+            "number": 1,
+            "html_url": "https://github.com/foo/bar/pull/1",
+            "updated_at": "2026-05-01T00:00:00Z",
+            "merged_at": "2026-05-01T01:00:00Z",
+        },
+        {
+            "number": 2,
+            "html_url": "https://github.com/foo/bar/pull/2",
+            "updated_at": "2026-05-02T00:00:00Z",
+            "merged_at": "2026-05-02T01:00:00Z",
+        },
+    ]
+    fake_payload = {"source": "github", "decisions": [], "title": "x"}
+
+    with (
+        patch(
+            "sources.github.poller.list_merged_pulls_since",
+            return_value=fake_pulls,
+        ),
+        patch(
+            "sources.github.adapter.GitHubAdapter.fetch_active",
+            return_value=fake_payload,
+        ),
+    ):
+        adapter = GitHubPollingAdapter()
+        result = adapter.pull(watermark_dir=tmp_path, config={"repos": ["foo/bar"]})
+
+    assert len(result) == 2
+    # Per-repo watermark advanced.
+    assert adapter._pending_watermarks["foo/bar"] == "2026-05-02T00:00:00Z"
+
+
+def test_pull_returns_empty_when_repos_missing(tmp_path, capsys):
+    from events.sources.github import GitHubPollingAdapter
+
+    adapter = GitHubPollingAdapter()
+    result = adapter.pull(watermark_dir=tmp_path, config={})
+    assert result == []
+    assert "owner/repo" in capsys.readouterr().err
+
+
+def test_pull_skips_malformed_repo_entries(tmp_path, capsys):
+    from events.sources.github import GitHubPollingAdapter
+    from secrets_store import put_secret
+
+    put_secret(source_id="github", key="api_key", value="ghp_x")
+
+    with patch(
+        "sources.github.poller.list_merged_pulls_since",
+        return_value=[],
+    ):
+        adapter = GitHubPollingAdapter()
+        # "no-slash" entry filtered before reaching the API.
+        result = adapter.pull(
+            watermark_dir=tmp_path,
+            config={"repos": ["no-slash-here", "foo/bar"]},
+        )
+
+    assert result == []  # no merged PRs in foo/bar
+
+
+def test_pull_per_repo_watermark_isolation(tmp_path):
+    """Slow repo should not re-pull everything when fast repo advances."""
+    from events.sources.github import GitHubPollingAdapter
+    from secrets_store import put_secret
+
+    put_secret(source_id="github", key="api_key", value="ghp_x")
+
+    # Seed disk watermark with one repo already advanced.
+    wm = tmp_path / "github.json"
+    wm.write_text(json.dumps({"foo/fast": "2026-05-15T00:00:00Z"}))
+
+    captured: list = []
+
+    def _capture(*, api_key, owner, repo, updated_after):
+        captured.append((f"{owner}/{repo}", updated_after))
+        return []
+
+    with patch(
+        "sources.github.poller.list_merged_pulls_since",
+        side_effect=_capture,
+    ):
+        adapter = GitHubPollingAdapter()
+        adapter.pull(
+            watermark_dir=tmp_path,
+            config={"repos": ["foo/fast", "foo/slow"]},
+        )
+
+    # fast repo passes its existing watermark; slow repo passes None.
+    by_repo = dict(captured)
+    assert by_repo["foo/fast"] == "2026-05-15T00:00:00Z"
+    assert by_repo["foo/slow"] is None
+
+
+def test_pull_skips_individual_pr_fetch_failures(tmp_path, capsys):
+    from events.sources.github import GitHubPollingAdapter
+    from secrets_store import put_secret
+
+    put_secret(source_id="github", key="api_key", value="ghp_x")
+
+    fake_pulls = [
+        {
+            "number": 1,
+            "html_url": "https://github.com/foo/bar/pull/1",
+            "updated_at": "2026-05-01T00:00:00Z",
+            "merged_at": "2026-05-01T01:00:00Z",
+        },
+        {
+            "number": 2,
+            "html_url": "https://github.com/foo/bar/pull/2",
+            "updated_at": "2026-05-02T00:00:00Z",
+            "merged_at": "2026-05-02T01:00:00Z",
+        },
+    ]
+
+    def _flaky(self, url):
+        if "/pull/1" in url:
+            raise RuntimeError("transient")
+        return {"source": "github", "decisions": [], "title": "x"}
+
+    with (
+        patch(
+            "sources.github.poller.list_merged_pulls_since",
+            return_value=fake_pulls,
+        ),
+        patch(
+            "sources.github.adapter.GitHubAdapter.fetch_active",
+            new=_flaky,
+        ),
+    ):
+        adapter = GitHubPollingAdapter()
+        result = adapter.pull(watermark_dir=tmp_path, config={"repos": ["foo/bar"]})
+
+    assert len(result) == 1
+    err = capsys.readouterr().err
+    assert "foo/bar#1" in err
+    # Watermark advances past PR 2 even though PR 1 was skipped.
+    assert adapter._pending_watermarks["foo/bar"] == "2026-05-02T00:00:00Z"
+
+
+def test_confirm_watermark_persists_per_repo_dict(tmp_path):
+    from events.sources.github import GitHubPollingAdapter
+
+    adapter = GitHubPollingAdapter()
+    adapter._watermark_path = tmp_path / "github.json"
+    adapter._pending_watermarks = {
+        "foo/bar": "2026-05-19T00:00:00Z",
+        "foo/baz": "2026-05-18T00:00:00Z",
+    }
+    adapter.confirm_watermark()
+    data = json.loads((tmp_path / "github.json").read_text())
+    assert data == {
+        "foo/bar": "2026-05-19T00:00:00Z",
+        "foo/baz": "2026-05-18T00:00:00Z",
+    }
+
+
+def test_registered_in_ADAPTERS():
+    from events.sources import ADAPTERS
+    from events.sources.github import GitHubPollingAdapter
+
+    assert ADAPTERS["github"] is GitHubPollingAdapter


### PR DESCRIPTION
## Summary

Adds GitHub as a polling source. Merged PRs in configured repos are enumerated via REST `pulls?state=closed&sort=updated&since=<watermark>`, filtered to actually-merged, and fed through Phase 3's active-ingest adapter.

### Config

\`\`\`yaml
sources:
  - type: github
    repos: ["BicameralAI/bicameral-mcp", "BicameralAI/other"]
    source_type_label: pr-review  # optional
\`\`\`

### Per-repo watermark

Watermark file `github.json` stores a dict keyed by `owner/repo` so a fast-moving repo doesn't strand slow-moving ones in the same source-config entry.

### Auth

Reuses Phase 3's `secrets_store source_id="github", key="api_key"`. PAT with `repo` scope OR GitHub App installation token.

Tests: 10 new passing.

Parent tracker: BicameralAI/bicameral-daemon#3.

🤖 Generated with [Claude Code](https://claude.com/claude-code)