### PR TITLE
feat(filters): foundations cycle 3 — content evaluation hook

### DIFF
--- a/events/sources/github.py
+++ b/events/sources/github.py
@@ -48,7 +48,7 @@ class GitHubPollingAdapter:
 
         # #337 cycle 2: per-repo filter overrides. Accept both bare strings
         # ("owner/repo") and dicts ({owner_repo: "...", filters: {...}}).
-        from filters import FilterSpec, evaluate_universal, merge_specs
+        from filters import FilterSpec, evaluate_filters, merge_specs
 
         source_level_filter = _parse_github_filter_block(config.get("filters") or {})
         repos_raw = config.get("repos") or []
@@ -155,7 +155,7 @@ class GitHubPollingAdapter:
                     "author": participants[0] if participants else "",
                     "timestamp": updated_at,
                 }
-                if not evaluate_universal(candidate, repo_spec):
+                if not evaluate_filters(candidate, repo_spec):
                     if updated_at > highest_updated:
                         highest_updated = updated_at
                     continue

--- a/events/sources/google_drive.py
+++ b/events/sources/google_drive.py
@@ -111,7 +111,7 @@ class GoogleDriveFolderAdapter:
 
         # #337 cycle 2: universal filter (source-level — folder_id is the
         # resource for Drive polling).
-        from filters import FilterSpec, evaluate_universal
+        from filters import FilterSpec, evaluate_filters
 
         try:
             source_spec = FilterSpec(**(config.get("filters") or {}))
@@ -147,7 +147,7 @@ class GoogleDriveFolderAdapter:
                 "author": participants[0] if participants else "",
                 "timestamp": mtime,
             }
-            if not evaluate_universal(candidate, source_spec):
+            if not evaluate_filters(candidate, source_spec):
                 if mtime > highest_mtime:
                     highest_mtime = mtime
                 continue

--- a/events/sources/linear.py
+++ b/events/sources/linear.py
@@ -89,7 +89,7 @@ class LinearPollingAdapter:
 
         # #337 cycle 2: universal filter for Linear. Source-level only —
         # Linear team-keys already serve as per-resource selection.
-        from filters import FilterSpec, evaluate_universal
+        from filters import FilterSpec, evaluate_filters
 
         try:
             source_spec = FilterSpec(**(config.get("filters") or {}))
@@ -126,7 +126,7 @@ class LinearPollingAdapter:
                 "author": author,
                 "timestamp": completed_at,
             }
-            if not evaluate_universal(candidate, source_spec):
+            if not evaluate_filters(candidate, source_spec):
                 if completed_at > highest_completed:
                     highest_completed = completed_at
                 continue

--- a/events/sources/notion.py
+++ b/events/sources/notion.py
@@ -93,7 +93,7 @@ class NotionPollingAdapter:
 
         # #337 cycle 2: universal filter (source-level — Notion's
         # database_id is the resource).
-        from filters import FilterSpec, evaluate_universal
+        from filters import FilterSpec, evaluate_filters
 
         try:
             source_spec = FilterSpec(**(config.get("filters") or {}))
@@ -128,7 +128,7 @@ class NotionPollingAdapter:
                 "author": participants[0] if participants else "",
                 "timestamp": edited,
             }
-            if not evaluate_universal(candidate, source_spec):
+            if not evaluate_filters(candidate, source_spec):
                 if edited > highest_edited:
                     highest_edited = edited
                 continue

--- a/events/sources/slack.py
+++ b/events/sources/slack.py
@@ -61,7 +61,7 @@ class SlackPollingAdapter:
         # entries. ``channels`` accepts either bare strings (legacy: inherit
         # source-level filter, no overrides) or dicts of shape
         # ``{id: "C…", filters: {...}}`` (per-resource filter overrides).
-        from filters import FilterSpec, evaluate_universal, merge_specs
+        from filters import FilterSpec, evaluate_filters, merge_specs
 
         source_level_filter = _parse_filter_block(config.get("filters") or {})
         channels_raw = config.get("channels") or []
@@ -174,7 +174,7 @@ class SlackPollingAdapter:
                     "author": msg.get("user") or "",
                     "timestamp": _slack_ts_to_iso_safe(msg_ts),
                 }
