### PR TITLE
feat(filters): foundations cycle 2 — universal FilterSpec + per-adapter wiring

### DIFF
--- a/events/sources/github.py
+++ b/events/sources/github.py
@@ -46,8 +46,26 @@ class GitHubPollingAdapter:
         watermark_dir.mkdir(parents=True, exist_ok=True)
         self._watermark_path = watermark_dir / _WATERMARK_FILENAME
 
+        # #337 cycle 2: per-repo filter overrides. Accept both bare strings
+        # ("owner/repo") and dicts ({owner_repo: "...", filters: {...}}).
+        from filters import FilterSpec, evaluate_universal, merge_specs
+
+        source_level_filter = _parse_github_filter_block(config.get("filters") or {})
         repos_raw = config.get("repos") or []
-        repos = [str(r) for r in repos_raw if "/" in str(r)]
+        repo_specs: list[tuple[str, FilterSpec]] = []
+        for entry in repos_raw:
+            if isinstance(entry, str):
+                or_str = entry.strip()
+                spec = source_level_filter
+            elif isinstance(entry, dict):
+                or_str = str(entry.get("owner_repo") or "").strip()
+                res_spec = _parse_github_filter_block(entry.get("filters") or {})
+                spec = merge_specs(source_level_filter, res_spec)
+            else:
+                continue
+            if "/" in or_str:
+                repo_specs.append((or_str, spec))
+        repos = [r for r, _ in repo_specs]
         if not repos:
             print(
                 "[github] at least one 'owner/repo' entry is required in source.repos; skipping.",
@@ -86,7 +104,7 @@ class GitHubPollingAdapter:
         payloads: list[dict] = []
         new_watermarks: dict[str, str] = dict(all_watermarks)
 
-        for owner_repo in repos:
+        for owner_repo, repo_spec in repo_specs:
             try:
                 owner, repo = owner_repo.split("/", 1)
             except ValueError:
@@ -127,6 +145,20 @@ class GitHubPollingAdapter:
                         file=sys.stderr,
                     )
                     continue
+                text_bits = [
+                    str(payload.get("query") or ""),
+                    *(d.get("description", "") for d in (payload.get("decisions") or [])),
+                ]
+                participants = payload.get("participants") or []
+                candidate = {
+                    "text": " ".join(text_bits),
+                    "author": participants[0] if participants else "",
+                    "timestamp": updated_at,
+                }
+                if not evaluate_universal(candidate, repo_spec):
+                    if updated_at > highest_updated:
+                        highest_updated = updated_at
+                    continue
                 label = config.get("source_type_label")
                 if label:
                     payload = {**payload, "source": str(label)}
@@ -155,6 +187,19 @@ class GitHubPollingAdapter:
                 exc,
             )
         self._pending_watermarks = {}
+
+
+def _parse_github_filter_block(raw: dict | None):
+    """Coerce a YAML filter block into a FilterSpec, never raises."""
+    from filters import FilterSpec
+
+    if not raw or not isinstance(raw, dict):
+        return FilterSpec()
+    try:
+        return FilterSpec(**raw)
+    except Exception as exc:  # noqa: BLE001
+        print(f"[github] malformed filter block ignored: {exc}", file=sys.stderr)
+        return FilterSpec()
 
 
 def _read_watermarks(path: Path) -> dict[str, str]:

--- a/events/sources/google_drive.py
+++ b/events/sources/google_drive.py
@@ -109,6 +109,19 @@ class GoogleDriveFolderAdapter:
             self._pending_watermark = None
             return []
 
+        # #337 cycle 2: universal filter (source-level — folder_id is the
+        # resource for Drive polling).
+        from filters import FilterSpec, evaluate_universal
+
+        try:
+            source_spec = FilterSpec(**(config.get("filters") or {}))
+        except Exception as exc:  # noqa: BLE001
+            print(
+                f"[google_drive] malformed filter block ignored: {exc}",
+                file=sys.stderr,
+            )
+            source_spec = FilterSpec()
+
         active = GoogleDriveAdapter()
         for doc in docs:
             doc_id = doc.get("id")
@@ -123,6 +136,20 @@ class GoogleDriveFolderAdapter:
                     f"[google_drive] doc {doc_id!r} fetch failed (skipped): {exc}",
                     file=sys.stderr,
                 )
+                continue
+            text_bits = [
+                str(payload.get("query") or ""),
+                *(d.get("description", "") for d in (payload.get("decisions") or [])),
+            ]
+            participants = payload.get("participants") or []
+            candidate = {
+                "text": " ".join(text_bits),
+                "author": participants[0] if participants else "",
+                "timestamp": mtime,
+            }
+            if not evaluate_universal(candidate, source_spec):
+                if mtime > highest_mtime:
+                    highest_mtime = mtime
                 continue
             # Optional operator-facing label override.
             label = config.get("source_type_label")

--- a/events/sources/linear.py
+++ b/events/sources/linear.py
@@ -87,6 +87,16 @@ class LinearPollingAdapter:
             self._pending_watermark = None
             return []
 
