### PR TITLE
feat(sources): Phase 4a — Slack active-ingest adapter

### DIFF
--- a/sources/slack/__init__.py
+++ b/sources/slack/__init__.py
@@ -1,0 +1,15 @@
+"""Slack source adapter (#337 Phase 4a — active ingest).
+
+Public API: ``SlackAdapter`` and ``parse_slack_url``.
+
+Auth: bot token persisted via ``secrets_store`` under
+``source_id="slack"``, key ``"api_key"``. Operator creates a Slack app
+at api.slack.com, grants ``channels:history`` + ``groups:history``
+scopes (and ``mpim:history`` / ``im:history`` only if intentionally
+ingesting DMs — Bicameral's policy is channel-only by default per
+#337's "no DMs" rule).
+"""
+
+from sources.slack.adapter import SlackAdapter, parse_slack_url
+
+__all__ = ["SlackAdapter", "parse_slack_url"]

--- a/sources/slack/adapter.py
+++ b/sources/slack/adapter.py
@@ -1,0 +1,220 @@
+"""Slack source adapter (#337 Phase 4a — active ingest).
+
+Active path: operator pastes a Slack thread URL → adapter fetches the
+thread + replies → normalizes to an IngestPayload. Passive (channel
+polling) is Phase 4b.
+
+URL forms accepted:
+    https://<workspace>.slack.com/archives/<channel_id>/p<ts_no_dot>
+    https://<workspace>.slack.com/archives/<channel_id>/p<ts_no_dot>?thread_ts=<root>
+
+The ``p<ts>`` segment encodes the message timestamp by stripping the
+decimal: ``p1700000000123456`` corresponds to Slack ``ts="1700000000.123456"``.
+When ``thread_ts`` is present it identifies the thread root; otherwise
+the message ``p<ts>`` IS the root.
+
+DM URLs (``/messages/<im_id>``) are rejected by design — Bicameral's
+ingest policy is channel-only per the parent tracker.
+"""
+
+from __future__ import annotations
+
+import re
+
+_THREAD_URL_RE = re.compile(
+    r"^https?://(?:[a-z0-9-]+\.)?slack\.com/archives/"
+    r"(?P<channel>[A-Z0-9]+)/p(?P<ts_compact>\d{16})"
+    r"(?:\?(?P<query>[^#]*))?(?:#.*)?$",
+    re.IGNORECASE,
+)
+
+
+class _ParsedSlackURL:
+    """URL parts used by the adapter."""
+
+    __slots__ = ("channel", "thread_ts", "url")
+
+    def __init__(self, *, channel: str, thread_ts: str, url: str) -> None:
+        self.channel = channel
+        self.thread_ts = thread_ts
+        self.url = url
+
+
+def parse_slack_url(url: str) -> _ParsedSlackURL:
+    """Extract channel_id + thread_ts from a Slack archive URL.
+
+    Returns a struct rather than a tuple so the call site reads cleanly
+    when both fields are referenced.
+
+    Raises:
+        ValueError: not a recognized Slack thread URL, or a DM URL
+            (DMs are out of scope by policy).
+    """
+    if "/messages/" in url.lower():
+        raise ValueError(f"DM URL not supported (Bicameral policy: channel-only): {url!r}")
+    m = _THREAD_URL_RE.match(url.strip())
+    if not m:
+        raise ValueError(
+            f"not a recognized Slack thread URL: {url!r}. "
+            "Expected slack.com/archives/<channel_id>/p<ts>."
+        )
+    channel = m.group("channel").upper()
+    ts_compact = m.group("ts_compact")
+    # p1700000000123456 → 1700000000.123456 (last 6 digits are microseconds).
+    message_ts = ts_compact[:-6] + "." + ts_compact[-6:]
+    # If the URL carries thread_ts=<root>, use that as the canonical
+    # thread anchor; otherwise the message itself is the root.
+    thread_ts = message_ts
+    query = m.group("query") or ""
+    for part in query.split("&"):
+        if part.startswith("thread_ts="):
+            thread_ts = part.split("=", 1)[1]
+            break
+    return _ParsedSlackURL(channel=channel, thread_ts=thread_ts, url=url.strip())
+
+
+def _is_decision_bearing(message: dict) -> bool:
+    """Filter out messages that aren't candidates for decision capture.
+
+    Out: bot messages (subtype set), channel-join/leave noise, empty text.
+    In: human messages with non-empty ``text`` or attachments.
+    """
+    if message.get("subtype") in {
+        "bot_message",
+        "channel_join",
+        "channel_leave",
+        "channel_topic",
+        "channel_purpose",
+        "channel_name",
+        "channel_archive",
+        "channel_unarchive",
+    }:
+        return False
+    text = (message.get("text") or "").strip()
+    if not text and not message.get("attachments"):
+        return False
+    return True
+
+
+def normalize_thread_to_payload(
+    messages: list[dict],
+    *,
+    channel: str,
+    thread_url: str,
+    user_resolver=None,
+) -> dict:
+    """Build the ingest payload from a Slack thread's messages.
+
+    ``user_resolver`` (optional) is a callable ``user_id -> dict`` that
+    returns a user-profile dict (``name``, ``profile.email``). When
+    supplied it's used to enrich ``participants``; when omitted the
+    Slack user IDs (``U…``) flow through unresolved.
+    """
+    decisions: list[dict] = []
+    participants: list[str] = []
+    seen_users: set[str] = set()
+
+    root_ts = messages[0].get("ts") if messages else ""
+    title = f"{channel}#{root_ts}"
+
+    for msg in messages:
+        if not _is_decision_bearing(msg):
+            continue
+        text = (msg.get("text") or "").strip()
+        if not text:
+            continue
+        msg_ts = msg.get("ts") or ""
+        decisions.append(
+            {
+                "description": text,
+                "title": f"{channel}#{msg_ts}" if msg_ts else title,
+            }
+        )
+        user_id = msg.get("user") or ""
+        if not user_id or user_id in seen_users:
+            continue
+        seen_users.add(user_id)
+        if user_resolver is not None:
+            try:
+                profile = user_resolver(user_id) or {}
+            except Exception:  # noqa: BLE001 — resolver is best-effort
+                profile = {}
+            email = ((profile.get("profile") or {}).get("email") or "").strip()
+            name = (profile.get("real_name") or profile.get("name") or "").strip()
+            participants.append(email or name or user_id)
+        else:
+            participants.append(user_id)
+
+    return {
+        "query": (decisions[0]["description"][:80] if decisions else title),
+        "source": "slack",
+        "title": title,
+        "date": _slack_ts_to_iso(root_ts) if root_ts else "",
+        "participants": participants,
+        "decisions": decisions,
+    }
+
+
+def _slack_ts_to_iso(ts: str) -> str:
+    """Convert Slack ``ts`` (epoch float as string) to ISO 8601.
+
+    Returns empty string on malformed input.
+    """
+    try:
+        from datetime import UTC, datetime
+
+        epoch = float(ts)
+        return datetime.fromtimestamp(epoch, tz=UTC).isoformat()
+    except (ValueError, OSError, OverflowError):
+        return ""
+
+
+class SlackAdapter:
+    """SourceAdapter implementation for Slack (active path)."""
+
+    source_id = "slack"
+
+    def can_handle_url(self, url: str) -> bool:
+        if "/messages/" in url.lower():
+            return False
+        return bool(_THREAD_URL_RE.match(url.strip()))
+
+    def fetch_active(self, url: str) -> dict:
+        parsed = parse_slack_url(url)
+        token = self._resolve_token()
+        from sources.slack.client import get_thread_replies
+
+        messages = get_thread_replies(
+            token=token, channel=parsed.channel, thread_ts=parsed.thread_ts
+        )
+        if not messages:
+            raise RuntimeError(
+                f"Slack returned no messages for {parsed.channel}#{parsed.thread_ts}. "
+                "Check that the bot is in the channel and has channels:history scope."
+            )
+
+        def _resolver(user_id: str) -> dict:
+            from sources.slack.client import get_user_info
+
+            return get_user_info(token=token, user_id=user_id)
+
+        return normalize_thread_to_payload(
+            messages,
+            channel=parsed.channel,
+            thread_url=parsed.url,
+            user_resolver=_resolver,
+        )
+
+    def _resolve_token(self) -> str:
+        from secrets_store import get_secret
+
+        token = get_secret(source_id=self.source_id, key="api_key")
+        if not token:
+            raise RuntimeError(
+                "Slack bot token not configured. Create a Slack app at "
+                "api.slack.com, grant channels:history + groups:history "
+                "scopes, then store the bot token (xoxb-...) via:\n"
+                '  python -c "from secrets_store import put_secret; '
+                "put_secret(source_id='slack', key='api_key', value='xoxb-...')\""
+            )
+        return token

