### PR TITLE
feat(notion): wire ingest + notion-pending CLI (#337 cycle 8b)

### DIFF
--- a/cli/notion_pending_cli.py
+++ b/cli/notion_pending_cli.py
@@ -1,0 +1,183 @@
+"""CLI: ``bicameral-mcp notion-pending`` — operator-facing tool to
+retrieve pending Notion ``verification_token`` values.
+
+After ``webhooks/notion.py`` receives a verification handshake POST,
+the token is persisted in ``secrets_store`` under a fingerprint-keyed
+slot and the fingerprint (not the full token) is logged to stderr.
+The operator runs this command to retrieve the full token by
+fingerprint, then pastes it into Notion's UI to complete the
+subscription handshake.
+
+Usage::
+
+    bicameral-mcp notion-pending              # list all pending entries
+    bicameral-mcp notion-pending <fingerprint>  # print full token
+
+The list form prints fingerprint + received-at age, NOT the token,
+so it's safe to run in shared terminals. The retrieve form prints
+the full token to stdout — operator is responsible for not leaving
+that scrolled-back in a shared terminal.
+
+This is the user-facing half of cycle-8's F3 review fix: the token
+never appears in stderr / log pipelines; operators retrieve it via
+this explicit command instead.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import sys
+import time
+
+# Same prefix the webhook handler uses. Source of truth lives in
+# ``webhooks.notion``; keep these in sync.
+_PENDING_PREFIX = "pending_"
+_FINGERPRINT_RE = re.compile(r"^[0-9a-f]{16}$")
+# Cap the listing output to keep the CLI usable when the registry
+# has been spammed by attacker-driven verification POSTs. Matches
+# the webhook handler's ``_MAX_PENDING_ENTRIES`` cap (review LOW-2)
+# so a healthy registry never hits the truncation footer.
+_LIST_MAX_ROWS = 100
+
+
+def _build_argparser(subparser: argparse.ArgumentParser) -> None:
+    """Wire the subcommand's args. Called from ``server.py``'s argparse."""
+    subparser.add_argument(
+        "fingerprint",
+        nargs="?",
+        default=None,
+        help=(
+            "16-char hex fingerprint logged by the webhook receiver when "
+            "Notion's verification POST arrived. Omit to list all pending "
+            "entries (without revealing tokens)."
+        ),
+    )
+
+
+def main(args: argparse.Namespace) -> int:
+    """Entry point invoked from ``server.py``'s ``_dispatch``.
+
+    Returns 0 on success, 1 on no-matching-entry, 2 on
+    invalid-fingerprint, 3 on secrets_store error.
+    """
+    try:
+        from secrets_store import get_secret, list_keys
+    except Exception as exc:  # noqa: BLE001
+        print(f"[notion-pending] secrets_store unavailable: {exc}", file=sys.stderr)
+        return 3
+
+    if args.fingerprint is None:
+        return _list_pending(list_keys, get_secret)
+
+    fingerprint = args.fingerprint.strip().lower()
+    if not _FINGERPRINT_RE.match(fingerprint):
+        print(
+            f"[notion-pending] fingerprint must be 16 lowercase hex chars; got "
+            f"{args.fingerprint!r}",
+            file=sys.stderr,
+        )
+        return 2
+
+    return _retrieve_token(fingerprint, get_secret)
+
+
+def _list_pending(list_keys_fn, get_secret_fn) -> int:
+    """Print fingerprint + age for every pending entry. Never
+    prints token contents."""
+    try:
+        keys = list_keys_fn(source_id="notion")
+    except Exception as exc:  # noqa: BLE001
+        print(f"[notion-pending] list_keys failed: {exc}", file=sys.stderr)
+        return 3
+
+    pending_keys = sorted([k for k in keys if k.startswith(_PENDING_PREFIX)])
+    if not pending_keys:
+        print("No pending Notion verification entries.")
+        return 0
+
+    total = len(pending_keys)
+    truncated = total > _LIST_MAX_ROWS
+    visible = pending_keys[:_LIST_MAX_ROWS]
+
+    now = int(time.time())
+    print(f"{'FINGERPRINT':<18}{'AGE':<14}STATUS")
+    for key in visible:
+        fingerprint = key[len(_PENDING_PREFIX) :]
+        raw = get_secret_fn(source_id="notion", key=key)
+        if not raw:
+            print(f"{fingerprint:<18}{'?':<14}(value missing)")
+            continue
+        try:
+            entry = json.loads(raw)
+            received_at = int(entry.get("received_at") or 0)
+        except (json.JSONDecodeError, TypeError, ValueError):
+            print(f"{fingerprint:<18}{'?':<14}(malformed entry)")
+            continue
+        age_s = now - received_at
+        age = _format_age(age_s)
+        # 24h TTL on adoption (webhooks.notion._PENDING_TTL_SECONDS).
+        status = "stale" if age_s > 86400 else "active"
+        print(f"{fingerprint:<18}{age:<14}{status}")
+    if truncated:
+        print(
+            f"... and {total - _LIST_MAX_ROWS} more (showing first {_LIST_MAX_ROWS}). "
+            "Registry may be spammed; consider rotating the receiver URL."
+        )
+    return 0
+
+
+def _retrieve_token(fingerprint: str, get_secret_fn) -> int:
+    """Print the full token for one fingerprint to stdout. Operator
+    pastes this into Notion's UI."""
+    key = f"{_PENDING_PREFIX}{fingerprint}"
+    try:
+        raw = get_secret_fn(source_id="notion", key=key)
+    except Exception as exc:  # noqa: BLE001
+        print(f"[notion-pending] get_secret failed: {exc}", file=sys.stderr)
+        return 3
+
+    if not raw:
+        print(
+            f"[notion-pending] no pending entry for fingerprint {fingerprint!r}",
+            file=sys.stderr,
+        )
+        return 1
+
+    try:
+        entry = json.loads(raw)
+    except json.JSONDecodeError as exc:
+        print(
+            f"[notion-pending] entry for {fingerprint!r} is malformed: {exc}",
+            file=sys.stderr,
+        )
+        return 3
+
+    token = entry.get("token")
+    if not isinstance(token, str) or not token:
+        print(
+            f"[notion-pending] entry for {fingerprint!r} has no token field",
+            file=sys.stderr,
+        )
+        return 3
+
+    # Full token to stdout, not stderr — operator-driven retrieval
+    # is the safe surface (cycle 8 review F3). No trailing newline
+    # so the operator can pipe directly into a clipboard tool
+    # (``xclip``, ``pbcopy``, etc.) without spurious whitespace.
+    sys.stdout.write(token)
+    sys.stdout.flush()
+    return 0
+
+
+def _format_age(seconds: int) -> str:
+    """Render an age-in-seconds as a compact human-readable string."""
+    if seconds < 60:
+        return f"{seconds}s"
+    if seconds < 3600:
+        return f"{seconds // 60}m"
+    if seconds < 86400:
+        return f"{seconds // 3600}h"
+    days = seconds // 86400
+    return f"{days}d"

--- a/server.py
+++ b/server.py
@@ -1529,6 +1529,16 @@ def _register_subparsers(parser: ArgumentParser, subparsers: Any) -> None:
     from cli.webhook_server_cli import _build_argparser as _ws_build
 
     _ws_build(webhook_server)
+    notion_pending = subparsers.add_parser(
+        "notion-pending",
+        help=(
+            "retrieve pending Notion verification_token by fingerprint, or list "
+            "all pending entries (#337 cycle 8b)"
+        ),
+    )
+    from cli.notion_pending_cli import _build_argparser as _np_build
+
+    _np_build(notion_pending)
     subparsers.add_parser(
         "ledger-export",
         help="export the full ledger as JSON-Lines to stdout (#252 Layer 4)",
@@ -1619,6 +1629,10 @@ def _dispatch(args: Any) -> int:
         from cli.webhook_server_cli import main as webhook_server_main
 
         return webhook_server_main(args)
+    if args.command == "notion-pending":
+        from cli.notion_pending_cli import main as notion_pending_main
+
+        return notion_pending_main(args)
     if args.command == "ledger-export":
         from cli.ledger_export_cli import main as export_main
 

--- a/tests/test_cli_notion_pending.py
+++ b/tests/test_cli_notion_pending.py
@@ -1,0 +1,173 @@
+"""Tests for the ``bicameral-mcp notion-pending`` CLI (#337 cycle 8b).
+
+Coverage:
+- _list_pending: empty registry, one pending entry, multiple entries,
+  malformed entry, missing value, stale-vs-active status
+- _retrieve_token: happy path, no matching entry, malformed entry,
+  missing token field
+- main: invalid fingerprint shape rejected with exit 2, secrets_store
+  unavailable returns exit 3
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import time
+
+import pytest
+
+from cli.notion_pending_cli import main as cli_main
+
+
+@pytest.fixture(autouse=True)
+def _disable_keyring(monkeypatch):
+    monkeypatch.setenv("BICAMERAL_KEYRING_DISABLE", "1")
+    from secrets_store.store import _reset_for_tests as _secrets_reset
+
+    _secrets_reset()
+    yield
+    _secrets_reset()
+
+
+def _put_pending(
+    fingerprint: str, token: str = "secret_xyz", received_at: int | None = None
+) -> None:
+    """Helper: store a pending entry in the shape the webhook receiver writes."""
+    from secrets_store import put_secret
+
+    entry = json.dumps(
+        {
+            "token": token,
+            "received_at": received_at if received_at is not None else int(time.time()),
+        }
+    )
+    put_secret(source_id="notion", key=f"pending_{fingerprint}", value=entry)
+
+
+def _args(fingerprint: str | None = None) -> argparse.Namespace:
+    return argparse.Namespace(fingerprint=fingerprint)
+
+
+# ── list mode ──────────────────────────────────────────────────────────────
+
+
+def test_list_empty_registry(capsys: pytest.CaptureFixture):
+    rc = cli_main(_args(None))
+    assert rc == 0
+    captured = capsys.readouterr()
+    assert "No pending Notion verification entries." in captured.out
+
+
+def test_list_one_entry_shows_fingerprint_not_token(capsys: pytest.CaptureFixture):
+    _put_pending("a" * 16, token="secret_should_not_appear")
+    rc = cli_main(_args(None))
+    assert rc == 0
+    captured = capsys.readouterr()
+    assert "a" * 16 in captured.out
+    assert "active" in captured.out
+    # Token must NOT appear in list-mode output (F3 review fix).
+    assert "secret_should_not_appear" not in captured.out
+
+
+def test_list_multiple_entries(capsys: pytest.CaptureFixture):
+    _put_pending("a" * 16)
+    _put_pending("b" * 16)
+    rc = cli_main(_args(None))
+    assert rc == 0
+    captured = capsys.readouterr()
+    assert "a" * 16 in captured.out
+    assert "b" * 16 in captured.out
+
+
+def test_list_stale_entry_flagged(capsys: pytest.CaptureFixture):
+    """Entries older than 24h are flagged as 'stale' (matching the
+    webhook handler's adoption-TTL cutoff)."""
+    _put_pending("c" * 16, received_at=0)  # epoch 1970
+    rc = cli_main(_args(None))
+    assert rc == 0
+    captured = capsys.readouterr()
+    assert "c" * 16 in captured.out
+    assert "stale" in captured.out
+
+
+def test_list_malformed_entry_does_not_crash(capsys: pytest.CaptureFixture):
+    """A pending key with a non-JSON value should print '(malformed entry)'
+    and continue rather than blowing up the whole listing."""
+    from secrets_store import put_secret
+
+    put_secret(source_id="notion", key="pending_" + "d" * 16, value="not-json")
+    _put_pending("e" * 16)
+    rc = cli_main(_args(None))
+    assert rc == 0
+    captured = capsys.readouterr()
+    assert "malformed entry" in captured.out
+    # Good entry still shown.
+    assert "e" * 16 in captured.out
+
+
+# ── retrieve mode ──────────────────────────────────────────────────────────
+
+
+def test_retrieve_token_happy_path(capsys: pytest.CaptureFixture):
+    _put_pending("a" * 16, token="secret_real_token_value")
+    rc = cli_main(_args("a" * 16))
+    assert rc == 0
+    captured = capsys.readouterr()
+    # Token to stdout, no trailing newline (so operator can pipe to
+    # clipboard tools without spurious whitespace).
+    assert captured.out == "secret_real_token_value"
+
+
+def test_retrieve_token_missing_returns_1(capsys: pytest.CaptureFixture):
+    rc = cli_main(_args("a" * 16))
+    assert rc == 1
+    captured = capsys.readouterr()
+    assert "no pending entry" in captured.err
+
+
+def test_retrieve_token_malformed_entry_returns_3(capsys: pytest.CaptureFixture):
+    from secrets_store import put_secret
+
+    put_secret(source_id="notion", key="pending_" + "a" * 16, value="not-json")
+    rc = cli_main(_args("a" * 16))
+    assert rc == 3
+    captured = capsys.readouterr()
+    assert "malformed" in captured.err
+
+
+def test_retrieve_token_no_token_field_returns_3(capsys: pytest.CaptureFixture):
+    from secrets_store import put_secret
+
+    put_secret(source_id="notion", key="pending_" + "a" * 16, value=json.dumps({"received_at": 1}))
+    rc = cli_main(_args("a" * 16))
+    assert rc == 3
+    captured = capsys.readouterr()
+    assert "no token field" in captured.err
+
+
+# ── input validation ──────────────────────────────────────────────────────
+
+
+def test_invalid_fingerprint_shape_rejected(capsys: pytest.CaptureFixture):
+    rc = cli_main(_args("NOT-HEX"))
+    assert rc == 2
+    captured = capsys.readouterr()
+    assert "16 lowercase hex" in captured.err
+
+
+def test_invalid_fingerprint_too_short(capsys: pytest.CaptureFixture):
+    rc = cli_main(_args("abc"))
+    assert rc == 2
+    captured = capsys.readouterr()
+    assert "16 lowercase hex" in captured.err
+
+
+def test_uppercase_fingerprint_normalized(capsys: pytest.CaptureFixture):
+    """Per the CLI's .lower() normalization — operators copy-pasting
+    from stderr shouldn't be tripped up by accidental capitalization."""
+    _put_pending("a" * 16, token="secret_lowercase_stored")
+    rc = cli_main(_args("A" * 16))
+    assert rc == 0
+    captured = capsys.readouterr()
+    assert captured.out == "secret_lowercase_stored"

--- a/tests/test_webhooks_notion.py
+++ b/tests/test_webhooks_notion.py
@@ -34,6 +34,38 @@ def _disable_keyring_and_reset_dedup(monkeypatch):
 
     _secrets_reset()
     _dedup_reset()
+
+    # Cycle 8b: stub fetch_active by default so tests that don't
+    # explicitly care about the ingest path (most pre-cycle-8b
+    # tests, written when the handler was ack-only) don't fail
+    # when the default ``page.content_updated`` event triggers a
+    # fetch against ``https://www.notion.so/page1`` (a non-real
+    # URL). Individual tests that exercise the fetch/ingest
+    # failure paths override this stub.
+    def _default_fetch(self, url):
+        return {
+            "query": "stub-title",
+            "source": "notion",
+            "title": "stub-title",
+            "date": "",
+            "participants": [],
+            "decisions": [{"description": "stub", "title": "stub-title"}],
+        }
+
+    monkeypatch.setattr("sources.notion.adapter.NotionAdapter.fetch_active", _default_fetch)
+
+    # Default ingest stub — tests that care about the ingest call
+    # override with their own monkeypatch. The stub matches the
+    # signature handle_ingest exposes (async + keyword-only args).
+    async def _default_ingest(ctx, payload, *, source_scope, ingest_mode):
+        pass
+
+    monkeypatch.setattr("handlers.ingest.handle_ingest", _default_ingest)
+
+    from types import SimpleNamespace as _SN
+
+    monkeypatch.setattr("context.BicameralContext.from_env", classmethod(lambda cls: _SN()))
+
     yield
     _secrets_reset()
     _dedup_reset()
@@ -201,6 +233,74 @@ def test_handle_verification_token_too_long_rejected():
     assert "length" in msg
 
 
+def test_handle_verification_pending_cap_rejects_new_fingerprint(
+    capsys: pytest.CaptureFixture, monkeypatch: pytest.MonkeyPatch
+):
+    """LOW-2 review fix: when the pending-entries set is at the cap,
+    NEW fingerprints are rejected with 429. Idempotent re-receipt
+    of an existing fingerprint still works."""
+    import webhooks.notion as _notion_mod
+
+    # Shrink the cap for testability.
+    monkeypatch.setattr(_notion_mod, "_MAX_PENDING_ENTRIES", 2)
+
+    from secrets_store import put_secret
+
+    put_secret(
+        source_id="notion",
+        key="pending_" + "a" * 16,
+        value=json.dumps({"token": "tok_a", "received_at": 1}),
+    )
+    put_secret(
+        source_id="notion",
+        key="pending_" + "b" * 16,
+        value=json.dumps({"token": "tok_b", "received_at": 1}),
+    )
+
+    body = json.dumps({"verification_token": "secret_third_attempt"}).encode("utf-8")
+    status, msg = handle(body=body, signature_header=None)
+    assert status == 429
+    assert "cap" in msg
+    err = capsys.readouterr().err
+    assert "cap reached" in err
+
+
+def test_handle_verification_pending_cap_allows_idempotent_resend(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    """LOW-2 review fix: re-receiving a verification POST with the
+    SAME token (same fingerprint) is allowed even at the cap. Notion
+    may retry the verification POST during operator setup."""
+    import webhooks.notion as _notion_mod
+
+    monkeypatch.setattr(_notion_mod, "_MAX_PENDING_ENTRIES", 2)
+
+    import hashlib
+
+    from secrets_store import get_secret, put_secret
+
+    existing_token = "secret_already_pending"
+    existing_fp = hashlib.sha256(existing_token.encode()).hexdigest()[:16]
+    put_secret(
+        source_id="notion",
+        key=f"pending_{existing_fp}",
+        value=json.dumps({"token": existing_token, "received_at": 1}),
+    )
+    put_secret(
+        source_id="notion",
+        key="pending_" + "f" * 16,
+        value=json.dumps({"token": "filler", "received_at": 1}),
+    )
+    # Now at cap (2). Re-send the verification for `existing_token`.
+    body = json.dumps({"verification_token": existing_token}).encode("utf-8")
+    status, _ = handle(body=body, signature_header=None)
+    assert status == 200
+    # received_at was refreshed.
+    raw = get_secret(source_id="notion", key=f"pending_{existing_fp}")
+    entry = json.loads(raw)
+    assert entry["received_at"] != 1
+
+
 def test_handle_verification_token_in_event_body_does_not_clobber():
     """Structural marker safety: if an attacker smuggles
     verification_token INTO an event payload (with `type` set), we
@@ -295,6 +395,282 @@ def test_handle_event_dedup_by_id():
     assert s1 == 200
     assert s2 == 200
     assert "duplicate" in msg2
+
+
+def test_handle_event_page_created_triggers_ingest(monkeypatch):
+    """Cycle 8b: page.created with a non-empty entity.id fetches the
+    page via NotionAdapter and pipes through handle_ingest."""
+    _put_token("sub-1", token="secret_token")
+
+    captured: dict = {}
+
+    # LOW-5 review fix: patch fetch_active on the real adapter
+    # class (narrower seam) rather than swapping the whole class.
+    # Catches constructor / _resolve_api_key regressions that a
+    # class-level swap would silently mask.
+    def _fake_fetch(self, url):
+        captured["fetch_url"] = url
+        return {
+            "query": "fetched-title",
+            "source": "notion",
+            "title": "fetched-title",
+            "date": "2026-05-20",
+            "participants": [],
+            "decisions": [{"description": "fetched-decision", "title": "fetched-title"}],
+        }
+
+    monkeypatch.setattr("sources.notion.adapter.NotionAdapter.fetch_active", _fake_fetch)
+
+    async def _fake_handle_ingest(ctx, payload, *, source_scope, ingest_mode):
+        captured["scope"] = source_scope
+        captured["mode"] = ingest_mode
+        captured["payload"] = payload
+
+    monkeypatch.setattr("handlers.ingest.handle_ingest", _fake_handle_ingest)
+    from types import SimpleNamespace as _SN
+
+    monkeypatch.setattr("context.BicameralContext.from_env", classmethod(lambda cls: _SN()))
+
+    body = _event_body(event_type="page.created")
+    status, msg = handle(body=body, signature_header=_sign("secret_token", body))
+    assert status == 200
+    assert "ingested" in msg
+    assert captured["scope"] == "notion"
+    assert captured["mode"] == "passive"
+    assert captured["payload"]["decisions"][0]["description"] == "fetched-decision"
+    # The fetch URL is built from entity.id with dashes stripped
+    # (handler normalizes to Notion's undashed UUID form). Test
+    # fixture entity.id is "page-1" → URL contains "page1".
+    assert "page1" in captured["fetch_url"]
+    assert "notion.so" in captured["fetch_url"]
+
+
+def test_handle_event_page_content_updated_triggers_ingest(monkeypatch):
+    """Same flow as page.created — pin that update events also
+    trigger fetch+ingest, not just create events."""
+    _put_token("sub-1", token="secret_token")
+
+    captured: dict = {}
+
+    def _fake_fetch(self, url):
+        return {
+            "query": "x",
+            "source": "notion",
+            "title": "x",
+            "date": "",
+            "participants": [],
+            "decisions": [{"description": "x", "title": "x"}],
+        }
+
+    monkeypatch.setattr("sources.notion.adapter.NotionAdapter.fetch_active", _fake_fetch)
+
+    async def _fake(ctx, payload, *, source_scope, ingest_mode):
+        captured["called"] = True
+
+    monkeypatch.setattr("handlers.ingest.handle_ingest", _fake)
+    from types import SimpleNamespace as _SN
+
+    monkeypatch.setattr("context.BicameralContext.from_env", classmethod(lambda cls: _SN()))
+
+    body = _event_body(event_type="page.content_updated")
+    status, _ = handle(body=body, signature_header=_sign("secret_token", body))
+    assert status == 200
+    assert captured.get("called") is True
+
+
+def test_handle_event_page_deleted_does_not_trigger_ingest(monkeypatch):
+    """page.deleted is acked but NOT fetched/ingested — same posture
+    as Linear's Issue.remove path (append-only contract)."""
+    _put_token("sub-1", token="secret_token")
+    fetch_called = []
+    ingest_called = []
+
+    def _fake_fetch(self, url):
+        fetch_called.append(url)
+        return {}
+
+    async def _fake(ctx, payload, *, source_scope, ingest_mode):
+        ingest_called.append(payload)
+
+    monkeypatch.setattr("sources.notion.adapter.NotionAdapter.fetch_active", _fake_fetch)
+    monkeypatch.setattr("handlers.ingest.handle_ingest", _fake)
+
+    body = _event_body(event_type="page.deleted")
+    status, msg = handle(body=body, signature_header=_sign("secret_token", body))
+    assert status == 200
+    assert "no ingest" in msg or "acknowledged" in msg
+    assert fetch_called == []
+    assert ingest_called == []
+
+
+def test_handle_event_page_event_missing_entity_id_skips_ingest(
+    monkeypatch, capsys: pytest.CaptureFixture
+):
+    """Defensive: page.* events with a missing entity.id are 200-acked
+    with a log but do NOT attempt to fetch (would otherwise hit the
+    Notion API with garbage)."""
+    _put_token("sub-1", token="secret_token")
+    fetch_called = []
+
+    def _fake_fetch(self, url):
+        fetch_called.append(url)
+        return {}
+
+    monkeypatch.setattr("sources.notion.adapter.NotionAdapter.fetch_active", _fake_fetch)
+
+    body = json.dumps(
+        {
+            "id": "evt-noent",
+            "timestamp": "2026-05-20T12:00:00.000Z",
+            "subscription_id": "sub-1",
+            "type": "page.content_updated",
+            "entity": {"type": "page"},  # NO id
+            "data": {},
+        }
+    ).encode("utf-8")
+    status, msg = handle(body=body, signature_header=_sign("secret_token", body))
+    assert status == 200
+    assert "entity.id" in msg or "acknowledged" in msg
+    assert fetch_called == []
+
+
+def test_handle_event_fetch_failure_acks_200_no_retry_amplification(
+    monkeypatch, capsys: pytest.CaptureFixture
+):
+    """Fetch failure is logged + 200-acked. Returning 5xx would cause
+    Notion to retry 8 times over 24h, amplifying transient fetch
+    failures into log spam. The audit log on stderr is the operator's
+    signal."""
+    _put_token("sub-1", token="secret_token")
+
+    # MED-1 fix: non-NotionAPIError exceptions (unclassified) now
+    # return 500 (transient default) so operator gets retry-storm
+    # visibility instead of silent loss. Pin the new posture.
+    def _broken_fetch(self, url):
+        raise RuntimeError("simulated transport failure")
+
+    monkeypatch.setattr("sources.notion.adapter.NotionAdapter.fetch_active", _broken_fetch)
+
+    body = _event_body(event_type="page.created")
+    status, msg = handle(body=body, signature_header=_sign("secret_token", body))
+    assert status == 500
+    assert "transient" in msg or "retry" in msg
+    err = capsys.readouterr().err
+    assert "simulated transport failure" in err
+
+
+def test_handle_event_fetch_5xx_returns_500_for_retry(monkeypatch, capsys: pytest.CaptureFixture):
+    """MED-1 fix: NotionAPIError with 5xx status → 500 so Notion's
+    8-retry envelope is the right backpressure mechanism."""
+    _put_token("sub-1", token="secret_token")
+
+    from sources.notion.client import NotionAPIError
+
+    def _fetch_503(self, url):
+        raise NotionAPIError("Service Unavailable", status_code=503)
+
+    monkeypatch.setattr("sources.notion.adapter.NotionAdapter.fetch_active", _fetch_503)
+
+    body = _event_body(event_type="page.created")
+    status, msg = handle(body=body, signature_header=_sign("secret_token", body))
+    assert status == 500
+    assert "transient" in msg
+    err = capsys.readouterr().err
+    assert "transient=True" in err
+
+
+def test_handle_event_fetch_429_returns_500_for_retry(monkeypatch, capsys: pytest.CaptureFixture):
+    """MED-1 fix: NotionAPIError with 429 (rate limit) → 500 so
+    Notion's retry envelope acts as the backoff."""
+    _put_token("sub-1", token="secret_token")
+
+    from sources.notion.client import NotionAPIError
+
+    def _fetch_429(self, url):
+        raise NotionAPIError("Rate limited", status_code=429)
+
+    monkeypatch.setattr("sources.notion.adapter.NotionAdapter.fetch_active", _fetch_429)
+
+    body = _event_body(event_type="page.created")
+    status, _ = handle(body=body, signature_header=_sign("secret_token", body))
+    assert status == 500
+
+
+def test_handle_event_fetch_404_returns_200_no_retry(monkeypatch, capsys: pytest.CaptureFixture):
+    """MED-1 fix: NotionAPIError with 4xx-not-429 (page deleted,
+    permission revoked) is deterministic → 200 ack. Retry would
+    amplify the deterministic failure."""
+    _put_token("sub-1", token="secret_token")
+
+    from sources.notion.client import NotionAPIError
+
+    def _fetch_404(self, url):
+        raise NotionAPIError("Not Found", status_code=404)
+
+    monkeypatch.setattr("sources.notion.adapter.NotionAdapter.fetch_active", _fetch_404)
+
+    body = _event_body(event_type="page.created")
+    status, msg = handle(body=body, signature_header=_sign("secret_token", body))
+    assert status == 200
+    assert "fetch failed" in msg
+    err = capsys.readouterr().err
+    assert "transient=False" in err
+
+
+def test_handle_event_ingest_hard_gate_refusal_acks_200(monkeypatch):
+    """Hard-gate refusal (e.g. PHI detected): _IngestRefused → 200 ack
+    (NOT 422 like the cycle-5/6/7 receivers). Reason: Notion retries
+    on ALL non-2xx (not just 5xx), and we don't want 8 retries of a
+    payload that the gate already rejected for compliance reasons.
+    Operator visibility via the gate's own audit-log emit."""
+    _put_token("sub-1", token="secret_token")
+
+    def _fake_fetch(self, url):
+        return {
+            "query": "x",
+            "source": "notion",
+            "title": "x",
+            "date": "",
+            "participants": [],
+            "decisions": [{"description": "x", "title": "x"}],
+        }
+
+    monkeypatch.setattr("sources.notion.adapter.NotionAdapter.fetch_active", _fake_fetch)
+
+    from handlers.ingest import _IngestRefused
+
+    async def _refuse(ctx, payload, *, source_scope, ingest_mode):
+        raise _IngestRefused(reason="sensitive_data:phi")
+
+    monkeypatch.setattr("handlers.ingest.handle_ingest", _refuse)
+    from types import SimpleNamespace as _SN
+
+    monkeypatch.setattr("context.BicameralContext.from_env", classmethod(lambda cls: _SN()))
+
+    body = _event_body(event_type="page.created")
+    status, msg = handle(body=body, signature_header=_sign("secret_token", body))
+    assert status == 200
+    assert "refused" in msg
+    assert "phi" in msg
+
+
+def test_handle_event_comment_created_does_not_fetch(monkeypatch):
+    """v0 scope: comment.* events ack-only; comment fetching requires
+    a Notion API path the adapter doesn't yet expose. Defer to a
+    later cycle. Pin that no fetch attempt happens."""
+    _put_token("sub-1", token="secret_token")
+    fetch_called = []
+
+    def _fake_fetch(self, url):
+        fetch_called.append(url)
+        return {}
+
+    monkeypatch.setattr("sources.notion.adapter.NotionAdapter.fetch_active", _fake_fetch)
+
+    body = _event_body(event_type="comment.created")
+    status, _ = handle(body=body, signature_header=_sign("secret_token", body))
+    assert status == 200
+    assert fetch_called == []
 
 
 def test_handle_event_attempt_number_4_logged(capsys: pytest.CaptureFixture):

--- a/webhooks/notion.py
+++ b/webhooks/notion.py
@@ -81,6 +81,13 @@ class WebhookVerificationError(Exception):
 _PENDING_PREFIX = "pending_"
 _SUBSCRIPTION_PREFIX = "subscription_"
 _PENDING_TTL_SECONDS = 24 * 60 * 60
+# LOW-2 review fix: cap the number of pending entries to bound the
+# memory cost of attacker-driven fake-verification POSTs. At ~120
+# bytes per JSON entry, 100 entries ≈ 12 KiB — well within the
+# dict-fallback memory budget. New verifications past the cap are
+# rejected with 429 (operator can investigate via
+# ``bicameral-mcp notion-pending``).
+_MAX_PENDING_ENTRIES = 100
 # secrets_store keys must match [A-Za-z0-9._-]+; subscription_id
 # from Notion is a UUID but we validate defensively in case the
 # body is attacker-crafted.
@@ -240,7 +247,25 @@ def _handle_verification(payload: dict) -> tuple[int, str]:
     entry = json.dumps({"token": token, "received_at": int(time.time())})
 
     try:
-        from secrets_store import put_secret
+        from secrets_store import list_keys, put_secret
+
+        # LOW-2 review fix: bound the pending-entries set. Idempotent
+        # re-receipt of the same fingerprint (Notion retrying the
+        # verification POST itself, or operator-side retry) is
+        # ALLOWED — it overwrites the existing entry and doesn't
+        # count against the cap. Only NEW fingerprints past the cap
+        # are rejected.
+        existing = [k for k in list_keys(source_id="notion") if k.startswith(_PENDING_PREFIX)]
+        is_new = _pending_key(fingerprint) not in existing
+        if is_new and len(existing) >= _MAX_PENDING_ENTRIES:
+            print(
+                f"[notion-webhook] pending-entries cap reached "
+                f"({len(existing)} >= {_MAX_PENDING_ENTRIES}); rejecting new "
+                f"fingerprint={fingerprint!r}. Use `bicameral-mcp notion-pending` "
+                "to inspect and clean up stale entries.",
+                file=sys.stderr,
+            )
+            return 429, f"pending-entries cap reached ({_MAX_PENDING_ENTRIES})"
 
         put_secret(source_id="notion", key=_pending_key(fingerprint), value=entry)
     except Exception as exc:  # noqa: BLE001
@@ -434,12 +459,129 @@ def _handle_event(body: bytes, payload: dict, signature_header: str | None) -> t
             file=sys.stderr,
         )
 
-    # v0: ack-only with a dirty-marker log. Cycle 8b adds the actual
-    # handle_ingest invocations once the wire is validated against
-    # real operator deliveries.
+    # Cycle 8b: actually ingest decision-bearing events. The
+    # webhook is the trigger; the canonical content still flows
+    # through ``sources/notion/adapter.py:fetch_active`` so the
+    # passive and active paths land identical payloads.
+    #
+    # ``page.*`` events with a non-deleted entity → fetch + ingest.
+    # ``page.deleted`` → ack only (append-only contract, same
+    # posture as Linear's Issue/Comment remove path).
+    # ``comment.*``, ``data_source.*``, ``database.*`` → ack only;
+    # later cycles add comment fetching, schema-change handling.
+    if event_type in {"page.created", "page.content_updated", "page.properties_updated"}:
+        entity = payload.get("entity") or {}
+        page_id = entity.get("id")
+        if not page_id or not isinstance(page_id, str):
+            print(
+                f"[notion-webhook] event_id={event_id!r} type={event_type!r} "
+                f"missing entity.id; skipping ingest",
+                file=sys.stderr,
+            )
+            return 200, f"event id={event_id!r} type={event_type!r} acknowledged (no entity.id)"
+        return _ingest_page(event_id, event_type, page_id)
+
+    # Acknowledged, no ingest. Cycle 8c-or-later will add comment
+    # fetching (needs a new Notion API path beyond the existing
+    # adapter) and decide whether schema / data_source events get
+    # any treatment.
     print(
         f"[notion-webhook] event_id={event_id!r} type={event_type!r} "
-        f"subscription_id={subscription_id!r} (ingest follow-up deferred to cycle 8b)",
+        f"subscription_id={subscription_id!r} (no ingest for this event type)",
         file=sys.stderr,
     )
     return 200, f"event id={event_id!r} type={event_type!r} acknowledged"
+
+
+def _ingest_page(event_id: str, event_type: str, page_id: str) -> tuple[int, str]:
+    """Fetch a Notion page via the active adapter and pipe through
+    ``handle_ingest`` in passive mode.
+
+    Mirrors the GitHub/Slack/Linear webhook → handle_ingest path:
+    ``asyncio.run()`` inside the to_thread worker. Cycle 9 review
+    M3 flagged this nested-loop pattern as a latent reliability
+    issue (per-request loop create/teardown overhead); a follow-up
+    cycle will revisit by making handle() itself async. Until
+    then, the pattern matches the rest of the chain.
+
+    Failure posture: ALL failures (fetch error, refusal, generic
+    ingest error) return 200 to Notion. Notion retries on every
+    non-2xx (not just 5xx like Drive), and we do NOT want 8 retries
+    of a payload that's already failed for a deterministic reason.
+    Operator visibility is via stderr + the gate's own audit-log
+    emit. This deviates from cycles 5/6/7 (which return 422 on
+    refusal) — the deviation is documented in the
+    research-brief-notion §5 retry-policy analysis.
+    """
+    try:
+        from sources.notion.adapter import NotionAdapter
+        from sources.notion.client import NotionAPIError
+
+        adapter = NotionAdapter()
+        # Build a canonical Notion URL from the page_id. The
+        # adapter accepts both dashed and undashed UUIDs; the
+        # webhook payload provides the undashed form.
+        page_url = f"https://www.notion.so/{page_id.replace('-', '')}"
+        ingest_payload = adapter.fetch_active(page_url)
+    except NotionAPIError as exc:
+        # MED-1 fix: split transient from deterministic fetch
+        # failures. 5xx + 429 are exactly the cases where Notion's
+        # 8-retry / 24h envelope is the right backpressure — return
+        # 500 so the provider retries and the operator sees the
+        # storm in their network metrics. 4xx-not-429 (page gone,
+        # permission revoked, malformed page_id) is genuinely
+        # deterministic; 200-ack with stderr so we don't amplify.
+        status_code = exc.status_code
+        is_transient = status_code is None or status_code == 429 or status_code >= 500
+        print(
+            f"[notion-webhook] page fetch failed for {page_id!r} "
+            f"(event_id={event_id!r}, http_status={status_code}, "
+            f"transient={is_transient}): {exc}",
+            file=sys.stderr,
+        )
+        if is_transient:
+            return 500, (
+                f"event id={event_id!r} fetch failed (transient http={status_code}); "
+                "Notion will retry"
+            )
+        return 200, f"event id={event_id!r} type={event_type!r} acknowledged (fetch failed)"
+    except Exception as exc:  # noqa: BLE001
+        # Non-NotionAPIError exceptions (e.g. malformed URL parse,
+        # adapter import failure, transport-layer bugs we haven't
+        # classified). Treat as transient by default — operator
+        # visibility via the retry storm is more useful than silent
+        # loss.
+        print(
+            f"[notion-webhook] page fetch raised non-API exception for {page_id!r} "
+            f"(event_id={event_id!r}): {type(exc).__name__}: {exc}",
+            file=sys.stderr,
+        )
+        return 500, f"event id={event_id!r} fetch failed (unclassified); Notion will retry"
+
+    try:
+        import asyncio
+
+        from context import BicameralContext
+        from handlers.ingest import _IngestRefused, handle_ingest
+
+        ctx = BicameralContext.from_env()
+
+        async def _ingest() -> None:
+            await handle_ingest(ctx, ingest_payload, source_scope="notion", ingest_mode="passive")
+
+        asyncio.run(_ingest())
+    except _IngestRefused as exc:
+        print(
+            f"[notion-webhook] hard-gate refusal for page {page_id!r} "
+            f"(event_id={event_id!r}): {exc.reason}",
+            file=sys.stderr,
+        )
+        return 200, f"event id={event_id!r} acknowledged (refused: {exc.reason})"
+    except Exception as exc:  # noqa: BLE001
+        print(
+            f"[notion-webhook] ingest failed for page {page_id!r} (event_id={event_id!r}): {exc}",
+            file=sys.stderr,
+        )
+        return 200, f"event id={event_id!r} acknowledged (ingest failed)"
+
+    return 200, f"event id={event_id!r} type={event_type!r} ingested page {page_id!r}"


### PR DESCRIPTION
## Summary

Cycle 8 follow-up. The cycle-8 receiver (#451, merged) acked Notion events without doing anything with them; this PR wires the receiver into actual ledger ingest via the existing \`NotionAdapter\`, and adds the operator-facing \`bicameral-mcp notion-pending\` CLI — the user-facing half of cycle 8's F3 review fix.

## Highlights

- \`_ingest_page\` wires \`page.created\`, \`page.content_updated\`, \`page.properties_updated\` through \`NotionAdapter.fetch_active\` + \`handle_ingest(ingest_mode=\"passive\")\`. \`page.deleted\` stays ack-only (append-only contract). \`comment.*\`, \`database.*\`, \`data_source.*\` deferred to a later cycle.
- \`bicameral-mcp notion-pending\` lists pending verification entries (fingerprint + age + status, never reveals the token). \`bicameral-mcp notion-pending <fingerprint>\` writes the full token to stdout with no trailing newline so operator can pipe to \`xclip\`/\`pbcopy\`.
- \`_handle_verification\` now caps pending entries at 100 to bound attacker-DoS memory pressure (review LOW-2).

## Adversarial review applied

\`code-reviewer\` ran a pre-ship pass. **SHIP WITH MINOR FIXES** (1 MED + 6 LOW). Three addressed in-PR:

| # | Finding | Fix |
|---|---|---|
| MED-1 | Fetch failures collapsed to 200 — transient (5xx, 429) silently lost; no DLQ | Split: 5xx/429/transport-layer → 500 (use Notion's 8-retry envelope as backpressure); 4xx-not-429 + \`_IngestRefused\` → 200 (deterministic, no retry amplification) |
| LOW-2 | No bound on pending entries → attacker-DoS via fake-verification POSTs | Cap at 100; idempotent re-send by same fingerprint still allowed; new past cap → 429; CLI list mode mirrors the cap with a "and N more" footer |
| LOW-5 | Test class-swap masked constructor regressions | Method-level monkeypatch + autouse fixture stubbing \`fetch_active\` for the inherited ack-only tests |

LOW deferred to fast-follow: URL-construction cosmetic refactor, CLI \`--help\` token-stdout note, \`comment.*\` operator visibility, sociable-test ctx tautology, list-then-get race (benign), exit-code semantic alignment with \`source_auth_cli\`.

Items cleared: SSRF (page_id is HMAC-verified + URL host hard-coded), HMAC bypass via verification-token smuggling, subscription_id path traversal, replay defense (dedup TTL covers retry envelope), stale-pending TTL still good, F2c attacker-pending poisoning still defended, fingerprint regex parity with handler emit, CLI never prints tokens in list mode.

## Tests: +20 new (+12 webhook + 8 CLI), 123 webhook+CLI tests total green

\`pytest tests/test_webhooks_*.py tests/test_cli_notion_pending.py -q\` → 123 passed

## Scope deferred (cycle 8c)

- \`comment.*\` ingest (new Notion API path beyond existing adapter)
- \`database.*\` / \`data_source.*\` decision treatment (product question)
- \`bicameral-mcp notion-expect-subscription <id>\` CLI to pre-bind pending tokens
- Centralized CLI exit-code constants

## Test plan
- [x] All webhook + CLI tests green
- [x] Ruff format + check clean
- [ ] CI green on PR

Part of BicameralAI/bicameral-daemon#3.

🤖 Generated with [Claude Code](https://claude.com/claude-code)