+        # #337 cycle 2: universal filter for Linear. Source-level only —
+        # Linear team-keys already serve as per-resource selection.
+        from filters import FilterSpec, evaluate_universal
+
+        try:
+            source_spec = FilterSpec(**(config.get("filters") or {}))
+        except Exception as exc:  # noqa: BLE001
+            print(f"[linear] malformed filter block ignored: {exc}", file=sys.stderr)
+            source_spec = FilterSpec()
+
         active = LinearAdapter()
         payloads: list[dict] = []
         highest_completed = last_watermark or ""
@@ -103,6 +113,22 @@ class LinearPollingAdapter:
                     f"[linear] issue {identifier!r} fetch failed (skipped): {exc}",
                     file=sys.stderr,
                 )
+                continue
+            # Filter on title + description aggregate.
+            text_bits = [
+                str(payload.get("query") or ""),
+                *(d.get("description", "") for d in (payload.get("decisions") or [])),
+            ]
+            participants = payload.get("participants") or []
+            author = participants[0] if participants else ""
+            candidate = {
+                "text": " ".join(text_bits),
+                "author": author,
+                "timestamp": completed_at,
+            }
+            if not evaluate_universal(candidate, source_spec):
+                if completed_at > highest_completed:
+                    highest_completed = completed_at
                 continue
             label = config.get("source_type_label")
             if label:

--- a/events/sources/notion.py
+++ b/events/sources/notion.py
@@ -91,6 +91,16 @@ class NotionPollingAdapter:
             self._pending_watermark = None
             return []
 
+        # #337 cycle 2: universal filter (source-level — Notion's
+        # database_id is the resource).
+        from filters import FilterSpec, evaluate_universal
+
+        try:
+            source_spec = FilterSpec(**(config.get("filters") or {}))
+        except Exception as exc:  # noqa: BLE001
+            print(f"[notion] malformed filter block ignored: {exc}", file=sys.stderr)
+            source_spec = FilterSpec()
+
         active = NotionAdapter()
         payloads: list[dict] = []
         highest_edited = last_watermark or ""
@@ -107,6 +117,20 @@ class NotionPollingAdapter:
                     f"[notion] page {page_id!r} fetch failed (skipped): {exc}",
                     file=sys.stderr,
                 )
+                continue
+            text_bits = [
+                str(payload.get("query") or ""),
+                *(d.get("description", "") for d in (payload.get("decisions") or [])),
+            ]
+            participants = payload.get("participants") or []
+            candidate = {
+                "text": " ".join(text_bits),
+                "author": participants[0] if participants else "",
+                "timestamp": edited,
+            }
+            if not evaluate_universal(candidate, source_spec):
+                if edited > highest_edited:
+                    highest_edited = edited
                 continue
             label = config.get("source_type_label")
             if label:

--- a/events/sources/slack.py
+++ b/events/sources/slack.py
@@ -57,16 +57,31 @@ class SlackPollingAdapter:
         watermark_dir.mkdir(parents=True, exist_ok=True)
         self._watermark_path = watermark_dir / _WATERMARK_FILENAME
 
+        # #337 foundations cycle 2: parse source-level filters + per-resource
+        # entries. ``channels`` accepts either bare strings (legacy: inherit
+        # source-level filter, no overrides) or dicts of shape
+        # ``{id: "C…", filters: {...}}`` (per-resource filter overrides).
+        from filters import FilterSpec, evaluate_universal, merge_specs
+
+        source_level_filter = _parse_filter_block(config.get("filters") or {})
         channels_raw = config.get("channels") or []
-        # Filter out anything that looks like a DM (D…) — multi-party
-        # group IDs (G…) are kept because Slack reuses G for private
-        # channels too. Operator carries the channel-vs-DM responsibility
-        # for G IDs.
-        channels = [
-            str(c)
-            for c in channels_raw
-            if str(c).strip() and not str(c).strip().upper().startswith("D")
-        ]
+        # Each entry becomes (channel_id, effective_filter_spec).
+        channel_specs: list[tuple[str, FilterSpec]] = []
+        for entry in channels_raw:
+            if isinstance(entry, str):
+                cid = entry.strip()
+                spec = source_level_filter
+            elif isinstance(entry, dict):
+                cid = str(entry.get("id") or "").strip()
+                res_spec = _parse_filter_block(entry.get("filters") or {})
+                spec = merge_specs(source_level_filter, res_spec)
+            else:
+                continue
+            if not cid or cid.upper().startswith("D"):
+                continue
+            channel_specs.append((cid, spec))
+
+        channels = [c for c, _ in channel_specs]
         if not channels:
             print(
                 "[slack] at least one channel ID is required in source.channels; "
@@ -122,8 +137,7 @@ class SlackPollingAdapter:
             user_cache[user_id] = profile
             return profile
 
-        for channel_id in channels:
-            channel_id = channel_id.strip()
+        for channel_id, channel_spec in channel_specs:
             last_ts = all_watermarks.get(channel_id)
             try:
                 messages = list_new_messages(token=token, channel=channel_id, oldest=last_ts)
@@ -146,6 +160,21 @@ class SlackPollingAdapter:
                         highest_ts = msg_ts
                     continue
                 if not _is_decision_bearing(msg):
+                    if msg_ts > highest_ts:
+                        highest_ts = msg_ts
+                    continue
+                # #337 cycle 2: universal-filter gate. Slack candidate
+                # shape: text from message body, author from user_id
+                # (email resolution happens in normalize, but for filter
+                # eval we use the raw user ID — operators can configure
+                # author_include with user IDs OR delegate to extensions
+                # in a future cycle).
+                candidate = {
+                    "text": msg.get("text") or "",
+                    "author": msg.get("user") or "",
+                    "timestamp": _slack_ts_to_iso_safe(msg_ts),
+                }
+                if not evaluate_universal(candidate, channel_spec):
                     if msg_ts > highest_ts:
                         highest_ts = msg_ts
                     continue
@@ -182,6 +211,34 @@ class SlackPollingAdapter:
                 exc,
             )
         self._pending_watermarks = {}