-                if not evaluate_universal(candidate, channel_spec):
+                if not evaluate_filters(candidate, channel_spec):
                     if msg_ts > highest_ts:
                         highest_ts = msg_ts
                     continue

--- a/filters/__init__.py
+++ b/filters/__init__.py
@@ -28,7 +28,18 @@ one via :func:`merge_specs`). Per-resource filters override source-level
 filters for the same field; non-overridden fields inherit.
 """
 
-from filters.evaluator import evaluate_universal, merge_specs
+from filters.evaluator import (
+    evaluate_filters,
+    evaluate_universal,
+    merge_specs,
+    run_eval_hook,
+)
 from filters.spec import FilterSpec
 
-__all__ = ["FilterSpec", "evaluate_universal", "merge_specs"]
+__all__ = [
+    "FilterSpec",
+    "evaluate_filters",
+    "evaluate_universal",
+    "merge_specs",
+    "run_eval_hook",
+]

--- a/filters/evaluator.py
+++ b/filters/evaluator.py
@@ -2,7 +2,30 @@
 
 from __future__ import annotations
 
+from collections.abc import Callable
+from typing import Any
+
 from filters.spec import FilterSpec
+
+
+def evaluate_filters(candidate: dict, spec: FilterSpec) -> bool:
+    """Combined filter gate: universal primitives + content-eval hook.
+
+    Adapters call this once per candidate. Returns True iff the
+    candidate passes both layers:
+
+    1. :func:`evaluate_universal` — declarative primitives. Cheap.
+    2. :func:`run_eval_hook` — operator-defined callable (only invoked
+       when ``spec.eval_hook`` is non-empty). Expensive.
+
+    The two-layer ordering keeps the operator hook on the hot path only
+    for candidates that already survived the cheap declarative filter.
+    """
+    if not evaluate_universal(candidate, spec):
+        return False
+    if spec.eval_hook:
+        return run_eval_hook(spec.eval_hook, candidate)
+    return True
 
 
 def evaluate_universal(candidate: dict, spec: FilterSpec) -> bool:
@@ -51,6 +74,96 @@ def evaluate_universal(candidate: dict, spec: FilterSpec) -> bool:
             return False
 
     return True
+
+
+_HOOK_CACHE: dict[str, Callable[[dict], Any]] = {}
+_FAILED_HOOKS: set[str] = set()
+
+
+def run_eval_hook(hook_path: str, candidate: dict) -> bool:
+    """Resolve ``hook_path`` (``"module.path:function_name"``) and run it.
+
+    Returns False on any failure (malformed path, import error, callable
+    not found, hook raises, non-bool return). Logs to stderr the first
+    time each unique hook_path fails — subsequent items in the same
+    process don't re-spam.
+
+    Module + callable are cached after first successful resolution.
+    Failed paths are remembered in ``_FAILED_HOOKS`` and short-circuit
+    to False without re-attempting the import.
+
+    Never raises. The operator's hook is treated as a best-effort filter,
+    not a critical gate — filter failures should not kill the poll loop.
+    """
+    import importlib
+    import sys
+
+    fn = _HOOK_CACHE.get(hook_path)
+    if fn is None:
+        if hook_path in _FAILED_HOOKS:
+            return False
+        if ":" not in hook_path:
+            print(
+                f"[filters] eval_hook {hook_path!r} malformed (expected "
+                "'module.path:function_name'); items will be rejected.",
+                file=sys.stderr,
+            )
+            _FAILED_HOOKS.add(hook_path)
+            return False
+        module_path, _, attr = hook_path.partition(":")
+        try:
+            mod = importlib.import_module(module_path)
+        except Exception as exc:  # noqa: BLE001 — surface, never crash poller
+            print(
+                f"[filters] eval_hook {hook_path!r} import failed "
+                f"({type(exc).__name__}: {exc}); items will be rejected.",
+                file=sys.stderr,
+            )
+            _FAILED_HOOKS.add(hook_path)
+            return False
+        try:
+            fn = getattr(mod, attr)
+        except AttributeError:
+            print(
+                f"[filters] eval_hook {hook_path!r}: module imported but "
+                f"has no attribute {attr!r}; items will be rejected.",
+                file=sys.stderr,
+            )
+            _FAILED_HOOKS.add(hook_path)
+            return False
+        if not callable(fn):
+            print(
+                f"[filters] eval_hook {hook_path!r}: {attr!r} is not "
+                "callable; items will be rejected.",
+                file=sys.stderr,
+            )
+            _FAILED_HOOKS.add(hook_path)
+            return False
+        _HOOK_CACHE[hook_path] = fn
+
+    try:
+        result = fn(candidate)
+    except Exception as exc:  # noqa: BLE001 — hook is operator code, treat as filter
+        print(
+            f"[filters] eval_hook {hook_path!r} raised on candidate "
+            f"({type(exc).__name__}: {exc}); item rejected.",
+            file=sys.stderr,
+        )
+        return False
+    if not isinstance(result, bool):
+        print(
+            f"[filters] eval_hook {hook_path!r} returned non-bool "
+            f"({type(result).__name__}); item rejected. Hook must return bool.",
+            file=sys.stderr,
+        )
+        return False
+    return result
+
+
+def _reset_hook_caches_for_tests() -> None:
+    """Test-only — clear the module-level resolution caches."""
+    _HOOK_CACHE.clear()
+    _FAILED_HOOKS.clear()
 
 
 def merge_specs(source_level: FilterSpec, resource_level: FilterSpec | None) -> FilterSpec:

--- a/filters/spec.py
+++ b/filters/spec.py
@@ -65,6 +65,22 @@ class FilterSpec(BaseModel):
             "BEFORE this. Empty string disables."
         ),
     )
+    eval_hook: str = Field(
+        default="",
+        description=(
+            "Dotted import path to an operator-defined callable that returns "
+            "True for candidates that should pass the filter. Shape: "
+            "``'module.submodule:function_name'``. The callable receives "
+            "the same normalized candidate dict the universal evaluator "
+            "sees (``{text, author, timestamp}``) and must return a bool. "
+            "Hook runs AFTER the universal primitives — cheap declarative "
+            "filters cull first, expensive operator logic only sees survivors. "
+            "Operator's hook code runs in the same Python process; we don't "
+            "sandbox (operator owns their Bicameral install). Resolution "
+            "errors, non-bool returns, and exceptions all reject the "
+            "candidate conservatively and log to stderr."
+        ),
+    )
     extensions: dict[str, Any] = Field(
         default_factory=dict,
         description=(

--- a/tests/test_filters_eval_hook.py
+++ b/tests/test_filters_eval_hook.py
@@ -1,0 +1,332 @@
+"""Tests for #337 foundations cycle 3 — content evaluation hook.
+
+The hook is a dotted import path (``"module.path:function_name"``) that
+the operator points at a callable in their own code. The
+:func:`run_eval_hook` helper resolves the path, calls the callable,
+and treats every failure mode (malformed path, ImportError,
+AttributeError, non-callable, exception, non-bool return) as a
+filter rejection with a stderr warning. Failed paths are cached so
+subsequent items in the same process don't re-spam.
+
+We test the helper directly + the combined ``evaluate_filters``
+function + the per-adapter wiring.
+"""
+
+from __future__ import annotations
+
+import sys
+import types
+
+import pytest
+
+from filters import FilterSpec, evaluate_filters, run_eval_hook
+from filters.evaluator import _reset_hook_caches_for_tests
+
+
+@pytest.fixture(autouse=True)
+def _reset_caches():
+    _reset_hook_caches_for_tests()
+    yield
+    _reset_hook_caches_for_tests()
+
+
+def _install_fake_module(name: str, **funcs):
+    """Install a dummy module on sys.modules with the given callables."""
+    mod = types.ModuleType(name)
+    for fname, fn in funcs.items():
+        setattr(mod, fname, fn)
+    sys.modules[name] = mod
+    return mod
+
+
+@pytest.fixture
+def fake_hooks_module():
+    """Module fake_eval_hooks with a few sample callables for hook tests."""
+    mod = _install_fake_module(
+        "fake_eval_hooks",
+        always_true=lambda cand: True,
+        always_false=lambda cand: False,
+        contains_urgent=lambda cand: "urgent" in (cand.get("text") or "").lower(),
+        raises=lambda cand: (_ for _ in ()).throw(RuntimeError("hook crashed")),
+        returns_none=lambda cand: None,
+        returns_string=lambda cand: "truthy but not bool",
+        not_callable_constant=42,
+    )
+    yield mod
+    sys.modules.pop("fake_eval_hooks", None)
+
+
+# ── run_eval_hook ───────────────────────────────────────────────────────────
+
+
+def test_hook_returns_true_passes(fake_hooks_module):
+    assert run_eval_hook("fake_eval_hooks:always_true", {"text": "x"}) is True
+
+
+def test_hook_returns_false_rejects(fake_hooks_module):
+    assert run_eval_hook("fake_eval_hooks:always_false", {"text": "x"}) is False
+
+
+def test_hook_receives_candidate_dict(fake_hooks_module):
+    assert run_eval_hook("fake_eval_hooks:contains_urgent", {"text": "URGENT decision"}) is True
+    assert run_eval_hook("fake_eval_hooks:contains_urgent", {"text": "lunch?"}) is False
+
+
+def test_hook_malformed_path_rejects(capsys):
+    # Missing colon → "module.path:function_name" expected shape.
+    assert run_eval_hook("no_colon_here", {"text": "x"}) is False
+    err = capsys.readouterr().err
+    assert "malformed" in err
+
+
+def test_hook_module_not_found_rejects(capsys):
+    assert run_eval_hook("nonexistent_module_xyz:fn", {"text": "x"}) is False
+    err = capsys.readouterr().err
+    assert "import failed" in err
+
+
+def test_hook_attribute_not_found_rejects(capsys, fake_hooks_module):
+    assert run_eval_hook("fake_eval_hooks:does_not_exist", {"text": "x"}) is False
+    err = capsys.readouterr().err
+    assert "has no attribute" in err
+
+
+def test_hook_not_callable_rejects(capsys, fake_hooks_module):
+    assert run_eval_hook("fake_eval_hooks:not_callable_constant", {"text": "x"}) is False
+    err = capsys.readouterr().err
+    assert "not" in err.lower() and "callable" in err.lower()
+
+
+def test_hook_raises_rejects(capsys, fake_hooks_module):
+    assert run_eval_hook("fake_eval_hooks:raises", {"text": "x"}) is False
+    err = capsys.readouterr().err
+    assert "raised" in err
+
+
+def test_hook_returns_non_bool_rejects(capsys, fake_hooks_module):
+    assert run_eval_hook("fake_eval_hooks:returns_string", {"text": "x"}) is False
+    err = capsys.readouterr().err
+    assert "non-bool" in err
+
+
+def test_hook_returns_none_rejects(capsys, fake_hooks_module):
+    # None is non-bool — same failure path.
+    assert run_eval_hook("fake_eval_hooks:returns_none", {"text": "x"}) is False
+    err = capsys.readouterr().err
+    assert "non-bool" in err
+
+
+def test_failed_hook_path_cached_no_respam(capsys):
+    """Second call with the same failed path doesn't re-print the warning."""
+    run_eval_hook("nonexistent_module_xyz:fn", {"text": "x"})
+    run_eval_hook("nonexistent_module_xyz:fn", {"text": "y"})
+    err = capsys.readouterr().err
+    # Only one "import failed" line, not two.
+    assert err.count("import failed") == 1
+
+
+def test_successful_hook_path_cached(fake_hooks_module):
+    """Multiple successful calls use the cached callable (one resolution)."""
+    # Confirm both calls return correct results — caching is a
+    # performance hint, the contract is: behavior is identical across
+    # calls.
+    assert run_eval_hook("fake_eval_hooks:always_true", {"text": "a"}) is True
+    assert run_eval_hook("fake_eval_hooks:always_true", {"text": "b"}) is True
+
+
+# ── evaluate_filters (universal + hook composition) ─────────────────────────
+
+
+def test_evaluate_filters_no_hook_falls_through_to_universal():
+    spec = FilterSpec(keyword_include=["decided"])
+    assert evaluate_filters({"text": "decided"}, spec)
+    assert not evaluate_filters({"text": "discussed"}, spec)
+
+
+def test_evaluate_filters_universal_rejects_before_hook(fake_hooks_module):
+    """When the universal layer rejects, the hook never runs.
+
+    Pin this by setting the hook to one that would PASS, but the
+    universal filter to one that won't — the hook running would pass
+    the item, but it should be rejected by the universal layer first.
+    """
+    spec = FilterSpec(
+        keyword_include=["never-matches"],
+        eval_hook="fake_eval_hooks:always_true",
+    )
+    assert not evaluate_filters({"text": "anything else"}, spec)
+
+
+def test_evaluate_filters_hook_runs_only_when_universal_passes(fake_hooks_module):
+    spec = FilterSpec(
+        keyword_include=["decided"],
+        eval_hook="fake_eval_hooks:always_false",
+    )
+    # Universal passes (text contains "decided"), but hook rejects.
+    assert not evaluate_filters({"text": "decided to ship"}, spec)
+
+
+def test_evaluate_filters_both_pass(fake_hooks_module):
+    spec = FilterSpec(
+        keyword_include=["decided"],
+        eval_hook="fake_eval_hooks:contains_urgent",
+    )
+    assert evaluate_filters({"text": "decided urgent matter"}, spec)
+
+
+# ── Per-adapter wiring ──────────────────────────────────────────────────────
+
+
+def test_linear_adapter_uses_eval_hook(tmp_path, monkeypatch, fake_hooks_module):
+    from unittest.mock import patch
+
+    from events.sources.linear import LinearPollingAdapter
+    from secrets_store import put_secret
+    from secrets_store.store import _reset_for_tests
+
+    monkeypatch.setenv("BICAMERAL_KEYRING_DISABLE", "1")
+    _reset_for_tests()
+
+    put_secret(source_id="linear", key="api_key", value="lin_t")
+
+    fake_issues = [
+        {
+            "identifier": "BIC-1",
+            "url": "https://linear.app/x/issue/BIC-1",
+            "completedAt": "2026-05-01T00:00:00Z",
+        },
+        {
+            "identifier": "BIC-2",
+            "url": "https://linear.app/x/issue/BIC-2",
+            "completedAt": "2026-05-02T00:00:00Z",
+        },
+    ]
+
+    def _fetch(self, url):
+        if "BIC-1" in url:
+            return {"query": "urgent fix", "decisions": [], "participants": []}
+        return {"query": "regular work", "decisions": [], "participants": []}
+
+    with (
+        patch("sources.linear.poller.list_completed_issues", return_value=fake_issues),
+        patch("sources.linear.adapter.LinearAdapter.fetch_active", new=_fetch),
+    ):
+        adapter = LinearPollingAdapter()
+        result = adapter.pull(
+            watermark_dir=tmp_path,
+            config={"filters": {"eval_hook": "fake_eval_hooks:contains_urgent"}},
+        )
+
+    assert len(result) == 1
+    assert adapter._pending_watermark == "2026-05-02T00:00:00Z"
+
+
+def test_slack_adapter_uses_eval_hook(tmp_path, monkeypatch, fake_hooks_module):
+    from unittest.mock import patch
+
+    from events.sources.slack import SlackPollingAdapter
+    from secrets_store import put_secret
+    from secrets_store.store import _reset_for_tests
+
+    monkeypatch.setenv("BICAMERAL_KEYRING_DISABLE", "1")
+    _reset_for_tests()
+
+    put_secret(source_id="slack", key="api_key", value="xoxb-t")
+    fake_msgs = [
+        {"ts": "1700000001.000000", "user": "U1", "text": "urgent: ship it"},
+        {"ts": "1700000002.000000", "user": "U2", "text": "lunch?"},
+    ]
+    with (
+        patch("sources.slack.poller.list_new_messages", return_value=fake_msgs),
+        patch("sources.slack.client.get_user_info", return_value={}),
+    ):
+        adapter = SlackPollingAdapter()
+        result = adapter.pull(
+            watermark_dir=tmp_path,
+            config={
+                "channels": ["C01A"],
+                "filters": {"eval_hook": "fake_eval_hooks:contains_urgent"},
+            },
+        )
+
+    assert len(result) == 1
+    assert "urgent" in result[0].get("decisions", [{}])[0].get("description", "").lower()
+
+
+def test_adapter_continues_when_hook_raises(tmp_path, monkeypatch, fake_hooks_module, capsys):
+    """Hook crashing must not crash the poll loop — that item is
+    rejected, others (or none) still pass."""
+    from unittest.mock import patch
+
+    from events.sources.linear import LinearPollingAdapter
+    from secrets_store import put_secret
+    from secrets_store.store import _reset_for_tests
+
+    monkeypatch.setenv("BICAMERAL_KEYRING_DISABLE", "1")
+    _reset_for_tests()
+
+    put_secret(source_id="linear", key="api_key", value="lin_t")
+
+    fake_issues = [
+        {
+            "identifier": "BIC-1",
+            "url": "https://linear.app/x/issue/BIC-1",
+            "completedAt": "2026-05-01T00:00:00Z",
+        },
+    ]
+    with (
+        patch("sources.linear.poller.list_completed_issues", return_value=fake_issues),
+        patch(
+            "sources.linear.adapter.LinearAdapter.fetch_active",
+            return_value={"query": "x", "decisions": [], "participants": []},
+        ),
+    ):
+        adapter = LinearPollingAdapter()
+        result = adapter.pull(
+            watermark_dir=tmp_path,
+            config={"filters": {"eval_hook": "fake_eval_hooks:raises"}},
+        )
+
+    assert result == []
+    # Watermark still advances past the rejected item.
+    assert adapter._pending_watermark == "2026-05-01T00:00:00Z"
+    # Operator gets a stderr warning.
+    assert "raised" in capsys.readouterr().err
+
+
+def test_adapter_continues_when_hook_path_invalid(tmp_path, monkeypatch, capsys):
+    """Bad import path is loud but non-fatal — poller continues."""
+    from unittest.mock import patch
+
+    from events.sources.linear import LinearPollingAdapter
+    from secrets_store import put_secret
+    from secrets_store.store import _reset_for_tests
+
+    monkeypatch.setenv("BICAMERAL_KEYRING_DISABLE", "1")
+    _reset_for_tests()
+
+    put_secret(source_id="linear", key="api_key", value="lin_t")
+
+    fake_issues = [
+        {
+            "identifier": "BIC-1",
+            "url": "https://linear.app/x/issue/BIC-1",
+            "completedAt": "2026-05-01T00:00:00Z",
+        },
+    ]
+    with (
+        patch("sources.linear.poller.list_completed_issues", return_value=fake_issues),
+        patch(
+            "sources.linear.adapter.LinearAdapter.fetch_active",
+            return_value={"query": "x", "decisions": [], "participants": []},
+        ),
+    ):
+        adapter = LinearPollingAdapter()
+        result = adapter.pull(
+            watermark_dir=tmp_path,
+            config={"filters": {"eval_hook": "totally_made_up_module_xyz:fn"}},
+        )
+
+    # Item rejected (hook resolution failed), but poller didn't crash.
+    assert result == []
+    assert "import failed" in capsys.readouterr().err


