### PR TITLE
feat(drive-renew): --token-rotation policy + honest missing-resourceId log

### DIFF
--- a/cli/drive_renew_cli.py
+++ b/cli/drive_renew_cli.py
@@ -40,7 +40,8 @@ expiring within the threshold (default: 43200s = 12h), it issues a
 successor:
 
 1. Call ``files.watch`` with a new UUID channel_id, the same
-   callback_url, a fresh token, and a fresh 24h expiration.
+   callback_url, a fresh or preserved token (see ``--token-rotation``
+   below), and a fresh 24h expiration.
 2. Persist the new ``ChannelRecord``.
 3. Call ``channels.stop`` on the old channel.
 4. Delete the old registry entry.
@@ -58,10 +59,34 @@ Usage::
     bicameral-mcp drive-renew                      # default: renew <12h
     bicameral-mcp drive-renew --threshold-seconds 28800  # renew <8h
     bicameral-mcp drive-renew --dry-run            # report what would happen
+    bicameral-mcp drive-renew --token-rotation preserve  # keep the token
 
-Token rotation: every renewal issues a fresh token via
-``secrets.token_urlsafe(32)``. Cycle-8 review F2 lesson applied —
-limiting the operational window of any one token to ~24h.
+## Token rotation (cycle-9c review MED-3)
+
+``--token-rotation`` controls the successor channel's token:
+
+- ``always`` (default) — mint a fresh ``secrets.token_urlsafe(32)``
+  per renewal. Cycle-8 review F2 lesson: this bounds the operational
+  window of any one token to ~24h. This is the secure default.
+- ``preserve`` — the successor reuses the existing channel's token.
+  Intended for operators whose external tooling pins the channel
+  token. **Security tradeoff**: a leaked token then stays valid
+  across every renewal indefinitely, instead of being bounded to a
+  single renewal period. The operator owns this tradeoff knowingly.
+
+``preserve`` only changes the rotation cadence — token *validation*
+(the constant-time compare in ``webhooks.google_drive``) is
+unchanged either way.
+
+## Why the ``HttpError`` import is function-scoped (cycle-9c LOW-1)
+
+The ``from googleapiclient.errors import HttpError`` inside
+``_renew_one`` is intentionally NOT hoisted to module level. It sits
+in a ``try/except`` that returns a graceful per-channel failure
+string if ``googleapiclient`` is unavailable. Hoisting it would turn
+that graceful degradation into a whole-CLI ``ImportError`` at import
+time. The function-scoped import is load-bearing; cycle-9c review
+LOW-1 ("hoist it") is evaluated and deliberately not actioned.
 """
 
 from __future__ import annotations
@@ -104,6 +129,19 @@ def _build_argparser(subparser: argparse.ArgumentParser) -> None:
         "--dry-run",
         action="store_true",
         help="Report what would be renewed without making any API calls.",
+    )
+    subparser.add_argument(
+        "--token-rotation",
+        choices=["always", "preserve"],
+        default="always",
+        help=(
+            "Successor-channel token policy. 'always' (default) mints a "
+            "fresh token per renewal, bounding any one token's lifetime "
+            "to ~24h. 'preserve' reuses the existing channel token across "
+            "renewals — for operators whose external tooling pins the "
+            "token. SECURITY TRADEOFF: with 'preserve' a leaked token "
+            "stays valid indefinitely instead of for one renewal period."
+        ),
     )
 
 
@@ -299,10 +337,22 @@ def _run_pass(args, records, registry) -> int:
         )
         return 3
 
+    token_rotation = args.token_rotation
+    if token_rotation == "preserve":
+        # One posture notice per pass (not per channel) so an operator
+        # who set this in a cron job sees the security tradeoff in the
+        # logs.
+        print(
+            "[drive-renew] --token-rotation=preserve: successor channels "
+            "reuse the existing token; a leaked token is not bounded to a "
+            "single renewal period.",
+            file=sys.stderr,
+        )
+
     succeeded: list[str] = []
     failed: list[tuple[str, str]] = []
     for record in due_renewable:
-        result = _renew_one(record, service, registry)
+        result = _renew_one(record, service, registry, token_rotation=token_rotation)
         if result is None:
             succeeded.append(record.channel_id)
         else:
@@ -318,10 +368,13 @@ def _run_pass(args, records, registry) -> int:
     return 0 if not failed else 2
 
 
-def _renew_one(record, service, registry) -> str | None:
+def _renew_one(record, service, registry, *, token_rotation: str = "always") -> str | None:
     """Issue a successor channel for ``record``, persist, stop old,
     delete old registry entry. Returns ``None`` on full success or a
     short failure reason string.