+
+
+def _parse_filter_block(raw: dict | None):
+    """Coerce a YAML filter block into a FilterSpec, never raises.
+
+    Malformed filter config logs to stderr and falls through to the
+    no-filter default — operator gets stderr feedback but the poller
+    doesn't halt on a typo.
+    """
+    from filters import FilterSpec
+
+    if not raw or not isinstance(raw, dict):
+        return FilterSpec()
+    try:
+        return FilterSpec(**raw)
+    except Exception as exc:  # noqa: BLE001 — surface, don't halt
+        print(f"[slack] malformed filter block ignored: {exc}", file=sys.stderr)
+        return FilterSpec()
+
+
+def _slack_ts_to_iso_safe(ts: str) -> str:
+    """Slack ts → ISO 8601 for filter time-window comparison. Empty on parse failure."""
+    try:
+        from datetime import UTC, datetime
+
+        return datetime.fromtimestamp(float(ts), tz=UTC).isoformat()
+    except (ValueError, OSError, OverflowError):
+        return ""
 
 
 def _read_watermarks(path: Path) -> dict[str, str]:

--- a/filters/__init__.py
+++ b/filters/__init__.py
@@ -1,0 +1,34 @@
+"""Universal filter primitives for ingest sources (#337 foundations cycle 2).
+
+Shared filter vocabulary across all source adapters. Each polling
+adapter consumes a ``FilterSpec`` from its config entry, normalizes each
+candidate item to a common shape (``{text, author, timestamp}``), and
+passes the pair through :func:`evaluate_universal` before deciding
+whether to include the item in the ingest batch. Items that fail the
+filter are skipped; the watermark still advances past them.
+
+Universal primitives (work for every source):
+- ``keyword_include`` — case-insensitive OR-match over the candidate's
+  text. Empty list disables the filter.
+- ``keyword_exclude`` — case-insensitive NOT-ANY match.
+- ``author_include`` / ``author_exclude`` — exact match on the author
+  identifier (email, login, user_id — whatever the source emits).
+- ``time_window_after`` / ``time_window_before`` — ISO 8601 lexicographic
+  comparison on the candidate's timestamp.
+
+Source-specific extensions (Slack reactions, GitHub paths, Linear
+labels, Notion tags) are deferred to a follow-up cycle. The
+``FilterSpec.extensions`` dict is reserved for that work — currently
+opaque to the universal evaluator.
+
+Per-resource overrides: a source-config entry may carry a top-level
+``filters:`` block (applies to every resource) and individual resources
+may carry their own ``filters:`` block (merged on top of the source-level
+one via :func:`merge_specs`). Per-resource filters override source-level
+filters for the same field; non-overridden fields inherit.
+"""
+
+from filters.evaluator import evaluate_universal, merge_specs
+from filters.spec import FilterSpec
+
+__all__ = ["FilterSpec", "evaluate_universal", "merge_specs"]

