### PR TITLE
feat(webhooks): Linear webhook receiver (#337 cycle 7)

### DIFF
--- a/tests/test_webhooks_linear.py
+++ b/tests/test_webhooks_linear.py
@@ -1,0 +1,540 @@
+"""Tests for the Linear webhook handler (#337 cycle 7).
+
+Coverage parity with the Slack/GitHub suites:
+- verify_signature: missing/non-hex header, missing secret, mismatch,
+  body-byte sensitivity, constant-time-compare pin, body-timestamp
+  staleness gate
+- handle: missing signature → 401, malformed JSON → 400 (before HMAC
+  cost), Issue create with description ingests, Issue create without
+  description ignored, Comment create ingests, Comment update ignored,
+  remove acknowledged, unknown event type acknowledged, delivery-id
+  dedup, missing Linear-Delivery still processes (timestamp gate
+  applies), hard-gate refusal → 422
+"""
+
+from __future__ import annotations
+
+import hashlib
+import hmac
+import json
+import time
+from types import SimpleNamespace
+from unittest.mock import patch
+
+import pytest
+
+from webhooks.linear import (
+    WebhookVerificationError,
+    check_timestamp_skew,
+    handle,
+    verify_signature,
+)
+
+
+@pytest.fixture(autouse=True)
+def _disable_keyring_and_reset_dedup(monkeypatch):
+    monkeypatch.setenv("BICAMERAL_KEYRING_DISABLE", "1")
+    from secrets_store.store import _reset_for_tests as _secrets_reset
+    from webhooks.dedup import _reset_for_tests as _dedup_reset
+
+    _secrets_reset()
+    _dedup_reset()
+    yield
+    _secrets_reset()
+    _dedup_reset()
+
+
+def _sign(secret: str, body: bytes) -> str:
+    """Compute the hex HMAC Linear would send for ``body``."""
+    return hmac.new(secret.encode("utf-8"), msg=body, digestmod=hashlib.sha256).hexdigest()
+
+
+def _now_ms() -> int:
+    return int(time.time() * 1000)
+
+
+# ── verify_signature ────────────────────────────────────────────────────────
+
+
+def test_verify_signature_success():
+    body = b'{"action":"create","type":"Issue"}'
+    secret = "s3cr3t"
+    sig = _sign(secret, body)
+    verify_signature(body=body, signature_header=sig, secret=secret)  # does not raise
+
+
+def test_verify_signature_missing_signature_raises():
+    with pytest.raises(WebhookVerificationError, match="Signature"):
+        verify_signature(body=b"x", signature_header=None, secret="s")
+
+
+def test_verify_signature_missing_secret_raises():
+    with pytest.raises(WebhookVerificationError, match="webhook_secret"):
+        verify_signature(body=b"x", signature_header="a" * 64, secret="")
+
+
+def test_verify_signature_non_hex_header_rejected():
+    """M1 fix: non-hex headers that pass the length check are caught
+    by compare_digest (constant-time byte-mismatch). Pre-HMAC charset
+    scan was removed to close a position-of-first-bad-byte timing
+    oracle."""
+    bad_hex = "not-hex-" + "a" * 56  # 64 chars but not hex
+    with pytest.raises(WebhookVerificationError, match="signature mismatch"):
+        verify_signature(body=b"x", signature_header=bad_hex, secret="s")
+
+
+def test_verify_signature_wrong_length_header_rejected():
+    with pytest.raises(WebhookVerificationError, match="64 chars"):
+        verify_signature(body=b"x", signature_header="ab" * 31, secret="s")
+
+
+def test_verify_signature_uppercase_hex_accepted():
+    """Linear's docs show lowercase hex; defensive: also accept uppercase."""
+    body = b"x"
+    secret = "s"
+    sig = _sign(secret, body).upper()
+    verify_signature(body=body, signature_header=sig, secret=secret)
+
+
+def test_verify_signature_mismatch_raises():
+    with pytest.raises(WebhookVerificationError, match="signature mismatch"):
+        verify_signature(body=b"x", signature_header="a" * 64, secret="s")
+
+
+def test_verify_signature_body_byte_sensitivity():
+    """Single-byte body change must invalidate the signature — pins
+    that HMAC sees the full body, not a truncated/normalized form."""
+    secret = "s"
+    sig = _sign(secret, b"original")
+    with pytest.raises(WebhookVerificationError, match="signature mismatch"):
+        verify_signature(body=b"originaL", signature_header=sig, secret=secret)
+
+
+def test_check_timestamp_skew_stale_rejected():
+    """H1 fix: timestamp staleness gate now a separate function that
+    runs AFTER HMAC verify (operates on authenticated values only).
+    Past the 60s window → reject."""
+    with pytest.raises(WebhookVerificationError, match="stale"):
+        check_timestamp_skew(_now_ms() - 120_000)
+
+
+def test_check_timestamp_skew_future_skew_rejected():
+    """Bidirectional gate — future-skewed timestamps also rejected."""
+    with pytest.raises(WebhookVerificationError, match="stale"):
+        check_timestamp_skew(_now_ms() + 120_000)
+
+
+def test_check_timestamp_skew_fresh_passes():
+    """Within the 60s window → does not raise."""
+    check_timestamp_skew(_now_ms())
+
+
+# ── handle: routing ─────────────────────────────────────────────────────────
+
+
+def _put_secret(value: str = "s") -> None:
+    from secrets_store import put_secret
+
+    put_secret(source_id="linear", key="webhook_secret", value=value)
+
+
+def _issue_create_body(*, description: str = "real decision text") -> bytes:
+    return json.dumps(
+        {
+            "action": "create",
+            "type": "Issue",
+            "data": {
+                "id": "issue-uuid",
+                "identifier": "BIC-100",
+                "title": "Some title",
+                "description": description,
+                "url": "https://linear.app/bic/issue/BIC-100/some-title",
+                "updatedAt": "2026-05-19T00:00:00Z",
+                "assignee": {"email": "alice@example.com"},
+            },
+            "url": "https://linear.app/bic/issue/BIC-100/some-title",
+            "webhookTimestamp": _now_ms(),
+        }
+    ).encode("utf-8")
+
+
+def _comment_create_body(*, body_text: str = "real comment text") -> bytes:
+    return json.dumps(
+        {
+            "action": "create",
+            "type": "Comment",
+            "data": {
+                "id": "comment-uuid",
+                "body": body_text,
+                "user": {"email": "bob@example.com"},
+                "issue": {
+                    "identifier": "BIC-100",
+                    "title": "Some title",
+                },
+                "updatedAt": "2026-05-19T00:00:00Z",
+            },
+            "url": "https://linear.app/bic/issue/BIC-100#comment-uuid",
+            "webhookTimestamp": _now_ms(),
+        }
+    ).encode("utf-8")
+
+
+def test_handle_invalid_json_returns_400():
+    _put_secret()
+    status, msg = handle(
+        body=b"not-json",
+        event_header="Issue",
+        delivery_header="d1",
+        signature_header=_sign("s", b"not-json"),
+    )
+    assert status == 400
+    assert "JSON" in msg
+
+
+def test_handle_missing_signature_returns_401():
+    _put_secret()
+    body = _issue_create_body()
+    status, msg = handle(
+        body=body,
+        event_header="Issue",
+        delivery_header="d1",
+        signature_header=None,
+    )
+    assert status == 401
+
+
+def test_handle_signature_mismatch_returns_401():
+    _put_secret()
+    body = _issue_create_body()
+    status, msg = handle(
+        body=body,
+        event_header="Issue",
+        delivery_header="d1",
+        signature_header="0" * 64,
+    )
+    assert status == 401
+    assert "verification" in msg
+
+
+def test_handle_stale_body_timestamp_returns_401():
+    _put_secret()
+    payload = {
+        "action": "create",
+        "type": "Issue",
+        "data": {"identifier": "BIC-100", "title": "t", "description": "d"},
+        "webhookTimestamp": _now_ms() - 120_000,  # 2 min stale
+    }
+    body = json.dumps(payload).encode("utf-8")
+    status, msg = handle(
+        body=body,
+        event_header="Issue",
+        delivery_header="d-stale",
+        signature_header=_sign("s", body),
+    )
+    assert status == 401
+    assert "stale" in msg
+
+
+def test_handle_issue_create_with_description_ingests():
+    _put_secret()
+    body = _issue_create_body()
+    with patch("webhooks.linear._dispatch_to_ingest") as mock_dispatch:
+        mock_dispatch.return_value = (200, "ingested BIC-100")
+        status, msg = handle(
+            body=body,
+            event_header="Issue",
+            delivery_header="d-issue",
+            signature_header=_sign("s", body),
+        )
+    assert status == 200
+    assert mock_dispatch.called
+    norm = mock_dispatch.call_args.args[0]
+    assert norm["source"] == "linear"
+    assert norm["title"] == "BIC-100"
+    assert len(norm["decisions"]) == 1
+    assert norm["decisions"][0]["description"] == "real decision text"
+    assert "alice@example.com" in norm["participants"]
+
+
+def test_handle_issue_create_without_description_ignored():
+    _put_secret()
+    body = _issue_create_body(description="")
+    with patch("webhooks.linear._dispatch_to_ingest") as mock_dispatch:
+        status, msg = handle(
+            body=body,
+            event_header="Issue",
+            delivery_header="d-empty",
+            signature_header=_sign("s", body),
+        )
+    assert status == 200
+    assert "no description" in msg
+    assert not mock_dispatch.called
+
+
+def test_handle_issue_remove_acknowledged_no_ingest():
+    """Append-only contract — we do NOT propagate Linear removes to the
+    ledger. Erasure goes through #221 / GDPR, not the webhook path."""
+    _put_secret()
+    payload = json.loads(_issue_create_body())
+    payload["action"] = "remove"
+    body = json.dumps(payload).encode("utf-8")
+    with patch("webhooks.linear._dispatch_to_ingest") as mock_dispatch:
+        status, msg = handle(
+            body=body,
+            event_header="Issue",
+            delivery_header="d-rm",
+            signature_header=_sign("s", body),
+        )
+    assert status == 200
+    assert "remove" in msg
+    assert not mock_dispatch.called
+
+
+def test_handle_comment_create_ingests():
+    _put_secret()
+    body = _comment_create_body()
+    with patch("webhooks.linear._dispatch_to_ingest") as mock_dispatch:
+        mock_dispatch.return_value = (200, "ingested Comment on BIC-100 ()")
+        status, msg = handle(
+            body=body,
+            event_header="Comment",
+            delivery_header="d-cm",
+            signature_header=_sign("s", body),
+        )
+    assert status == 200
+    norm = mock_dispatch.call_args.args[0]
+    assert norm["source"] == "linear"
+    assert norm["title"] == "BIC-100"
+    assert norm["decisions"][0]["title"] == "BIC-100#comment-comment-uuid"
+    assert norm["decisions"][0]["description"] == "real comment text"
+
+
+def test_handle_comment_update_acknowledged_no_ingest():
+    _put_secret()
+    payload = json.loads(_comment_create_body())
+    payload["action"] = "update"
+    body = json.dumps(payload).encode("utf-8")
+    with patch("webhooks.linear._dispatch_to_ingest") as mock_dispatch:
+        status, msg = handle(
+            body=body,
+            event_header="Comment",
+            delivery_header="d-cm-up",
+            signature_header=_sign("s", body),
+        )
+    assert status == 200
+    assert "update" in msg
+    assert not mock_dispatch.called
+
+
+def test_handle_unknown_event_type_acknowledged():
+    _put_secret()
+    payload = {
+        "action": "create",
+        "type": "Reaction",
+        "webhookTimestamp": _now_ms(),
+    }
+    body = json.dumps(payload).encode("utf-8")
+    status, msg = handle(
+        body=body,
+        event_header="Reaction",
+        delivery_header="d-react",
+        signature_header=_sign("s", body),
+    )
+    assert status == 200
+    assert "acknowledged" in msg or "not yet" in msg
+
+
+def test_handle_delivery_id_dedup():
+    _put_secret()
+    body = _issue_create_body()
+    sig = _sign("s", body)
+    with patch("webhooks.linear._dispatch_to_ingest") as mock_dispatch:
+        mock_dispatch.return_value = (200, "ingested")
+        s1, _ = handle(
+            body=body, event_header="Issue", delivery_header="d-dup", signature_header=sig
+        )
+        s2, msg2 = handle(
+            body=body, event_header="Issue", delivery_header="d-dup", signature_header=sig
+        )
+    assert s1 == 200
+    assert s2 == 200
+    assert "duplicate" in msg2
+    # ingest only called once
+    assert mock_dispatch.call_count == 1
+
+
+def test_handle_missing_delivery_id_but_timestamp_present_still_processes():
+    """H2 fix: missing Linear-Delivery is fine IF webhookTimestamp is
+    present — the staleness gate still bounds replay to 60s."""
+    _put_secret()
+    body = _issue_create_body()  # includes webhookTimestamp
+    with patch("webhooks.linear._dispatch_to_ingest") as mock_dispatch:
+        mock_dispatch.return_value = (200, "ingested")
+        status, _ = handle(
+            body=body, event_header="Issue", delivery_header=None, signature_header=_sign("s", body)
+        )
+    assert status == 200
+    assert mock_dispatch.called
+
+
+def test_handle_missing_delivery_and_missing_timestamp_rejected():
+    """H2 fix: both replay-defense fields missing → 400. Either an
+    attacker stripping defenses or a misconfigured provider — neither
+    should hit the ingest pipeline."""
+    _put_secret()
+    payload = {
+        "action": "create",
+        "type": "Issue",
+        "data": {"identifier": "BIC-100", "title": "t", "description": "d"},
+        # NO webhookTimestamp
+    }
+    body = json.dumps(payload).encode("utf-8")
+    with patch("webhooks.linear._dispatch_to_ingest") as mock_dispatch:
+        status, msg = handle(
+            body=body,
+            event_header="Issue",
+            delivery_header=None,
+            signature_header=_sign("s", body),
+        )
+    assert status == 400
+    assert "both missing" in msg
+    assert not mock_dispatch.called
+
+
+def test_handle_missing_timestamp_but_delivery_present_processes():
+    """H2 corollary: webhookTimestamp absent is fine IF Linear-Delivery
+    is present — dedup cache covers the replay window."""
+    _put_secret()
+    payload = {
+        "action": "create",
+        "type": "Issue",
+        "data": {
+            "identifier": "BIC-100",
+            "title": "t",
+            "description": "real",
+        },
+        # NO webhookTimestamp
+    }
+    body = json.dumps(payload).encode("utf-8")
+    with patch("webhooks.linear._dispatch_to_ingest") as mock_dispatch:
+        mock_dispatch.return_value = (200, "ingested")
+        status, _ = handle(
+            body=body,
+            event_header="Issue",
+            delivery_header="d-no-ts",
+            signature_header=_sign("s", body),
+        )
+    assert status == 200
+    assert mock_dispatch.called
+
+
+def test_handle_event_header_vs_body_type_mismatch_rejected():
+    """H3 fix: signed-body / unsigned-header asymmetry. An attacker
+    with leaked-secret access could otherwise route Issue payloads as
+    other event types to bypass ingest, or route other types as Issue
+    to ingest them anyway. Mismatch must reject."""
+    _put_secret()
+    body = _issue_create_body()  # body.type = "Issue"
+    with patch("webhooks.linear._dispatch_to_ingest") as mock_dispatch:
+        status, msg = handle(
+            body=body,
+            event_header="Reaction",  # header says Reaction
+            delivery_header="d-mismatch",
+            signature_header=_sign("s", body),
+        )
+    assert status == 400
+    assert "header" in msg and "body.type" in msg
+    assert not mock_dispatch.called
+
+
+def test_handle_verify_runs_before_json_parse():
+    """H1 regression: malformed JSON with INVALID signature must return
+    401 (verify failure), NOT 400 (parse failure). Bad signature must
+    not reach json.loads at all."""
+    _put_secret()
+    status, msg = handle(
+        body=b"not-json-payload",
+        event_header="Issue",
+        delivery_header="d-h1",
+        signature_header="0" * 64,  # well-formed length but wrong
+    )
+    assert status == 401
+    assert "verification" in msg
+
+
+def test_handle_hard_gate_refusal_returns_422():
+    """When the ingest pipeline raises _IngestRefused (e.g. PHI hard
+    gate), surface 422 — provider should NOT retry."""
+    _put_secret()
+    body = _issue_create_body()
+
+    from handlers.ingest import _IngestRefused
+
+    with patch("webhooks.linear._dispatch_to_ingest") as mock_dispatch:
+        # Simulate _dispatch_to_ingest catching the refusal internally.
+        mock_dispatch.return_value = (422, "refused: sensitive_data:phi")
+        status, msg = handle(
+            body=body,
+            event_header="Issue",
+            delivery_header="d-refuse",
+            signature_header=_sign("s", body),
+        )
+    assert status == 422
+    assert "refused" in msg
+    # Side-channel: verify _IngestRefused is importable from the path
+    # the handler uses so the actual integration works.
+    assert _IngestRefused is not None
+
+
+def test_handle_event_header_falls_back_to_body_type():
+    """Missing Linear-Event header → fall back to body.type. Linear's
+    docs say the header is canonical but defensive coding accommodates
+    operators behind proxies that strip non-standard headers."""
+    _put_secret()
+    body = _issue_create_body()
+    with patch("webhooks.linear._dispatch_to_ingest") as mock_dispatch:
+        mock_dispatch.return_value = (200, "ingested")
+        status, _ = handle(
+            body=body,
+            event_header=None,
+            delivery_header="d-noheader",
+            signature_header=_sign("s", body),
+        )
+    assert status == 200
+    assert mock_dispatch.called
+
+
+# ── _dispatch_to_ingest (sociable: real ingest path) ────────────────────────
+
+
+def test_dispatch_to_ingest_uses_passive_mode(monkeypatch):
+    """Pin the ingest contract — webhook path always passes
+    ingest_mode='passive' so Phase 0a DLQ catches per-item failures."""
+    from webhooks.linear import _dispatch_to_ingest
+
+    captured: dict = {}
+
+    async def _fake_handle_ingest(ctx, payload, *, source_scope, ingest_mode):
+        captured["scope"] = source_scope
+        captured["mode"] = ingest_mode
+        captured["payload"] = payload
+
+    monkeypatch.setattr("handlers.ingest.handle_ingest", _fake_handle_ingest)
+    # BicameralContext.from_env may try keyring; replace with a stub.
+    monkeypatch.setattr(
+        "context.BicameralContext.from_env", classmethod(lambda cls: SimpleNamespace())
+    )
+
+    norm = {
+        "query": "Some title",
+        "source": "linear",
+        "title": "BIC-100",
+        "date": "2026-05-19T00:00:00Z",
+        "participants": ["alice@example.com"],
+        "decisions": [{"description": "x", "title": "BIC-100"}],
+    }
+    status, msg = _dispatch_to_ingest(norm, label="Issue BIC-100 (url)")
+    assert status == 200
+    assert captured["scope"] == "linear"
+    assert captured["mode"] == "passive"
+    assert captured["payload"]["title"] == "BIC-100"

--- a/webhooks/linear.py
+++ b/webhooks/linear.py
@@ -1,0 +1,341 @@
+"""Linear webhook handler (#337 cycle 7).
+
+Linear's webhook contract:
+
+- Header ``Linear-Signature``: HMAC-SHA256 of the raw request body, hex-encoded.
+  No ``v0=`` style prefix; the header value IS the hex digest.
+- Header ``Linear-Delivery``: per-delivery UUID. Used for retry dedup.
+- Header ``Linear-Event``: high-level event class (``Issue``, ``Comment``,
+  ``Project``, ``Reaction``, etc.). Routing key.
+- Body: JSON envelope with ``{action, type, data, url, createdAt,
+  webhookId, webhookTimestamp}``. ``action`` ∈ {``create``, ``update``,
+  ``remove``}; ``data`` is the entity payload (not the GraphQL shape used
+  by the active-fetch adapter, but contains the same load-bearing fields:
+  ``id``, ``identifier``, ``title``, ``description`` for Issue;
+  ``id``, ``body``, ``user``, ``issue`` for Comment).
+
+## Replay defense
+
+Linear's docs recommend two layers:
+
+1. ``webhookTimestamp`` in the body (epoch ms). Reject if more than
+   60 seconds stale — tighter than Slack's 5-min window because Linear
+   doesn't expose this as a header and operators can't easily tune.
+2. ``Linear-Delivery`` dedup cache (24h TTL, shared with GitHub / Slack).
+
+Order: timestamp gate first (constant-time-attack mitigation, same
+reasoning as Slack), HMAC second, dedup third.
+
+## Event coverage (cycle 7 minimum)
+
+- ``Issue`` create/update with non-empty description → ingest as decision.
+- ``Comment`` create with non-empty body → ingest as decision.
+- ``Issue`` remove / ``Comment`` remove → 200 ack, no ingest.
+- Anything else (``Project``, ``Reaction``, ``Cycle``, ...) → 200 ack,
+  documented as not-yet-supported.
+
+Webhook does NOT round-trip to the Linear API; the body fields are
+sufficient for v0. A future enhancement can fetch the full issue shape
+when the webhook event lacks decision-bearing context (e.g. issue
+update where ``data`` only carries the changed fields).
+"""
+
+from __future__ import annotations
+
+import hashlib
+import hmac
+import json
+import sys
+import time
+
+# Linear: 60-second skew tolerance. Tighter than Slack (5 min) because
+# Linear's payload-side timestamp is not operator-tunable and Linear's
+# infrastructure is internal-network-tight; a 60s gate still tolerates
+# normal clock skew without leaving a wide replay window.
+_MAX_TIMESTAMP_SKEW_SECONDS = 60
+
+
+class WebhookVerificationError(Exception):
+    """Raised when signature OR timestamp verification fails."""
+
+
+def verify_signature(
+    *,
+    body: bytes,
+    signature_header: str | None,
+    secret: str,
+) -> None:
+    """Verify Linear's webhook signature against raw body bytes.
+
+    Order:
+    1. Missing signature header or secret → reject.
+    2. Length sanity check (constant-time-safe: same path for all
+       wrong lengths).
+    3. HMAC-SHA256(secret, body) compared constant-time against the
+       header value (hex). ``compare_digest`` itself rejects non-hex
+       characters via byte-mismatch — no separate charset check
+       (M1 review finding: pre-HMAC charset scan adds a position-of-
+       first-bad-byte timing oracle for zero functional benefit).
+
+    Timestamp staleness gate is now a SEPARATE function
+    (:func:`check_timestamp_skew`) that runs AFTER signature verify,
+    so we never parse / extract from unauthenticated bytes.
+
+    Raises:
+        WebhookVerificationError: every failure mode.
+    """
+    if not signature_header:
+        raise WebhookVerificationError("missing Linear-Signature header")
+    if not secret:
+        raise WebhookVerificationError("no webhook_secret configured for this source")
+    if len(signature_header) != 64:
+        raise WebhookVerificationError(
+            f"Linear-Signature not 64 chars: got {len(signature_header)}"
+        )
+    expected_hex = hmac.new(secret.encode("utf-8"), msg=body, digestmod=hashlib.sha256).hexdigest()
+    if not hmac.compare_digest(signature_header.lower(), expected_hex):
+        raise WebhookVerificationError("signature mismatch")
+
+
+def check_timestamp_skew(body_timestamp_ms: int, *, now: float | None = None) -> None:
+    """Reject if ``body_timestamp_ms`` is more than 60s away from now.
+
+    Runs AFTER :func:`verify_signature` per H1 review finding —
+    operates on authenticated values only.
+
+    Raises:
+        WebhookVerificationError: when |now - ts| > 60s in either
+            direction.
+    """
+    current_ms = int((time.time() if now is None else now) * 1000)
+    if abs(current_ms - body_timestamp_ms) > _MAX_TIMESTAMP_SKEW_SECONDS * 1000:
+        raise WebhookVerificationError(
+            f"webhookTimestamp stale: |now - {body_timestamp_ms}ms| > "
+            f"{_MAX_TIMESTAMP_SKEW_SECONDS}s"
+        )
+
+
+def handle(
+    *,
+    body: bytes,
+    event_header: str | None,
+    delivery_header: str | None,
+    signature_header: str | None,
+) -> tuple[int, str]:
+    """Process one Linear webhook delivery.
+
+    Returns ``(http_status, response_body)`` — Linear doesn't require
+    a JSON response shape, so plain text is fine for every code path.
+    """
+    try:
+        from secrets_store import get_secret
+
+        secret = get_secret(source_id="linear", key="webhook_secret") or ""
+    except Exception as exc:  # noqa: BLE001
+        print(f"[linear-webhook] secret lookup failed: {exc}", file=sys.stderr)
+        return 500, f"secret lookup failed: {exc}"
+
+    # H1 review finding: verify HMAC against raw bytes BEFORE any
+    # JSON parsing. Slack and GitHub do the same — Linear no longer
+    # diverges. Unauthenticated bytes never reach json.loads.
+    try:
+        verify_signature(
+            body=body,
+            signature_header=signature_header,
+            secret=secret,
+        )
+    except WebhookVerificationError as exc:
+        print(f"[linear-webhook] verification failed: {exc}", file=sys.stderr)
+        return 401, f"verification failed: {exc}"
+
+    try:
+        payload = json.loads(body.decode("utf-8"))
+    except Exception as exc:  # noqa: BLE001
+        print(f"[linear-webhook] body not JSON-decodable: {exc}", file=sys.stderr)
+        return 400, f"body not JSON: {exc}"
+
+    raw_ts = payload.get("webhookTimestamp")
+    body_timestamp_ms: int | None = None
+    if isinstance(raw_ts, int):
+        body_timestamp_ms = raw_ts
+    elif isinstance(raw_ts, str) and all(c in "0123456789" for c in raw_ts) and raw_ts:
+        # Strict ASCII-decimal: avoids str.isdigit() accepting Arabic-
+        # Indic / other Unicode digits that int() then parses.
+        body_timestamp_ms = int(raw_ts)
+
+    # H2 review finding: closing both replay channels in one go.
+    # Require at least ONE of Linear-Delivery (dedup) OR
+    # webhookTimestamp (staleness gate) to be present. Linear has
+    # emitted Linear-Delivery on every webhook since v1 (2020) — there
+    # is no "older config" in the wild that omits it. Both-missing is
+    # either a provider bug or an attacker stripping replay defenses.
+    if not delivery_header and body_timestamp_ms is None:
+        print(
+            "[linear-webhook] Linear-Delivery AND webhookTimestamp both missing; rejecting "
+            "(no replay defense possible)",
+            file=sys.stderr,
+        )
+        return 400, "Linear-Delivery and webhookTimestamp both missing; cannot dedup"
+
+    # Timestamp staleness gate runs AFTER signature verify (H1 fix).
+    if body_timestamp_ms is not None:
+        try:
+            check_timestamp_skew(body_timestamp_ms)
+        except WebhookVerificationError as exc:
+            print(f"[linear-webhook] verification failed: {exc}", file=sys.stderr)
+            return 401, f"verification failed: {exc}"
+
+    # Replay defense layer 2: delivery-id dedup. Linear retries failed
+    # deliveries up to 5× over ~30 min; the dedup window covers that.
+    if delivery_header:
+        from webhooks.dedup import get_dedup_cache
+
+        cache = get_dedup_cache()
+        if cache.is_duplicate("linear", delivery_header):
+            print(
+                f"[linear-webhook] duplicate Linear-Delivery {delivery_header!r} ignored",
+                file=sys.stderr,
+            )
+            return 200, "duplicate"
+        cache.mark_seen("linear", delivery_header)
+
+    action = payload.get("action") or ""
+    # H3 review finding: header vs body.type cross-check. The signature
+    # covers the body but NOT the header — an attacker with a leaked
+    # secret could otherwise route a malicious Issue body as "Reaction"
+    # (free 200-ack-no-ingest, payload staging) or route a Reaction
+    # body as "Issue" (ingest as if it were an Issue). Requiring
+    # equality when both are present closes both directions.
+    header_type = (event_header or "").strip()
+    body_type = (payload.get("type") or "").strip()
+    if header_type and body_type and header_type != body_type:
+        print(
+            f"[linear-webhook] Linear-Event header={header_type!r} != body.type={body_type!r}; "
+            "rejecting (signed-body vs unsigned-header mismatch)",
+            file=sys.stderr,
+        )
+        return 400, f"Linear-Event header={header_type!r} != body.type={body_type!r}"
+    event_type = header_type or body_type
+
+    if event_type == "Issue":
+        return _ingest_issue(payload, action)
+    if event_type == "Comment":
+        return _ingest_comment(payload, action)
+
+    return 200, f"event type={event_type!r} acknowledged (not yet ingested)"
+
+
+def _ingest_issue(payload: dict, action: str) -> tuple[int, str]:
+    """Normalize an Issue create/update event and ingest as a decision."""
+    if action == "remove":
+        # We don't propagate deletes to the ledger — the append-only
+        # contract means past decisions persist by design. Operators
+        # who need erasure use the #221 / GDPR path, not this.
+        return 200, "Issue remove acknowledged (no ledger mutation)"
+
+    data = payload.get("data") or {}
+    identifier = (data.get("identifier") or "").strip()
+    title = (data.get("title") or "").strip()
+    description = (data.get("description") or "").strip()
+
+    if not identifier or not title:
+        return 200, "Issue missing identifier/title; ignored"
+    if not description:
+        # Title-only Issue updates land here on first create. We don't
+        # want to seed the ledger with empty-description rows, so skip.
+        return 200, f"Issue {identifier} has no description; ignored"
+
+    issue_url = data.get("url") or payload.get("url") or ""
+
+    # Build the payload in the same shape as the active adapter so
+    # downstream handle_ingest behavior is identical for active vs
+    # webhook ingest.
+    norm = {
+        "query": title,
+        "source": "linear",
+        "title": identifier,
+        "date": data.get("updatedAt") or data.get("createdAt") or "",
+        "participants": _participants_from_data(data),
+        "decisions": [{"description": description, "title": identifier}],
+    }
+
+    return _dispatch_to_ingest(norm, label=f"Issue {identifier} ({issue_url})")
+
+
+def _ingest_comment(payload: dict, action: str) -> tuple[int, str]:
+    """Normalize a Comment create event and ingest as a decision."""
+    if action != "create":
+        # Edits and removes — same reasoning as Issue remove.
+        return 200, f"Comment {action} acknowledged (no ledger mutation)"
+
+    data = payload.get("data") or {}
+    body_text = (data.get("body") or "").strip()
+    if not body_text:
+        return 200, "Comment body empty; ignored"
+
+    comment_id = data.get("id") or ""
+    issue = data.get("issue") or {}
+    identifier = (issue.get("identifier") or "").strip()
+    if not identifier:
+        return 200, "Comment missing issue.identifier; ignored"
+
+    decision_title = f"{identifier}#comment-{comment_id}" if comment_id else identifier
+    norm = {
+        "query": (issue.get("title") or identifier),
+        "source": "linear",
+        "title": identifier,
+        "date": data.get("updatedAt") or data.get("createdAt") or "",
+        "participants": _participants_from_data(data),
+        "decisions": [{"description": body_text, "title": decision_title}],
+    }
+
+    return _dispatch_to_ingest(norm, label=f"Comment on {identifier} ({payload.get('url') or ''})")
+
+
+def _participants_from_data(data: dict) -> list[str]:
+    """Best-effort participant extraction from a webhook body.
+
+    Linear's webhook payloads are shallower than the GraphQL response
+    — they include the actor (``user`` for Comment, sometimes
+    ``assignee`` on Issue) but not the full thread. We collect what's
+    present; the active-fetch path remains the authoritative source
+    when full participant context is required.
+    """
+    out: list[str] = []
+    seen: set[str] = set()
+    for field in ("user", "assignee", "creator"):
+        person = data.get(field)
+        if not isinstance(person, dict):
+            continue
+        email = (person.get("email") or "").strip()
+        if email and email not in seen:
+            seen.add(email)
+            out.append(email)
+    return out
+
+
+def _dispatch_to_ingest(norm: dict, *, label: str) -> tuple[int, str]:
+    """Run handle_ingest with the normalized payload."""
+    try:
+        import asyncio
+
+        from context import BicameralContext
+        from handlers.ingest import _IngestRefused, handle_ingest
+
+        ctx = BicameralContext.from_env()
+
+        async def _ingest() -> None:
+            await handle_ingest(ctx, norm, source_scope="linear", ingest_mode="passive")
+
+        asyncio.run(_ingest())
+    except _IngestRefused as exc:
+        print(
+            f"[linear-webhook] hard-gate refusal for {label}: {exc.reason}",
+            file=sys.stderr,
+        )
+        return 422, f"refused: {exc.reason}"
+    except Exception as exc:  # noqa: BLE001
+        print(f"[linear-webhook] ingest failed for {label}: {exc}", file=sys.stderr)
+        return 500, f"ingest failed: {exc}"
+
+    return 200, f"ingested {label}"

--- a/webhooks/server.py
+++ b/webhooks/server.py
@@ -11,6 +11,8 @@ NOT terminate TLS ourselves.
 
 Routes:
 - ``POST /webhooks/github``  → ``webhooks.github.handle``
+- ``POST /webhooks/slack``   → ``webhooks.slack.handle``
+- ``POST /webhooks/linear``  → ``webhooks.linear.handle``
 - ``GET /health``            → 200 ack (for load-balancer health checks)
 
 ## Hardening (post code-review)
@@ -208,6 +210,13 @@ async def _process_request(reader: asyncio.StreamReader, writer: asyncio.StreamW
         await _respond(writer, status, message, content_type=content_type)
         return
 
+    if path == "/webhooks/linear":
+        status, message = await asyncio.to_thread(
+            _dispatch_linear, body, MappingProxyType(dict(headers))
+        )
+        await _respond(writer, status, message)
+        return
+
     await _respond(writer, 404, "not found")
 
 
@@ -223,6 +232,18 @@ def _dispatch_github(body: bytes, headers) -> tuple[int, str]:
         delivery_id=delivery,
         body=body,
         signature_header=signature,
+    )
+
+
+def _dispatch_linear(body: bytes, headers) -> tuple[int, str]:
+    """Sync entrypoint into the Linear handler (called via to_thread)."""
+    from webhooks.linear import handle
+
+    return handle(
+        body=body,
+        event_header=headers.get("linear-event"),
+        delivery_header=headers.get("linear-delivery"),
+        signature_header=headers.get("linear-signature"),
     )
 
 


### PR DESCRIPTION
## Summary

Third webhook receiver in the BicameralAI/bicameral-daemon#3 chain. Stacked on top of BicameralAI/bicameral-mcp#448 (Slack). Adds Linear support to the asyncio HTTP receiver:

- HMAC-SHA256 over raw body (hex in \`Linear-Signature\`)
- Two-layer replay defense: 60s body timestamp window + delivery-id dedup (shared 24h LRU)
- Issue create/update with description → ingest; Comment create → ingest; remove/update on Comment / Issue → 200 ack (append-only contract, no ledger mutation)

## Adversarial review applied

\`code-reviewer\` ran a pre-ship pass. Verdict: **FIX BEFORE SHIP** with 3 HIGH + 1 MED + 3 LOW. All 4 HIGH/MED addressed in-PR:

| # | Finding | Fix |
|---|---|---|
| H1 | Body parsed before HMAC verify — unauthenticated bytes hit \`json.loads\` | Verify-first against raw bytes; \`webhookTimestamp\` extracted post-verify; staleness gate moved to separate \`check_timestamp_skew\` |
| H2 | \`Linear-Delivery\` + \`webhookTimestamp\` both-missing = unbounded replay | Reject 400 if both absent; either alone still permitted |
| H3 | Header \`Linear-Event\` vs body \`type\` mismatch — signed-body / unsigned-header asymmetry exploitable in both directions | Require equality when both present |
| M1 | Pre-HMAC charset scan = position-of-first-bad-byte timing oracle | Drop charset check (compare_digest catches non-hex byte-mismatch) |

LOW findings (participant-email validation, control-char strip on identifiers, generic 401 body) deferred — parity with GitHub/Slack handlers; would land as a sweep across all three rather than Linear-only.

## Stacking

This PR targets \`feat/webhook-receiver-slack\` (PR BicameralAI/bicameral-mcp#448), not \`dev\` directly. Once BicameralAI/bicameral-mcp#448 lands on dev, this PR's base should be re-targeted to \`dev\` (auto-rebase via GitHub UI or manual rebase).

## Tests: 30 new, 98 total webhook tests passing

\`pytest tests/test_webhooks_slack.py tests/test_webhooks_github.py tests/test_webhooks_server.py tests/test_webhooks_dedup.py tests/test_webhooks_linear.py -q\` → 98 passed

## Test plan
- [x] All webhook tests green
- [x] Ruff format + check clean
- [ ] CI green on PR (after BicameralAI/bicameral-mcp#448 lands)
- [ ] Manual rebase + retarget to \`dev\` once BicameralAI/bicameral-mcp#448 merges

Part of BicameralAI/bicameral-daemon#3.

🤖 Generated with [Claude Code](https://claude.com/claude-code)