### PR TITLE
fix(drive): partition dedup buckets + mark-after-ack (#337 cycle 9d follow-up)

### DIFF
--- a/tests/test_webhooks_dedup.py
+++ b/tests/test_webhooks_dedup.py
@@ -65,3 +65,68 @@ def test_get_dedup_cache_returns_singleton():
     b = get_dedup_cache()
     assert a is b
     _reset_for_tests()
+
+
+# ── partitioned buckets ─────────────────────────────────────────────────────
+
+
+def test_partition_isolates_eviction():
+    """The LOW-1 property: a flood into one partition evicts only that
+    partition's oldest entries — another partition's entries survive."""
+    cache = DeliveryDedupCache(max_entries=2, ttl_seconds=60)
+    # Partition B records one entry.
+    cache.mark_seen("google_drive", "b-keep", partition="ch-B")
+    # Partition A is flooded past its per-bucket cap of 2.
+    cache.mark_seen("google_drive", "a1", partition="ch-A")
+    cache.mark_seen("google_drive", "a2", partition="ch-A")
+    cache.mark_seen("google_drive", "a3", partition="ch-A")  # evicts a1 within ch-A
+    assert cache.is_duplicate("google_drive", "a1", partition="ch-A") is False
+    assert cache.is_duplicate("google_drive", "a2", partition="ch-A") is True
+    assert cache.is_duplicate("google_drive", "a3", partition="ch-A") is True
+    # ch-B's entry is untouched by ch-A's flood.
+    assert cache.is_duplicate("google_drive", "b-keep", partition="ch-B") is True
+
+
+def test_partition_none_is_its_own_bucket():
+    """An entry marked under a named partition is not a duplicate when
+    queried with the default partition=None."""
+    cache = DeliveryDedupCache()
+    cache.mark_seen("google_drive", "x", partition="ch-1")
+    assert cache.is_duplicate("google_drive", "x", partition=None) is False
+    assert cache.is_duplicate("google_drive", "x", partition="ch-1") is True
+
+
+def test_partition_distinct_channels_independent():
+    """Same delivery_id under two channel partitions are independent."""
+    cache = DeliveryDedupCache()
+    cache.mark_seen("google_drive", "msg-7", partition="ch-A")
+    assert cache.is_duplicate("google_drive", "msg-7", partition="ch-A") is True
+    assert cache.is_duplicate("google_drive", "msg-7", partition="ch-B") is False
+
+
+def test_max_partitions_evicts_lru_bucket():
+    """Bucket COUNT is bounded: creating a 3rd bucket past max_partitions=2
+    evicts the least-recently-written bucket wholesale."""
+    cache = DeliveryDedupCache(max_entries=10, max_partitions=2, ttl_seconds=60)
+    cache.mark_seen("google_drive", "d", partition="ch-A")
+    cache.mark_seen("google_drive", "d", partition="ch-B")
+    assert cache._partition_count() == 2
+    cache.mark_seen("google_drive", "d", partition="ch-C")  # evicts ch-A (LRU bucket)
+    assert cache._partition_count() == 2
+    assert cache.is_duplicate("google_drive", "d", partition="ch-A") is False
+    assert cache.is_duplicate("google_drive", "d", partition="ch-B") is True
+    assert cache.is_duplicate("google_drive", "d", partition="ch-C") is True
+
+
+def test_mark_seen_bumps_bucket_recency():
+    """A write to an existing bucket refreshes its LRU position, so an
+    actively-written bucket is not the one evicted under partition pressure."""
+    cache = DeliveryDedupCache(max_entries=10, max_partitions=2, ttl_seconds=60)
+    cache.mark_seen("google_drive", "d", partition="ch-A")
+    cache.mark_seen("google_drive", "d", partition="ch-B")
+    # Re-write ch-A — it becomes most-recently-written.
+    cache.mark_seen("google_drive", "d2", partition="ch-A")
+    cache.mark_seen("google_drive", "d", partition="ch-C")  # evicts ch-B, not ch-A
+    assert cache.is_duplicate("google_drive", "d", partition="ch-A") is True
+    assert cache.is_duplicate("google_drive", "d", partition="ch-B") is False
+    assert cache.is_duplicate("google_drive", "d", partition="ch-C") is True

--- a/tests/test_webhooks_google_drive.py
+++ b/tests/test_webhooks_google_drive.py
@@ -1137,3 +1137,143 @@ def test_handle_sync_message_dedup(reg: ChannelRegistry):
     assert "sync acknowledged" in msg1
     assert status2 == 200
     assert msg2 == "duplicate"
+
+
+# ── cycle 9d review LOW-2: mark-after-ack ───────────────────────────────────
+
+
+def test_handle_5xx_does_not_mark_dedup(reg: ChannelRegistry, monkeypatch):
+    """Mark-after-ack: a transient fetch failure returns 500 and must
+    NOT mark the delivery seen — Drive's retry of the same
+    (channel_id, message_number) must re-dispatch, not be dedup'd.
+    fetch_active is called on BOTH invocations."""
+    reg.register(_record())
+    fetch_count: list[int] = []
+
+    from unittest.mock import MagicMock
+
+    from googleapiclient.errors import HttpError
+
+    def _fetch_503(self, url):
+        fetch_count.append(1)
+        resp = MagicMock(status=503, reason="Service Unavailable")
+        cause = HttpError(resp=resp, content=b"")
+        raise RuntimeError("Google Docs API call failed: 503") from cause
+
+    monkeypatch.setattr("sources.google_drive.adapter.GoogleDriveAdapter.fetch_active", _fetch_503)
+
+    for _ in range(2):
+        status, _ = handle(
+            body=b"",
+            channel_id="ch-1",
+            channel_token="tok-1",
+            resource_id="res-1",
+            resource_state="update",
+            message_number="42",
+            registry=reg,
+        )
+        assert status == 500
+    assert len(fetch_count) == 2, (
+        f"fetch_active called {len(fetch_count)} times; 500 wrongly marked the delivery"
+    )
+
+
+def test_handle_deterministic_4xx_ack_marks_dedup(reg: ChannelRegistry, monkeypatch):
+    """Mark-after-ack: a deterministic 4xx fetch failure returns 200
+    (Drive will not retry) and therefore DOES mark the delivery — a
+    replay of the same delivery is dedup-suppressed. Proves a
+    200-that-is-not-a-success-ingest still marks."""
+    reg.register(_record())
+    fetch_count: list[int] = []
+
+    from unittest.mock import MagicMock
+
+    from googleapiclient.errors import HttpError
+
+    def _fetch_404(self, url):
+        fetch_count.append(1)
+        resp = MagicMock(status=404, reason="Not Found")
+        cause = HttpError(resp=resp, content=b"not found")
+        raise RuntimeError("Google Docs API call failed: 404") from cause
+
+    monkeypatch.setattr("sources.google_drive.adapter.GoogleDriveAdapter.fetch_active", _fetch_404)
+
+    status1, _ = handle(
+        body=b"",
+        channel_id="ch-1",
+        channel_token="tok-1",
+        resource_id="res-1",
+        resource_state="update",
+        message_number="42",
+        registry=reg,
+    )
+    status2, msg2 = handle(
+        body=b"",
+        channel_id="ch-1",
+        channel_token="tok-1",
+        resource_id="res-1",
+        resource_state="update",
+        message_number="42",
+        registry=reg,
+    )
+    assert status1 == 200
+    assert status2 == 200
+    assert msg2 == "duplicate"
+    assert len(fetch_count) == 1, (
+        f"fetch_active called {len(fetch_count)} times; deterministic 200 failed to mark"
+    )
+
+
+def test_handle_dedup_partition_isolates_by_channel(reg: ChannelRegistry, monkeypatch):
+    """LOW-1 end-to-end: the handler passes partition=channel_id, so a
+    flood on one channel cannot evict another channel's replay
+    protection. Drive the dedup cache to a tiny per-bucket capacity
+    and confirm a marked delivery on ch-quiet survives a flood on
+    ch-noisy."""
+    reg.register(_record(channel_id="ch-quiet", resource_id="res-q", token="tok-q"))
+    reg.register(_record(channel_id="ch-noisy", resource_id="res-n", token="tok-n"))
+
+    import webhooks.dedup as dedup_mod
+    from webhooks.dedup import DeliveryDedupCache, _reset_for_tests
+
+    _reset_for_tests()
+    # Install a cache with a per-bucket cap of 2 so a 3-delivery flood
+    # on ch-noisy would evict its own oldest — but must not touch
+    # ch-quiet's bucket.
+    dedup_mod._singleton = DeliveryDedupCache(max_entries=2, ttl_seconds=60)
+
+    def _ok_fetch(self, url):
+        return {
+            "query": "t",
+            "source": "google_drive",
+            "title": "t",
+            "date": "",
+            "participants": [],
+            "decisions": [{"description": "d", "title": "t"}],
+        }
+
+    monkeypatch.setattr("sources.google_drive.adapter.GoogleDriveAdapter.fetch_active", _ok_fetch)
+
+    def _deliver(channel_id, resource_id, token, message_number):
+        return handle(
+            body=b"",
+            channel_id=channel_id,
+            channel_token=token,
+            resource_id=resource_id,
+            resource_state="update",
+            message_number=message_number,
+            registry=reg,
+        )
+
+    # One delivery on the quiet channel.
+    _deliver("ch-quiet", "res-q", "tok-q", "1")
+    # Flood the noisy channel past its per-bucket cap of 2.
+    for mn in ["1", "2", "3"]:
+        _deliver("ch-noisy", "res-n", "tok-n", mn)
+    # The quiet channel's delivery is still deduped — its bucket was
+    # untouched by the noisy flood.
+    status, msg = _deliver("ch-quiet", "res-q", "tok-q", "1")
+    assert status == 200
+    assert msg == "duplicate", "ch-noisy flood evicted ch-quiet's replay protection"
+
+    _reset_for_tests()

--- a/webhooks/dedup.py
+++ b/webhooks/dedup.py
@@ -3,14 +3,30 @@
 Webhook providers retry failed deliveries — the same payload may
 arrive 2-N times within a short window. To prevent duplicate ingest,
 we track delivery IDs (``X-GitHub-Delivery``, Slack's ``X-Slack-Request-Timestamp``
-plus ``X-Slack-Retry-Num``, Linear's webhook ID) in a bounded LRU
-keyed on ``(source, delivery_id)``.
+plus ``X-Slack-Retry-Num``, Linear's webhook ID) in bounded LRUs
+keyed on ``delivery_id``.
 
-Cache is in-process. Default TTL is 24 hours to cover GitHub's full
-retry envelope (8 attempts over ~24h, with exponential backoff that
-can stretch past the 15-min mark for late retries). Capacity default
-1000 entries — operators handling high webhook volume should raise
-this or accept that dedup is best-effort beyond that window.
+## Partitioned buckets
+
+The cache is a bounded map of buckets. Each bucket is an independent
+bounded-LRU+TTL, keyed ``(source, partition)``:
+
+- ``source`` — the provider (``"github"``, ``"google_drive"``, ...).
+- ``partition`` — an optional sub-namespace within a source. The
+  Google Drive handler passes ``partition=channel_id`` so a noisy
+  channel evicts only its OWN oldest entries, never another
+  channel's replay protection. The other four handlers omit
+  ``partition`` (it defaults to ``None``) and share one bucket per
+  source — their delivery IDs are globally unique so per-channel
+  fairness does not apply.
+
+``max_entries`` caps each bucket; ``max_partitions`` caps the bucket
+COUNT (LRU eviction of a whole bucket when exceeded). Total memory
+is therefore bounded at ``max_partitions * max_entries`` entries.
+
+Default per-bucket TTL is 24 hours to cover GitHub's full retry
+envelope (8 attempts over ~24h, with exponential backoff that can
+stretch past the 15-min mark for late retries).
 
 Multi-process limitation: operators running multiple Bicameral
 processes behind a load balancer would NOT share this cache —
@@ -33,10 +49,13 @@ from collections import OrderedDict
 
 
 class DeliveryDedupCache:
-    """Bounded LRU + TTL cache for webhook delivery dedup.
+    """Bounded, partitioned LRU + TTL cache for webhook delivery dedup.
 
-    Eviction: oldest entry dropped when ``max_entries`` exceeded.
-    Expiry: entries older than ``ttl_seconds`` are not considered hits.
+    The cache holds one bucket per ``(source, partition)``. Within a
+    bucket: oldest entry dropped when ``max_entries`` exceeded; entries
+    older than ``ttl_seconds`` are not considered hits. Across buckets:
+    least-recently-written bucket dropped when ``max_partitions``
+    exceeded.
 
     Usage::
 
@@ -46,53 +65,84 @@ class DeliveryDedupCache:
             return
         cache.mark_seen("github", "abc-123-uuid")
         # ... process the delivery ...
+
+    Drive passes a partition so per-channel floods stay isolated::
+
+        if cache.is_duplicate("google_drive", did, partition=channel_id):
+            return
+        cache.mark_seen("google_drive", did, partition=channel_id)
     """
 
-    def __init__(self, *, max_entries: int = 1000, ttl_seconds: int = 86400) -> None:
+    def __init__(
+        self,
+        *,
+        max_entries: int = 1000,
+        max_partitions: int = 512,
+        ttl_seconds: int = 86400,
+    ) -> None:
         self._max = max_entries
+        self._max_partitions = max_partitions
         self._ttl = ttl_seconds
         self._lock = threading.Lock()
-        # Maps (source, delivery_id) -> insertion epoch.
-        self._entries: OrderedDict[tuple[str, str], float] = OrderedDict()
+        # Maps (source, partition) -> bucket. Bucket maps delivery_id
+        # -> insertion epoch. Outer OrderedDict gives LRU-of-buckets.
+        self._buckets: OrderedDict[tuple[str, str | None], OrderedDict[str, float]] = OrderedDict()
 
-    def is_duplicate(self, source: str, delivery_id: str) -> bool:
-        """Return True if this delivery_id has been seen for ``source`` within TTL."""
+    def is_duplicate(self, source: str, delivery_id: str, *, partition: str | None = None) -> bool:
+        """Return True if ``delivery_id`` was seen for ``(source, partition)`` within TTL."""
         if not delivery_id:
             return False
-        key = (source, delivery_id)
+        bucket_key = (source, partition)
         with self._lock:
-            entry = self._entries.get(key)
+            bucket = self._buckets.get(bucket_key)
+            if bucket is None:
+                return False
+            entry = bucket.get(delivery_id)
             if entry is None:
                 return False
             if time.time() - entry > self._ttl:
                 # Expired — treat as not-duplicate AND drop the stale entry.
-                self._entries.pop(key, None)
+                bucket.pop(delivery_id, None)
                 return False
             return True
 
-    def mark_seen(self, source: str, delivery_id: str) -> None:
-        """Record that ``delivery_id`` has been processed for ``source``."""
+    def mark_seen(self, source: str, delivery_id: str, *, partition: str | None = None) -> None:
+        """Record that ``delivery_id`` has been processed for ``(source, partition)``."""
         if not delivery_id:
             return
-        key = (source, delivery_id)
+        bucket_key = (source, partition)
         now = time.time()
         with self._lock:
-            # If already present, refresh its position (it's not technically
-            # an LRU since we don't bump on is_duplicate, but mark_seen
-            # is the dominant write — newer write wins).
-            if key in self._entries:
-                self._entries.move_to_end(key)
-                self._entries[key] = now
+            bucket = self._buckets.get(bucket_key)
+            if bucket is None:
+                bucket = OrderedDict()
+                self._buckets[bucket_key] = bucket
+                # Evict least-recently-written bucket beyond capacity.
+                while len(self._buckets) > self._max_partitions:
+                    self._buckets.popitem(last=False)
             else:
-                self._entries[key] = now
-                # Evict oldest beyond capacity.
-                while len(self._entries) > self._max:
-                    self._entries.popitem(last=False)
+                # Bucket-recency bump on write (matches the entry-level
+                # policy: mark_seen is the dominant write — newer write
+                # wins; is_duplicate does not bump).
+                self._buckets.move_to_end(bucket_key)
+            if delivery_id in bucket:
+                bucket.move_to_end(delivery_id)
+                bucket[delivery_id] = now
+            else:
+                bucket[delivery_id] = now
+                # Evict oldest entry beyond per-bucket capacity.
+                while len(bucket) > self._max:
+                    bucket.popitem(last=False)
 
     def _size(self) -> int:
-        """Test-only — current entry count."""
+        """Test-only — current entry count across all buckets."""
         with self._lock:
-            return len(self._entries)
+            return sum(len(b) for b in self._buckets.values())
+
+    def _partition_count(self) -> int:
+        """Test-only — current bucket count."""
+        with self._lock:
+            return len(self._buckets)
 
 
 # Process-wide singleton. Webhook handlers reach for this directly.

--- a/webhooks/google_drive.py
+++ b/webhooks/google_drive.py
@@ -203,15 +203,19 @@ def handle(
 
     delivery_id = f"{channel_id}:{message_number}" if message_number else ""
     cache = get_dedup_cache()
-    if cache.is_duplicate("google_drive", delivery_id):
+    # `partition=channel_id` (LOW-1): a noisy channel evicts only its
+    # own bucket's oldest entries, never another channel's replay
+    # protection.
+    if cache.is_duplicate("google_drive", delivery_id, partition=channel_id):
         print(
             f"[drive-webhook] duplicate delivery {channel_id!r}:{message_number!r} ignored",
             file=sys.stderr,
         )
         return 200, "duplicate"
-    cache.mark_seen("google_drive", delivery_id)
 
     state = (resource_state or "").strip().lower()
+
+    result: tuple[int, str]
 
     # Sync message: Drive sends one of these immediately after
     # channels.watch to confirm the URL is reachable. Per Drive's
@@ -232,35 +236,46 @@ def handle(
             f"[drive-webhook] sync ack for channel {channel_id!r}",
             file=sys.stderr,
         )
-        return 200, f"sync acknowledged for channel {channel_id!r}"
-
+        result = (200, f"sync acknowledged for channel {channel_id!r}")
     # Non-sync state: look up the file_id in the registry, fetch via
     # the active adapter, pipe through handle_ingest.
     # ``trash``/``remove`` are append-only-contract acks: we do NOT
     # propagate deletes to the ledger (operator uses #221 / GDPR path
     # for erasure, not this).
-    if state in {"add", "update", "change", "untrash"}:
+    elif state in {"add", "update", "change", "untrash"}:
         # verify_notification rejected missing channel_id above, so by
         # this point channel_id is guaranteed non-empty. Assert it for
         # the type-checker (mypy can't propagate the implicit narrow).
         assert channel_id is not None
-        return _ingest_change(channel_id, state, registry=registry)
-    if state in {"remove", "trash"}:
+        result = _ingest_change(channel_id, state, registry=registry)
+    elif state in {"remove", "trash"}:
         print(
             f"[drive-webhook] channel {channel_id!r} state={state!r} "
             f"acknowledged (append-only contract; no ingest)",
             file=sys.stderr,
         )
-        return 200, f"channel {channel_id!r} state={state!r} acknowledged (no ingest)"
+        result = (200, f"channel {channel_id!r} state={state!r} acknowledged (no ingest)")
+    else:
+        # Unknown / future state — still 200 (Drive's retry posture
+        # would retry on 5xx, and we don't want to retry on a state we
+        # simply haven't taught the handler about yet).
+        print(
+            f"[drive-webhook] channel {channel_id!r} unknown state {state!r}; acking",
+            file=sys.stderr,
+        )
+        result = (200, f"channel {channel_id!r} state={state!r} acknowledged (unknown)")
 
-    # Unknown / future state — still 200 (Drive's retry posture
-    # would retry on 5xx, and we don't want to retry on a state we
-    # simply haven't taught the handler about yet).
-    print(
-        f"[drive-webhook] channel {channel_id!r} unknown state {state!r}; acking",
-        file=sys.stderr,
-    )
-    return 200, f"channel {channel_id!r} state={state!r} acknowledged (unknown)"
+    # Cycle 9d review LOW-2: mark-after-ack. Drive uniquely reuses
+    # (channel_id, message_number) on its 5xx automatic retry, so
+    # marking before dispatch would let a process kill mid-ingest
+    # silently swallow Drive's retry. Mark only once the handler has
+    # decided a 200 (success, sync ack, delete-state ack,
+    # deterministic-failure ack) — Drive will not retry a 200, so the
+    # mark suppresses a genuine provider replay. A 500 path is left
+    # unmarked so Drive's retry re-dispatches.
+    if result[0] == 200 and delivery_id:
+        cache.mark_seen("google_drive", delivery_id, partition=channel_id)
+    return result
 
 
 def _ingest_change(channel_id: str, state: str, *, registry=None) -> tuple[int, str]:


### PR DESCRIPTION
## Summary

Addresses the two LOW findings from PR #455's adversarial review. **Stacked on #455** — both findings target code cycle 9d introduced, so the base is `feat/drive-cycle9d-dedup` (retarget to `dev` once #455 merges).

## LOW-1 — per-`(source, partition)` dedup buckets

`DeliveryDedupCache` was one process-global 1000-entry LRU: a high-volume webhook source/channel could evict another channel's replay-protection entries.

The cache is now a bounded map of buckets — each an independent bounded-LRU+TTL keyed `(source, partition)`. Bucket COUNT is itself bounded by `max_partitions` (LRU eviction of whole buckets), so memory stays bounded at `max_partitions × max_entries`.

- New keyword-only `partition` param (default `None`) on `is_duplicate` / `mark_seen`.
- The Drive handler passes `partition=channel_id` → a noisy channel evicts only its own bucket's oldest entries.
- The four peer handlers (github/slack/linear/notion) omit `partition` → share one `(source, None)` bucket, **byte-identical** to their prior behavior.
- `max_entries` keeps its name; meaning shifts from global cap to per-bucket cap. Existing dedup tests use the default partition and are unaffected.

## LOW-2 — Drive-specific mark-after-ack

`handle()` marked a delivery seen **before** dispatching to `_ingest_change`. A process kill mid-ingest left the delivery marked-but-unprocessed, and Drive's automatic retry (which reuses `channel_id:message_number`) was then dedup-suppressed and silently lost.

`handle()` now assigns its `(status, body)` result through an `if/elif/else` chain; a single tail marks the delivery **only when `status == 200`**. A 500 path is left unmarked so Drive's retry re-dispatches.

This is **Drive-only**: the four peer providers issue a fresh delivery ID on retry, so mark-before-process has no ghost-ingest window for them — they stay unchanged.

The widened check→mark window admits concurrent double-ingest of one delivery; that collapses to a single row at the ledger `canonical_id` upsert. **No lock is added** — the dedup cache is a quota-saver and replay-damper, never a once-only mutual-exclusion primitive. The plan audit explicitly ruled a cross-fetch lock would itself be a contention regression.

## Governance

- Independent `architect-reviewer` plan audit: **PASS**, L2.
- Adversarial `code-reviewer` pre-push pass: **SHIP** — 0 HIGH, 0 MED, 2 LOW (both cleared as non-blocking).

## Test plan

- [x] 5 new `test_webhooks_dedup.py` tests: partition eviction isolation, partition-None bucketing, distinct-channel independence, `max_partitions` bucket eviction, bucket-recency bump.
- [x] 3 new `test_webhooks_google_drive.py` tests: 5xx-does-not-mark, deterministic-4xx-ack-marks, end-to-end partition isolation.
- [x] `pytest tests/test_webhooks_*.py` → 200 passed, 1 skipped (POSIX-only).
- [x] `ruff check` + `ruff format --check` clean; `mypy` via CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)