--- a/sources/slack/client.py
+++ b/sources/slack/client.py
@@ -1,0 +1,156 @@
+"""Thin Slack Web API client (#337 Phase 4a — active ingest).
+
+stdlib ``urllib.request`` — same hardening as Linear/Notion/GitHub
+clients (15s timeout, 4 MiB response cap, Bearer in Authorization
+header). Endpoint: ``https://slack.com/api/<method>``.
+
+Slack's API returns 200 even on logical failures, with ``ok: false``
+in the JSON body. The client raises ``SlackAPIError`` on either HTTP
+non-2xx or ``ok=false`` responses so callers don't have to repeat the
+branch.
+"""
+
+from __future__ import annotations
+
+import json
+import urllib.error
+import urllib.parse
+import urllib.request
+
+_API_BASE = "https://slack.com/api"
+_REQUEST_TIMEOUT_SECONDS = 15.0
+_MAX_RESPONSE_BYTES = 4 * 1024 * 1024
+_MAX_PAGINATION_PAGES = 10  # 10 * 200 messages = 2000 per fetch
+
+
+class SlackAPIError(RuntimeError):
+    """Raised on Slack API failure (HTTP non-2xx OR ``ok=false`` in body)."""
+
+    def __init__(
+        self, message: str, *, status_code: int | None = None, slack_error: str | None = None
+    ) -> None:
+        self.status_code = status_code
+        self.slack_error = slack_error
+        super().__init__(message)
+
+
+def _get(*, token: str, method: str, params: dict | None = None) -> dict:
+    """GET ``slack.com/api/<method>`` with optional query params.
+
+    Returns the parsed JSON body on ``ok=true``. Raises ``SlackAPIError``
+    otherwise, surfacing Slack's ``error`` string when present.
+    """
+    url = f"{_API_BASE}/{method}"
+    if params:
+        url = url + "?" + urllib.parse.urlencode(params)
+    headers = {
+        "Authorization": f"Bearer {token}",
+        "Accept": "application/json",
+        "User-Agent": "bicameral-mcp/source-slack",
+    }
+    req = urllib.request.Request(url, headers=headers, method="GET")
+    try:
+        with urllib.request.urlopen(req, timeout=_REQUEST_TIMEOUT_SECONDS) as resp:
+            raw = resp.read(_MAX_RESPONSE_BYTES + 1)
+            if len(raw) > _MAX_RESPONSE_BYTES:
+                raise SlackAPIError(
+                    f"Slack response exceeded {_MAX_RESPONSE_BYTES} bytes",
+                    status_code=resp.status,
+                )
+    except urllib.error.HTTPError as exc:
+        raise SlackAPIError(
+            f"Slack API HTTP {exc.code}: {exc.reason}",
+            status_code=exc.code,
+        ) from exc
+    except urllib.error.URLError as exc:
+        raise SlackAPIError(f"Slack API network error: {exc.reason}") from exc
+
+    try:
+        data = json.loads(raw.decode("utf-8"))
+    except json.JSONDecodeError as exc:
+        raise SlackAPIError(f"Slack API returned non-JSON: {exc}") from exc
+
+    if not data.get("ok"):
+        slack_error = data.get("error") or "unknown_error"
+        raise SlackAPIError(
+            f"Slack API error: {slack_error}",
+            slack_error=slack_error,
+        )
+    return data
+
+
+def get_thread_replies(*, token: str, channel: str, thread_ts: str) -> list[dict]:
+    """Return all messages in a thread (root + replies), oldest first.
+
+    Paginates via Slack's ``next_cursor`` until exhausted or until the
+    page cap fires.
+    """
+    out: list[dict] = []
+    cursor: str | None = None
+    pages = 0
+    while True:
+        params: dict[str, str] = {
+            "channel": channel,
+            "ts": thread_ts,
+            "limit": "200",
+        }
+        if cursor is not None:
+            params["cursor"] = cursor
+        data = _get(token=token, method="conversations.replies", params=params)
+        out.extend(data.get("messages") or [])
+        pages += 1
+        cursor = (data.get("response_metadata") or {}).get("next_cursor")
+        if not cursor:
+            break
+        if pages >= _MAX_PAGINATION_PAGES:
+            raise SlackAPIError(
+                f"thread has more than {_MAX_PAGINATION_PAGES * 200} replies — "
+                "narrow the ingest target"
+            )
+    return out
+
+
+def get_user_info(*, token: str, user_id: str) -> dict:
+    """Fetch user profile metadata. Used to resolve names + emails for
+    participant attribution."""
+    data = _get(token=token, method="users.info", params={"user": user_id})
+    return data.get("user") or {}
+
+
+def get_conversations_history(
+    *,
+    token: str,
+    channel: str,
+    oldest: str | None = None,
+    limit: int = 200,
+) -> list[dict]:
+    """Return recent messages in a channel since ``oldest`` (a Slack ``ts``).
+
+    Slack's ``conversations.history`` returns messages newest-first by
+    default. Caller is responsible for sorting / watermarking on ``ts``.
+    Paginates via ``next_cursor``.
+    """
+    out: list[dict] = []
+    cursor: str | None = None
+    pages = 0
+    while True:
+        params: dict[str, str] = {
+            "channel": channel,
+            "limit": str(limit),
+        }
+        if oldest:
+            params["oldest"] = oldest
+        if cursor is not None:
+            params["cursor"] = cursor
+        data = _get(token=token, method="conversations.history", params=params)
+        out.extend(data.get("messages") or [])
+        pages += 1
+        cursor = (data.get("response_metadata") or {}).get("next_cursor")
+        if not cursor:
+            break
+        if pages >= _MAX_PAGINATION_PAGES:
+            raise SlackAPIError(
+                f"channel has more than {_MAX_PAGINATION_PAGES * limit} messages "
+                "since the watermark — narrow the channel or shorten the watch window"
+            )
+    return out