+
+    ``token_rotation`` is ``"always"`` (mint a fresh token) or
+    ``"preserve"`` (reuse ``record.token``); see the module docstring.
 
     Failure modes are local to this function and reported via the
     return value so the outer loop continues with the next record.
@@ -338,7 +391,22 @@ def _renew_one(record, service, registry) -> str | None:
         return f"googleapiclient import failed: {exc}"
 
     new_channel_id = str(uuid.uuid4())
-    new_token = secrets.token_urlsafe(_TOKEN_BYTES)
+    if token_rotation == "preserve" and record.token:
+        new_token = record.token
+    else:
+        if token_rotation == "preserve":
+            # `preserve` requested but the stored token is empty
+            # (registry corruption / pre-9c row). Minting a fresh
+            # token is the strictly-secure fallback — persisting a
+            # tokenless successor would produce a channel that
+            # `verify_notification` rejects on every delivery.
+            print(
+                f"[drive-renew] --token-rotation=preserve requested for "
+                f"channel {record.channel_id!r} but its stored token is "
+                f"empty; minting a fresh token for the successor.",
+                file=sys.stderr,
+            )
+        new_token = secrets.token_urlsafe(_TOKEN_BYTES)
     new_expiration_ms = int((time.time() + _MAX_TTL_SECONDS) * 1000)
 
     # ── Step 1: files.watch on the same file_id with the successor
@@ -371,17 +439,23 @@ def _renew_one(record, service, registry) -> str | None:
 
     new_resource_id = response.get("resourceId") or ""
     if not new_resource_id:
-        # Successor channel was created on Drive's side but we can't
-        # validate or stop it. Best-effort cleanup so we don't leak.
+        # LOW-2 (cycle-9c review): the successor channel WAS created on
+        # Drive's side (files.watch succeeded) but the response carries
+        # no resourceId. channels.stop REQUIRES a resourceId — there is
+        # no API call that can stop this channel. The prior code called
+        # stop() with an empty resourceId (a doomed request) and
+        # swallowed the failure: cleanup theater. Emit an honest
+        # MANUAL ACTION line instead. The channel self-expires within
+        # Drive's max TTL (~24h).
         print(
-            f"[drive-renew] successor channel for {record.channel_id!r} "
-            "has no resourceId in the response; attempting cleanup",
+            f"[drive-renew] MANUAL ACTION: a successor channel "
+            f"id={new_channel_id!r} was created for {record.channel_id!r} "
+            f"but its resourceId is absent from the files.watch response, "
+            f"so it cannot be stopped via the API. It will expire on its "
+            f"own within {_MAX_TTL_SECONDS}s (~24h). To stop it sooner, "
+            f"locate it via the Drive API and stop it manually.",
             file=sys.stderr,
         )
-        try:
-            service.channels().stop(body={"id": new_channel_id, "resourceId": ""}).execute()
-        except Exception:  # noqa: BLE001
-            pass
         return "successor response missing resourceId"
 
     # ── Step 2: persist new ChannelRecord.

--- a/tests/test_cli_drive_renew.py
+++ b/tests/test_cli_drive_renew.py
@@ -12,7 +12,9 @@ Coverage:
 - Happy path renews 1 channel: persists new record, stops old,
   deletes old entry
 - callback_url empty (pre-9c row) → skipped with reason; not a hard fail