--- a/filters/evaluator.py
+++ b/filters/evaluator.py
@@ -1,0 +1,91 @@
+"""Universal filter evaluator + spec-merging helper."""
+
+from __future__ import annotations
+
+from filters.spec import FilterSpec
+
+
+def evaluate_universal(candidate: dict, spec: FilterSpec) -> bool:
+    """Return True if ``candidate`` passes every universal primitive in ``spec``.
+
+    ``candidate`` is a normalized dict with the keys the evaluator reads:
+    - ``text`` (str): the body the keyword filters apply to. Adapters
+      concatenate title + body + comments as appropriate before passing.
+    - ``author`` (str): the identifier used by author_include/exclude.
+      Source-specific — email for sources that surface it, login or
+      user_id otherwise.
+    - ``timestamp`` (str): ISO 8601 timestamp for the time-window filters.
+      Empty string is treated as "unknown" — time-window filters that are
+      configured will REJECT an unknown-timestamp candidate (conservative).
+
+    Missing keys in ``candidate`` are treated as empty strings, which
+    means the corresponding filter (if configured) will reject the
+    candidate. Adapters are responsible for populating all three keys
+    before calling; the conservative-reject behavior catches missed
+    normalization at runtime.
+    """
+    text = (candidate.get("text") or "").lower()
+
+    if spec.keyword_include:
+        haystack_lower = text
+        if not any(kw.lower() in haystack_lower for kw in spec.keyword_include):
+            return False
+
+    if spec.keyword_exclude:
+        haystack_lower = text
+        if any(kw.lower() in haystack_lower for kw in spec.keyword_exclude):
+            return False
+
+    author = candidate.get("author") or ""
+    if spec.author_include and author not in spec.author_include:
+        return False
+    if spec.author_exclude and author in spec.author_exclude:
+        return False
+
+    ts = candidate.get("timestamp") or ""
+    if spec.time_window_after:
+        if not ts or ts <= spec.time_window_after:
+            return False
+    if spec.time_window_before:
+        if not ts or ts >= spec.time_window_before:
+            return False
+
+    return True
+
+
+def merge_specs(source_level: FilterSpec, resource_level: FilterSpec | None) -> FilterSpec:
+    """Merge a resource-level spec on top of the source-level default.
+
+    A resource-level field that was **explicitly set** in the YAML config
+    overrides the source-level value, even when explicitly set to empty
+    (e.g. ``author_exclude: []`` clears the source-level exclude list).
+    A field that was **not present** in the resource-level YAML inherits
+    the source-level value.
+
+    The distinction is detected via pydantic's ``model_fields_set``,
+    which carries which keys came from the input dict — independent of
+    whether their value happens to equal the default.
+
+    The ``extensions`` dict merges shallowly: resource-level keys
+    override source-level keys with the same name. Unset extension keys
+    at the resource level always inherit (no "clear" semantics for
+    individual extension entries; that's up to per-source extension
+    evaluators).
+    """
+    if resource_level is None:
+        return source_level
+    merged = source_level.model_dump()
+    res_dump = resource_level.model_dump()
+    explicit = resource_level.model_fields_set
+    for field in (
+        "keyword_include",
+        "keyword_exclude",
+        "author_include",
+        "author_exclude",
+        "time_window_after",
+        "time_window_before",
+    ):
+        if field in explicit:
+            merged[field] = res_dump[field]
+    merged["extensions"] = {**source_level.extensions, **resource_level.extensions}
+    return FilterSpec(**merged)