--- a/tests/test_slack_adapter.py
+++ b/tests/test_slack_adapter.py
@@ -1,0 +1,306 @@
+"""Tests for #337 Phase 4a — Slack active-ingest adapter."""
+
+from __future__ import annotations
+
+import io
+import json
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+
+@pytest.fixture(autouse=True)
+def _disable_keyring(monkeypatch):
+    monkeypatch.setenv("BICAMERAL_KEYRING_DISABLE", "1")
+    from secrets_store.store import _reset_for_tests
+
+    _reset_for_tests()
+    yield
+    _reset_for_tests()
+
+
+def _mock_response(body):
+    raw = json.dumps(body).encode("utf-8")
+    resp = io.BytesIO(raw)
+    resp.status = 200
+
+    class _Ctx:
+        def __enter__(self):
+            return resp
+
+        def __exit__(self, *args):
+            return False
+
+    return _Ctx()
+
+
+# ── URL parsing ─────────────────────────────────────────────────────────────
+
+
+@pytest.mark.parametrize(
+    "url,channel,thread_ts",
+    [
+        (
+            "https://acme.slack.com/archives/C12345ABC/p1700000000123456",
+            "C12345ABC",
+            "1700000000.123456",
+        ),
+        (
+            "https://acme.slack.com/archives/C12345ABC/p1700000000999999?thread_ts=1699999999.000001",
+            "C12345ABC",
+            "1699999999.000001",
+        ),
+        (
+            "https://acme.slack.com/archives/c12345abc/p1700000000123456",
+            "C12345ABC",
+            "1700000000.123456",
+        ),
+    ],
+)
+def test_parse_slack_url_accepts_valid(url, channel, thread_ts):
+    from sources.slack.adapter import parse_slack_url
+
+    parsed = parse_slack_url(url)
+    assert parsed.channel == channel
+    assert parsed.thread_ts == thread_ts
+
+
+@pytest.mark.parametrize(
+    "url",
+    [
+        "https://github.com/foo/bar",
+        "https://acme.slack.com/messages/D12345ABC/p1700000000123456",  # DM
+        "https://acme.slack.com/archives/",
+        "https://acme.slack.com/archives/C12345/p12345",  # ts too short
+        "",
+    ],
+)
+def test_parse_slack_url_rejects_invalid(url):
+    from sources.slack.adapter import parse_slack_url
+
+    with pytest.raises(ValueError):
+        parse_slack_url(url)
+
+
+# ── Normalization ───────────────────────────────────────────────────────────
+
+
+def test_normalize_thread_filters_bot_and_join_messages():
+    from sources.slack.adapter import normalize_thread_to_payload
+
+    messages = [
+        {"ts": "1700000000.000001", "user": "U1", "text": "Real decision"},
+        {
+            "ts": "1700000001.000001",
+            "user": "USLACKBOT",
+            "text": "set channel topic",
+            "subtype": "channel_topic",
+        },
+        {
+            "ts": "1700000002.000001",
+            "user": "U2",
+            "text": "bot autoresponse",
+            "subtype": "bot_message",
+        },
+        {"ts": "1700000003.000001", "user": "U2", "text": "Counter-point"},
+    ]
+    payload = normalize_thread_to_payload(
+        messages,
+        channel="C12345ABC",
+        thread_url="https://acme.slack.com/archives/C12345ABC/p1700000000000001",
+    )
+    assert payload["source"] == "slack"
+    assert len(payload["decisions"]) == 2  # the two human messages
+    assert "Real decision" in payload["decisions"][0]["description"]
+    assert "Counter-point" in payload["decisions"][1]["description"]
+
+
+def test_normalize_thread_dedups_participants():
+    from sources.slack.adapter import normalize_thread_to_payload
+
+    messages = [
+        {"ts": "1700000000.000001", "user": "U1", "text": "first"},
+        {"ts": "1700000001.000001", "user": "U1", "text": "second from same user"},
+        {"ts": "1700000002.000001", "user": "U2", "text": "third"},
+    ]
+    payload = normalize_thread_to_payload(
+        messages,
+        channel="C12345ABC",
+        thread_url="https://acme.slack.com/archives/C12345ABC/p1700000000000001",
+    )
+    assert payload["participants"] == ["U1", "U2"]
+
+
+def test_normalize_thread_resolves_user_to_email_when_resolver_supplied():
+    from sources.slack.adapter import normalize_thread_to_payload
+
+    messages = [
+        {"ts": "1700000000.000001", "user": "U1", "text": "decision"},
+    ]
+    resolver = MagicMock(
+        return_value={
+            "real_name": "Alice",
+            "profile": {"email": "alice@example.com"},
+        }
+    )
+    payload = normalize_thread_to_payload(
+        messages,
+        channel="C12345ABC",
+        thread_url="https://acme.slack.com/archives/C12345ABC/p1700000000000001",
+        user_resolver=resolver,
+    )
+    assert payload["participants"] == ["alice@example.com"]
+
+
+def test_normalize_thread_falls_back_to_name_when_no_email():
+    from sources.slack.adapter import normalize_thread_to_payload
+
+    messages = [{"ts": "1700000000.000001", "user": "U1", "text": "x"}]
+    resolver = MagicMock(return_value={"real_name": "Alice", "profile": {}})
+    payload = normalize_thread_to_payload(
+        messages,
+        channel="C12345ABC",
+        thread_url="https://acme.slack.com/archives/C12345ABC/p1700000000000001",
+        user_resolver=resolver,
+    )
+    assert payload["participants"] == ["Alice"]
+
+
+def test_normalize_thread_falls_back_to_user_id_on_resolver_failure():
+    from sources.slack.adapter import normalize_thread_to_payload
+
+    messages = [{"ts": "1700000000.000001", "user": "U1", "text": "x"}]
+
+    def _failing(_):
+        raise RuntimeError("transient")
+
+    payload = normalize_thread_to_payload(
+        messages,
+        channel="C12345ABC",
+        thread_url="https://acme.slack.com/archives/C12345ABC/p1700000000000001",
+        user_resolver=_failing,
+    )
+    assert payload["participants"] == ["U1"]
+
+
+def test_normalize_thread_date_uses_root_ts_iso():
+    from sources.slack.adapter import normalize_thread_to_payload
+
+    messages = [{"ts": "1700000000.123456", "user": "U1", "text": "x"}]
+    payload = normalize_thread_to_payload(
+        messages,
+        channel="C12345ABC",
+        thread_url="https://acme.slack.com/archives/C12345ABC/p1700000000123456",
+    )
+    # 1700000000 epoch == 2023-11-14T22:13:20Z. Just assert the ISO shape +
+    # that the date field is non-empty.
+    assert payload["date"].startswith("2023-")
+
+
+# ── Client + Adapter integration ────────────────────────────────────────────
+
+
+def test_client_raises_on_ok_false():
+    from sources.slack.client import SlackAPIError, _get
+
+    with patch(
+        "urllib.request.urlopen",
+        return_value=_mock_response({"ok": False, "error": "invalid_auth"}),
+    ):
+        with pytest.raises(SlackAPIError) as exc_info:
+            _get(token="bad", method="conversations.replies")
+    assert exc_info.value.slack_error == "invalid_auth"
+
+
+def test_client_get_thread_replies_paginates():
+    from sources.slack.client import get_thread_replies
+
+    page1 = {
+        "ok": True,
+        "messages": [{"ts": "1700000000.000001", "user": "U1", "text": "a"}],
+        "response_metadata": {"next_cursor": "cursor-1"},
+    }
+    page2 = {
+        "ok": True,
+        "messages": [{"ts": "1700000001.000001", "user": "U1", "text": "b"}],
+        "response_metadata": {"next_cursor": ""},
+    }
+    with patch(
+        "urllib.request.urlopen",
+        side_effect=[_mock_response(page1), _mock_response(page2)],
+    ):
+        msgs = get_thread_replies(token="xoxb-t", channel="C1", thread_ts="1700000000.000001")
+    assert len(msgs) == 2
+
+
+def test_adapter_can_handle_url():
+    from sources.slack.adapter import SlackAdapter
+
+    a = SlackAdapter()
+    assert a.can_handle_url("https://acme.slack.com/archives/C12345ABC/p1700000000123456")
+    assert not a.can_handle_url("https://github.com/foo/bar")
+    assert not a.can_handle_url("https://acme.slack.com/messages/D12345/p1700000000123456")
+
+
+def test_adapter_fetch_active_round_trip(monkeypatch):
+    from secrets_store import put_secret
+    from sources.slack.adapter import SlackAdapter
+
+    put_secret(source_id="slack", key="api_key", value="xoxb-test")
+
+    thread_replies = {
+        "ok": True,
+        "messages": [
+            {"ts": "1700000000.000001", "user": "U1", "text": "Decision A"},
+            {"ts": "1700000001.000001", "user": "U2", "text": "Counter B"},
+        ],
+        "response_metadata": {"next_cursor": ""},
+    }
+    user_u1 = {
+        "ok": True,
+        "user": {"real_name": "Alice", "profile": {"email": "alice@example.com"}},
+    }
+    user_u2 = {
+        "ok": True,
+        "user": {"real_name": "Bob", "profile": {"email": "bob@example.com"}},
+    }
+
+    with patch(
+        "urllib.request.urlopen",
+        side_effect=[
+            _mock_response(thread_replies),
+            _mock_response(user_u1),
+            _mock_response(user_u2),
+        ],
+    ):
+        adapter = SlackAdapter()
+        result = adapter.fetch_active("https://acme.slack.com/archives/C12345ABC/p1700000000000001")
+
+    assert result["source"] == "slack"
+    assert len(result["decisions"]) == 2
+    assert result["participants"] == ["alice@example.com", "bob@example.com"]
+
+
+def test_adapter_raises_when_token_missing():
+    from sources.slack.adapter import SlackAdapter
+
+    a = SlackAdapter()
+    with pytest.raises(RuntimeError, match="bot token not configured"):
+        a.fetch_active("https://acme.slack.com/archives/C12345ABC/p1700000000000001")
+
+
+def test_adapter_raises_on_empty_thread(monkeypatch):
+    from secrets_store import put_secret
+    from sources.slack.adapter import SlackAdapter
+
+    put_secret(source_id="slack", key="api_key", value="xoxb-test")
+
+    with patch(
+        "urllib.request.urlopen",
+        return_value=_mock_response(
+            {"ok": True, "messages": [], "response_metadata": {"next_cursor": ""}}
+        ),
+    ):
+        adapter = SlackAdapter()
+        with pytest.raises(RuntimeError, match="no messages"):
+            adapter.fetch_active("https://acme.slack.com/archives/C12345ABC/p1700000000000001")