### PR DESCRIPTION
## Summary

Foundations cycle 3. Adds operator-defined Python callables as the escape hatch for filtering beyond declarative primitives — closes the user's original \"link to a script for content evaluation\" call-out.

### Config

\`\`\`yaml
sources:
  - type: slack
    filters:
      keyword_include: [decided]
      eval_hook: \"my_team.bicameral_hooks:is_real_decision\"
\`\`\`

Operator writes:

\`\`\`python
# my_team/bicameral_hooks.py
def is_real_decision(candidate: dict) -> bool:
    # candidate = {text, author, timestamp}
    return bool(...)  # arbitrary logic
\`\`\`

### Pipeline order

Universal primitives first → eval_hook second (only on survivors). Cheap declarative filters cull before the operator's potentially-expensive callable runs. One unified entry point now: \`evaluate_filters(candidate, spec)\`.

### Failure isolation

Every conceivable hook failure mode resolves to \"reject this candidate + log to stderr + don't crash the poll loop\":

| Failure | Behavior |
|---|---|
| Malformed path (no colon) | reject + warn + cache failure |
| Module not found | reject + warn + cache |
| Attribute not found | reject + warn + cache |
| Not callable | reject + warn + cache |
| Hook raises | reject + warn (no cache — exceptions can be candidate-dependent) |
| Non-bool return | reject + warn (no cache — same reasoning) |

Successful resolutions cached for the process lifetime.

### Threat model

Operator's hook runs same-process, no sandbox. Operator owns their Bicameral install; we don't pretend to defend against operator-supplied malicious code. Language-agnostic subprocess hook is deliberately deferred to cycle 3b.

Tests: 20 new (every failure mode + per-adapter wiring + pipeline-order pin) + 85 prior = 105 passing.

Parent tracker: BicameralAI/bicameral-daemon#3.

🤖 Generated with [Claude Code](https://claude.com/claude-code)