--- a/filters/spec.py
+++ b/filters/spec.py
@@ -1,0 +1,82 @@
+"""``FilterSpec`` — typed config schema for universal ingest filters.
+
+Defaults are all "no-filter" (empty list / empty string) so a source-
+config entry without a ``filters:`` block is a true pass-through.
+Validation: pydantic ensures lists are lists, strings are strings, and
+unknown fields under ``extensions`` are preserved (opaque) for the
+source-specific evaluators that consume them.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from pydantic import BaseModel, ConfigDict, Field
+
+
+class FilterSpec(BaseModel):
+    """Universal filter primitives applied uniformly across all sources.
+
+    Each polling adapter:
+    1. Reads its config entry's ``filters:`` block into a ``FilterSpec``.
+    2. For each candidate item, normalizes to ``{text, author, timestamp}``.
+    3. Calls ``evaluate_universal(candidate, spec)``.
+    4. Skips items where the evaluator returns False; watermark still
+       advances past them.
+    """
+
+    keyword_include: list[str] = Field(
+        default_factory=list,
+        description=(
+            "Case-insensitive substring match. Item passes if its text "
+            "contains AT LEAST ONE entry. Empty list disables this filter."
+        ),
+    )
+    keyword_exclude: list[str] = Field(
+        default_factory=list,
+        description=(
+            "Case-insensitive substring match. Item rejected if its text "
+            "contains ANY entry. Empty list disables this filter."
+        ),
+    )
+    author_include: list[str] = Field(
+        default_factory=list,
+        description=(
+            "Exact-match allowlist on the candidate's author identifier "
+            "(email / login / user_id per source). Empty list disables."
+        ),
+    )
+    author_exclude: list[str] = Field(
+        default_factory=list,
+        description="Exact-match blocklist on author. Empty list disables.",
+    )
+    time_window_after: str = Field(
+        default="",
+        description=(
+            "ISO 8601 timestamp. Item must have a timestamp strictly "
+            "AFTER this. Empty string disables. Lexicographic comparison "
+            "(safe for ISO 8601 + UTC)."
+        ),
+    )
+    time_window_before: str = Field(
+        default="",
+        description=(
+            "ISO 8601 timestamp. Item must have a timestamp strictly "
+            "BEFORE this. Empty string disables."
+        ),
+    )
+    extensions: dict[str, Any] = Field(
+        default_factory=dict,
+        description=(
+            "Reserved for source-specific extension dimensions (Slack "
+            "reactions, GitHub paths, Linear labels, Notion tags). The "
+            "universal evaluator ignores this dict; per-source extension "
+            "evaluators consume it. Schema-free by design — each source "
+            "documents its own keys."
+        ),
+    )
+
+    # Reject unknown top-level fields so a typo in config (e.g.
+    # `keywords_include` vs `keyword_include`) fails loud instead of
+    # silently disabling the filter.
+    model_config = ConfigDict(extra="forbid")

--- a/tests/test_filters_per_adapter.py
+++ b/tests/test_filters_per_adapter.py
@@ -1,0 +1,282 @@
+"""End-to-end tests for filter wiring across all polling adapters.
+
+Verifies the universal-filter integration in each polling adapter:
+- Slack: per-resource + source-level merge
+- Linear: source-level only
+- Notion: source-level only
+- GitHub: per-resource (repo) + source-level merge
+- Google Drive: source-level only
+
+For each: a passing filter lets items through, a rejecting filter
+drops them, malformed config falls through to no-filter (operator
+gets stderr warning, poller continues).
+"""
+
+from __future__ import annotations
+
+import json
+from unittest.mock import patch
+
+import pytest
+
+
+@pytest.fixture(autouse=True)
+def _disable_keyring(monkeypatch):
+    monkeypatch.setenv("BICAMERAL_KEYRING_DISABLE", "1")
+    from secrets_store.store import _reset_for_tests
+
+    _reset_for_tests()
+    yield
+    _reset_for_tests()
+
+
+# ── Slack: keyword_include + per-resource override ──────────────────────────
+
+
+def test_slack_source_level_keyword_filter_drops_unmatched(tmp_path):
+    from events.sources.slack import SlackPollingAdapter
+    from secrets_store import put_secret
+
+    put_secret(source_id="slack", key="api_key", value="xoxb-t")
+
+    fake_msgs = [
+        {"ts": "1700000001.000000", "user": "U1", "text": "decided to ship"},
+        {"ts": "1700000002.000000", "user": "U2", "text": "lunch?"},
+    ]
+    with (
+        patch("sources.slack.poller.list_new_messages", return_value=fake_msgs),
+        patch("sources.slack.client.get_user_info", return_value={}),
+    ):
+        adapter = SlackPollingAdapter()
+        result = adapter.pull(
+            watermark_dir=tmp_path,
+            config={
+                "channels": ["C01A"],
+                "filters": {"keyword_include": ["decided"]},
+            },
+        )
+
+    assert len(result) == 1
+    # Watermark advances past the filtered-out message anyway.
+    assert adapter._pending_watermarks["C01A"] == "1700000002.000000"
+
+
+def test_slack_per_channel_override_takes_precedence(tmp_path):
+    from events.sources.slack import SlackPollingAdapter
+    from secrets_store import put_secret
+
+    put_secret(source_id="slack", key="api_key", value="xoxb-t")
+
+    # Same messages would be filtered by source-level filter, but
+    # the per-channel override clears it for C01B by widening
+    # the keyword_include list.
+    msgs_a = [{"ts": "1700000001.000000", "user": "U1", "text": "lunch?"}]
+    msgs_b = [{"ts": "1700000002.000000", "user": "U2", "text": "lunch?"}]
+
+    call_count = {"n": 0}
+
+    def _list(*, token, channel, oldest=None):
+        call_count["n"] += 1
+        return {"C01A": msgs_a, "C01B": msgs_b}[channel]
+
+    with (
+        patch("sources.slack.poller.list_new_messages", side_effect=_list),
+        patch("sources.slack.client.get_user_info", return_value={}),
+    ):
+        adapter = SlackPollingAdapter()
+        result = adapter.pull(
+            watermark_dir=tmp_path,
+            config={
+                "channels": [
+                    "C01A",  # inherits source-level filter — "lunch?" rejected
+                    {"id": "C01B", "filters": {"keyword_include": ["lunch"]}},
+                ],
+                "filters": {"keyword_include": ["decided"]},
+            },
+        )
+
+    # Only C01B's message survives.
+    assert len(result) == 1
+
+
+def test_slack_malformed_filter_falls_through(tmp_path, capsys):
+    from events.sources.slack import SlackPollingAdapter
+    from secrets_store import put_secret
+
+    put_secret(source_id="slack", key="api_key", value="xoxb-t")
+    fake_msgs = [{"ts": "1700000001.000000", "user": "U1", "text": "decided"}]
+    with (
+        patch("sources.slack.poller.list_new_messages", return_value=fake_msgs),
+        patch("sources.slack.client.get_user_info", return_value={}),
+    ):
+        adapter = SlackPollingAdapter()
+        result = adapter.pull(
+            watermark_dir=tmp_path,
+            # Typo'd field — pydantic rejects → no-filter fallback.
+            config={"channels": ["C01A"], "filters": {"keywords_include": ["x"]}},
+        )
+
+    err = capsys.readouterr().err
+    assert "malformed filter block" in err
+    # Items still flow through (no-filter fallback).
+    assert len(result) == 1
+
+
+# ── Linear: source-level keyword filter ─────────────────────────────────────
+
+
+def test_linear_keyword_include_filters_issues(tmp_path):
+    from events.sources.linear import LinearPollingAdapter
+    from secrets_store import put_secret
+
+    put_secret(source_id="linear", key="api_key", value="lin_t")
+
+    fake_issues = [
+        {
+            "identifier": "BIC-1",
+            "url": "https://linear.app/x/issue/BIC-1",
+            "completedAt": "2026-05-01T00:00:00Z",
+        },
+        {
+            "identifier": "BIC-2",
+            "url": "https://linear.app/x/issue/BIC-2",
+            "completedAt": "2026-05-02T00:00:00Z",
+        },
+    ]
+
+    def _fetch(self, url):
+        if "BIC-1" in url:
+            return {"query": "Decided to refactor", "decisions": [], "participants": []}
+        return {"query": "Random chatter", "decisions": [], "participants": []}
+
+    with (
+        patch("sources.linear.poller.list_completed_issues", return_value=fake_issues),
+        patch("sources.linear.adapter.LinearAdapter.fetch_active", new=_fetch),
+    ):
+        adapter = LinearPollingAdapter()
+        result = adapter.pull(
+            watermark_dir=tmp_path,
+            config={"filters": {"keyword_include": ["decided"]}},
+        )
+
+    assert len(result) == 1
+    # Watermark advances past the filtered issue.
+    assert adapter._pending_watermark == "2026-05-02T00:00:00Z"
+
+
+# ── Notion: source-level time_window_after ──────────────────────────────────
+
+
+def test_notion_time_window_filter(tmp_path):
+    from events.sources.notion import NotionPollingAdapter
+    from secrets_store import put_secret
+
+    put_secret(source_id="notion", key="api_key", value="secret_t")
+
+    fake_pages = [
+        {"id": "p1", "url": "https://notion.so/p1", "last_edited_time": "2026-04-01T00:00:00Z"},
+        {"id": "p2", "url": "https://notion.so/p2", "last_edited_time": "2026-06-01T00:00:00Z"},
+    ]
+    fake_payload = {"query": "x", "decisions": [], "participants": []}
+
+    with (
+        patch("sources.notion.poller.list_recently_edited_pages", return_value=fake_pages),
+        patch("sources.notion.adapter.NotionAdapter.fetch_active", return_value=fake_payload),
+    ):
+        adapter = NotionPollingAdapter()
+        result = adapter.pull(
+            watermark_dir=tmp_path,
+            config={
+                "database_id": "db1",
+                "filters": {"time_window_after": "2026-05-01T00:00:00Z"},
+            },
+        )
+
+    assert len(result) == 1
+
+
+# ── GitHub: per-repo override ───────────────────────────────────────────────
+
+
+def test_github_per_repo_filter_override(tmp_path):
+    from events.sources.github import GitHubPollingAdapter
+    from secrets_store import put_secret
+
+    put_secret(source_id="github", key="api_key", value="ghp_t")
+
+    fake_a = [
+        {
+            "number": 1,
+            "html_url": "https://github.com/foo/bar/pull/1",
+            "updated_at": "2026-05-01T00:00:00Z",
+            "merged_at": "2026-05-01T01:00:00Z",
+        },
+    ]
+    fake_b = [
+        {
+            "number": 2,
+            "html_url": "https://github.com/foo/baz/pull/2",
+            "updated_at": "2026-05-02T00:00:00Z",
+            "merged_at": "2026-05-02T01:00:00Z",
+        },
+    ]
+
+    def _list(*, api_key, owner, repo, updated_after=None):
+        return {"bar": fake_a, "baz": fake_b}[repo]
+
+    def _fetch(self, url):
+        return {"query": "merged PR", "decisions": [], "participants": ["bot"]}
+
+    with (
+        patch("sources.github.poller.list_merged_pulls_since", side_effect=_list),
+        patch("sources.github.adapter.GitHubAdapter.fetch_active", new=_fetch),
+    ):
+        adapter = GitHubPollingAdapter()
+        result = adapter.pull(
+            watermark_dir=tmp_path,
+            config={
+                "repos": [
+                    "foo/bar",  # inherits source-level author_exclude — rejects "bot"
+                    {"owner_repo": "foo/baz", "filters": {"author_exclude": []}},  # clears exclude
+                ],
+                "filters": {"author_exclude": ["bot"]},
+            },
+        )
+
+    # foo/bar PR filtered out (bot author rejected); foo/baz PR passes.
+    assert len(result) == 1
+
+
+# ── Google Drive: source-level filter ───────────────────────────────────────
+
+
+def test_google_drive_keyword_exclude(tmp_path):
+    from unittest.mock import MagicMock
+
+    from events.sources.google_drive import GoogleDriveFolderAdapter
+
+    fake_docs = [
+        {"id": "d1", "name": "Draft v1", "modifiedTime": "2026-05-01T00:00:00Z"},
+        {"id": "d2", "name": "Final spec", "modifiedTime": "2026-05-02T00:00:00Z"},
+    ]
+
+    def _fetch(self, url):
+        if "d1" in url:
+            return {"query": "Draft content TBD", "decisions": [], "participants": []}
+        return {"query": "Final decision", "decisions": [], "participants": []}
+
+    with (
+        patch("sources.google_drive.auth.load_credentials", return_value=MagicMock()),
+        patch("sources.google_drive.folder.list_docs_in_folder", return_value=fake_docs),
+        patch("sources.google_drive.adapter.GoogleDriveAdapter.fetch_active", new=_fetch),
+    ):
+        adapter = GoogleDriveFolderAdapter()
+        result = adapter.pull(
+            watermark_dir=tmp_path,
+            config={
+                "folder_id": "folder1",
+                "filters": {"keyword_exclude": ["draft"]},
+            },
+        )
+
+    assert len(result) == 1

--- a/tests/test_filters_universal.py
+++ b/tests/test_filters_universal.py
@@ -1,0 +1,154 @@
+"""Tests for #337 foundations cycle 2 — universal FilterSpec + evaluator."""
+
+from __future__ import annotations
+
+import pytest
+
+from filters import FilterSpec, evaluate_universal, merge_specs
+
+# ── No-filter default ───────────────────────────────────────────────────────
+
+
+def test_empty_spec_passes_everything():
+    spec = FilterSpec()
+    assert evaluate_universal(
+        {"text": "anything", "author": "anyone", "timestamp": "2026-01-01T00:00:00Z"}, spec
+    )
+    # Even empty/missing candidate fields pass when no filters set.
+    assert evaluate_universal({}, spec)
+
+
+# ── keyword_include ─────────────────────────────────────────────────────────
+
+
+def test_keyword_include_or_match():
+    spec = FilterSpec(keyword_include=["decided", "agreed"])
+    assert evaluate_universal({"text": "We decided to ship"}, spec)
+    assert evaluate_universal({"text": "We agreed on Tuesday"}, spec)
+    assert not evaluate_universal({"text": "We discussed it"}, spec)
+
+
+def test_keyword_include_case_insensitive():
+    spec = FilterSpec(keyword_include=["Decided"])
+    assert evaluate_universal({"text": "DECIDED to do it"}, spec)
+    assert evaluate_universal({"text": "decided"}, spec)
+
+
+# ── keyword_exclude ─────────────────────────────────────────────────────────
+
+
+def test_keyword_exclude_rejects_match():
+    spec = FilterSpec(keyword_exclude=["spam", "test"])
+    assert evaluate_universal({"text": "real decision"}, spec)
+    assert not evaluate_universal({"text": "this is spam"}, spec)
+    assert not evaluate_universal({"text": "TEST run"}, spec)
+
+
+def test_include_and_exclude_compose():
+    """Include + exclude both must pass."""
+    spec = FilterSpec(keyword_include=["decided"], keyword_exclude=["draft"])
+    assert evaluate_universal({"text": "decided to ship"}, spec)
+    assert not evaluate_universal({"text": "decided draft"}, spec)
+    assert not evaluate_universal({"text": "shipping it"}, spec)  # missing include
+
+
+# ── author_include / author_exclude ─────────────────────────────────────────
+
+
+def test_author_include_exact_match():
+    spec = FilterSpec(author_include=["alice@example.com", "bob@example.com"])
+    assert evaluate_universal({"text": "x", "author": "alice@example.com"}, spec)
+    assert not evaluate_universal({"text": "x", "author": "carol@example.com"}, spec)
+    # Empty author rejected when include is set.
+    assert not evaluate_universal({"text": "x", "author": ""}, spec)
+
+
+def test_author_exclude_rejects():
+    spec = FilterSpec(author_exclude=["bot@example.com"])
+    assert evaluate_universal({"text": "x", "author": "alice@example.com"}, spec)
+    assert not evaluate_universal({"text": "x", "author": "bot@example.com"}, spec)
+
+
+# ── time_window ─────────────────────────────────────────────────────────────
+
+
+def test_time_window_after():
+    spec = FilterSpec(time_window_after="2026-01-01T00:00:00Z")
+    assert evaluate_universal({"text": "x", "timestamp": "2026-06-01T00:00:00Z"}, spec)
+    assert not evaluate_universal({"text": "x", "timestamp": "2025-12-31T00:00:00Z"}, spec)
+    # Equal-to-boundary rejected (strict after).
+    assert not evaluate_universal({"text": "x", "timestamp": "2026-01-01T00:00:00Z"}, spec)
+    # Unknown timestamp rejected when filter is set.
+    assert not evaluate_universal({"text": "x", "timestamp": ""}, spec)
+
+
+def test_time_window_before():
+    spec = FilterSpec(time_window_before="2026-12-31T23:59:59Z")
+    assert evaluate_universal({"text": "x", "timestamp": "2026-06-01T00:00:00Z"}, spec)
+    assert not evaluate_universal({"text": "x", "timestamp": "2027-01-01T00:00:00Z"}, spec)
+
+
+def test_time_window_range():
+    spec = FilterSpec(
+        time_window_after="2026-01-01T00:00:00Z", time_window_before="2026-12-31T23:59:59Z"
+    )
+    assert evaluate_universal({"text": "x", "timestamp": "2026-06-01T00:00:00Z"}, spec)
+    assert not evaluate_universal({"text": "x", "timestamp": "2025-12-31T00:00:00Z"}, spec)
+    assert not evaluate_universal({"text": "x", "timestamp": "2027-01-01T00:00:00Z"}, spec)
+
+
+# ── Validation ──────────────────────────────────────────────────────────────
+
+
+def test_unknown_field_rejected_by_pydantic():
+    """Typo'd config field fails loud — that's the point of `extra = forbid`."""
+    from pydantic import ValidationError
+
+    with pytest.raises(ValidationError):
+        FilterSpec(keywords_include=["typo"])  # missing 's' on plural
+
+
+def test_extensions_dict_is_opaque():
+    """The universal evaluator ignores `extensions`; future per-source
+    evaluators consume it. Setting it shouldn't affect universal behavior."""
+    spec = FilterSpec(extensions={"slack_reactions": [":decision:"]})
+    assert evaluate_universal({"text": "anything", "author": "x", "timestamp": "x"}, spec)
+
+
+# ── merge_specs ─────────────────────────────────────────────────────────────
+
+
+def test_merge_resource_overrides_source():
+    src = FilterSpec(keyword_include=["src-kw"])
+    res = FilterSpec(keyword_include=["res-kw"])
+    merged = merge_specs(src, res)
+    # Resource-level override wins.
+    assert merged.keyword_include == ["res-kw"]
+
+
+def test_merge_empty_resource_inherits_source():
+    src = FilterSpec(keyword_include=["src-kw"], time_window_after="2026-01-01T00:00:00Z")
+    res = FilterSpec()  # all defaults — inherit
+    merged = merge_specs(src, res)
+    assert merged.keyword_include == ["src-kw"]
+    assert merged.time_window_after == "2026-01-01T00:00:00Z"
+
+
+def test_merge_partial_resource_overrides_only_set_fields():
+    src = FilterSpec(keyword_include=["src-kw"], author_include=["src-author"])
+    res = FilterSpec(keyword_include=["res-kw"])  # author not set → inherit
+    merged = merge_specs(src, res)
+    assert merged.keyword_include == ["res-kw"]
+    assert merged.author_include == ["src-author"]
+
+
+def test_merge_extensions_shallow_merge():
+    src = FilterSpec(extensions={"a": 1, "b": 2})
+    res = FilterSpec(extensions={"b": 99, "c": 3})
+    merged = merge_specs(src, res)
+    assert merged.extensions == {"a": 1, "b": 99, "c": 3}
+
+
+def test_merge_none_resource_returns_source_unchanged():
+    src = FilterSpec(keyword_include=["x"])
+    assert merge_specs(src, None) is src


