### PR TITLE
feat(drive): wire webhook into delivery-id dedup (#337 cycle 9d)

### DIFF
--- a/cli/drive_renew_cli.py
+++ b/cli/drive_renew_cli.py
@@ -11,20 +11,29 @@ renewal cadence or ingest stops at the 24h mark.
 During the renewal window (between step 2 / persist-new and step 3
 / stop-old) BOTH the old and new channels are active on Drive's
 side. Drive will deliver the same change notification to both
-channels with DIFFERENT ``X-Goog-Channel-Id`` headers. The
-:mod:`webhooks.google_drive` handler does NOT currently consult
-:mod:`webhooks.dedup` (unlike the other four providers' handlers)
-— so a change inside the renewal window will fire ``handle_ingest``
-TWICE for the same file_id. Suppression of the duplicate falls to
-the ledger's content-hash idempotency (`#216`), which is a
-weaker contract than per-delivery dedup.
+channels with DIFFERENT ``X-Goog-Channel-Id`` headers — so a
+change inside the renewal window fires ``handle_ingest`` once per
+channel for the same file_id.
 
-This is a pre-existing cycle-9b gap that renewal aggravates.
-Cycle 9d adds proper dedup keyed on ``(channel_id,
-message_number)``. Until then, operators running this CLI should
-expect a small rate of duplicate-ledger-row attempts during
-renewal windows (suppressed by content-hash idempotency, visible
-in the audit log).
+Cycle 9d wired :mod:`webhooks.google_drive` into
+:mod:`webhooks.dedup`, but that dedup keys on
+``(channel_id, message_number)`` — it suppresses Drive's
+provider-side RETRY of the *same* delivery (5xx retry envelope,
+identical headers). It does NOT suppress the renewal-window
+duplicate above: the old and successor channels carry different
+``channel_id`` values, so the two deliveries produce different
+dedup keys and both reach ``handle_ingest``.
+
+The renewal-window duplicate is therefore suppressed one layer
+down, by the ledger's ``canonical_id`` upsert idempotency
+(``upsert_decision`` / ``upsert_input_span``; tracked under #216):
+a re-ingest of the same file content resolves to the same
+``canonical_id`` and updates rather than inserts. The only cost of
+the renewal-window overlap is a wasted ``files.get`` for content
+already ingested — no duplicate ledger row. This is an accepted
+floor, not a gap to close: a notification carries no cross-channel
+change identifier, so per-delivery dedup structurally cannot key
+the two channels together.
 
 This CLI does one pass over the channel registry. For each channel
 expiring within the threshold (default: 43200s = 12h), it issues a

--- a/tests/test_webhooks_google_drive.py
+++ b/tests/test_webhooks_google_drive.py
@@ -79,8 +79,16 @@ def _reset_singleton(monkeypatch):
 
     monkeypatch.setattr("context.BicameralContext.from_env", classmethod(lambda cls: _SN()))
 
+    # Cycle 9d: dedup singleton is process-local; without reset between
+    # tests the dedup cache cross-contaminates and tests that re-use
+    # default (channel_id="ch-1", message_number="42") would silently
+    # short-circuit on the second-and-later test.
+    from webhooks.dedup import _reset_for_tests as _dedup_reset
+
+    _dedup_reset()
     yield
     _channels_reset()
+    _dedup_reset()
 
 
 def _record(
@@ -833,8 +841,48 @@ def test_handle_body_is_ignored(reg: ChannelRegistry):
         message_number="42",
         registry=reg,
     )
+    # Use a distinct message_number so cycle-9d dedup does not short-
+    # circuit the second call and mask the body-is-ignored invariant.
     status2, _ = handle(
         body=b'{"unexpected": "body"}',
+        channel_id="ch-1",
+        channel_token="tok-1",
+        resource_id="res-1",
+        resource_state="update",
+        message_number="43",
+        registry=reg,
+    )
+    assert status1 == status2 == 200
+
+
+# ── cycle 9d: per-delivery dedup ────────────────────────────────────────────
+
+
+def test_handle_duplicate_delivery_returns_200_no_ingest(reg: ChannelRegistry, monkeypatch):
+    """Replay of the same (channel_id, message_number) short-circuits
+    with 200 + "duplicate" on the second hit. The adapter's
+    fetch_active must be called EXACTLY ONCE across two invocations
+    — proves dedup runs before _ingest_change."""
+    reg.register(_record(file_id="dedup-file-1"))
+    fetch_count: list[int] = []
+
+    def _counting_fetch(self, url):
+        fetch_count.append(1)
+        return {
+            "query": "t",
+            "source": "google_drive",
+            "title": "t",
+            "date": "",
+            "participants": [],
+            "decisions": [{"description": "d", "title": "t"}],
+        }
+
+    monkeypatch.setattr(
+        "sources.google_drive.adapter.GoogleDriveAdapter.fetch_active", _counting_fetch
+    )
+
+    status1, msg1 = handle(
+        body=b"",
         channel_id="ch-1",
         channel_token="tok-1",
         resource_id="res-1",
@@ -842,4 +890,250 @@ def test_handle_body_is_ignored(reg: ChannelRegistry):
         message_number="42",
         registry=reg,
     )
-    assert status1 == status2 == 200
+    status2, msg2 = handle(
+        body=b"",
+        channel_id="ch-1",
+        channel_token="tok-1",
+        resource_id="res-1",
+        resource_state="update",
+        message_number="42",
+        registry=reg,
+    )
+    assert status1 == 200
+    assert status2 == 200
+    assert "ingested" in msg1
+    assert msg2 == "duplicate"
+    assert len(fetch_count) == 1, f"fetch_active called {len(fetch_count)} times; want 1"
+
+
+def test_handle_dedup_isolates_by_channel_id(reg: ChannelRegistry, monkeypatch):
+    """Same message_number from two distinct channel_ids must BOTH
+    process (no cross-channel collision)."""
+    reg.register(_record(channel_id="ch-A", resource_id="res-A", token="tok-A"))
+    reg.register(_record(channel_id="ch-B", resource_id="res-B", token="tok-B"))
+    fetch_count: list[int] = []
+
+    def _counting_fetch(self, url):
+        fetch_count.append(1)
+        return {
+            "query": "t",
+            "source": "google_drive",
+            "title": "t",
+            "date": "",
+            "participants": [],
+            "decisions": [{"description": "d", "title": "t"}],
+        }
+
+    monkeypatch.setattr(
+        "sources.google_drive.adapter.GoogleDriveAdapter.fetch_active", _counting_fetch
+    )
+
+    for cid, rid, tok in [("ch-A", "res-A", "tok-A"), ("ch-B", "res-B", "tok-B")]:
+        status, msg = handle(
+            body=b"",
+            channel_id=cid,
+            channel_token=tok,
+            resource_id=rid,
+            resource_state="update",
+            message_number="7",
+            registry=reg,
+        )
+        assert status == 200
+        assert "ingested" in msg, f"channel {cid!r} short-circuited; cross-channel collision"
+    assert len(fetch_count) == 2
+
+
+def test_handle_dedup_isolates_by_message_number(reg: ChannelRegistry, monkeypatch):
+    """Same channel_id with two distinct message_numbers must BOTH
+    process (not a same-channel collision)."""
+    reg.register(_record())
+    fetch_count: list[int] = []
+
+    def _counting_fetch(self, url):
+        fetch_count.append(1)
+        return {
+            "query": "t",
+            "source": "google_drive",
+            "title": "t",
+            "date": "",
+            "participants": [],
+            "decisions": [{"description": "d", "title": "t"}],
+        }
+
+    monkeypatch.setattr(
+        "sources.google_drive.adapter.GoogleDriveAdapter.fetch_active", _counting_fetch
+    )
+
+    for mn in ["100", "101"]:
+        status, msg = handle(
+            body=b"",
+            channel_id="ch-1",
+            channel_token="tok-1",
+            resource_id="res-1",
+            resource_state="update",
+            message_number=mn,
+            registry=reg,
+        )
+        assert status == 200
+        assert "ingested" in msg, f"message_number {mn!r} short-circuited; same-channel collision"
+    assert len(fetch_count) == 2
+
+
+def test_handle_dedup_isolates_by_source(reg: ChannelRegistry, monkeypatch):
+    """A mark_seen under source='github' for the same delivery_id
+    must NOT cause the Drive handler to short-circuit (source scoping
+    pin; closes a class of webhook-source-collision bugs)."""
+    reg.register(_record())
+    fetch_count: list[int] = []
+
+    def _counting_fetch(self, url):
+        fetch_count.append(1)
+        return {
+            "query": "t",
+            "source": "google_drive",
+            "title": "t",
+            "date": "",
+            "participants": [],
+            "decisions": [{"description": "d", "title": "t"}],
+        }
+
+    monkeypatch.setattr(
+        "sources.google_drive.adapter.GoogleDriveAdapter.fetch_active", _counting_fetch
+    )
+
+    # Poison the cache under a different source with the same key shape.
+    from webhooks.dedup import get_dedup_cache
+
+    get_dedup_cache().mark_seen("github", "ch-1:42")
+
+    status, msg = handle(
+        body=b"",
+        channel_id="ch-1",
+        channel_token="tok-1",
+        resource_id="res-1",
+        resource_state="update",
+        message_number="42",
+        registry=reg,
+    )
+    assert status == 200
+    assert "ingested" in msg, "cross-source dedup leak — source scoping broken"
+    assert len(fetch_count) == 1
+
+
+def test_handle_missing_message_number_does_not_dedup(reg: ChannelRegistry, monkeypatch):
+    """When Drive omits X-Goog-Message-Number (no contract guarantee),
+    dedup MUST fail-open — two back-to-back identical deliveries with
+    None message_number both reach _ingest_change. Canonical_id
+    upsert at the ledger layer is the safety net."""
+    reg.register(_record())
+    fetch_count: list[int] = []
+
+    def _counting_fetch(self, url):
+        fetch_count.append(1)
+        return {
+            "query": "t",
+            "source": "google_drive",
+            "title": "t",
+            "date": "",
+            "participants": [],
+            "decisions": [{"description": "d", "title": "t"}],
+        }
+
+    monkeypatch.setattr(
+        "sources.google_drive.adapter.GoogleDriveAdapter.fetch_active", _counting_fetch
+    )
+
+    for _ in range(2):
+        status, msg = handle(
+            body=b"",
+            channel_id="ch-1",
+            channel_token="tok-1",
+            resource_id="res-1",
+            resource_state="update",
+            message_number=None,
+            registry=reg,
+        )
+        assert status == 200
+        assert "ingested" in msg, "missing message_number caused dedup short-circuit"
+    assert len(fetch_count) == 2
+
+
+def test_handle_verification_failure_does_not_mark_dedup(reg: ChannelRegistry, monkeypatch):
+    """An unverified delivery (401) MUST NOT poison the cache —
+    otherwise an attacker who controls (channel_id, message_number)
+    but lacks the token could pre-burn cache slots and block legit
+    deliveries. After a 401, the same (channel_id, message_number)
+    with valid credentials must still process normally."""
+    reg.register(_record())
+    fetch_count: list[int] = []
+
+    def _counting_fetch(self, url):
+        fetch_count.append(1)
+        return {
+            "query": "t",
+            "source": "google_drive",
+            "title": "t",
+            "date": "",
+            "participants": [],
+            "decisions": [{"description": "d", "title": "t"}],
+        }
+
+    monkeypatch.setattr(
+        "sources.google_drive.adapter.GoogleDriveAdapter.fetch_active", _counting_fetch
+    )
+
+    # Bad delivery — wrong token → 401.
+    bad_status, _ = handle(
+        body=b"",
+        channel_id="ch-1",
+        channel_token="WRONG-TOK",
+        resource_id="res-1",
+        resource_state="update",
+        message_number="42",
+        registry=reg,
+    )
+    assert bad_status == 401
+
+    # Good delivery, same (channel_id, message_number) — must process.
+    good_status, good_msg = handle(
+        body=b"",
+        channel_id="ch-1",
+        channel_token="tok-1",
+        resource_id="res-1",
+        resource_state="update",
+        message_number="42",
+        registry=reg,
+    )
+    assert good_status == 200
+    assert "ingested" in good_msg, "401 poisoned the dedup cache; good delivery short-circuited"
+    assert len(fetch_count) == 1
+
+
+def test_handle_sync_message_dedup(reg: ChannelRegistry):
+    """A replayed sync message returns 200+"duplicate" on the second
+    hit — dedup is the single gate at the top of handle(), before
+    the sync branch. The first sync still acks normally."""
+    reg.register(_record())
+
+    status1, msg1 = handle(
+        body=b"",
+        channel_id="ch-1",
+        channel_token="tok-1",
+        resource_id="res-1",
+        resource_state="sync",
+        message_number="1",
+        registry=reg,
+    )
+    status2, msg2 = handle(
+        body=b"",
+        channel_id="ch-1",
+        channel_token="tok-1",
+        resource_id="res-1",
+        resource_state="sync",
+        message_number="1",
+        registry=reg,
+    )
+    assert status1 == 200
+    assert "sync acknowledged" in msg1
+    assert status2 == 200
+    assert msg2 == "duplicate"

--- a/webhooks/google_drive.py
+++ b/webhooks/google_drive.py
@@ -187,6 +187,30 @@ def handle(
         print(f"[drive-webhook] verification failed: {exc}", file=sys.stderr)
         return 401, f"verification failed: {exc}"
 
+    # Cycle 9d: per-delivery dedup. Drive auto-retries on 5xx with the
+    # same (channel_id, message_number); without dedup, a single logical
+    # event can fire `_ingest_change` multiple times. The
+    # `upsert_decision` / `upsert_input_span` canonical_id UUIDv5 upserts
+    # in the ledger are the idempotency safety net for any retries that
+    # slip past this gate, but suppressing the duplicate before
+    # `_ingest_change` also avoids the wasted Drive API quota of a
+    # second `files.get` for content we already ingested. Dedup is
+    # placed AFTER verification so unverified deliveries cannot poison
+    # the cache. Empty `message_number` (Drive does not guarantee the
+    # header) fail-opens through `is_duplicate`'s existing empty-id
+    # contract; canonical_id upsert remains the safety net.
+    from webhooks.dedup import get_dedup_cache
+
+    delivery_id = f"{channel_id}:{message_number}" if message_number else ""
+    cache = get_dedup_cache()
+    if cache.is_duplicate("google_drive", delivery_id):
+        print(
+            f"[drive-webhook] duplicate delivery {channel_id!r}:{message_number!r} ignored",
+            file=sys.stderr,
+        )
+        return 200, "duplicate"
+    cache.mark_seen("google_drive", delivery_id)
+
     state = (resource_state or "").strip().lower()
 
     # Sync message: Drive sends one of these immediately after


### PR DESCRIPTION
## Summary

Closes the actionable half of **HIGH-1** from PR #454's (cycle 9c) adversarial review. Drive's webhook handler was the only one of five receivers (github, slack, linear, notion, **google_drive**) not consulting `webhooks/dedup.py`.

This cycle wires `webhooks/google_drive.py::handle()` into the existing dedup cache using the established peer pattern (**verify → dedup → dispatch**).

## What this dedup catches — and what it does not

- **CATCHES — Drive provider-side retry**: Drive re-sends the *same* delivery on its 5xx retry envelope with identical headers. The key `(channel_id, message_number)` suppresses the repeat.
- **DOES NOT CATCH — renewal-window duplicate**: during channel renewal the old and successor channels are both live, and Drive delivers the same change to each with **different `channel_id`s** → different dedup keys → both reach `handle_ingest`. A notification carries no cross-channel change identifier, so per-delivery dedup *structurally cannot* key the two channels together.
- The renewal-window duplicate is suppressed one layer down by the ledger `canonical_id` upsert idempotency (`upsert_decision` / `upsert_input_span`, #216): a re-ingest of identical content resolves to the same `canonical_id` and updates rather than inserts. The only cost is a wasted `files.get` during the brief overlap — never a duplicate ledger row. **This is an accepted floor, not a gap to close.**

## Design

- **Key**: `(source="google_drive", delivery_id=f"{channel_id}:{message_number}")`. `X-Goog-Message-Number` is a non-sequential integer, unique-per-delivery within a channel.
- **Placement**: AFTER `verify_notification` — an attacker without a valid `(channel_id, channel_token, resource_id)` triple cannot poison the cache.
- **Empty `message_number` → fail-open**: Drive does not guarantee the header; empty `delivery_id` routes through the existing empty-id contract. `canonical_id` upsert is the safety net.
- **Mark-before-process** (matches the four peer handlers). *(Follow-up: cycle-9d review LOW-2 proposes a Drive-specific mark-after-ack, since Drive uniquely reuses delivery IDs on retry — tracked in the stacked follow-up PR.)*

## Also in this PR

Corrects the now-stale HIGH-1 docstring in `cli/drive_renew_cli.py` (landed via #454): it previously implied cycle 9d's `(channel_id, message_number)` dedup resolves the renewal-window duplicate. Reworded to state the provider-retry vs renewal-window distinction accurately.

## Governance

- Independent `architect-reviewer` plan audit: **PASS**, L2.
- Adversarial `code-reviewer` pre-push pass: **SHIP** — 0 HIGH, 0 MED, 3 LOW (all deferred; LOW-1 + LOW-2 addressed in the stacked follow-up PR).

## Test plan

- [x] 7 new sociable tests (real `DeliveryDedupCache`, real `handle()`): happy-path single-ingest, channel-id isolation, message-number isolation, source isolation, missing-message-number fail-open, verification-failure-no-cache-poison, sync-replay dedup.
- [x] 1 surgical fix to `test_handle_body_is_ignored` (distinct `message_number`s across its two calls).
- [x] `pytest tests/test_webhooks_*.py` → 192 passed, 1 skipped (POSIX-only).
- [x] `ruff check` + `ruff format --check` clean; `mypy` via CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)