### PR DESCRIPTION
## Summary

Adds Slack as an active-ingest source. Operator pastes a thread URL → adapter fetches replies + resolves participants → IngestPayload.

### Deferral revisited

This phase was originally gated on BicameralAI/bicameral-daemon#4 outbound ChannelAdapter landing. On investigation: BicameralAI/bicameral-mcp#354 (the only Slack work in BicameralAI/bicameral-daemon#4's stack) was **closed without merging** and was webhook-based outbound, not OAuth. Slack **ingest** needs bot-token auth — a completely different model. There was no shared scaffolding to wait for, so the deferral premise was wrong. Proceeding with the same operator-stores-bot-token pattern as Linear/Notion/GitHub.

### Surface

- \`sources/slack/client.py\` — stdlib urllib Web API client. Handles Slack's \`ok=false\`-on-HTTP-200 quirk by raising \`SlackAPIError(slack_error="invalid_auth"|...)\`. Reusable for Phase 4b (channel polling).
- \`sources/slack/adapter.py\` — URL parse (\`slack.com/archives/<channel>/p<ts_compact>\`), decision-bearing filter (drops bot_message/join/leave/topic subtypes), participant resolution via users.info (email > name > user_id).

### Policy

- **DMs rejected by URL parser** — channel-only per parent tracker.
- Bot token stored via \`secrets_store source_id="slack", key="api_key"\`.
- Required scopes for the operator's Slack app: \`channels:history\`, \`groups:history\` (the adapter doesn't request \`im:history\` / \`mpim:history\` — DM ingest is explicitly out of scope).

Tests: 20 passing.

Parent tracker: BicameralAI/bicameral-daemon#3.

🤖 Generated with [Claude Code](https://claude.com/claude-code)