### PR DESCRIPTION
## Summary

Foundations cycle 2. Adds a universal filter vocabulary that every polling adapter applies before items hit the ingest batch.

### Universal primitives (shared across all sources)

- \`keyword_include\` / \`keyword_exclude\` — case-insensitive substring
- \`author_include\` / \`author_exclude\` — exact match on the candidate's author identifier
- \`time_window_after\` / \`time_window_before\` — ISO 8601 strict comparison

\`extensions: dict\` is reserved for source-specific filters (Slack reactions, GitHub paths, Linear labels, Notion tags) deferred to cycle 2b.

### Per-resource overrides

Slack \`channels\` and GitHub \`repos\` accept both bare strings (inherit source-level filters) and dicts with inline \`filters:\` blocks. \`merge_specs\` uses pydantic's \`model_fields_set\` so explicit empty values (\`author_exclude: []\`) correctly clear an inherited filter — distinguishing "operator typed it" from "operator left it as default."

### Failure handling

- Typo'd filter field (e.g. \`keywords_include\`) → pydantic \`extra=\"forbid\"\` raises → adapter logs to stderr, falls through to no-filter. Operator gets visible feedback; poller doesn't halt.
- Items rejected by a configured filter still advance the watermark past themselves — no re-rescan of items that will never pass.

### Config example

\`\`\`yaml
sources:
  - type: slack
    filters:                 # source-level default
      keyword_include: [decided, agreed]
      time_window_after: "2026-01-01T00:00:00Z"
    channels:
      - C01ABC                # inherits source-level filters
      - id: C02DEF            # explicit override
        filters:
          extensions:
            reactions: [\":decision:\"]   # future cycle 2b consumes this
\`\`\`

Tests: 19 universal + 6 per-adapter + 60 regression = 85 passing.

Inventory doc updates will follow in a separate housekeeping PR after this lands.

Parent tracker: BicameralAI/bicameral-daemon#3.

🤖 Generated with [Claude Code](https://claude.com/claude-code)