### PR TITLE
docs(readme): link the trust-boundary scope statement (#215 Track 1)

### DIFF
--- a/README.md
+++ b/README.md
@@ -198,6 +198,8 @@ All data stays local. The embedded SurrealDB runs in-process — no separate ser
 
 We take privacy seriously. Bicameral runs entirely on your laptop — code, decisions, and transcripts never leave the machine unless you explicitly opt into team mode (which only shares an append-only event file via your existing git remote). Telemetry is anonymous integers + tool names only — opt out with `BICAMERAL_TELEMETRY=0`. The full posture (host-trust model, acceptable use, install-trust model, audit log, diagnose output, ledger export, availability stance) is in [`docs/policies/`](docs/policies/); reporting + supply-chain attestation in [`SECURITY.md`](SECURITY.md).
 
+**Trust boundary**: bicameral-mcp is a local-install developer tool — the trust boundary is the OS user account, and multi-user, hosted, or shared-machine deployments are out of scope. The canonical scope statement (which deployment shapes are in or out of scope for the unauthenticated MCP stdio transport) is [`docs/policies/threat-model-and-trust-boundary.md`](docs/policies/threat-model-and-trust-boundary.md).
+
 ---
 
 ## License


### PR DESCRIPTION
## Summary

BicameralAI/bicameral-daemon#9 Track 1 (compliance gap **SOC2-01**) shipped the canonical trust-boundary scope statement at `docs/policies/threat-model-and-trust-boundary.md`, but the README never linked it. A SOC 2 reviewer skimming the README would not discover it — which defeats the point of Track 1 (the scope statement is *evidence*; evidence has to be findable).

This adds a **Trust boundary** pointer to the README's Privacy & Compliance section: the one-sentence scope statement plus a direct link to the full doc.

## Scope

- Track 1 of BicameralAI/bicameral-daemon#9 is now fully closed (doc exists + is discoverable).
- Track 2 (the auth shim) remains explicitly out of BicameralAI/bicameral-daemon#9 scope per the issue body — gated on team-mode evolving into a server-mediated tier.

## Test plan

- [x] Docs-only change; no code paths touched.
- [x] Link target `docs/policies/threat-model-and-trust-boundary.md` exists and is the doc that declares itself the Track 1 deliverable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)