### PR TITLE
fix(release): ship sigstore bundles in the wheel so install verification re-engages (#292)

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -22,39 +22,54 @@ jobs:
       - name: Install build tools
         run: pip install hatchling build cyclonedx-bom
 
-      - name: Build package
-        run: python -m build
-
       - name: Install cosign
+        # #292: pin cosign to a specific 2.6.x release. `sign-blob
+        # --new-bundle-format` (required so sigstore-python's
+        # Bundle.from_json can read the output) needs cosign >= 2.4.0.
+        # cosign 3.x makes the protobuf bundle the default and retires
+        # the flag — migrating to 3.x is a deliberate deferred follow-up,
+        # so the version is pinned explicitly here.
         uses: sigstore/cosign-installer@v3
+        with:
+          cosign-release: 'v2.6.1'
 
       - name: Generate hooks-manifest.json
         run: |
-          # Install the just-built wheel so release.hooks_source can import setup_wizard.
-          pip install dist/bicameral_mcp-*.whl
-          mkdir -p dist/share/bicameral-mcp
-          python -m release.hooks_manifest_generator dist/share/bicameral-mcp/hooks-manifest.json
+          # #292: generate the manifest into the source-tree path that the
+          # hatch `shared-data` table reads, BEFORE `python -m build`. The
+          # manifest build hook (scripts/hooks_manifest_build_hook.py) sees
+          # the pre-signed `.sigstore` bundle written by the next step and
+          # skips regeneration, so the signed bytes survive into the wheel.
+          mkdir -p share/bicameral-mcp
+          python -m release.hooks_manifest_generator share/bicameral-mcp/hooks-manifest.json
 
       - name: Cosign keyless sign hooks-manifest
         run: |
-          cosign sign-blob --yes \
-            --output-signature dist/share/bicameral-mcp/hooks-manifest.json.sig \
-            --output-certificate dist/share/bicameral-mcp/hooks-manifest.json.crt \
-            dist/share/bicameral-mcp/hooks-manifest.json
+          # `--new-bundle-format` emits the Sigstore protobuf bundle that
+          # sigstore-python's Bundle.from_json() reads (cosign's legacy
+          # bundle JSON is rejected). Single-file `.sigstore` output.
+          cosign sign-blob --yes --new-bundle-format \
+            --bundle share/bicameral-mcp/hooks-manifest.json.sigstore \
+            share/bicameral-mcp/hooks-manifest.json
 
       - name: Generate skills-manifest.toml (#218 LLM-06)
         run: |
-          # SkillsManifestBuildHook bundles the manifest into the wheel at
-          # wheel-build time; this step writes a separate copy under dist/share
-          # for cosign signing + GitHub Release upload (mirrors hooks-manifest).
-          python -m release.skills_manifest_generator dist/share/bicameral-mcp/skills-manifest.toml
+          # Mirror of the hooks-manifest step: generate into the source-tree
+          # `shared-data` path before `python -m build`.
+          python -m release.skills_manifest_generator share/bicameral-mcp/skills-manifest.toml
 
       - name: Cosign keyless sign skills-manifest (#218 LLM-06)
         run: |
-          cosign sign-blob --yes \
-            --output-signature dist/share/bicameral-mcp/skills-manifest.toml.sig \
-            --output-certificate dist/share/bicameral-mcp/skills-manifest.toml.crt \
-            dist/share/bicameral-mcp/skills-manifest.toml
+          cosign sign-blob --yes --new-bundle-format \
+            --bundle share/bicameral-mcp/skills-manifest.toml.sigstore \
+            share/bicameral-mcp/skills-manifest.toml
+
+      - name: Build package
+        # #292: runs AFTER manifest generation + signing. The manifest
+        # build hook detects the pre-signed `.sigstore` bundles and skips
+        # regeneration; hatch `shared-data` bundles each manifest + its
+        # `.sigstore` into the wheel so install-time verification re-engages.
+        run: python -m build
 
       - name: Generate CycloneDX 1.5 SBOM
         run: |
@@ -86,13 +101,13 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
+          # #292: attach each manifest + its single-file `.sigstore` bundle
+          # (replaces the old `.sig` + `.crt` attachments).
           gh release upload "${{ github.event.release.tag_name }}" \
-            dist/share/bicameral-mcp/hooks-manifest.json \
-            dist/share/bicameral-mcp/hooks-manifest.json.sig \
-            dist/share/bicameral-mcp/hooks-manifest.json.crt \
-            dist/share/bicameral-mcp/skills-manifest.toml \
-            dist/share/bicameral-mcp/skills-manifest.toml.sig \
-            dist/share/bicameral-mcp/skills-manifest.toml.crt \
+            share/bicameral-mcp/hooks-manifest.json \
+            share/bicameral-mcp/hooks-manifest.json.sigstore \
+            share/bicameral-mcp/skills-manifest.toml \
+            share/bicameral-mcp/skills-manifest.toml.sigstore \
             dist/bicameral-mcp.sbom.json \
             dist/bicameral-mcp.sbom.intoto.jsonl \
             dist/release-tag-commit.txt \
@@ -122,10 +137,11 @@ jobs:
 
       - name: Strip non-PyPI artifacts before upload
         run: |
-          # share/ holds GitHub-Release artifacts (manifest + sigs + SBOM
-          # attestation + tag-commit signature); not part of the wheel/sdist
-          # PyPI upload. Tag-commit artifacts (#218 SOC2-03) are at dist/
-          # root, not under dist/share/, so enumerate explicitly.
+          # dist/ holds GitHub-Release-only artifacts (SBOM document + Rekor
+          # attestation + tag-commit signature) that must not be uploaded to
+          # PyPI. #292: the manifests + `.sigstore` bundles now live under
+          # share/ (bundled into the wheel via hatch shared-data) and never
+          # enter dist/, so there is no dist/share to strip.
           rm -rf dist/share \
             dist/bicameral-mcp.sbom.json \
             dist/bicameral-mcp.sbom.intoto.jsonl \

--- a/docs/RELEASE_EVIDENCE_PROCEDURE.md
+++ b/docs/RELEASE_EVIDENCE_PROCEDURE.md
@@ -31,12 +31,15 @@ gh release create v<VERSION> --generate-notes
 
 The publish workflow (`.github/workflows/publish.yml`) automatically:
 
-- Builds the wheel (with the bundled `share/bicameral-mcp/hooks-manifest.json` from the hatch build hook)
-- Cosign keyless-signs `hooks-manifest.json` (LLM-11 / #218)
+- Generates `hooks-manifest.json` + `skills-manifest.toml` into `share/bicameral-mcp/`
+- Cosign keyless-signs both manifests with `cosign sign-blob --new-bundle-format --bundle`, emitting single-file `.sigstore` bundles (LLM-11, LLM-06 / #218; bundle format / #292)
+- Builds the wheel — the manifest build hook detects the pre-signed `.sigstore` bundles and skips regeneration, and hatch `shared-data` bundles each manifest + its `.sigstore` into the wheel (#292)
 - Generates the CycloneDX 1.5 SBOM and Rekor attestation (OWASP-01 / #218)
 - Cosign keyless-signs the release tag's commit SHA (SOC2-03 / #218 — this document's surface)
 - Attaches all signed artifacts to the GitHub Release
 - Publishes the wheel + sdist to PyPI
+
+> **#292 ordering invariant**: manifest generation + `cosign sign-blob` run **before** `python -m build`. The build hook is idempotent — a pre-signed `.sigstore` makes it skip regeneration so the signed bytes survive into the wheel. `tests/test_publish_workflow_lint.py` enforces this ordering.
 
 ## Post-release verification
 
@@ -45,7 +48,8 @@ After the publish workflow completes:
 - [ ] Confirm the workflow succeeded in GitHub Actions
 - [ ] Confirm the GitHub Release page lists all expected signed artifacts:
   - `bicameral_mcp-<version>-py3-none-any.whl` (the wheel)
-  - `hooks-manifest.json` + `hooks-manifest.json.sig` + `hooks-manifest.json.crt`
+  - `hooks-manifest.json` + `hooks-manifest.json.sigstore`
+  - `skills-manifest.toml` + `skills-manifest.toml.sigstore`
   - `bicameral-mcp.sbom.json` + `bicameral-mcp.sbom.intoto.jsonl`
   - `release-tag-commit.txt` + `release-tag-commit.txt.sig` + `release-tag-commit.txt.crt`
 - [ ] Confirm the wheel + sdist are visible on https://pypi.org/project/bicameral-mcp/
@@ -112,14 +116,20 @@ The `release-tag-commit.txt` file contains the commit SHA the release tag pointe
 
 ### Verify the hooks-manifest signature
 
+The manifests are signed as single-file Sigstore `.sigstore` bundles
+(#292). Verify with the `--bundle` form:
+
 ```bash
 cosign verify-blob \
+  --new-bundle-format \
   --certificate-identity-regexp "^https://github.com/BicameralAI/bicameral-mcp/" \
   --certificate-oidc-issuer "https://token.actions.githubusercontent.com" \
-  --signature hooks-manifest.json.sig \
-  --certificate hooks-manifest.json.crt \
+  --bundle hooks-manifest.json.sigstore \
   hooks-manifest.json
 ```
+
+The same command verifies `skills-manifest.toml` against
+`skills-manifest.toml.sigstore`.
 
 ### Verify the SBOM Rekor attestation
 
@@ -132,6 +142,78 @@ cosign verify-attestation \
 ```
 
 The `bicameral-mcp.sbom.json` is the SBOM document; the `.intoto.jsonl` is the Rekor in-toto attestation that binds the SBOM to the wheel.
+
+## Verify install-time signature (#292)
+
+Since #292, the wheel ships each manifest **and** its `.sigstore` bundle
+(`hooks-manifest.json.sigstore`, `skills-manifest.toml.sigstore`) via
+hatch `shared-data`. At install time `bicameral-mcp setup` re-engages
+signature verification end-to-end.
+
+### What `bicameral-mcp setup` does at the signature layer
+
+Before writing any host hook config or copying any skill file, the wizard:
+
+1. Calls `setup_wizard._bundled_manifest_paths()` /
+   `_bundled_skills_manifest_paths()`, which locate the manifest + its
+   `.sigstore` bundle under `<sys.prefix>/share/bicameral-mcp/`. A
+   **zero-byte** `.sigstore` (the local-dev placeholder a non-release
+   build emits) is treated as absent → the helper returns `None` and
+   verification defers.
+2. When a real (non-empty) bundle is present, `release.manifest_verify` /
+   `release.skills_verify` load it with `sigstore.models.Bundle.from_json`
+   and verify the manifest via
+   `sigstore.verify.Verifier.production().verify_artifact()` under a
+   composite identity policy
+   (`GitHubWorkflowRepository("BicameralAI/bicameral-mcp")` **and**
+   `GitHubWorkflowName("Publish to PyPI")`).
+3. The verified manifest's per-entry SHA-256 values are cross-checked
+   against the exact bytes the installer is about to write/copy. Any
+   mismatch → `SignatureError` and the install aborts (fail-closed).
+
+### Confirm the verifier actually ran (no bypass)
+
+A clean install emits **no** `verification_bypassed` event. To confirm:
+
+```bash
+# After `bicameral-mcp setup`, inspect the ledger event stream for the repo.
+# A severity-3 verification_bypassed event means the signature check was
+# skipped via the emergency bypass env var — investigate before trusting
+# the install.
+grep -r '"event_type": "verification_bypassed"' ~/.bicameral/ 2>/dev/null || \
+  echo "no verification_bypassed events — verifier ran clean"
+```
+
+### Emergency bypass
+
+If verification fails on a known-good release (e.g. a transient Sigstore
+outage) the install can be forced through with:
+
+- `BICAMERAL_HOOKS_VERIFY_DISABLE=1` — bypass the hooks-manifest verifier
+- `BICAMERAL_SKILLS_VERIFY_DISABLE=1` — bypass the skills-manifest verifier
+
+Each bypass swallows the `SignatureError` **and writes a severity-3
+`verification_bypassed` ledger event** (with `manifest_kind: "skills"`
+for the skills surface) so the bypass is auditable. Use only when the
+failure is understood; the bypass is fail-open by design.
+
+### Manually verify the wheel's bundled `.sigstore`
+
+To verify a wheel's bundled bundle directly, extract it from the wheel
+(`shared-data` lands under `<dist>.data/data/share/bicameral-mcp/`) and
+run `cosign verify-blob --new-bundle-format --bundle ...` as shown in the
+"Verify the hooks-manifest signature" section above.
+
+### Release-time acceptance step (v0.14.5+)
+
+Because keyless cosign signing requires a GitHub Actions OIDC token, the
+end-to-end install-time path cannot be exercised before a real signed
+release exists. For the first release that ships #292, record this
+manual acceptance step in the release evidence:
+
+- [ ] A fresh `pipx install bicameral-mcp==<version>` followed by
+  `bicameral-mcp setup` completes **without** a `SignatureError` and
+  **without** a `verification_bypassed` event.
 
 ## Cross-references
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -54,7 +54,12 @@ dependencies = [
   # sentinel (#252 Layer 2) and operator-driven export/import (Layer 4).
   "surrealdb==2.0.0",
   "questionary>=2.0.0",
-  "sigstore>=3.0",
+  # Upper bound (#292): sigstore-python 4.x could break the Bundle /
+  # Verifier API the install-time verifiers pin (Bundle.from_json,
+  # Verifier.production().verify_artifact, policy.AllOf). Bump the
+  # ceiling deliberately after re-validating release/manifest_verify.py
+  # and release/skills_verify.py against the new major.
+  "sigstore>=3.0,<4.0",
   # Google Drive backend for team-mode replication (#277).
   "google-auth-oauthlib>=1.2",
   "google-api-python-client>=2.100",
@@ -118,6 +123,14 @@ path = "scripts/hooks_manifest_build_hook.py"
 [tool.hatch.build.targets.wheel.shared-data]
 "share/bicameral-mcp/hooks-manifest.json" = "share/bicameral-mcp/hooks-manifest.json"
 "share/bicameral-mcp/skills-manifest.toml" = "share/bicameral-mcp/skills-manifest.toml"
+# #292: ship the single-file Sigstore bundles alongside the manifests so
+# install-time verification re-engages. In a release build the publish
+# workflow signs the manifests before `python -m build` and these point
+# at real `.sigstore` bundles; in a local-dev build the build hook writes
+# empty placeholder bundles so this table resolves (a zero-byte bundle is
+# treated as absent by setup_wizard._bundled_*_manifest_paths).
+"share/bicameral-mcp/hooks-manifest.json.sigstore" = "share/bicameral-mcp/hooks-manifest.json.sigstore"
+"share/bicameral-mcp/skills-manifest.toml.sigstore" = "share/bicameral-mcp/skills-manifest.toml.sigstore"
 
 [tool.ruff]
 line-length = 100

--- a/release/manifest_verify.py
+++ b/release/manifest_verify.py
@@ -1,9 +1,9 @@
-"""Install-time verifier for ``hooks-manifest.json`` (#218 Phase 2).
+"""Install-time verifier for ``hooks-manifest.json`` (#218 Phase 2, #292).
 
 Loads the bundled manifest, verifies its keyless cosign signature via
-``_VERIFIER_HOOK`` (default: ``sigstore-python``), then cross-checks the
-SHA-256 of every command the installer is about to write against the
-verified manifest. Mismatch → ``SignatureError``.
+``_VERIFIER_HOOK`` (default: real ``sigstore-python`` verification),
+then cross-checks the SHA-256 of every command the installer is about
+to write against the verified manifest. Mismatch → ``SignatureError``.
 
 Bypass posture: ``BICAMERAL_HOOKS_VERIFY_DISABLE=1`` swallows the
 ``SignatureError`` after writing a severity-3 ``verification_bypassed``
@@ -11,8 +11,15 @@ ledger event via ``EventFileWriter``. Without the env var, the error
 propagates to the caller (fail-closed).
 
 The ``_VERIFIER_HOOK`` is a module-level function pointer to enable
-swapping in an offline-keypair verifier in a future #218 sub-task
-without touching this module's call sites.
+swapping the verifier in tests without touching this module's call
+sites.
+
+#292: the publish workflow signs the manifest with ``cosign sign-blob
+--new-bundle-format --bundle`` and ships the single-file ``.sigstore``
+bundle inside the wheel via hatch ``shared-data``. The verifier loads
+that bundle with ``sigstore.models.Bundle.from_json`` and verifies it
+with ``sigstore.verify.Verifier.production().verify_artifact()`` under
+a composite GitHub-workflow identity policy.
 """
 
 from __future__ import annotations
@@ -24,7 +31,7 @@ from collections.abc import Callable
 from datetime import UTC, datetime
 from pathlib import Path
 
-_VERIFIER_FN = Callable[[Path, Path, Path], None]
+_VERIFIER_FN = Callable[[Path, Path], None]  # (manifest_path, bundle_path)
 
 
 class SignatureError(Exception):
@@ -32,40 +39,55 @@ class SignatureError(Exception):
     SHA-256 mismatch, malformed manifest)."""
 
 
-def _sigstore_verify(manifest_path: Path, sig_path: Path, cert_path: Path) -> None:
-    """Default verifier: sigstore-python keyless verification.
+def _sigstore_verify(manifest_path: Path, bundle_path: Path) -> None:
+    """Default verifier: real sigstore-python keyless verification (#292).
 
-    v1 stub: sigstore-python integration is a deferred follow-up.
-    The publish workflow emits cosign-signed artifacts to the GitHub
-    Release, but v1 does NOT ship them bundled in the wheel — the
-    hatch shared-data wiring carries only the unsigned manifest. As a
-    result, ``setup_wizard._bundled_manifest_paths()`` returns None for
-    all current production installs and this verifier is never invoked
-    on the production install path.
+    Loads the single-file Sigstore ``.sigstore`` bundle produced by the
+    publish workflow's ``cosign sign-blob --new-bundle-format --bundle``
+    step and verifies the manifest against it via
+    ``Verifier.production().verify_artifact()``.
 
-    When wheel-bundling of `.sig` and `.crt` lands in a follow-up #218
-    sub-task, this stub gets replaced with a real ``Verifier.production()``
-    call against ``sigstore.models.Bundle``. Until then, raising
-    ``SignatureError`` is the honest fail-closed posture: if a bundled
-    manifest IS detected (someone manually placed artifacts under
-    ``<sys.prefix>/share/bicameral-mcp/``), refuse the install with a
-    clear "sigstore integration pending" message rather than
-    silently passing.
+    The identity policy is composite — it binds the signing certificate
+    to the ``Publish to PyPI`` workflow in ``BicameralAI/bicameral-mcp``,
+    independent of the triggering release tag (``policy.Identity`` is
+    exact-match, so a ``...@refs/tags/v*`` glob is not usable).
 
-    Tests monkeypatch ``_VERIFIER_HOOK`` to bypass this stub entirely;
-    see ``tests/test_setup_wizard_hook_verify.py``.
+    Fail-closed: missing manifest, missing bundle, malformed bundle,
+    tampered manifest bytes, or an identity mismatch all raise
+    ``SignatureError``. Tests substitute ``_VERIFIER_HOOK`` to drive the
+    wiring without an OIDC-signed bundle; see
+    ``tests/test_manifest_verify_sigstore.py``.
     """
     if not manifest_path.exists():
         raise SignatureError(f"manifest not found: {manifest_path}")
-    if not sig_path.exists():
-        raise SignatureError(f"signature not found: {sig_path}")
-    if not cert_path.exists():
-        raise SignatureError(f"certificate not found: {cert_path}")
-    raise SignatureError(
-        "sigstore-python keyless verification is a deferred #218 follow-up. "
-        "Set BICAMERAL_HOOKS_VERIFY_DISABLE=1 to bypass (writes severity-3 "
-        "verification_bypassed ledger event)."
-    )
+    if not bundle_path.exists():
+        raise SignatureError(f"sigstore bundle not found: {bundle_path}")
+    try:
+        from sigstore.models import Bundle
+        from sigstore.verify import Verifier, policy
+    except ImportError as exc:
+        raise SignatureError(
+            f"sigstore-python not installed: {exc}. Install it (it is a "
+            "first-class dependency) or set BICAMERAL_HOOKS_VERIFY_DISABLE=1 "
+            "to bypass (writes a severity-3 verification_bypassed ledger event)."
+        ) from exc
+    try:
+        verifier = Verifier.production()
+        bundle = Bundle.from_json(bundle_path.read_bytes())
+        verifier.verify_artifact(
+            input_=manifest_path.read_bytes(),
+            bundle=bundle,
+            policy=policy.AllOf(
+                [
+                    policy.GitHubWorkflowRepository("BicameralAI/bicameral-mcp"),
+                    policy.GitHubWorkflowName("Publish to PyPI"),
+                ]
+            ),
+        )
+    except SignatureError:
+        raise
+    except Exception as exc:
+        raise SignatureError(f"sigstore verification failed: {exc}") from exc
 
 
 _VERIFIER_HOOK: _VERIFIER_FN = _sigstore_verify
@@ -73,20 +95,20 @@ _VERIFIER_HOOK: _VERIFIER_FN = _sigstore_verify
 
 def verify_hooks_manifest(
     manifest_path: Path,
-    sig_path: Path,
-    cert_path: Path,
+    bundle_path: Path,
     expected_hooks: dict[str, str],
 ) -> None:
     """Verify the manifest signature and cross-check SHA-256 entries.
 
-    ``expected_hooks`` maps ``event_type`` → ``sha256(command_bytes)`` for
-    every hook the caller intends to write. Every entry must appear in
-    the verified manifest with matching SHA-256; any miss raises
-    ``SignatureError``.
+    ``bundle_path`` is the single-file Sigstore ``.sigstore`` bundle that
+    ships alongside the manifest in the wheel. ``expected_hooks`` maps
+    ``event_type`` → ``sha256(command_bytes)`` for every hook the caller
+    intends to write. Every entry must appear in the verified manifest
+    with matching SHA-256; any miss raises ``SignatureError``.
     """
     if not manifest_path.exists():
         raise SignatureError(f"manifest not found: {manifest_path}")
-    _VERIFIER_HOOK(manifest_path, sig_path, cert_path)
+    _VERIFIER_HOOK(manifest_path, bundle_path)
 
     parsed = json.loads(manifest_path.read_text(encoding="utf-8"))
     by_event = {h["event_type"]: h["sha256"] for h in parsed.get("hooks", [])}
@@ -118,8 +140,7 @@ def _get_event_writer():
 
 def verify_hooks_or_bypass(
     manifest_path: Path,
-    sig_path: Path,
-    cert_path: Path,
+    bundle_path: Path,
     expected_hooks: dict[str, str],
 ) -> None:
     """Verify the manifest; on failure, honor the bypass env var.
@@ -130,7 +151,7 @@ def verify_hooks_or_bypass(
     re-raises (fail-closed).
     """
     try:
-        verify_hooks_manifest(manifest_path, sig_path, cert_path, expected_hooks)
+        verify_hooks_manifest(manifest_path, bundle_path, expected_hooks)
     except SignatureError:
         if os.environ.get("BICAMERAL_HOOKS_VERIFY_DISABLE") != "1":
             raise

--- a/release/skills_verify.py
+++ b/release/skills_verify.py
@@ -1,9 +1,9 @@
-"""Install-time verifier for ``skills/MANIFEST.toml`` (#218 LLM-06).
+"""Install-time verifier for ``skills/MANIFEST.toml`` (#218 LLM-06, #292).
 
 Mirrors `release.manifest_verify` (#237 LLM-11) for the skills-content
 surface. Loads the bundled manifest, verifies its keyless cosign
-signature via ``_VERIFIER_HOOK`` (default: same deferred sigstore-python
-stub as #237), then cross-checks the SHA-256 of every skill file the
+signature via ``_VERIFIER_HOOK`` (default: real ``sigstore-python``
+verification), then cross-checks the SHA-256 of every skill file the
 installer is about to copy against the verified manifest. Mismatch →
 ``SignatureError``.
 
@@ -13,10 +13,12 @@ ledger event via ``EventFileWriter`` with ``manifest_kind: "skills"``
 for disambiguation against the LLM-11 hooks-manifest bypass events.
 Without the env var, the error propagates to the caller (fail-closed).
 
-Cosign keyless verification activation depends on the same deferred
-sigstore-python wiring as #237 LLM-11; both verifiers activate together
-when the stub at this module's `_sigstore_verify` is replaced with a
-real `Verifier.production()` call.
+#292: the publish workflow signs the manifest with ``cosign sign-blob
+--new-bundle-format --bundle`` and ships the single-file ``.sigstore``
+bundle inside the wheel via hatch ``shared-data``. The verifier loads
+that bundle with ``sigstore.models.Bundle.from_json`` and verifies it
+with ``sigstore.verify.Verifier.production().verify_artifact()`` under
+a composite GitHub-workflow identity policy.
 """
 
 from __future__ import annotations
@@ -28,7 +30,7 @@ from collections.abc import Callable
 from datetime import UTC, datetime
 from pathlib import Path
 
-_VERIFIER_FN = Callable[[Path, Path, Path], None]
+_VERIFIER_FN = Callable[[Path, Path], None]  # (manifest_path, bundle_path)
 
 
 class SignatureError(Exception):
@@ -36,33 +38,55 @@ class SignatureError(Exception):
     SHA-256 mismatch, malformed manifest)."""
 
 
-def _sigstore_verify(manifest_path: Path, sig_path: Path, cert_path: Path) -> None:
-    """Default verifier: sigstore-python keyless verification.
+def _sigstore_verify(manifest_path: Path, bundle_path: Path) -> None:
+    """Default verifier: real sigstore-python keyless verification (#292).
 
-    v1 stub: sigstore-python integration is a deferred follow-up
-    (mirrors `release/manifest_verify.py:_sigstore_verify` from #237).
-    Wheel-bundling of `.sig` and `.crt` is not yet shipping, so this
-    stub is unreachable in the current production install path —
-    `setup_wizard._bundled_skills_manifest_paths()` returns None for
-    all current installs.
+    Loads the single-file Sigstore ``.sigstore`` bundle produced by the
+    publish workflow's ``cosign sign-blob --new-bundle-format --bundle``
+    step and verifies the manifest against it via
+    ``Verifier.production().verify_artifact()``.
 
-    When the deferred sigstore-python wiring lands, this stub is
-    replaced with a real `Verifier.production()` call against
-    `sigstore.models.Bundle`. Both LLM-11 (hooks) and LLM-06 (skills)
-    verification activate together at that point.
+    The identity policy is composite — it binds the signing certificate
+    to the ``Publish to PyPI`` workflow in ``BicameralAI/bicameral-mcp``,
+    independent of the triggering release tag (``policy.Identity`` is
+    exact-match, so a ``...@refs/tags/v*`` glob is not usable).
+
+    Fail-closed: missing manifest, missing bundle, malformed bundle,
+    tampered manifest bytes, or an identity mismatch all raise
+    ``SignatureError``. Tests substitute ``_VERIFIER_HOOK`` to drive the
+    wiring without an OIDC-signed bundle; see
+    ``tests/test_skills_verify_sigstore.py``.
     """
     if not manifest_path.exists():
         raise SignatureError(f"manifest not found: {manifest_path}")
-    if not sig_path.exists():
-        raise SignatureError(f"signature not found: {sig_path}")
-    if not cert_path.exists():
-        raise SignatureError(f"certificate not found: {cert_path}")
-    raise SignatureError(
-        "sigstore-python keyless verification is a deferred #218 follow-up "
-        "(shared stub with LLM-11 hooks-manifest verifier). Set "
-        "BICAMERAL_SKILLS_VERIFY_DISABLE=1 to bypass (writes severity-3 "
-        "verification_bypassed ledger event)."
-    )
+    if not bundle_path.exists():
+        raise SignatureError(f"sigstore bundle not found: {bundle_path}")
+    try:
+        from sigstore.models import Bundle
+        from sigstore.verify import Verifier, policy
+    except ImportError as exc:
+        raise SignatureError(
+            f"sigstore-python not installed: {exc}. Install it (it is a "
+            "first-class dependency) or set BICAMERAL_SKILLS_VERIFY_DISABLE=1 "
+            "to bypass (writes a severity-3 verification_bypassed ledger event)."
+        ) from exc
+    try:
+        verifier = Verifier.production()
+        bundle = Bundle.from_json(bundle_path.read_bytes())
+        verifier.verify_artifact(
+            input_=manifest_path.read_bytes(),
+            bundle=bundle,
+            policy=policy.AllOf(
+                [
+                    policy.GitHubWorkflowRepository("BicameralAI/bicameral-mcp"),
+                    policy.GitHubWorkflowName("Publish to PyPI"),
+                ]
+            ),
+        )
+    except SignatureError:
+        raise
+    except Exception as exc:
+        raise SignatureError(f"sigstore verification failed: {exc}") from exc
 
 
 _VERIFIER_HOOK: _VERIFIER_FN = _sigstore_verify
@@ -70,20 +94,20 @@ _VERIFIER_HOOK: _VERIFIER_FN = _sigstore_verify
 
 def verify_skills_manifest(
     manifest_path: Path,
-    sig_path: Path,
-    cert_path: Path,
+    bundle_path: Path,
     expected_skills: dict[str, dict[str, str]],
 ) -> None:
     """Verify the manifest signature and cross-check per-file SHA-256.
 
-    ``expected_skills`` maps ``{skill_name: {filename: sha256_hex}}`` for
-    every file the caller intends to copy. Every entry must appear in
-    the verified manifest with matching SHA-256; any miss raises
-    ``SignatureError``.
+    ``bundle_path`` is the single-file Sigstore ``.sigstore`` bundle that
+    ships alongside the manifest in the wheel. ``expected_skills`` maps
+    ``{skill_name: {filename: sha256_hex}}`` for every file the caller
+    intends to copy. Every entry must appear in the verified manifest
+    with matching SHA-256; any miss raises ``SignatureError``.
     """
     if not manifest_path.exists():
         raise SignatureError(f"manifest not found: {manifest_path}")
-    _VERIFIER_HOOK(manifest_path, sig_path, cert_path)
+    _VERIFIER_HOOK(manifest_path, bundle_path)
 
     parsed = tomllib.loads(manifest_path.read_text(encoding="utf-8"))
     manifest_skills = parsed.get("skills", {})
@@ -119,8 +143,7 @@ def _get_event_writer():
 
 def verify_skills_or_bypass(
     manifest_path: Path,
-    sig_path: Path,
-    cert_path: Path,
+    bundle_path: Path,
     expected_skills: dict[str, dict[str, str]],
 ) -> None:
     """Verify the manifest; on failure, honor the bypass env var.
@@ -131,7 +154,7 @@ def verify_skills_or_bypass(
     re-raises (fail-closed).
     """
     try:
-        verify_skills_manifest(manifest_path, sig_path, cert_path, expected_skills)
+        verify_skills_manifest(manifest_path, bundle_path, expected_skills)
     except SignatureError:
         if os.environ.get("BICAMERAL_SKILLS_VERIFY_DISABLE") != "1":
             raise

--- a/scripts/hooks_manifest_build_hook.py
+++ b/scripts/hooks_manifest_build_hook.py
@@ -18,9 +18,19 @@ respective files under ``sys.prefix/share/bicameral-mcp/`` and the
 matching verifier cross-checks SHA-256 entries before any
 host-config-write or skill-copy.
 
-Cosign signature emission lives in the publish workflow (separate
-from the wheel build); the .sig and .crt are attached to the GitHub
-Release rather than bundled into the wheel.
+#292 — sigstore bundle handling:
+
+- **Release build**: the publish workflow generates each manifest and
+  signs it with ``cosign sign-blob --new-bundle-format --bundle`` BEFORE
+  ``python -m build``. When this hook runs it sees a ``<manifest>`` and a
+  pre-signed ``<manifest>.sigstore`` already present and SKIPS manifest
+  regeneration — regenerating would change the manifest bytes and void
+  the signature. The ``shared-data`` table then bundles both files.
+- **Local-dev build**: no OIDC token, so no signing. This hook generates
+  the manifest and writes an EMPTY placeholder ``<manifest>.sigstore`` so
+  the ``shared-data`` table resolves. ``setup_wizard._bundled_*`` treats
+  a zero-byte bundle as absent → verification defers, as it did before
+  #292.
 """
 
 from __future__ import annotations
@@ -42,18 +52,49 @@ class ManifestsBuildHook(BuildHookInterface):
         self._generate_hooks_manifest(root)
         self._generate_skills_manifest(root)
 
+    @staticmethod
+    def _has_signed_bundle(manifest: Path) -> bool:
+        """True when a NON-EMPTY ``<manifest>.sigstore`` exists next to
+        ``manifest`` — i.e. the publish workflow pre-signed it. A zero-byte
+        placeholder (local-dev) counts as absent so the manifest still
+        regenerates on a plain local build."""
+        bundle = Path(str(manifest) + ".sigstore")
+        return bundle.exists() and bundle.stat().st_size > 0
+
+    @staticmethod
+    def _ensure_placeholder_bundle(manifest: Path) -> None:
+        """Write an empty placeholder ``<manifest>.sigstore`` when none
+        exists, so the hatch ``shared-data`` entry resolves on a local-dev
+        build. The placeholder is never signed and never verifies; it only
+        satisfies the packager. A real bundle (release build) is left
+        untouched."""
+        bundle = Path(str(manifest) + ".sigstore")
+        if not bundle.exists():
+            bundle.parent.mkdir(parents=True, exist_ok=True)
+            bundle.write_bytes(b"")
+
     def _generate_hooks_manifest(self, root: Path) -> None:
+        out = root / "share" / "bicameral-mcp" / "hooks-manifest.json"
+        if self._has_signed_bundle(out):
+            # Pre-signed by the publish workflow — regenerating would void
+            # the signature. Leave both manifest and bundle as-is.
+            return
         from release import hooks_manifest_generator, hooks_source
 
-        out = root / "share" / "bicameral-mcp" / "hooks-manifest.json"
         out.parent.mkdir(parents=True, exist_ok=True)
         manifest = hooks_manifest_generator.generate_manifest(hooks_source)
         hooks_manifest_generator.write_manifest(manifest, out)
+        self._ensure_placeholder_bundle(out)
 
     def _generate_skills_manifest(self, root: Path) -> None:
+        out = root / "share" / "bicameral-mcp" / "skills-manifest.toml"
+        if self._has_signed_bundle(out):
+            # Pre-signed by the publish workflow — regenerating would void
+            # the signature. Leave both manifest and bundle as-is.
+            return
         from release import skills_manifest_generator, skills_source
 
-        out = root / "share" / "bicameral-mcp" / "skills-manifest.toml"
         out.parent.mkdir(parents=True, exist_ok=True)
         manifest = skills_manifest_generator.generate_manifest(skills_source.walk_skills())
         skills_manifest_generator.write_manifest(manifest, out)
+        self._ensure_placeholder_bundle(out)

--- a/setup_wizard.py
+++ b/setup_wizard.py
@@ -20,31 +20,29 @@ import sys
 from pathlib import Path
 
 
-def _bundled_manifest_paths() -> tuple[Path, Path, Path] | None:
-    """Locate bundled ``hooks-manifest.json`` + ``.sig`` + ``.crt``.
+def _bundled_manifest_paths() -> tuple[Path, Path] | None:
+    """Locate bundled ``hooks-manifest.json`` + its ``.sigstore`` bundle.
 
     Returns ``None`` when no artifacts are bundled (dev install from
     source checkout — no production wheel context, so no LLM-11 threat
-    surface). Returns the triple only when ALL THREE artifacts are
-    found alongside the installed package via hatch ``shared-data``.
+    surface). Returns the ``(manifest, bundle)`` pair only when BOTH
+    are found alongside the installed package via hatch ``shared-data``.
 
-    The all-or-nothing check guards against the interim packaging
-    state where the wheel ships the manifest but the release-side
-    sigstore-python signing step has not yet been wired up — without
-    this guard the verifier hits a missing-signature path that the
-    docstring of ``release.manifest_verify._sigstore_verify`` claims
-    is unreachable. Restoring the check is a no-op once the release
-    pipeline starts emitting ``.sig``/``.crt`` alongside the manifest.
+    The all-or-nothing check guards against the local-dev packaging
+    state where the build hook writes an empty placeholder ``.sigstore``
+    so hatch ``shared-data`` resolves. A zero-byte bundle is treated as
+    absent (never signed, never verifies) → ``None``, so verification
+    defers exactly as it did before the release pipeline emitted real
+    bundles (#292).
     """
     candidates = [
         Path(sys.prefix) / "share" / "bicameral-mcp" / "hooks-manifest.json",
         Path(__file__).parent.parent / "share" / "bicameral-mcp" / "hooks-manifest.json",
     ]
     for c in candidates:
-        sig = Path(str(c) + ".sig")
-        crt = Path(str(c) + ".crt")
-        if c.exists() and sig.exists() and crt.exists():
-            return c, sig, crt
+        bundle = Path(str(c) + ".sigstore")
+        if c.exists() and bundle.exists() and bundle.stat().st_size > 0:
+            return c, bundle
     return None
 
 
@@ -63,29 +61,28 @@ def _verify_intended_writes(*event_types: str) -> None:
     manifest_verify.verify_hooks_or_bypass(*paths, expected)
 
 
-def _bundled_skills_manifest_paths() -> tuple[Path, Path, Path] | None:
-    """Locate bundled ``skills-manifest.toml`` + ``.sig`` + ``.crt`` (#218 LLM-06).
+def _bundled_skills_manifest_paths() -> tuple[Path, Path] | None:
+    """Locate bundled ``skills-manifest.toml`` + its ``.sigstore`` bundle (#218 LLM-06).
 
     Returns ``None`` when no artifacts are bundled (dev install from
     source checkout — no production wheel context, so the LLM-06
-    design-constraint gate is N/A). Returns the triple only when ALL
-    THREE artifacts are found alongside the installed package via
+    design-constraint gate is N/A). Returns the ``(manifest, bundle)``
+    pair only when BOTH are found alongside the installed package via
     hatch ``shared-data``.
 
     Mirrors ``_bundled_manifest_paths`` for the skills-content surface,
-    including the all-or-nothing guard against the interim packaging
-    state where the wheel ships the manifest but no sigstore signature
-    yet.
+    including the zero-byte-bundle-as-absent guard against the local-dev
+    packaging state where the build hook writes an empty placeholder
+    ``.sigstore`` (#292).
     """
     candidates = [
         Path(sys.prefix) / "share" / "bicameral-mcp" / "skills-manifest.toml",
         Path(__file__).parent.parent / "share" / "bicameral-mcp" / "skills-manifest.toml",
     ]
     for c in candidates:
-        sig = Path(str(c) + ".sig")
-        crt = Path(str(c) + ".crt")
-        if c.exists() and sig.exists() and crt.exists():
-            return c, sig, crt
+        bundle = Path(str(c) + ".sigstore")
+        if c.exists() and bundle.exists() and bundle.stat().st_size > 0:
+            return c, bundle
     return None
 
 

--- a/tests/test_build_hook_idempotency.py
+++ b/tests/test_build_hook_idempotency.py
@@ -1,0 +1,197 @@
+"""Idempotency tests for the manifest build hook (#292).
+
+``scripts/hooks_manifest_build_hook.py`` runs at wheel-build time. #292
+makes it:
+
+1. SKIP manifest regeneration when a non-empty pre-signed ``<manifest>.sigstore``
+   bundle already exists (regenerating would change the bytes and void the
+   signature the publish workflow produced before ``python -m build``).
+2. GENERATE the manifest when no signed bundle is present, AND write an
+   empty placeholder ``<manifest>.sigstore`` so the hatch ``shared-data``
+   table resolves on a local-dev (unsigned) build.
+
+The hook subclasses ``hatchling``'s ``BuildHookInterface``. ``hatchling``
+is a build-time-only dependency and is not installed in the test
+environment, so a minimal stub module is registered before import — this
+is a genuine external boundary (the hatch build framework), and the
+idempotency logic under test never touches it. The real
+``release.hooks_manifest_generator`` / ``release.skills_manifest_generator``
+collaborators ARE run (sociable).
+"""
+
+from __future__ import annotations
+
+import importlib
+import sys
+import types
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+
+def _ensure_hatchling_stub() -> None:
+    """Register a minimal ``hatchling.builders.hooks.plugin.interface``
+    stub if hatchling is not installed, so the build-hook module imports.
+    No-op when the real hatchling is present."""
+    try:
+        import hatchling.builders.hooks.plugin.interface  # noqa: F401
+
+        return
+    except ImportError:
+        pass
+
+    class _StubBuildHookInterface:
+        """Stand-in for hatchling's BuildHookInterface. The build-hook only
+        uses ``self.root`` and overrides ``initialize`` — both supplied by
+        the test subclass / fixture, never by this base."""
+
+    for name in (
+        "hatchling",
+        "hatchling.builders",
+        "hatchling.builders.hooks",
+        "hatchling.builders.hooks.plugin",
+        "hatchling.builders.hooks.plugin.interface",
+    ):
+        if name not in sys.modules:
+            sys.modules[name] = types.ModuleType(name)
+    sys.modules[
+        "hatchling.builders.hooks.plugin.interface"
+    ].BuildHookInterface = _StubBuildHookInterface
+
+
+_ensure_hatchling_stub()
+build_hook = importlib.import_module("scripts.hooks_manifest_build_hook")
+
+
+@pytest.fixture
+def hook(tmp_path: Path):
+    """A ManifestsBuildHook whose `root` points at an isolated tmp tree.
+
+    `BuildHookInterface.__init__` is bypassed (it expects hatch wiring);
+    the hook only reads `self.root`, which we set directly."""
+    instance = build_hook.ManifestsBuildHook.__new__(build_hook.ManifestsBuildHook)
+    instance.__dict__["root"] = str(tmp_path)
+    return instance
+
+
+# --- _has_signed_bundle / _ensure_placeholder_bundle (static helpers) -------
+
+
+def test_has_signed_bundle_false_when_bundle_missing(tmp_path: Path) -> None:
+    manifest = tmp_path / "hooks-manifest.json"
+    manifest.write_text("{}")
+    assert build_hook.ManifestsBuildHook._has_signed_bundle(manifest) is False
+
+
+def test_has_signed_bundle_false_when_bundle_empty(tmp_path: Path) -> None:
+    """A zero-byte placeholder is NOT a signed bundle."""
+    manifest = tmp_path / "hooks-manifest.json"
+    manifest.write_text("{}")
+    (tmp_path / "hooks-manifest.json.sigstore").write_bytes(b"")
+    assert build_hook.ManifestsBuildHook._has_signed_bundle(manifest) is False
+
+
+def test_has_signed_bundle_true_when_bundle_non_empty(tmp_path: Path) -> None:
+    manifest = tmp_path / "hooks-manifest.json"
+    manifest.write_text("{}")
+    (tmp_path / "hooks-manifest.json.sigstore").write_bytes(b"REAL-BUNDLE")
+    assert build_hook.ManifestsBuildHook._has_signed_bundle(manifest) is True
+
+
+def test_ensure_placeholder_bundle_creates_empty_file(tmp_path: Path) -> None:
+    manifest = tmp_path / "share" / "bicameral-mcp" / "hooks-manifest.json"
+    build_hook.ManifestsBuildHook._ensure_placeholder_bundle(manifest)
+    bundle = Path(str(manifest) + ".sigstore")
+    assert bundle.exists()
+    assert bundle.stat().st_size == 0
+
+
+def test_ensure_placeholder_bundle_leaves_real_bundle_untouched(tmp_path: Path) -> None:
+    """A pre-existing (real) bundle is never overwritten by the placeholder
+    writer — that would destroy the signature."""
+    manifest = tmp_path / "hooks-manifest.json"
+    bundle = tmp_path / "hooks-manifest.json.sigstore"
+    bundle.write_bytes(b"REAL-SIGNED-BUNDLE")
+    build_hook.ManifestsBuildHook._ensure_placeholder_bundle(manifest)
+    assert bundle.read_bytes() == b"REAL-SIGNED-BUNDLE"
+
+
+# --- _generate_hooks_manifest (skip-vs-regenerate + placeholder) ------------
+
+
+def test_generate_hooks_manifest_creates_manifest_and_placeholder(hook, tmp_path: Path) -> None:
+    """Local-dev path: no pre-signed bundle → the real generator runs and
+    a zero-byte placeholder `.sigstore` is written."""
+    hook._generate_hooks_manifest(tmp_path)
+    manifest = tmp_path / "share" / "bicameral-mcp" / "hooks-manifest.json"
+    bundle = tmp_path / "share" / "bicameral-mcp" / "hooks-manifest.json.sigstore"
+    assert manifest.exists() and manifest.stat().st_size > 0
+    assert bundle.exists() and bundle.stat().st_size == 0
+
+
+def test_generate_hooks_manifest_skips_when_signed_bundle_present(hook, tmp_path: Path) -> None:
+    """Release path: a pre-signed bundle is present → the hook leaves the
+    manifest bytes UNTOUCHED (regenerating would void the signature)."""
+    share = tmp_path / "share" / "bicameral-mcp"
+    share.mkdir(parents=True)
+    manifest = share / "hooks-manifest.json"
+    bundle = share / "hooks-manifest.json.sigstore"
+    sentinel = '{"manifest_version": 1, "hooks": [], "_presigned": true}'
+    manifest.write_text(sentinel, encoding="utf-8")
+    bundle.write_bytes(b"REAL-SIGNED-BUNDLE")
+
+    hook._generate_hooks_manifest(tmp_path)
+
+    assert manifest.read_text(encoding="utf-8") == sentinel, (
+        "build hook regenerated a pre-signed manifest — signature voided"
+    )
+    assert bundle.read_bytes() == b"REAL-SIGNED-BUNDLE"
+
+
+def test_generate_hooks_manifest_regenerates_when_bundle_zero_byte(hook, tmp_path: Path) -> None:
+    """A zero-byte placeholder bundle does NOT count as pre-signed: a
+    re-run regenerates the manifest (a stale local-dev manifest must
+    refresh)."""
+    share = tmp_path / "share" / "bicameral-mcp"
+    share.mkdir(parents=True)
+    manifest = share / "hooks-manifest.json"
+    bundle = share / "hooks-manifest.json.sigstore"
+    manifest.write_text("STALE", encoding="utf-8")
+    bundle.write_bytes(b"")
+
+    hook._generate_hooks_manifest(tmp_path)
+
+    assert manifest.read_text(encoding="utf-8") != "STALE"
+    assert "manifest_version" in manifest.read_text(encoding="utf-8")
+
+
+# --- _generate_skills_manifest (mirror) ------------------------------------
+
+
+def test_generate_skills_manifest_creates_manifest_and_placeholder(hook, tmp_path: Path) -> None:
+    hook._generate_skills_manifest(tmp_path)
+    manifest = tmp_path / "share" / "bicameral-mcp" / "skills-manifest.toml"
+    bundle = tmp_path / "share" / "bicameral-mcp" / "skills-manifest.toml.sigstore"
+    assert manifest.exists() and manifest.stat().st_size > 0
+    assert bundle.exists() and bundle.stat().st_size == 0
+
+
+def test_generate_skills_manifest_skips_when_signed_bundle_present(hook, tmp_path: Path) -> None:
+    share = tmp_path / "share" / "bicameral-mcp"
+    share.mkdir(parents=True)
+    manifest = share / "skills-manifest.toml"
+    bundle = share / "skills-manifest.toml.sigstore"
+    sentinel = "manifest_version = 1\n# presigned\n"
+    manifest.write_text(sentinel, encoding="utf-8")
+    bundle.write_bytes(b"REAL-SIGNED-BUNDLE")
+
+    hook._generate_skills_manifest(tmp_path)
+
+    assert manifest.read_text(encoding="utf-8") == sentinel, (
+        "build hook regenerated a pre-signed skills-manifest — signature voided"
+    )
+    assert bundle.read_bytes() == b"REAL-SIGNED-BUNDLE"

--- a/tests/test_installer_packaging.py
+++ b/tests/test_installer_packaging.py
@@ -69,3 +69,49 @@ def test_wheel_skill_md_is_non_empty(built_wheel: Path):
             content = f.read().decode("utf-8")
     assert "name:" in content, f"{sample} has no `name:` frontmatter; possible truncation"
     assert len(content) > 100, f"{sample} suspiciously small ({len(content)} bytes)"
+
+
+# --- #292: sigstore-bundle packaging contract ------------------------------
+
+
+def _shared_data_members(wheel: Path) -> set[str]:
+    """Return wheel members under the hatch `shared-data` install prefix
+    (`<dist>.data/data/share/bicameral-mcp/...`)."""
+    with zipfile.ZipFile(wheel) as zf:
+        names = zf.namelist()
+    return {n for n in names if "share/bicameral-mcp/" in n}
+
+
+def test_wheel_bundles_manifests_and_sigstore_bundles(built_wheel: Path):
+    """#292: the wheel must ship BOTH manifests AND their `.sigstore`
+    bundles via hatch `shared-data` (4 files total) so install-time
+    verification can re-engage. A local-dev build emits zero-byte
+    placeholder bundles — they are still present as wheel members.
+    """
+    members = _shared_data_members(built_wheel)
+    required_suffixes = [
+        "share/bicameral-mcp/hooks-manifest.json",
+        "share/bicameral-mcp/hooks-manifest.json.sigstore",
+        "share/bicameral-mcp/skills-manifest.toml",
+        "share/bicameral-mcp/skills-manifest.toml.sigstore",
+    ]
+    for suffix in required_suffixes:
+        assert any(m.endswith(suffix) for m in members), (
+            f"wheel missing shared-data member ending in {suffix!r}; "
+            f"present share/ members: {sorted(members)}"
+        )
+
+
+def test_wheel_manifests_are_non_empty(built_wheel: Path):
+    """The manifests themselves must carry content (the build hook ran).
+    The `.sigstore` bundles MAY be zero-byte placeholders on a local-dev
+    build, so only the manifests are size-checked here."""
+    members = _shared_data_members(built_wheel)
+    with zipfile.ZipFile(built_wheel) as zf:
+        for suffix in (
+            "share/bicameral-mcp/hooks-manifest.json",
+            "share/bicameral-mcp/skills-manifest.toml",
+        ):
+            member = next(m for m in members if m.endswith(suffix))
+            data = zf.read(member)
+            assert len(data) > 0, f"{member} is empty; build hook did not generate the manifest"

--- a/tests/test_manifest_verify_sigstore.py
+++ b/tests/test_manifest_verify_sigstore.py
@@ -1,0 +1,161 @@
+"""Sigstore-bundle verifier tests for ``release.manifest_verify`` (#292).
+
+Locks the install-time hooks-manifest verification contract after the
+switch from a ``(manifest, sig, cert)`` triple to a ``(manifest, bundle)``
+pair where ``bundle`` is a single-file Sigstore ``.sigstore`` artifact:
+
+- Missing manifest → ``SignatureError`` (via ``_sigstore_verify`` directly)
+- Missing bundle → ``SignatureError`` (via ``_sigstore_verify`` directly)
+- ``_VERIFIER_HOOK`` seam drives ``verify_hooks_or_bypass`` happy path
+- Bypass env var ON → swallows + writes severity-3 ``verification_bypassed``
+- One seam test pins the ``_sigstore_verify`` 2-arg call shape
+
+The real ``Verifier.production()`` cannot run without an OIDC-signed
+bundle (Plan #292 Open Question 3 authorizes the narrow ``_VERIFIER_HOOK``
+seam for the wiring tests). The default ``_sigstore_verify`` is exercised
+only for its fail-closed file-presence guards, which run before any
+network/crypto.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from pathlib import Path
+
+import pytest
+
+from release import manifest_verify
+
+
+def _write_manifest(tmp_path: Path, hooks: list[dict[str, str]]) -> Path:
+    """Render a hooks-manifest.json carrying the SHA-256 of each command."""
+    manifest_path = tmp_path / "hooks-manifest.json"
+    entries = [
+        {
+            "event_type": h["event_type"],
+            "command": h["command"],
+            "sha256": hashlib.sha256(h["command"].encode("utf-8")).hexdigest(),
+        }
+        for h in hooks
+    ]
+    manifest_path.write_text(json.dumps({"manifest_version": 1, "hooks": entries}))
+    return manifest_path
+
+
+def _expected(hooks: list[dict[str, str]]) -> dict[str, str]:
+    return {
+        h["event_type"]: hashlib.sha256(h["command"].encode("utf-8")).hexdigest() for h in hooks
+    }
+
+
+def test_sigstore_verify_raises_when_manifest_absent(tmp_path: Path) -> None:
+    """Fail-closed: a missing manifest path raises before any sigstore work."""
+    manifest = tmp_path / "nope-hooks-manifest.json"
+    bundle = tmp_path / "nope-hooks-manifest.json.sigstore"
+    bundle.write_bytes(b"BUNDLE")
+    with pytest.raises(manifest_verify.SignatureError, match="manifest not found"):
+        manifest_verify._sigstore_verify(manifest, bundle)
+
+
+def test_sigstore_verify_raises_when_bundle_absent(tmp_path: Path) -> None:
+    """Fail-closed: a present manifest but missing `.sigstore` bundle raises."""
+    manifest = _write_manifest(tmp_path, [{"event_type": "git:post-commit", "command": "git x"}])
+    bundle = tmp_path / "hooks-manifest.json.sigstore"  # never created
+    with pytest.raises(manifest_verify.SignatureError, match="sigstore bundle not found"):
+        manifest_verify._sigstore_verify(manifest, bundle)
+
+
+def test_sigstore_verify_raises_on_malformed_bundle(tmp_path: Path) -> None:
+    """Fail-closed: a present manifest + a `.sigstore` file of non-JSON
+    garbage raises ``SignatureError``. ``Bundle.from_json`` rejects
+    malformed input locally — before any Rekor/Fulcio network call — so
+    this exercises the REAL ``_sigstore_verify`` (no `_VERIFIER_HOOK`
+    seam) and pins that a corrupt bundle cannot slip past verification."""
+    manifest = _write_manifest(tmp_path, [{"event_type": "git:post-commit", "command": "git x"}])
+    bundle = tmp_path / "hooks-manifest.json.sigstore"
+    bundle.write_bytes(b"not-a-sigstore-bundle {{{ truncated garbage")
+    with pytest.raises(manifest_verify.SignatureError):
+        manifest_verify._sigstore_verify(manifest, bundle)
+
+
+def test_verify_hooks_or_bypass_happy_path_via_seam(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """With the `_VERIFIER_HOOK` seam substituted for a no-op, a manifest
+    that carries the expected command SHA-256s verifies cleanly (no
+    exception → returns None)."""
+    hooks = [{"event_type": "git:post-commit", "command": "git log -1"}]
+    manifest = _write_manifest(tmp_path, hooks)
+    bundle = tmp_path / "hooks-manifest.json.sigstore"
+    bundle.write_bytes(b"FAKE-SIGSTORE-BUNDLE")
+
+    monkeypatch.setattr(manifest_verify, "_VERIFIER_HOOK", lambda *_: None)
+    monkeypatch.delenv("BICAMERAL_HOOKS_VERIFY_DISABLE", raising=False)
+
+    result = manifest_verify.verify_hooks_or_bypass(manifest, bundle, _expected(hooks))
+    assert result is None
+
+
+def test_verify_hooks_or_bypass_writes_event_when_bypassed(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Bypass posture: a failing verifier + BICAMERAL_HOOKS_VERIFY_DISABLE=1
+    swallows the SignatureError and writes a severity-3
+    ``verification_bypassed`` event."""
+    hooks = [{"event_type": "git:post-commit", "command": "git log -1"}]
+    manifest = _write_manifest(tmp_path, hooks)
+    bundle = tmp_path / "hooks-manifest.json.sigstore"
+    bundle.write_bytes(b"FAKE-SIGSTORE-BUNDLE")
+
+    captured: list[tuple[str, dict]] = []
+
+    class StubWriter:
+        def write(self, event_type, payload):
+            captured.append((event_type, payload))
+            return tmp_path / "stub.jsonl"
+
+    def bad_verifier(*_args):
+        raise manifest_verify.SignatureError("sigstore verification failed: tampered")
+
+    monkeypatch.setattr(manifest_verify, "_VERIFIER_HOOK", bad_verifier)
+    monkeypatch.setattr(manifest_verify, "_get_event_writer", lambda: StubWriter())
+    monkeypatch.setenv("BICAMERAL_HOOKS_VERIFY_DISABLE", "1")
+
+    result = manifest_verify.verify_hooks_or_bypass(manifest, bundle, _expected(hooks))
+    assert result is None
+    assert len(captured) == 1
+    event_type, payload = captured[0]
+    assert event_type == "verification_bypassed"
+    assert payload["severity"] == 3
+    assert payload["reason"] == "BICAMERAL_HOOKS_VERIFY_DISABLE=1"
+    assert "manifest_sha256" in payload
+
+
+def test_sigstore_verify_call_shape_is_two_arg(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Pin the `_sigstore_verify` call shape: `verify_hooks_manifest` invokes
+    `_VERIFIER_HOOK` with exactly `(manifest_path, bundle_path)` — the 2-arg
+    contract the real `Verifier.production()` wiring depends on (#292)."""
+    seen: list[tuple] = []
+
+    def recording_hook(*args):
+        seen.append(args)
+
+    hooks = [{"event_type": "git:post-commit", "command": "git log -1"}]
+    # Build a manifest in a tmp dir via pytest's tmp_path is unavailable here;
+    # use a recording hook + a real on-disk manifest from a fixture dir.
+    import tempfile
+
+    with tempfile.TemporaryDirectory() as td:
+        tmp = Path(td)
+        manifest = _write_manifest(tmp, hooks)
+        bundle = tmp / "hooks-manifest.json.sigstore"
+        bundle.write_bytes(b"BUNDLE")
+        monkeypatch.setattr(manifest_verify, "_VERIFIER_HOOK", recording_hook)
+        manifest_verify.verify_hooks_manifest(manifest, bundle, _expected(hooks))
+
+    assert len(seen) == 1
+    args = seen[0]
+    assert len(args) == 2, f"_VERIFIER_HOOK must be called with 2 args, got {len(args)}"
+    assert isinstance(args[0], Path) and isinstance(args[1], Path)
+    assert str(args[1]).endswith(".sigstore")

--- a/tests/test_publish_workflow_lint.py
+++ b/tests/test_publish_workflow_lint.py
@@ -1,0 +1,112 @@
+"""Workflow-lint guard for `.github/workflows/publish.yml` (#292).
+
+The #292 supply-chain invariant: manifest generation + ``cosign sign-blob``
+MUST run BEFORE ``python -m build``. The build hook is idempotent — it
+respects a pre-signed ``.sigstore`` bundle and skips regeneration — so if
+the build ran first it would emit an UNSIGNED manifest and the later sign
+step would sign a file that never reaches the wheel. This test asserts the
+step ordering in the YAML source so a reorder cannot land silently.
+
+Also pins the two non-negotiable cosign details:
+- ``cosign-installer`` is version-pinned via ``cosign-release`` (a 2.6.x
+  release; ``--new-bundle-format`` needs cosign >= 2.4.0).
+- both ``sign-blob`` invocations pass ``--new-bundle-format`` so cosign
+  emits the Sigstore protobuf bundle ``sigstore-python`` can read.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+PUBLISH_YML = REPO_ROOT / ".github" / "workflows" / "publish.yml"
+
+
+def _yaml_text() -> str:
+    return PUBLISH_YML.read_text(encoding="utf-8")
+
+
+def test_publish_workflow_exists() -> None:
+    assert PUBLISH_YML.exists(), f"missing workflow: {PUBLISH_YML}"
+
+
+def _build_step_index(text: str) -> int:
+    """Index of the actual `python -m build` STEP (the `run:` line), not a
+    mention of it in a comment."""
+    idx = text.find("run: python -m build")
+    assert idx != -1, "publish.yml has no `run: python -m build` step"
+    return idx
+
+
+def test_cosign_sign_precedes_python_build() -> None:
+    """The cosign sign-blob steps must appear BEFORE `python -m build` in
+    the YAML source order (#292 workflow-ordering invariant)."""
+    text = _yaml_text()
+    first_sign = text.find("cosign sign-blob")
+    build_idx = _build_step_index(text)
+
+    assert first_sign != -1, "publish.yml has no `cosign sign-blob` step"
+    assert first_sign < build_idx, (
+        "cosign sign-blob must run before `python -m build`: signing after "
+        "the build emits an unsigned manifest into the wheel"
+    )
+
+
+def test_both_manifests_signed_before_build() -> None:
+    """Both the hooks-manifest and skills-manifest sign steps precede the
+    build — not just the first one."""
+    text = _yaml_text()
+    build_idx = _build_step_index(text)
+    hooks_sign = text.find("hooks-manifest.json.sigstore")
+    skills_sign = text.find("skills-manifest.toml.sigstore")
+
+    assert hooks_sign != -1 and hooks_sign < build_idx, (
+        "hooks-manifest must be signed before `python -m build`"
+    )
+    assert skills_sign != -1 and skills_sign < build_idx, (
+        "skills-manifest must be signed before `python -m build`"
+    )
+
+
+def test_cosign_installer_is_version_pinned() -> None:
+    """`sigstore/cosign-installer` must pin a specific cosign release via
+    `cosign-release` — `--new-bundle-format` requires cosign >= 2.4.0 and
+    an unpinned installer could drift onto cosign 3.x where the flag is
+    retired (#292 Open Question 1)."""
+    text = _yaml_text()
+    assert "sigstore/cosign-installer" in text, "publish.yml does not install cosign"
+    assert "cosign-release:" in text, "cosign-installer must pin a version via `cosign-release:`"
+    # The pin must be a 2.x release (>= 2.4.0 for --new-bundle-format).
+    assert "cosign-release: 'v2." in text or 'cosign-release: "v2.' in text, (
+        "cosign-release must pin a cosign 2.x version"
+    )
+
+
+def test_sign_blob_uses_new_bundle_format() -> None:
+    """Every `cosign sign-blob` for a manifest must pass `--new-bundle-format`
+    so the output is the Sigstore protobuf bundle `sigstore-python`'s
+    `Bundle.from_json()` can read."""
+    text = _yaml_text()
+    # Count manifest sign-blob steps (those producing a `.sigstore` bundle).
+    manifest_sign_steps = text.count("--bundle share/bicameral-mcp/")
+    assert manifest_sign_steps == 2, (
+        f"expected 2 manifest `cosign sign-blob --bundle` steps, found {manifest_sign_steps}"
+    )
+    new_format_count = text.count("--new-bundle-format")
+    assert new_format_count >= 2, (
+        f"both manifest sign-blob steps must pass `--new-bundle-format` (found {new_format_count})"
+    )
+
+
+def test_release_attaches_sigstore_bundles_not_sig_crt() -> None:
+    """The GitHub Release attachment step ships the single-file `.sigstore`
+    bundles; the legacy `.sig` + `.crt` manifest attachments are gone."""
+    text = _yaml_text()
+    assert "hooks-manifest.json.sigstore" in text
+    assert "skills-manifest.toml.sigstore" in text
+    assert "hooks-manifest.json.sig " not in text and "hooks-manifest.json.sig\n" not in text, (
+        "legacy hooks-manifest .sig attachment still present"
+    )
+    assert "skills-manifest.toml.crt" not in text, (
+        "legacy skills-manifest .crt attachment still present"
+    )

--- a/tests/test_setup_wizard.py
+++ b/tests/test_setup_wizard.py
@@ -224,38 +224,48 @@ def test_detect_runner_does_not_return_broken_module_fallback():
 
 
 def _write_manifest_only(share_dir: Path, manifest_filename: str) -> Path:
-    """Write a fake manifest with NO sig/crt companions — simulates the
-    interim packaging state where the wheel ships the manifest but the
-    release-side sigstore signing step has not yet been wired up."""
+    """Write a fake manifest with NO `.sigstore` bundle companion —
+    simulates the packaging state where the wheel ships the manifest but
+    the release-side sigstore signing step did not run (#292)."""
     share_dir.mkdir(parents=True, exist_ok=True)
     manifest = share_dir / manifest_filename
     manifest.write_text("manifest_version = 1\n", encoding="utf-8")
-    assert not (share_dir / f"{manifest_filename}.sig").exists()
-    assert not (share_dir / f"{manifest_filename}.crt").exists()
+    assert not (share_dir / f"{manifest_filename}.sigstore").exists()
     return manifest
 
 
-def _write_full_triple(share_dir: Path, manifest_filename: str) -> tuple[Path, Path, Path]:
-    """Write all three artifacts (manifest + .sig + .crt) — simulates the
-    fully-signed wheel produced once the release pipeline emits sigstore
-    artifacts. Should cause the helpers to return the triple."""
+def _write_manifest_with_placeholder_bundle(
+    share_dir: Path, manifest_filename: str
+) -> tuple[Path, Path]:
+    """Write a manifest + a ZERO-BYTE `.sigstore` placeholder — simulates
+    the local-dev build where the manifest build hook writes an empty
+    placeholder so hatch `shared-data` resolves (#292). The helpers must
+    treat the empty bundle as absent."""
     share_dir.mkdir(parents=True, exist_ok=True)
     manifest = share_dir / manifest_filename
     manifest.write_text("manifest_version = 1\n", encoding="utf-8")
-    sig = share_dir / f"{manifest_filename}.sig"
-    sig.write_bytes(b"FAKE-SIG")
-    crt = share_dir / f"{manifest_filename}.crt"
-    crt.write_bytes(b"FAKE-CERT")
-    return manifest, sig, crt
+    bundle = share_dir / f"{manifest_filename}.sigstore"
+    bundle.write_bytes(b"")
+    return manifest, bundle
 
 
-def test_bundled_hooks_manifest_paths_returns_none_when_sig_missing(tmp_path, monkeypatch):
-    """Hotfix v0.14.4 regression guard: the helper must return None when
-    the wheel ships the .json manifest without the .sig/.crt companions.
-    Otherwise the install-time verifier hits a missing-signature path
-    and aborts setup. Restoring sigstore wiring (release-side) makes
-    this test naturally pass via the all-three-present branch — see
-    test_bundled_hooks_manifest_paths_returns_triple_when_all_present."""
+def _write_full_pair(share_dir: Path, manifest_filename: str) -> tuple[Path, Path]:
+    """Write both artifacts (manifest + non-empty `.sigstore` bundle) —
+    simulates the fully-signed wheel produced once the release pipeline
+    emits a sigstore bundle. Should cause the helpers to return the
+    `(manifest, bundle)` pair (#292)."""
+    share_dir.mkdir(parents=True, exist_ok=True)
+    manifest = share_dir / manifest_filename
+    manifest.write_text("manifest_version = 1\n", encoding="utf-8")
+    bundle = share_dir / f"{manifest_filename}.sigstore"
+    bundle.write_bytes(b'{"mediaType": "application/vnd.dev.sigstore.bundle+json"}')
+    return manifest, bundle
+
+
+def test_bundled_hooks_manifest_paths_returns_none_when_bundle_missing(tmp_path, monkeypatch):
+    """The helper must return None when the wheel ships the .json
+    manifest without the `.sigstore` bundle companion — verification
+    defers rather than aborting setup on a missing-bundle path (#292)."""
     fake_prefix = tmp_path / "venv"
     share_dir = fake_prefix / "share" / "bicameral-mcp"
     _write_manifest_only(share_dir, "hooks-manifest.json")
@@ -267,8 +277,8 @@ def test_bundled_hooks_manifest_paths_returns_none_when_sig_missing(tmp_path, mo
     assert setup_wizard._bundled_manifest_paths() is None
 
 
-def test_bundled_skills_manifest_paths_returns_none_when_sig_missing(tmp_path, monkeypatch):
-    """Hotfix v0.14.4 regression guard (skills surface mirror)."""
+def test_bundled_skills_manifest_paths_returns_none_when_bundle_missing(tmp_path, monkeypatch):
+    """Skills-surface mirror of the missing-`.sigstore` case (#292)."""
     fake_prefix = tmp_path / "venv"
     share_dir = fake_prefix / "share" / "bicameral-mcp"
     _write_manifest_only(share_dir, "skills-manifest.toml")
@@ -280,31 +290,59 @@ def test_bundled_skills_manifest_paths_returns_none_when_sig_missing(tmp_path, m
     assert setup_wizard._bundled_skills_manifest_paths() is None
 
 
-def test_bundled_hooks_manifest_paths_returns_triple_when_all_present(tmp_path, monkeypatch):
-    """Once the release pipeline emits .sig/.crt alongside the manifest,
-    the helper resumes returning the triple — verifier re-engages with
-    no code change at install time."""
+def test_bundled_hooks_manifest_paths_returns_none_when_bundle_zero_byte(tmp_path, monkeypatch):
+    """A zero-byte `.sigstore` is the local-dev placeholder the build hook
+    writes so hatch `shared-data` resolves; it is never signed and never
+    verifies, so the helper treats it as absent → None (#292)."""
     fake_prefix = tmp_path / "venv"
     share_dir = fake_prefix / "share" / "bicameral-mcp"
-    manifest, sig, crt = _write_full_triple(share_dir, "hooks-manifest.json")
+    _write_manifest_with_placeholder_bundle(share_dir, "hooks-manifest.json")
+
+    monkeypatch.setattr(setup_wizard.sys, "prefix", str(fake_prefix))
+    fake_init = tmp_path / "fake-pkg" / "setup_wizard.py"
+    monkeypatch.setattr(setup_wizard, "__file__", str(fake_init))
+
+    assert setup_wizard._bundled_manifest_paths() is None
+
+
+def test_bundled_skills_manifest_paths_returns_none_when_bundle_zero_byte(tmp_path, monkeypatch):
+    """Skills-surface mirror of the zero-byte-placeholder case (#292)."""
+    fake_prefix = tmp_path / "venv"
+    share_dir = fake_prefix / "share" / "bicameral-mcp"
+    _write_manifest_with_placeholder_bundle(share_dir, "skills-manifest.toml")
+
+    monkeypatch.setattr(setup_wizard.sys, "prefix", str(fake_prefix))
+    fake_init = tmp_path / "fake-pkg" / "setup_wizard.py"
+    monkeypatch.setattr(setup_wizard, "__file__", str(fake_init))
+
+    assert setup_wizard._bundled_skills_manifest_paths() is None
+
+
+def test_bundled_hooks_manifest_paths_returns_pair_when_all_present(tmp_path, monkeypatch):
+    """Once the release pipeline emits a non-empty `.sigstore` bundle
+    alongside the manifest, the helper returns the `(manifest, bundle)`
+    pair — verifier re-engages with no code change at install time."""
+    fake_prefix = tmp_path / "venv"
+    share_dir = fake_prefix / "share" / "bicameral-mcp"
+    manifest, bundle = _write_full_pair(share_dir, "hooks-manifest.json")
 
     monkeypatch.setattr(setup_wizard.sys, "prefix", str(fake_prefix))
     fake_init = tmp_path / "fake-pkg" / "setup_wizard.py"
     monkeypatch.setattr(setup_wizard, "__file__", str(fake_init))
 
     result = setup_wizard._bundled_manifest_paths()
-    assert result == (manifest, sig, crt)
+    assert result == (manifest, bundle)
 
 
-def test_bundled_skills_manifest_paths_returns_triple_when_all_present(tmp_path, monkeypatch):
-    """Skills-surface mirror of the all-three-present case."""
+def test_bundled_skills_manifest_paths_returns_pair_when_all_present(tmp_path, monkeypatch):
+    """Skills-surface mirror of the manifest+bundle-present case (#292)."""
     fake_prefix = tmp_path / "venv"
     share_dir = fake_prefix / "share" / "bicameral-mcp"
-    manifest, sig, crt = _write_full_triple(share_dir, "skills-manifest.toml")
+    manifest, bundle = _write_full_pair(share_dir, "skills-manifest.toml")
 
     monkeypatch.setattr(setup_wizard.sys, "prefix", str(fake_prefix))
     fake_init = tmp_path / "fake-pkg" / "setup_wizard.py"
     monkeypatch.setattr(setup_wizard, "__file__", str(fake_init))
 
     result = setup_wizard._bundled_skills_manifest_paths()
-    assert result == (manifest, sig, crt)
+    assert result == (manifest, bundle)

--- a/tests/test_setup_wizard_hook_verify.py
+++ b/tests/test_setup_wizard_hook_verify.py
@@ -25,13 +25,16 @@ import pytest
 from release import manifest_verify
 
 
-def _signed_manifest(tmp_path: Path, hooks: list[dict[str, str]]) -> tuple[Path, Path, Path]:
-    """Write a fake signed manifest + sig + cert to tmp_path."""
+def _signed_manifest(tmp_path: Path, hooks: list[dict[str, str]]) -> tuple[Path, Path]:
+    """Write a fake manifest + its `.sigstore` bundle to tmp_path (#292).
+
+    Returns the `(manifest, bundle)` pair. Real sigstore verification is
+    monkeypatched via `_VERIFIER_HOOK`, so the bundle bytes are a
+    placeholder."""
     import json
 
     manifest_path = tmp_path / "hooks-manifest.json"
-    sig_path = tmp_path / "hooks-manifest.json.sig"
-    cert_path = tmp_path / "hooks-manifest.json.crt"
+    bundle_path = tmp_path / "hooks-manifest.json.sigstore"
     entries = []
     for h in hooks:
         entries.append(
@@ -42,9 +45,8 @@ def _signed_manifest(tmp_path: Path, hooks: list[dict[str, str]]) -> tuple[Path,
             }
         )
     manifest_path.write_text(json.dumps({"manifest_version": 1, "hooks": entries}))
-    sig_path.write_bytes(b"FAKE-SIG")
-    cert_path.write_bytes(b"FAKE-CERT")
-    return manifest_path, sig_path, cert_path
+    bundle_path.write_bytes(b"FAKE-SIGSTORE-BUNDLE")
+    return manifest_path, bundle_path
 
 
 def _expected_hooks(hooks: list[dict[str, str]]) -> dict[str, str]:
@@ -61,10 +63,10 @@ def test_verify_hooks_manifest_returns_none_for_valid_signed_manifest(
         {"event_type": "claude:PostToolUse:Bash", "command": "echo a"},
         {"event_type": "git:post-commit", "command": "git log -1"},
     ]
-    m, s, c = _signed_manifest(tmp_path, hooks)
+    m, b = _signed_manifest(tmp_path, hooks)
     monkeypatch.setattr(manifest_verify, "_VERIFIER_HOOK", lambda *_: None)
     # No exception raised → contract satisfied (returns None).
-    result = manifest_verify.verify_hooks_manifest(m, s, c, _expected_hooks(hooks))
+    result = manifest_verify.verify_hooks_manifest(m, b, _expected_hooks(hooks))
     assert result is None
 
 
@@ -72,26 +74,26 @@ def test_verify_hooks_manifest_raises_signature_error_when_sig_invalid(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
     hooks = [{"event_type": "git:post-commit", "command": "git log -1"}]
-    m, s, c = _signed_manifest(tmp_path, hooks)
+    m, b = _signed_manifest(tmp_path, hooks)
 
     def bad_verifier(*_args):
         raise manifest_verify.SignatureError("sigstore: invalid signature")
 
     monkeypatch.setattr(manifest_verify, "_VERIFIER_HOOK", bad_verifier)
     with pytest.raises(manifest_verify.SignatureError):
-        manifest_verify.verify_hooks_manifest(m, s, c, _expected_hooks(hooks))
+        manifest_verify.verify_hooks_manifest(m, b, _expected_hooks(hooks))
 
 
 def test_verify_hooks_manifest_raises_when_command_sha256_mismatches(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
     hooks = [{"event_type": "git:post-commit", "command": "git log -1"}]
-    m, s, c = _signed_manifest(tmp_path, hooks)
+    m, b = _signed_manifest(tmp_path, hooks)
     monkeypatch.setattr(manifest_verify, "_VERIFIER_HOOK", lambda *_: None)
     # Caller claims to want a DIFFERENT command than what the manifest carries.
     wrong = {"git:post-commit": hashlib.sha256(b"git log -2").hexdigest()}
     with pytest.raises(manifest_verify.SignatureError):
-        manifest_verify.verify_hooks_manifest(m, s, c, wrong)
+        manifest_verify.verify_hooks_manifest(m, b, wrong)
 
 
 def test_verify_hooks_manifest_raises_when_manifest_file_missing(
@@ -99,20 +101,19 @@ def test_verify_hooks_manifest_raises_when_manifest_file_missing(
 ) -> None:
     monkeypatch.setattr(manifest_verify, "_VERIFIER_HOOK", lambda *_: None)
     nope = tmp_path / "absent.json"
-    sig = tmp_path / "absent.json.sig"
-    crt = tmp_path / "absent.json.crt"
+    bundle = tmp_path / "absent.json.sigstore"
     with pytest.raises(manifest_verify.SignatureError):
-        manifest_verify.verify_hooks_manifest(nope, sig, crt, {})
+        manifest_verify.verify_hooks_manifest(nope, bundle, {})
 
 
 def test_verifier_hook_is_swappable_at_module_level(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
     hooks = [{"event_type": "git:post-commit", "command": "git log -1"}]
-    m, s, c = _signed_manifest(tmp_path, hooks)
+    m, b = _signed_manifest(tmp_path, hooks)
     sentinel = MagicMock(return_value=None)
     monkeypatch.setattr(manifest_verify, "_VERIFIER_HOOK", sentinel)
-    manifest_verify.verify_hooks_manifest(m, s, c, _expected_hooks(hooks))
+    manifest_verify.verify_hooks_manifest(m, b, _expected_hooks(hooks))
     # Function-pointer extension surface contract: the module-level pointer
     # is the verifier called by `verify_hooks_manifest`.
     sentinel.assert_called_once()
@@ -125,7 +126,7 @@ def test_install_claude_hooks_proceeds_with_bypass_event_when_env_var_set(
     swallowed, severity-3 ``verification_bypassed`` event written, install
     proceeds. Captures the event-write call."""
     hooks = [{"event_type": "git:post-commit", "command": "git log -1"}]
-    m, s, c = _signed_manifest(tmp_path, hooks)
+    m, b = _signed_manifest(tmp_path, hooks)
 
     captured_events: list[tuple[str, dict]] = []
 
@@ -142,7 +143,7 @@ def test_install_claude_hooks_proceeds_with_bypass_event_when_env_var_set(
     monkeypatch.setattr(manifest_verify, "_get_event_writer", lambda: StubWriter())
 
     # The helper raises only when bypass is OFF; with bypass ON it returns None.
-    result = manifest_verify.verify_hooks_or_bypass(m, s, c, _expected_hooks(hooks))
+    result = manifest_verify.verify_hooks_or_bypass(m, b, _expected_hooks(hooks))
     assert result is None
     assert len(captured_events) == 1
     event_type, payload = captured_events[0]
@@ -157,7 +158,7 @@ def test_install_claude_hooks_raises_signature_error_when_env_var_unset(
 ) -> None:
     """Bypass OFF: SignatureError propagates to caller (fail-closed)."""
     hooks = [{"event_type": "git:post-commit", "command": "git log -1"}]
-    m, s, c = _signed_manifest(tmp_path, hooks)
+    m, b = _signed_manifest(tmp_path, hooks)
 
     def bad_verifier(*_args):
         raise manifest_verify.SignatureError("intentional test failure")
@@ -166,4 +167,4 @@ def test_install_claude_hooks_raises_signature_error_when_env_var_unset(
     monkeypatch.delenv("BICAMERAL_HOOKS_VERIFY_DISABLE", raising=False)
 
     with pytest.raises(manifest_verify.SignatureError):
-        manifest_verify.verify_hooks_or_bypass(m, s, c, _expected_hooks(hooks))
+        manifest_verify.verify_hooks_or_bypass(m, b, _expected_hooks(hooks))

--- a/tests/test_setup_wizard_skills_verify.py
+++ b/tests/test_setup_wizard_skills_verify.py
@@ -28,16 +28,16 @@ from release import skills_verify
 def _signed_manifest(
     tmp_path: Path,
     skills: dict[str, dict[str, bytes]],
-) -> tuple[Path, Path, Path]:
-    """Write a fake signed manifest + sig + cert to tmp_path.
+) -> tuple[Path, Path]:
+    """Write a fake manifest + its `.sigstore` bundle to tmp_path (#292).
 
-    `skills` is `{skill_name: {filename: file_bytes}}`. The test
-    rendered manifest carries the SHA-256 of each file; the .sig and
-    .crt are placeholder bytes (real verification is monkeypatched).
+    `skills` is `{skill_name: {filename: file_bytes}}`. The rendered
+    manifest carries the SHA-256 of each file; the `.sigstore` bundle is
+    placeholder bytes (real verification is monkeypatched via
+    `_VERIFIER_HOOK`). Returns the `(manifest, bundle)` pair.
     """
     manifest_path = tmp_path / "skills-manifest.toml"
-    sig_path = tmp_path / "skills-manifest.toml.sig"
-    cert_path = tmp_path / "skills-manifest.toml.crt"
+    bundle_path = tmp_path / "skills-manifest.toml.sigstore"
 
     lines = ["manifest_version = 1", ""]
     for skill_name in sorted(skills):
@@ -47,9 +47,8 @@ def _signed_manifest(
             lines.append(f'"{filename}" = "{digest}"')
         lines.append("")
     manifest_path.write_text("\n".join(lines), encoding="utf-8")
-    sig_path.write_bytes(b"FAKE-SIG")
-    cert_path.write_bytes(b"FAKE-CERT")
-    return manifest_path, sig_path, cert_path
+    bundle_path.write_bytes(b"FAKE-SIGSTORE-BUNDLE")
+    return manifest_path, bundle_path
 
 
 def _expected_skills(skills: dict[str, dict[str, bytes]]) -> dict[str, dict[str, str]]:
@@ -67,9 +66,9 @@ def test_verify_skills_manifest_returns_none_for_valid_signed_manifest(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
     skills = {"bicameral-ingest": {"SKILL.md": b"ingest body"}}
-    m, s, c = _signed_manifest(tmp_path, skills)
+    m, b = _signed_manifest(tmp_path, skills)
     monkeypatch.setattr(skills_verify, "_VERIFIER_HOOK", lambda *_: None)
-    result = skills_verify.verify_skills_manifest(m, s, c, _expected_skills(skills))
+    result = skills_verify.verify_skills_manifest(m, b, _expected_skills(skills))
     assert result is None
 
 
@@ -77,25 +76,25 @@ def test_verify_skills_manifest_raises_signature_error_when_sig_invalid(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
     skills = {"bicameral-ingest": {"SKILL.md": b"body"}}
-    m, s, c = _signed_manifest(tmp_path, skills)
+    m, b = _signed_manifest(tmp_path, skills)
 
     def bad_verifier(*_args):
         raise skills_verify.SignatureError("sigstore: invalid signature")
 
     monkeypatch.setattr(skills_verify, "_VERIFIER_HOOK", bad_verifier)
     with pytest.raises(skills_verify.SignatureError):
-        skills_verify.verify_skills_manifest(m, s, c, _expected_skills(skills))
+        skills_verify.verify_skills_manifest(m, b, _expected_skills(skills))
 
 
 def test_verify_skills_manifest_raises_when_file_sha256_mismatches(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
     skills = {"bicameral-ingest": {"SKILL.md": b"body"}}
-    m, s, c = _signed_manifest(tmp_path, skills)
+    m, b = _signed_manifest(tmp_path, skills)
     monkeypatch.setattr(skills_verify, "_VERIFIER_HOOK", lambda *_: None)
     wrong = {"bicameral-ingest": {"SKILL.md": hashlib.sha256(b"different").hexdigest()}}
     with pytest.raises(skills_verify.SignatureError):
-        skills_verify.verify_skills_manifest(m, s, c, wrong)
+        skills_verify.verify_skills_manifest(m, b, wrong)
 
 
 def test_verify_skills_manifest_raises_when_manifest_file_missing(
@@ -103,20 +102,19 @@ def test_verify_skills_manifest_raises_when_manifest_file_missing(
 ) -> None:
     monkeypatch.setattr(skills_verify, "_VERIFIER_HOOK", lambda *_: None)
     nope = tmp_path / "absent.toml"
-    sig = tmp_path / "absent.toml.sig"
-    crt = tmp_path / "absent.toml.crt"
+    bundle = tmp_path / "absent.toml.sigstore"
     with pytest.raises(skills_verify.SignatureError):
-        skills_verify.verify_skills_manifest(nope, sig, crt, {})
+        skills_verify.verify_skills_manifest(nope, bundle, {})
 
 
 def test_verifier_hook_is_swappable_at_module_level(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
     skills = {"bicameral-ingest": {"SKILL.md": b"body"}}
-    m, s, c = _signed_manifest(tmp_path, skills)
+    m, b = _signed_manifest(tmp_path, skills)
     sentinel = MagicMock(return_value=None)
     monkeypatch.setattr(skills_verify, "_VERIFIER_HOOK", sentinel)
-    skills_verify.verify_skills_manifest(m, s, c, _expected_skills(skills))
+    skills_verify.verify_skills_manifest(m, b, _expected_skills(skills))
     sentinel.assert_called_once()
 
 
@@ -127,7 +125,7 @@ def test_install_skills_proceeds_with_bypass_event_when_env_var_set(
     writing severity-3 verification_bypassed event with
     manifest_kind=skills."""
     skills = {"bicameral-ingest": {"SKILL.md": b"body"}}
-    m, s, c = _signed_manifest(tmp_path, skills)
+    m, b = _signed_manifest(tmp_path, skills)
 
     captured_events: list[tuple[str, dict]] = []
 
@@ -143,7 +141,7 @@ def test_install_skills_proceeds_with_bypass_event_when_env_var_set(
     monkeypatch.setenv("BICAMERAL_SKILLS_VERIFY_DISABLE", "1")
     monkeypatch.setattr(skills_verify, "_get_event_writer", lambda: StubWriter())
 
-    result = skills_verify.verify_skills_or_bypass(m, s, c, _expected_skills(skills))
+    result = skills_verify.verify_skills_or_bypass(m, b, _expected_skills(skills))
     assert result is None
     assert len(captured_events) == 1
     event_type, payload = captured_events[0]
@@ -159,7 +157,7 @@ def test_install_skills_raises_signature_error_when_env_var_unset(
 ) -> None:
     """Bypass OFF: SignatureError propagates to caller (fail-closed)."""
     skills = {"bicameral-ingest": {"SKILL.md": b"body"}}
-    m, s, c = _signed_manifest(tmp_path, skills)
+    m, b = _signed_manifest(tmp_path, skills)
 
     def bad_verifier(*_args):
         raise skills_verify.SignatureError("intentional test failure")
@@ -168,4 +166,4 @@ def test_install_skills_raises_signature_error_when_env_var_unset(
     monkeypatch.delenv("BICAMERAL_SKILLS_VERIFY_DISABLE", raising=False)
 
     with pytest.raises(skills_verify.SignatureError):
-        skills_verify.verify_skills_or_bypass(m, s, c, _expected_skills(skills))
+        skills_verify.verify_skills_or_bypass(m, b, _expected_skills(skills))

--- a/tests/test_skills_verify_sigstore.py
+++ b/tests/test_skills_verify_sigstore.py
@@ -1,0 +1,157 @@
+"""Sigstore-bundle verifier tests for ``release.skills_verify`` (#292).
+
+Mirror of ``tests/test_manifest_verify_sigstore.py`` for the skills
+surface. Locks the install-time skills-manifest verification contract
+after the switch from a ``(manifest, sig, cert)`` triple to a
+``(manifest, bundle)`` pair where ``bundle`` is a single-file Sigstore
+``.sigstore`` artifact:
+
+- Missing manifest → ``SignatureError`` (via ``_sigstore_verify`` directly)
+- Missing bundle → ``SignatureError`` (via ``_sigstore_verify`` directly)
+- ``_VERIFIER_HOOK`` seam drives ``verify_skills_or_bypass`` happy path
+- Bypass env var ON → swallows + writes severity-3 ``verification_bypassed``
+  with ``manifest_kind: "skills"``
+- One seam test pins the ``_sigstore_verify`` 2-arg call shape
+
+Plan #292 Open Question 3 authorizes the narrow ``_VERIFIER_HOOK`` seam:
+real ``Verifier.production()`` cannot run without an OIDC-signed bundle.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import tempfile
+from pathlib import Path
+
+import pytest
+
+from release import skills_verify
+
+
+def _write_manifest(tmp_path: Path, skills: dict[str, dict[str, bytes]]) -> Path:
+    """Render a skills-manifest.toml carrying the SHA-256 of each file."""
+    manifest_path = tmp_path / "skills-manifest.toml"
+    lines = ["manifest_version = 1", ""]
+    for skill_name in sorted(skills):
+        lines.append(f"[skills.{skill_name}]")
+        for filename in sorted(skills[skill_name]):
+            digest = hashlib.sha256(skills[skill_name][filename]).hexdigest()
+            lines.append(f'"{filename}" = "{digest}"')
+        lines.append("")
+    manifest_path.write_text("\n".join(lines), encoding="utf-8")
+    return manifest_path
+
+
+def _expected(skills: dict[str, dict[str, bytes]]) -> dict[str, dict[str, str]]:
+    return {
+        skill_name: {fn: hashlib.sha256(fb).hexdigest() for fn, fb in files.items()}
+        for skill_name, files in skills.items()
+    }
+
+
+def test_sigstore_verify_raises_when_manifest_absent(tmp_path: Path) -> None:
+    """Fail-closed: a missing manifest path raises before any sigstore work."""
+    manifest = tmp_path / "nope-skills-manifest.toml"
+    bundle = tmp_path / "nope-skills-manifest.toml.sigstore"
+    bundle.write_bytes(b"BUNDLE")
+    with pytest.raises(skills_verify.SignatureError, match="manifest not found"):
+        skills_verify._sigstore_verify(manifest, bundle)
+
+
+def test_sigstore_verify_raises_when_bundle_absent(tmp_path: Path) -> None:
+    """Fail-closed: a present manifest but missing `.sigstore` bundle raises."""
+    manifest = _write_manifest(tmp_path, {"bicameral-ingest": {"SKILL.md": b"body"}})
+    bundle = tmp_path / "skills-manifest.toml.sigstore"  # never created
+    with pytest.raises(skills_verify.SignatureError, match="sigstore bundle not found"):
+        skills_verify._sigstore_verify(manifest, bundle)
+
+
+def test_sigstore_verify_raises_on_malformed_bundle(tmp_path: Path) -> None:
+    """Fail-closed: a present manifest + a `.sigstore` file of non-JSON
+    garbage raises ``SignatureError``. ``Bundle.from_json`` rejects
+    malformed input locally — before any Rekor/Fulcio network call — so
+    this exercises the REAL ``_sigstore_verify`` (no `_VERIFIER_HOOK`
+    seam) and pins that a corrupt bundle cannot slip past verification."""
+    manifest = _write_manifest(tmp_path, {"bicameral-ingest": {"SKILL.md": b"body"}})
+    bundle = tmp_path / "skills-manifest.toml.sigstore"
+    bundle.write_bytes(b"not-a-sigstore-bundle {{{ truncated garbage")
+    with pytest.raises(skills_verify.SignatureError):
+        skills_verify._sigstore_verify(manifest, bundle)
+
+
+def test_verify_skills_or_bypass_happy_path_via_seam(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """With the `_VERIFIER_HOOK` seam substituted for a no-op, a manifest
+    that carries the expected per-file SHA-256s verifies cleanly."""
+    skills = {"bicameral-ingest": {"SKILL.md": b"ingest body"}}
+    manifest = _write_manifest(tmp_path, skills)
+    bundle = tmp_path / "skills-manifest.toml.sigstore"
+    bundle.write_bytes(b"FAKE-SIGSTORE-BUNDLE")
+
+    monkeypatch.setattr(skills_verify, "_VERIFIER_HOOK", lambda *_: None)
+    monkeypatch.delenv("BICAMERAL_SKILLS_VERIFY_DISABLE", raising=False)
+
+    result = skills_verify.verify_skills_or_bypass(manifest, bundle, _expected(skills))
+    assert result is None
+
+
+def test_verify_skills_or_bypass_writes_event_when_bypassed(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Bypass posture: a failing verifier + BICAMERAL_SKILLS_VERIFY_DISABLE=1
+    swallows the SignatureError and writes a severity-3
+    ``verification_bypassed`` event with ``manifest_kind: "skills"``."""
+    skills = {"bicameral-ingest": {"SKILL.md": b"body"}}
+    manifest = _write_manifest(tmp_path, skills)
+    bundle = tmp_path / "skills-manifest.toml.sigstore"
+    bundle.write_bytes(b"FAKE-SIGSTORE-BUNDLE")
+
+    captured: list[tuple[str, dict]] = []
+
+    class StubWriter:
+        def write(self, event_type, payload):
+            captured.append((event_type, payload))
+            return tmp_path / "stub.jsonl"
+
+    def bad_verifier(*_args):
+        raise skills_verify.SignatureError("sigstore verification failed: tampered")
+
+    monkeypatch.setattr(skills_verify, "_VERIFIER_HOOK", bad_verifier)
+    monkeypatch.setattr(skills_verify, "_get_event_writer", lambda: StubWriter())
+    monkeypatch.setenv("BICAMERAL_SKILLS_VERIFY_DISABLE", "1")
+
+    result = skills_verify.verify_skills_or_bypass(manifest, bundle, _expected(skills))
+    assert result is None
+    assert len(captured) == 1
+    event_type, payload = captured[0]
+    assert event_type == "verification_bypassed"
+    assert payload["severity"] == 3
+    assert payload["manifest_kind"] == "skills"
+    assert payload["reason"] == "BICAMERAL_SKILLS_VERIFY_DISABLE=1"
+    assert "manifest_sha256" in payload
+
+
+def test_sigstore_verify_call_shape_is_two_arg(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Pin the `_sigstore_verify` call shape: `verify_skills_manifest` invokes
+    `_VERIFIER_HOOK` with exactly `(manifest_path, bundle_path)` — the 2-arg
+    contract the real `Verifier.production()` wiring depends on (#292)."""
+    seen: list[tuple] = []
+
+    def recording_hook(*args):
+        seen.append(args)
+
+    skills = {"bicameral-ingest": {"SKILL.md": b"body"}}
+    with tempfile.TemporaryDirectory() as td:
+        tmp = Path(td)
+        manifest = _write_manifest(tmp, skills)
+        bundle = tmp / "skills-manifest.toml.sigstore"
+        bundle.write_bytes(b"BUNDLE")
+        monkeypatch.setattr(skills_verify, "_VERIFIER_HOOK", recording_hook)
+        skills_verify.verify_skills_manifest(manifest, bundle, _expected(skills))
+
+    assert len(seen) == 1
+    args = seen[0]
+    assert len(args) == 2, f"_VERIFIER_HOOK must be called with 2 args, got {len(args)}"
+    assert isinstance(args[0], Path) and isinstance(args[1], Path)
+    assert str(args[1]).endswith(".sigstore")


### PR DESCRIPTION
## Summary

**P0 supply-chain fix.** Closes BicameralAI/bicameral-daemon#27. The v0.14.x wheels ship the install-time manifests (`share/bicameral-mcp/{hooks-manifest.json,skills-manifest.toml}`) but **no signatures**, so `setup_wizard`'s verification path is inert — PR BicameralAI/bicameral-mcp#291 shipped a `None`-returning guard as a stopgap. This makes the signature artifacts actually arrive inside the wheel so verification re-engages end-to-end.

## Approach — Path A (single-file `.sigstore` bundles)

A parked cycle discovered cosign's separate-file output (`.sig` + `.crt`) **cannot** be verified by `sigstore-python` — `Bundle.from_parts` needs a Rekor `log_entry` only the single-file bundle carries. A fresh research pass surfaced a second constraint: cosign 2.x's default `--bundle` emits a *legacy* format `sigstore-python` rejects; the protobuf bundle needs **`--new-bundle-format`** (cosign ≥2.4.0). The pipeline now emits single-file `.sigstore` bundles with that flag, and the verifier loads them via `Bundle.from_json()`.

## Changes

- **`.github/workflows/publish.yml`** — generate + `cosign sign-blob --new-bundle-format --bundle` the manifests **before** `python -m build`, so the build hook bundles the signed artifacts into the wheel; `cosign-installer` pinned to **`v2.6.1`**.
- **`release/skills_verify.py` + `release/manifest_verify.py`** — real `Verifier.production().verify_artifact()` against a `Bundle.from_json()` bundle, composite identity policy `AllOf[GitHubWorkflowRepository, GitHubWorkflowName]`. Verifier signatures change 3-arg `(manifest, sig, cert)` → 2-arg `(manifest, bundle)`; the `_VERIFIER_HOOK` test seam is preserved.
- **`setup_wizard.py`** — `_bundled_*_manifest_paths` return `(manifest, bundle)` pairs; a zero-byte placeholder bundle is treated as absent → `None` → verification defers (the v0.14.4 floor, preserved for local-dev builds).
- **`scripts/hooks_manifest_build_hook.py`** — skip manifest regeneration when a non-empty signed bundle exists (regeneration would void the signature); write an empty placeholder `.sigstore` in local-dev mode so hatch `shared-data` resolves.
- **`pyproject.toml`** — `sigstore>=3.0,<4.0`; `shared-data` += the two `.sigstore` entries.

## Governance

- Independent `architect-reviewer` plan audit: **PASS**, L2 (3 rounds — each round hardened the verifier-signature blast-radius enumeration; the final plan's six-file call-site set was independently grep-verified).
- Adversarial `code-reviewer` pre-push pass: **SHIP** — 0 HIGH, 1 MED, 2 LOW. Every verification-skip path was traced and confirmed fail-closed.
  - **MED** (follow-up, not in this PR): the manifest is read twice (`_sigstore_verify` for the signature, `verify_*_manifest` for the SHA cross-check) — a benign TOCTOU bounded by the SHA cross-check and not exploitable without install-tree write access (out of the threat model). Fixing it means another verifier-signature change right after 3 signature-focused audit rounds — deferred deliberately.
  - **LOW-1** (fixed in this PR): added a malformed-bundle fail-closed test exercising the real `_sigstore_verify`.
  - **LOW-2** (documented): `_get_event_writer()` failure aborts the bypass path — intended fail-closed behavior.

## Test plan

- [x] 59 new/migrated tests green: verifier fail-closed paths (missing manifest, missing bundle, **malformed bundle**, identity-mismatch-via-seam), build-hook idempotency, workflow-ordering lint, and the triple→pair migration of the existing `test_setup_wizard*` verify tests.
- [x] `ruff check` + `ruff format --check` clean on all 15 files.
- [ ] `mypy` via CI.
- [ ] 4 `test_installer_packaging.py` tests need a network-capable build-isolation env — they error in the local sandbox (`python -m build` can't `pip install hatchling`); they run in CI. Packaging contract verified locally with `--no-isolation`.

## Honest limitation

Keyless cosign signing needs GitHub Actions OIDC and **cannot be exercised pre-merge**. The real `Verifier.production()` path is tested via the `_VERIFIER_HOOK` seam; end-to-end verification (a real signed release → fresh `pipx install` → no `SignatureError`) is a documented **v0.14.5 release-time acceptance step** in `docs/RELEASE_EVIDENCE_PROCEDURE.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)