-- successor response missing resourceId → cleanup + per-channel fail
+- successor response missing resourceId → honest MANUAL ACTION log,
+  no doomed channels.stop() call, per-channel fail (LOW-2)
+- --token-rotation always/preserve, empty-token fallback, bad value (MED-3)
 - persist failure → cleanup attempted + per-channel fail
 - old channels.stop 404 → tolerated (continue)
 - old registry.delete failure → tolerated + warning (don't fail the renewal)
@@ -45,8 +47,16 @@ def _reset_channels(tmp_path: Path):
     _channels_reset()
 
 
-def _args(threshold_seconds: int = 12 * 60 * 60, dry_run: bool = False) -> argparse.Namespace:
-    return argparse.Namespace(threshold_seconds=threshold_seconds, dry_run=dry_run)
+def _args(
+    threshold_seconds: int = 12 * 60 * 60,
+    dry_run: bool = False,
+    token_rotation: str = "always",
+) -> argparse.Namespace:
+    return argparse.Namespace(
+        threshold_seconds=threshold_seconds,
+        dry_run=dry_run,
+        token_rotation=token_rotation,
+    )
 
 
 def _record(
@@ -249,9 +259,14 @@ def test_pre_9c_rows_partition_does_not_mask_renewable_failures(
     assert "failed: 1" in captured.out  # only ch-403 counted
 
 
-def test_renew_missing_resource_id_on_successor_cleans_up(
+def test_renew_missing_resource_id_emits_manual_action(
     monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture
 ):
+    """LOW-2 (cycle-9c review): when the successor files.watch response
+    lacks resourceId, the channel cannot be stopped via the API
+    (channels.stop requires a resourceId). The handler must emit an
+    honest MANUAL ACTION log and must NOT make a doomed channels.stop()
+    call with an empty resourceId."""
     from cli.drive_renew_cli import main
     from sources.google_drive.channels import get_registry
 
@@ -266,9 +281,109 @@ def test_renew_missing_resource_id_on_successor_cleans_up(
     rc = main(_args())
     assert rc == 2
     captured = capsys.readouterr()
+    # Per-channel failure surfaced in the stdout summary.
     assert "resourceId" in captured.out
+    # Honest MANUAL ACTION log on stderr — no cleanup theater.
+    assert "MANUAL ACTION" in captured.err
+    # The doomed channels.stop() call must NOT have been made for the
+    # no-resourceId path (the old code called it with resourceId="").
+    assert fake_service.channels().stop.call_count == 0
     # Old entry still present — renewal didn't complete.
     assert get_registry().get("ch-noresid") is not None
+
+
+# ── MED-3: --token-rotation policy ──────────────────────────────────────────
+
+
+def _successor_record(registry, old_channel_id: str):
+    """After a successful renewal the registry holds exactly the
+    successor (old entry deleted). Return it."""
+    rows = [r for r in registry.list_all() if r.channel_id != old_channel_id]
+    assert len(rows) == 1, f"expected exactly one successor, got {len(rows)}"
+    return rows[0]
+
+
+def test_token_rotation_always_mints_fresh_token(
+    monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture
+):
+    """Default policy: the successor channel gets a freshly minted
+    token, distinct from the old channel's token."""
+    from cli.drive_renew_cli import main
+    from sources.google_drive.channels import get_registry
+
+    get_registry().register(_record(channel_id="ch-rot", token="tok-old"))
+
+    monkeypatch.setattr("sources.google_drive.auth.load_credentials", lambda: object())
+    fake_service = MagicMock()
+    fake_service.files().watch().execute.return_value = _watch_response()
+    monkeypatch.setattr("googleapiclient.discovery.build", lambda *a, **kw: fake_service)
+
+    rc = main(_args(token_rotation="always"))
+    assert rc == 0
+    successor = _successor_record(get_registry(), "ch-rot")
+    assert successor.token != "tok-old"
+    assert len(successor.token) > 0
+
+
+def test_token_rotation_preserve_reuses_token(
+    monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture
+):
+    """--token-rotation preserve: the successor channel reuses the old
+    channel's token verbatim."""
+    from cli.drive_renew_cli import main
+    from sources.google_drive.channels import get_registry
+
+    get_registry().register(_record(channel_id="ch-keep", token="tok-old"))
+
+    monkeypatch.setattr("sources.google_drive.auth.load_credentials", lambda: object())
+    fake_service = MagicMock()
+    fake_service.files().watch().execute.return_value = _watch_response()
+    monkeypatch.setattr("googleapiclient.discovery.build", lambda *a, **kw: fake_service)
+
+    rc = main(_args(token_rotation="preserve"))
+    assert rc == 0
+    successor = _successor_record(get_registry(), "ch-keep")
+    assert successor.token == "tok-old"
+    # Per-pass posture notice surfaced on stderr.
+    assert "preserve" in capsys.readouterr().err
+
+
+def test_token_rotation_preserve_empty_token_falls_back(
+    monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture
+):
+    """--token-rotation preserve on a row whose stored token is empty
+    (registry corruption / pre-9c) must fall back to minting a fresh
+    non-empty token — persisting a tokenless successor would produce a
+    channel that verify_notification rejects on every delivery."""
+    from cli.drive_renew_cli import main
+    from sources.google_drive.channels import get_registry
+
+    get_registry().register(_record(channel_id="ch-notoken", token=""))
+
+    monkeypatch.setattr("sources.google_drive.auth.load_credentials", lambda: object())
+    fake_service = MagicMock()
+    fake_service.files().watch().execute.return_value = _watch_response()
+    monkeypatch.setattr("googleapiclient.discovery.build", lambda *a, **kw: fake_service)
+
+    rc = main(_args(token_rotation="preserve"))
+    assert rc == 0
+    successor = _successor_record(get_registry(), "ch-notoken")
+    assert len(successor.token) > 0, "successor must not be tokenless"
+    # The fallback is logged so the operator sees it.
+    assert "empty" in capsys.readouterr().err
+
+
+def test_token_rotation_rejects_unknown_value():
+    """argparse choices reject an invalid --token-rotation value at
+    parse time."""
+    from cli.drive_renew_cli import _build_argparser
+
+    parser = argparse.ArgumentParser()
+    sub = parser.add_subparsers()
+    renew = sub.add_parser("drive-renew")
+    _build_argparser(renew)
+    with pytest.raises(SystemExit):
+        parser.parse_args(["drive-renew", "--token-rotation", "bogus"])
 
 
 def test_renew_files_watch_http_error_per_channel(


### PR DESCRIPTION
## Summary

The last two cycle-9c (`PR #454`) review fast-follow items for the `bicameral-mcp drive-renew` CLI.

## MED-3 — operator-pinnable token rotation

Renewal always minted a fresh token; some operators pin the channel token in external tooling. New **`--token-rotation {always,preserve}`** (default `always`):

- **`always`** — mint a fresh `secrets.token_urlsafe(32)` per renewal, bounding any one token's lifetime to ~24h. The secure default.
- **`preserve`** — the successor channel reuses the existing token. **Security tradeoff**: a leaked token then stays valid across renewals indefinitely. A once-per-pass stderr posture notice surfaces this in cron logs.
- **Empty-token fallback**: a `preserve` request against a row whose stored token is empty (registry corruption / pre-9c) falls back to a fresh mint + logs it — persisting a tokenless successor would produce a channel `verify_notification` rejects on every delivery.

`preserve` changes only rotation cadence; token *validation* (the constant-time compare in `webhooks/google_drive.py`) is untouched. `argparse choices` rejects invalid values at parse time.

## LOW-2 — honest missing-resourceId handling

When a successor `files.watch` response lacked `resourceId`, the old code called `channels.stop(body={"resourceId": ""})` — a doomed request (Drive requires a valid `resourceId`) whose failure was swallowed: cleanup theater. Replaced with a `MANUAL ACTION:` stderr log stating the channel cannot be stopped via the API and self-expires within Drive's ~24h max TTL. The per-channel failure still surfaces in the summary and exit code 2.

## LOW-1 — deliberately not actioned

The cycle-9c review suggested hoisting the function-scoped `HttpError` import. It sits in a `try/except` that degrades gracefully if `googleapiclient` is absent; hoisting would turn that into a whole-CLI `ImportError`. Recorded as evaluated/won't-fix with the rationale pinned in the module docstring.

## Governance

- Independent `architect-reviewer` plan audit: **PASS**, L2.
- Adversarial `code-reviewer` pre-push pass: **SHIP** — 0 HIGH, 0 MED, 2 LOW (both non-blocking; the suggested `getattr` guard was consciously declined — `args.token_rotation` is argparse-guaranteed and a hard `AttributeError` is the honest test-failure mode this repo's testing doctrine prefers).

## Test plan

- [x] 4 new MED-3 tests: `always` mints fresh, `preserve` reuses, `preserve` empty-token fallback, invalid value rejected.
- [x] 1 rewritten LOW-2 test (`test_renew_missing_resource_id_emits_manual_action`) — the old test asserting the doomed-cleanup contract was *replaced*, not left alongside.
- [x] `pytest tests/test_cli_drive_renew.py` → 24 passed.
- [x] `ruff check` + `ruff format --check` clean; `mypy` via CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)