### PR TITLE
feat(jira): active-ingest adapter + ADF flattener (#337 Jira Phase A)

### DIFF
--- a/sources/jira/__init__.py
+++ b/sources/jira/__init__.py
@@ -1,0 +1,22 @@
+"""Jira source adapter (#337 Phase A — active ingest).
+
+Public API: ``JiraAdapter`` (the SourceAdapter implementation),
+``parse_jira_url`` (URL parsing helper, exposed for tests), and
+``flatten_adf`` (the pure ADF -> plain-text flattener).
+
+Auth: persisted via ``secrets_store`` under ``source_id="jira"``, keys
+``"api_email"`` and ``"api_token"``. Jira Cloud uses HTTP Basic auth —
+``base64(email:token)`` — so two secret values are required (see
+``docs/vendor/jira/auth.md``). The adapter reads them on each fetch (no
+in-memory caching — keyring revocation propagates within one tool call).
+"""
+
+from sources.jira.adapter import JiraAdapter, normalize_issue_to_payload, parse_jira_url
+from sources.jira.adf import flatten_adf
+
+__all__ = [
+    "JiraAdapter",
+    "flatten_adf",
+    "normalize_issue_to_payload",
+    "parse_jira_url",
+]

--- a/sources/jira/adapter.py
+++ b/sources/jira/adapter.py
@@ -1,0 +1,238 @@
+"""Jira source adapter (#337 Phase A — active ingest).
+
+URL -> REST API v3 fetch -> normalized ingest payload. Auth pulled from
+the ``secrets_store`` under ``source_id="jira"``, keys ``"api_email"``
+and ``"api_token"`` (Jira Cloud Basic auth needs both).
+
+Jira URL form accepted (Jira Cloud only):
+    https://<tenant>.atlassian.net/browse/PROJ-123
+    https://<tenant>.atlassian.net/browse/PROJ-123/
+    https://<tenant>.atlassian.net/browse/PROJ-123?focusedId=...
+    https://<tenant>.atlassian.net/browse/PROJ-123#comment-123
+
+Output payload shape (matches the natural-format branch of
+``IngestPayload``):
+    {
+      "query": "<issue summary>",
+      "source": "jira",
+      "title": "PROJ-123",
+      "date": "<fields.updated or fields.created or empty>",
+      "participants": [<assignee>, <reporter>, <comment authors>],
+      "decisions": [
+        {"description": "<flattened description>", "title": "PROJ-123"},
+        {"description": "<flattened comment body>",
+         "title": "PROJ-123#comment-<id>"},
+        ...
+      ],
+    }
+
+In v3 the issue ``description`` and each comment ``body`` arrive as ADF
+JSON, so they are run through ``flatten_adf`` before payload assembly.
+Comments are ingested as separate decision proposals — the downstream
+caller-LLM / gap-judge chain decides which are real decisions vs ambient
+chatter. Empty / whitespace-only flattened bodies are filtered before
+payload assembly so ``handle_ingest`` doesn't silently drop the row
+(mirrors ``LinearAdapter``).
+
+This is a protocol-conforming, fully-tested library module shipped one
+phase ahead of its consumers (the Phase B webhook handler and the Phase E
+poller) — the same situation as ``LinearAdapter`` (#420 Phase 1a, shipped
+before its #433 poller). It is not an orphan: the Phase A tests exercise
+it end-to-end.
+"""
+
+from __future__ import annotations
+
+import re
+
+from sources.jira.adf import flatten_adf
+
+# Tenant: lowercase alphanumerics + hyphens. Key: a project prefix
+# (uppercase letter then uppercase alphanumerics) + ``-`` + a number.
+# Scheme/host matched case-insensitively; the key is upper-cased after.
+_JIRA_URL_RE = re.compile(
+    r"^https?://(?P<tenant>[a-z0-9-]+)\.atlassian\.net"
+    r"/browse/(?P<key>[A-Z][A-Z0-9]+-\d+)(?:[/?#].*)?$",
+    re.IGNORECASE,
+)
+
+
+def parse_jira_url(url: str) -> tuple[str, str]:
+    """Extract ``(base_url, issue_key)`` from a Jira Cloud issue URL.
+
+    ``base_url`` is derived solely from the validated tenant host
+    (``https://<tenant>.atlassian.net``) — no user-controlled string is
+    interpolated into the REST URL except the validated issue key.
+
+    Raises:
+        ValueError: URL doesn't match the Jira Cloud issue pattern.
+    """
+    m = _JIRA_URL_RE.match(url.strip())
+    if not m:
+        raise ValueError(
+            f"not a recognized Jira issue URL: {url!r}. "
+            "Expected https://<tenant>.atlassian.net/browse/<PROJECT-NUMBER>[/...]."
+        )
+    tenant = m.group("tenant").lower()
+    issue_key = m.group("key").upper()
+    return f"https://{tenant}.atlassian.net", issue_key
+
+
+def _user_token(user: object) -> str | None:
+    """Resolve a participant token from a Jira user object.
+
+    Jira often omits ``emailAddress`` (account privacy settings); fall
+    back to ``displayName`` — a display name is an acceptable participant
+    token and is better than dropping the contributor entirely.
+    """
+    if not isinstance(user, dict):
+        return None
+    email = user.get("emailAddress")
+    if isinstance(email, str) and email.strip():
+        return email
+    name = user.get("displayName")
+    if isinstance(name, str) and name.strip():
+        return name
+    return None
+
+
+def _comments(issue: dict) -> list[dict]:
+    """Return the inline comment list from a Get-issue response."""
+    fields = issue.get("fields")
+    if not isinstance(fields, dict):
+        return []
+    comment_page = fields.get("comment")
+    if not isinstance(comment_page, dict):
+        return []
+    comments = comment_page.get("comments")
+    if not isinstance(comments, list):
+        return []
+    return [c for c in comments if isinstance(c, dict)]
+
+
+def _normalize_participants(issue: dict) -> list[str]:
+    """Collect participant tokens — assignee, reporter, comment authors.
+
+    Excludes authors of empty / whitespace-only comments (emoji reactions
+    and "+1" comments don't make someone a decision participant).
+    Assignee and reporter are always included regardless of activity —
+    they own / raised the issue. De-duplicated, order-preserved.
+    """
+    fields = issue.get("fields")
+    fields = fields if isinstance(fields, dict) else {}
+    seen: set[str] = set()
+    out: list[str] = []
+
+    for token in (_user_token(fields.get("assignee")), _user_token(fields.get("reporter"))):
+        if token and token not in seen:
+            seen.add(token)
+            out.append(token)
+
+    for comment in _comments(issue):
+        if not flatten_adf(comment.get("body")).strip():
+            continue
+        token = _user_token(comment.get("author"))
+        if token and token not in seen:
+            seen.add(token)
+            out.append(token)
+
+    return out
+
+
+def _normalize_decisions(issue: dict, issue_key: str) -> list[dict]:
+    """Build the decisions list, filtering empty / whitespace-only bodies.
+
+    The issue ``description`` and each comment ``body`` arrive as ADF and
+    are flattened to plain text. Empty flattened bodies are dropped
+    (mirrors ``LinearAdapter._normalize_decisions``).
+    """
+    fields = issue.get("fields")
+    fields = fields if isinstance(fields, dict) else {}
+    decisions: list[dict] = []
+
+    description = flatten_adf(fields.get("description")).strip()
+    if description:
+        decisions.append({"description": description, "title": issue_key})
+
+    for comment in _comments(issue):
+        body = flatten_adf(comment.get("body")).strip()
+        if not body:
+            continue
+        comment_id = comment.get("id")
+        comment_id = comment_id if isinstance(comment_id, str) and comment_id else ""
+        decisions.append(
+            {
+                "description": body,
+                "title": f"{issue_key}#comment-{comment_id}" if comment_id else issue_key,
+            }
+        )
+
+    return decisions
+
+
+def normalize_issue_to_payload(issue: dict, issue_key: str) -> dict:
+    """Build the ingest payload from a Jira Get-issue response."""
+    fields = issue.get("fields")
+    fields = fields if isinstance(fields, dict) else {}
+    summary = fields.get("summary")
+    summary = summary if isinstance(summary, str) and summary.strip() else issue_key
+    return {
+        "query": summary,
+        "source": "jira",
+        "title": issue_key,
+        "date": fields.get("updated") or fields.get("created") or "",
+        "participants": _normalize_participants(issue),
+        "decisions": _normalize_decisions(issue, issue_key),
+    }
+
+
+class JiraAdapter:
+    """SourceAdapter implementation for Jira Cloud (active path)."""
+
+    source_id = "jira"
+
+    def can_handle_url(self, url: str) -> bool:
+        return bool(_JIRA_URL_RE.match(url.strip()))
+
+    def fetch_active(self, url: str) -> dict:
+        base_url, issue_key = parse_jira_url(url)
+        email, token = self._resolve_auth()
+        from sources.jira.client import get_issue
+
+        issue = get_issue(
+            base_url=base_url,
+            issue_key=issue_key,
+            email=email,
+            token=token,
+        )
+        if not isinstance(issue, dict) or not issue.get("fields"):
+            raise RuntimeError(
+                f"Jira returned no issue for key {issue_key!r}. "
+                "Check the API token's account has Browse-projects permission "
+                "for this project."
+            )
+        return normalize_issue_to_payload(issue, issue_key)
+
+    def _resolve_auth(self) -> tuple[str, str]:
+        """Pull the Jira account email + API token from the secrets store.
+
+        Separate method so tests can override without monkey-patching the
+        ``secrets_store`` module at import time. A missing secret raises a
+        ``RuntimeError`` carrying operator-facing setup guidance — never
+        the secret value itself.
+        """
+        from secrets_store import get_secret
+
+        email = get_secret(source_id=self.source_id, key="api_email")
+        token = get_secret(source_id=self.source_id, key="api_token")
+        if not email or not token:
+            raise RuntimeError(
+                "Jira credentials not configured. Set both the account "
+                "email and an API token via:\n"
+                '  python -c "from secrets_store import put_secret; '
+                "put_secret(source_id='jira', key='api_email', "
+                "value='you@example.com')\"\n"
+                '  python -c "from secrets_store import put_secret; '
+                "put_secret(source_id='jira', key='api_token', value='<token>')\""
+            )
+        return email, token

--- a/sources/jira/adf.py
+++ b/sources/jira/adf.py
@@ -1,0 +1,132 @@
+"""ADF -> plain-text flattener (#337 Phase A).
+
+In Jira Cloud REST API v3, an issue ``description`` and a comment ``body``
+arrive as Atlassian Document Format (ADF) JSON — a recursive tree rooted
+at a ``doc`` node — not plain strings. ``flatten_adf`` collapses that tree
+to plain text so downstream decision-extraction sees readable content.
+
+This is the single genuinely novel component of the Jira integration; it
+has no in-repo precedent. It is implemented directly from the reference
+algorithm in ``docs/vendor/jira/atlassian-document-format.md`` §6.
+
+Design constraints:
+- **Pure function.** No I/O, no globals, deterministic. Solitary unit
+  tests are correct here (per CLAUDE.md "solitary is correct for pure
+  helpers").
+- **Defensive.** Per-node ``attrs`` key names are only PARTIALLY VERIFIED
+  in the grounding doc, so every lookup uses ``.get()`` with a default.
+  A non-``doc`` root, ``version != 1``, ``None``, or a non-dict input all
+  return ``""``. Unknown node types recurse into ``content``. The function
+  never raises on malformed ADF — worst case it returns ``""`` or partial
+  text.
+- **v0 minimal.** ``link``-mark href appending is deliberately out of
+  scope: a ``text`` node's string is emitted unchanged. Recorded as a
+  deferred nicety.
+"""
+
+from __future__ import annotations
+
+# Block / container nodes whose flattened inner content is followed by a
+# newline (a paragraph / structural break in the plain-text output).
+_BLOCK_NEWLINE_TYPES = frozenset(
+    {
+        "paragraph",
+        "heading",
+        "blockquote",
+        "panel",
+        "codeBlock",
+        "rule",
+        "listItem",
+        "tableRow",
+    }
+)
+
+# Container nodes whose inner content is emitted verbatim with no extra
+# break (their children supply their own structure).
+_BLOCK_PASSTHROUGH_TYPES = frozenset({"bulletList", "orderedList", "table"})
+
+# Recursion-depth cap. A legitimate ADF document nests only a handful of
+# levels deep (lists in table cells in panels, etc.); 100 is far beyond
+# any real content. A hostile payload with thousands of nested nodes —
+# a few KB of JSON, well under the client's response-size cap — would
+# otherwise raise RecursionError and break this function's "never raises"
+# contract. Past the cap a node contributes "" (its subtree is dropped).
+_MAX_DEPTH = 100
+
+
+def _flatten_node(node: object, _depth: int = 0) -> str:
+    """Flatten a single ADF node (and its subtree) to plain text.
+
+    Tolerates anything: a non-dict node contributes ``""``. ``_depth`` is
+    internal — recursion past ``_MAX_DEPTH`` yields ``""`` so a
+    pathologically nested payload cannot raise ``RecursionError``.
+    """
+    if _depth > _MAX_DEPTH:
+        return ""
+    if not isinstance(node, dict):
+        return ""
+
+    node_type = node.get("type")
+
+    if node_type == "text":
+        # v0: emit the literal text unchanged; marks (strong/em/code/link
+        # /strike/underline/...) are presentational and dropped.
+        text = node.get("text")
+        return text if isinstance(text, str) else ""
+
+    if node_type == "hardBreak":
+        return "\n"
+
+    if node_type in {"emoji", "mention", "status"}:
+        attrs = node.get("attrs")
+        if isinstance(attrs, dict):
+            value = attrs.get("text")
+            if isinstance(value, str):
+                return value
+        return ""
+
+    if node_type == "inlineCard":
+        attrs = node.get("attrs")
+        if isinstance(attrs, dict):
+            value = attrs.get("url")
+            if isinstance(value, str):
+                return value
+        return ""
+
+    if node_type == "date":
+        # The epoch-ms timestamp carries no decision content; omit it.
+        return ""
+
+    # Block / container / unknown node: recurse into ``content``.
+    content = node.get("content")
+    children = content if isinstance(content, list) else []
+    inner = "".join(_flatten_node(child, _depth + 1) for child in children)
+
+    if node_type in _BLOCK_NEWLINE_TYPES:
+        return inner + "\n"
+    # bulletList / orderedList / table, ``doc``, and any unknown type all
+    # just pass their inner content through unchanged.
+    return inner
+
+
+def flatten_adf(doc: object) -> str:
+    """Flatten an ADF document to plain text.
+
+    Args:
+        doc: An ADF document — normally ``{"version": 1, "type": "doc",
+            "content": [...]}``. ``None``, a non-dict, a non-``doc`` root,
+            or ``version != 1`` all yield ``""``.
+
+    Returns:
+        The flattened plain-text content, ``.strip()``-ed. Never raises.
+    """
+    if not isinstance(doc, dict):
+        return ""
+    if doc.get("type") != "doc":
+        return ""
+    if doc.get("version") != 1:
+        return ""
+
+    content = doc.get("content")
+    children = content if isinstance(content, list) else []
+    return "".join(_flatten_node(child) for child in children).strip()

--- a/sources/jira/client.py
+++ b/sources/jira/client.py
@@ -1,0 +1,123 @@
+"""Thin Jira Cloud REST API v3 client (#337 Phase A).
+
+Uses stdlib ``urllib.request`` rather than adding ``httpx`` / ``requests``
+as a dependency — mirrors ``sources/linear/client.py`` and the precedent
+set by ``handlers/update.py``. A single endpoint (Get issue) keeps the
+surface tiny; if the Jira adapter family grows to need retries-with-
+backoff or streaming, swap to ``httpx`` then.
+
+Auth: Jira Cloud uses HTTP Basic auth — ``Authorization: Basic
+base64(email:token)`` (see ``docs/vendor/jira/auth.md``).
+
+Threat-model notes:
+- The API token never appears in a URL string (Authorization header
+  only) and never appears in a log line or an exception message — a
+  failed request's exception carries the HTTP status and the request
+  URL, never the ``Authorization`` header.
+- Response size is capped at 8 MiB; an issue with megabytes of comments
+  is a misuse signal — refuse rather than blow out memory.
+- Network timeout is fixed at 15s — long enough for slow Jira regions,
+  short enough that an operator-driven active fetch doesn't appear hung.
+"""
+
+from __future__ import annotations
+
+import base64
+import json
+import urllib.error
+import urllib.parse
+import urllib.request
+
+_REQUEST_TIMEOUT_SECONDS = 15.0
+_MAX_RESPONSE_BYTES = 8 * 1024 * 1024  # 8 MiB
+
+# Fields requested from Get issue. ``comment`` returns the default comment
+# page inline (fields.comment.comments[]) — no separate comment fetch is
+# needed for v0.
+_ISSUE_FIELDS = "summary,description,status,assignee,reporter,updated,created,comment"
+
+
+class JiraAPIError(RuntimeError):
+    """Raised for any non-recoverable Jira API failure.
+
+    Subclassed off ``RuntimeError`` so the ``SourceAdapter`` protocol
+    contract (raises ``RuntimeError`` on network/auth failure) is
+    satisfied. Carries ``status_code`` when the failure is HTTP-shaped;
+    ``None`` for network-level failures (DNS, timeout, connection reset).
+
+    The message never contains the API token or the ``Authorization``
+    header — only the HTTP status and the request URL.
+    """
+
+    def __init__(self, message: str, *, status_code: int | None = None) -> None:
+        self.status_code = status_code
+        super().__init__(message)
+
+
+def _basic_auth_header(email: str, token: str) -> str:
+    """Build the ``Basic <base64>`` Authorization header value.
+
+    The encoded credential is built immediately before the request and
+    never logged.
+    """
+    raw = f"{email}:{token}".encode()
+    return "Basic " + base64.b64encode(raw).decode("ascii")
+
+
+def get_issue(*, base_url: str, issue_key: str, email: str, token: str) -> dict:
+    """Fetch a Jira issue via REST API v3.
+
+    Issues ``GET {base_url}/rest/api/3/issue/{issue_key}`` with the
+    decision-bearing fields (summary, description, status, assignee,
+    reporter, timestamps, comments).
+
+    Args:
+        base_url: The tenant base, e.g. ``https://acme.atlassian.net``.
+        issue_key: The issue key, e.g. ``PROJ-123``.
+        email: The Atlassian account email (Basic-auth username).
+        token: The Atlassian API token (Basic-auth password).
+
+    Returns:
+        The parsed JSON response — the Jira issue object.
+
+    Raises:
+        JiraAPIError: HTTP non-2xx, oversized response, non-JSON body, or
+            any network-level failure. The message carries the status and
+            URL but never the auth header.
+    """
+    path = f"/rest/api/3/issue/{urllib.parse.quote(issue_key, safe='')}"
+    url = f"{base_url}{path}?{urllib.parse.urlencode({'fields': _ISSUE_FIELDS})}"
+    headers = {
+        "Authorization": _basic_auth_header(email, token),
+        "Accept": "application/json",
+        "User-Agent": "bicameral-mcp/source-jira",
+    }
+    req = urllib.request.Request(url, headers=headers, method="GET")
+    try:
+        with urllib.request.urlopen(req, timeout=_REQUEST_TIMEOUT_SECONDS) as resp:
+            # Read up to cap + 1 byte; if we get the +1 the response is over-cap.
+            raw = resp.read(_MAX_RESPONSE_BYTES + 1)
+            if len(raw) > _MAX_RESPONSE_BYTES:
+                raise JiraAPIError(
+                    f"Jira response exceeded {_MAX_RESPONSE_BYTES} bytes for {url}",
+                    status_code=resp.status,
+                )
+    except urllib.error.HTTPError as exc:
+        # exc.reason / exc.code are server-supplied; the request URL is
+        # ours. Neither carries the Authorization header.
+        raise JiraAPIError(
+            f"Jira API HTTP {exc.code}: {exc.reason} for {url}",
+            status_code=exc.code,
+        ) from exc
+    except urllib.error.URLError as exc:
+        raise JiraAPIError(f"Jira API network error for {url}: {exc.reason}") from exc
+
+    try:
+        parsed = json.loads(raw.decode("utf-8"))
+    except json.JSONDecodeError as exc:
+        raise JiraAPIError(f"Jira API returned non-JSON for {url}: {exc}") from exc
+
+    if not isinstance(parsed, dict):
+        raise JiraAPIError(f"Jira API returned a non-object response for {url}")
+
+    return parsed

--- a/tests/test_jira_adapter.py
+++ b/tests/test_jira_adapter.py
@@ -1,0 +1,504 @@
+"""Sociable tests for the Jira source adapter (#337 Phase A).
+
+These are *sociable* tests: the real ``JiraAdapter``, the real
+``normalize_issue_to_payload``, the real ``flatten_adf``, and the real
+``client.get_issue`` HTTP-construction path all run end-to-end. The only
+seam is the genuine external boundary — the outbound HTTP call to Jira,
+which we cannot run against a real SaaS in CI. That seam is pinned to the
+narrowest possible point: ``urllib.request.urlopen`` -> bytes response,
+exactly the seam ``tests/test_linear_adapter.py`` uses.
+
+URL parsing, the REST URL construction, the Basic-auth header, the ADF
+flattening of description + comments, participant resolution, secrets-
+store integration, and error handling all execute for real.
+"""
+
+from __future__ import annotations
+
+import io
+import json
+import urllib.error
+from unittest.mock import patch
+
+import pytest
+
+from sources.jira.adapter import (
+    JiraAdapter,
+    normalize_issue_to_payload,
+    parse_jira_url,
+)
+from sources.jira.client import JiraAPIError, get_issue
+
+# ── URL parsing ─────────────────────────────────────────────────────────────
+
+
+@pytest.mark.parametrize(
+    "url,expected_base,expected_key",
+    [
+        (
+            "https://acme.atlassian.net/browse/PROJ-123",
+            "https://acme.atlassian.net",
+            "PROJ-123",
+        ),
+        (
+            "https://acme.atlassian.net/browse/PROJ-123/",
+            "https://acme.atlassian.net",
+            "PROJ-123",
+        ),
+        (
+            "https://acme.atlassian.net/browse/PROJ-123?focusedId=99",
+            "https://acme.atlassian.net",
+            "PROJ-123",
+        ),
+        (
+            "https://acme.atlassian.net/browse/PROJ-123#comment-99",
+            "https://acme.atlassian.net",
+            "PROJ-123",
+        ),
+        (
+            "  https://my-team.atlassian.net/browse/ABC-1  ",
+            "https://my-team.atlassian.net",
+            "ABC-1",
+        ),
+        (
+            "HTTPS://ACME.ATLASSIAN.NET/browse/proj-7",
+            "https://acme.atlassian.net",
+            "PROJ-7",
+        ),
+        (
+            # The plan regex's ``(?:[/?#].*)?$`` tail accepts any trailing
+            # path after the key (mirrors Linear's ``/<slug>`` acceptance).
+            "https://acme.atlassian.net/browse/PROJ-123/extra/tail",
+            "https://acme.atlassian.net",
+            "PROJ-123",
+        ),
+    ],
+)
+def test_parse_jira_url_accepts_valid(url, expected_base, expected_key):
+    base_url, issue_key = parse_jira_url(url)
+    assert base_url == expected_base
+    assert issue_key == expected_key
+
+
+@pytest.mark.parametrize(
+    "url",
+    [
+        "https://github.com/foo/bar",
+        "https://acme.atlassian.net",
+        "https://acme.atlassian.net/browse/",
+        "https://acme.example.com/browse/PROJ-123",  # not atlassian.net
+        "https://acme.atlassian.net/browse/PROJ",  # bare key, no number
+        "https://acme.atlassian.net/browse/123-456",  # no project prefix
+        "PROJ-123",  # bare key, not a URL
+        "not-a-url",
+        "",
+    ],
+)
+def test_parse_jira_url_rejects_invalid(url):
+    with pytest.raises(ValueError):
+        parse_jira_url(url)
+
+
+# ── can_handle_url ──────────────────────────────────────────────────────────
+
+
+def test_adapter_can_handle_url():
+    a = JiraAdapter()
+    assert a.can_handle_url("https://acme.atlassian.net/browse/PROJ-1")
+    assert a.can_handle_url("https://acme.atlassian.net/browse/PROJ-1#comment-2")
+    assert not a.can_handle_url("https://github.com/foo/bar")
+    assert not a.can_handle_url("https://linear.app/foo/issue/BIC-1")
+    assert not a.can_handle_url("totally not a url")
+    assert a.source_id == "jira"
+
+
+# ── Fixtures: realistic Jira Get-issue responses ────────────────────────────
+
+
+def _adf(*paragraph_texts: str) -> dict:
+    """Build a minimal ADF doc, one paragraph per string."""
+    return {
+        "version": 1,
+        "type": "doc",
+        "content": [
+            {"type": "paragraph", "content": [{"type": "text", "text": t}]} for t in paragraph_texts
+        ],
+    }
+
+
+def _full_issue() -> dict:
+    """A realistic Get-issue response: ADF description + 2 ADF comments."""
+    return {
+        "id": "10001",
+        "key": "PROJ-123",
+        "fields": {
+            "summary": "Decide the ingest gate posture",
+            "description": _adf("We need to choose between hard-fail and WARN."),
+            "status": {
+                "name": "Done",
+                "statusCategory": {"key": "done", "name": "Done"},
+            },
+            "created": "2026-05-19T09:00:00.000+0000",
+            "updated": "2026-05-21T10:30:00.000+0000",
+            "assignee": {
+                "accountId": "acc-1",
+                "displayName": "Dev One",
+                "emailAddress": "dev@example.com",
+            },
+            "reporter": {
+                "accountId": "acc-2",
+                "displayName": "PM Two",
+                "emailAddress": "pm@example.com",
+            },
+            "comment": {
+                "startAt": 0,
+                "maxResults": 100,
+                "total": 2,
+                "comments": [
+                    {
+                        "id": "9001",
+                        "author": {
+                            "accountId": "acc-3",
+                            "displayName": "Reviewer Three",
+                            "emailAddress": "rev@example.com",
+                        },
+                        "body": _adf("Agreed — go with WARN plus an audit emit."),
+                        "created": "2026-05-20T11:00:00.000+0000",
+                    },
+                    {
+                        "id": "9002",
+                        "author": {
+                            "accountId": "acc-1",
+                            "displayName": "Dev One",
+                            "emailAddress": "dev@example.com",
+                        },
+                        "body": _adf("Implemented in the ingest handler."),
+                        "created": "2026-05-21T08:00:00.000+0000",
+                    },
+                ],
+            },
+        },
+    }
+
+
+# ── normalize_issue_to_payload (real, no seam) ──────────────────────────────
+
+
+def test_normalize_full_shape():
+    payload = normalize_issue_to_payload(_full_issue(), "PROJ-123")
+
+    assert payload["query"] == "Decide the ingest gate posture"
+    assert payload["source"] == "jira"
+    assert payload["title"] == "PROJ-123"
+    assert payload["date"] == "2026-05-21T10:30:00.000+0000"
+    # assignee, reporter, then comment authors — de-duped (dev@ appears once).
+    assert payload["participants"] == [
+        "dev@example.com",
+        "pm@example.com",
+        "rev@example.com",
+    ]
+    # description + 2 comments, all flattened to plain text.
+    assert len(payload["decisions"]) == 3
+    assert payload["decisions"][0]["description"] == (
+        "We need to choose between hard-fail and WARN."
+    )
+    assert payload["decisions"][0]["title"] == "PROJ-123"
+    assert payload["decisions"][1]["title"] == "PROJ-123#comment-9001"
+    assert payload["decisions"][2]["title"] == "PROJ-123#comment-9002"
+    assert payload["decisions"][1]["description"] == ("Agreed — go with WARN plus an audit emit.")
+
+
+def test_normalize_falls_back_to_created_when_updated_missing():
+    issue = _full_issue()
+    issue["fields"]["updated"] = None
+    payload = normalize_issue_to_payload(issue, "PROJ-123")
+    assert payload["date"] == "2026-05-19T09:00:00.000+0000"
+
+
+def test_normalize_summary_falls_back_to_key():
+    issue = _full_issue()
+    issue["fields"]["summary"] = None
+    payload = normalize_issue_to_payload(issue, "PROJ-123")
+    assert payload["query"] == "PROJ-123"
+
+
+def test_normalize_empty_description_is_omitted():
+    """An issue with no description still ingests its comments."""
+    issue = _full_issue()
+    issue["fields"]["description"] = None
+    payload = normalize_issue_to_payload(issue, "PROJ-123")
+    # description dropped; both comments survive.
+    assert len(payload["decisions"]) == 2
+    assert payload["decisions"][0]["title"] == "PROJ-123#comment-9001"
+
+
+def test_normalize_whitespace_only_comment_filtered():
+    issue = _full_issue()
+    # Replace one comment body with a whitespace-only ADF doc.
+    issue["fields"]["comment"]["comments"][1]["body"] = _adf("   ")
+    payload = normalize_issue_to_payload(issue, "PROJ-123")
+    # description + 1 non-empty comment; the whitespace comment is dropped.
+    assert len(payload["decisions"]) == 2
+    titles = [d["title"] for d in payload["decisions"]]
+    assert "PROJ-123#comment-9002" not in titles
+    # The whitespace commenter is not a participant either.
+    assert "dev@example.com" in payload["participants"]  # still assignee
+
+
+def test_normalize_participant_fallback_to_display_name():
+    """A comment author with no emailAddress falls back to displayName."""
+    issue = _full_issue()
+    issue["fields"]["comment"]["comments"][0]["author"] = {
+        "accountId": "acc-9",
+        "displayName": "Privacy Conscious",
+        # emailAddress omitted by privacy settings
+    }
+    payload = normalize_issue_to_payload(issue, "PROJ-123")
+    assert "Privacy Conscious" in payload["participants"]
+
+
+def test_normalize_empty_issue_yields_empty_decisions():
+    issue = {
+        "id": "1",
+        "key": "PROJ-1",
+        "fields": {
+            "summary": "Empty one",
+            "description": None,
+            "updated": "2026-05-21T00:00:00.000+0000",
+            "comment": {"comments": []},
+        },
+    }
+    payload = normalize_issue_to_payload(issue, "PROJ-1")
+    assert payload["decisions"] == []
+    assert payload["participants"] == []
+
+
+# ── HTTP boundary seam (mirrors test_linear_adapter._mock_response) ─────────
+
+
+def _mock_response(body: dict, status: int = 200):
+    """Build a fake urlopen context manager returning ``body`` as JSON."""
+    raw = json.dumps(body).encode("utf-8")
+    resp = io.BytesIO(raw)
+    resp.status = status  # type: ignore[attr-defined]
+
+    class _Ctx:
+        def __enter__(self):
+            return resp
+
+        def __exit__(self, *args):
+            return False
+
+    return _Ctx()
+
+
+# ── client.get_issue: real construction, seamed network ─────────────────────
+
+
+def test_get_issue_returns_parsed_body_and_builds_correct_request():
+    captured: dict = {}
+
+    def _fake_urlopen(req, timeout=None):
+        captured["url"] = req.full_url
+        captured["headers"] = {k.lower(): v for k, v in req.headers.items()}
+        captured["method"] = req.get_method()
+        return _mock_response(_full_issue())
+
+    with patch("urllib.request.urlopen", side_effect=_fake_urlopen):
+        issue = get_issue(
+            base_url="https://acme.atlassian.net",
+            issue_key="PROJ-123",
+            email="dev@example.com",
+            token="secret-token-xyz",
+        )
+
+    assert issue["key"] == "PROJ-123"
+    assert captured["method"] == "GET"
+    assert captured["url"].startswith(
+        "https://acme.atlassian.net/rest/api/3/issue/PROJ-123?fields="
+    )
+    # Auth header is Basic + base64; never the raw token.
+    auth = captured["headers"]["authorization"]
+    assert auth.startswith("Basic ")
+    assert "secret-token-xyz" not in auth
+    # The fields list requests the decision-bearing fields.
+    assert "description" in captured["url"]
+    assert "comment" in captured["url"]
+
+
+def test_get_issue_raises_on_http_error_without_leaking_token():
+    err = urllib.error.HTTPError(
+        url="https://acme.atlassian.net/rest/api/3/issue/PROJ-1",
+        code=401,
+        msg="Unauthorized",
+        hdrs=None,
+        fp=io.BytesIO(b""),
+    )
+    with patch("urllib.request.urlopen", side_effect=err):
+        with pytest.raises(JiraAPIError) as exc_info:
+            get_issue(
+                base_url="https://acme.atlassian.net",
+                issue_key="PROJ-1",
+                email="dev@example.com",
+                token="super-secret-token",
+            )
+    assert exc_info.value.status_code == 401
+    # The token must never appear in the exception message.
+    assert "super-secret-token" not in str(exc_info.value)
+
+
+def test_get_issue_raises_on_oversized_response():
+    big = ("x" * (8 * 1024 * 1024 + 100)).encode("utf-8")
+    resp = io.BytesIO(big)
+    resp.status = 200  # type: ignore[attr-defined]
+
+    class _Ctx:
+        def __enter__(self):
+            return resp
+
+        def __exit__(self, *args):
+            return False
+
+    with patch("urllib.request.urlopen", return_value=_Ctx()):
+        with pytest.raises(JiraAPIError, match="exceeded"):
+            get_issue(
+                base_url="https://acme.atlassian.net",
+                issue_key="PROJ-1",
+                email="dev@example.com",
+                token="t",
+            )
+
+
+def test_get_issue_raises_on_non_json_response():
+    raw = b"not json at all"
+    resp = io.BytesIO(raw)
+    resp.status = 200  # type: ignore[attr-defined]
+
+    class _Ctx:
+        def __enter__(self):
+            return resp
+
+        def __exit__(self, *args):
+            return False
+
+    with patch("urllib.request.urlopen", return_value=_Ctx()):
+        with pytest.raises(JiraAPIError, match="non-JSON"):
+            get_issue(
+                base_url="https://acme.atlassian.net",
+                issue_key="PROJ-1",
+                email="dev@example.com",
+                token="t",
+            )
+
+
+# ── JiraAdapter.fetch_active: full round trip, seamed network ───────────────
+
+
+def test_fetch_active_happy_path(monkeypatch):
+    """Real adapter + real normalizer + real flattener; only the HTTP
+    boundary is seamed."""
+    a = JiraAdapter()
+    monkeypatch.setattr(a, "_resolve_auth", lambda: ("dev@example.com", "tok"))
+
+    with patch("urllib.request.urlopen", return_value=_mock_response(_full_issue())):
+        result = a.fetch_active("https://acme.atlassian.net/browse/PROJ-123")
+
+    assert result["source"] == "jira"
+    assert result["title"] == "PROJ-123"
+    assert result["query"] == "Decide the ingest gate posture"
+    assert len(result["decisions"]) == 3
+    # Decisions are flattened plain text, not ADF dicts.
+    assert all(isinstance(d["description"], str) for d in result["decisions"])
+    assert result["decisions"][1]["title"] == "PROJ-123#comment-9001"
+    assert result["decisions"][2]["title"] == "PROJ-123#comment-9002"
+
+
+def test_fetch_active_comment_only_issue(monkeypatch):
+    """An issue with no description still ingests its comments."""
+    issue = _full_issue()
+    issue["fields"]["description"] = None
+    a = JiraAdapter()
+    monkeypatch.setattr(a, "_resolve_auth", lambda: ("dev@example.com", "tok"))
+
+    with patch("urllib.request.urlopen", return_value=_mock_response(issue)):
+        result = a.fetch_active("https://acme.atlassian.net/browse/PROJ-123")
+
+    assert len(result["decisions"]) == 2
+    assert result["decisions"][0]["title"] == "PROJ-123#comment-9001"
+
+
+def test_fetch_active_participant_fallback(monkeypatch):
+    """A comment author with no emailAddress contributes its displayName."""
+    issue = _full_issue()
+    issue["fields"]["comment"]["comments"][0]["author"] = {
+        "accountId": "acc-x",
+        "displayName": "No Email User",
+    }
+    a = JiraAdapter()
+    monkeypatch.setattr(a, "_resolve_auth", lambda: ("dev@example.com", "tok"))
+
+    with patch("urllib.request.urlopen", return_value=_mock_response(issue)):
+        result = a.fetch_active("https://acme.atlassian.net/browse/PROJ-123")
+
+    assert "No Email User" in result["participants"]
+
+
+def test_fetch_active_raises_when_issue_has_no_fields(monkeypatch):
+    a = JiraAdapter()
+    monkeypatch.setattr(a, "_resolve_auth", lambda: ("dev@example.com", "tok"))
+
+    with patch("urllib.request.urlopen", return_value=_mock_response({"key": "PROJ-9"})):
+        with pytest.raises(RuntimeError, match="no issue"):
+            a.fetch_active("https://acme.atlassian.net/browse/PROJ-9")
+
+
+# ── _resolve_auth: real secrets_store integration ───────────────────────────
+
+
+def test_resolve_auth_raises_when_secret_missing(monkeypatch):
+    """With no secrets configured, the adapter surfaces operator-facing
+    setup guidance — and never a secret value."""
+    monkeypatch.setenv("BICAMERAL_KEYRING_DISABLE", "1")
+    from secrets_store.store import _reset_for_tests
+
+    _reset_for_tests()
+
+    a = JiraAdapter()
+    with pytest.raises(RuntimeError) as exc_info:
+        a.fetch_active("https://acme.atlassian.net/browse/PROJ-1")
+    msg = str(exc_info.value)
+    assert "credentials not configured" in msg
+    assert "api_email" in msg
+    assert "api_token" in msg
+
+
+def test_resolve_auth_returns_both_secrets(monkeypatch):
+    """When both secrets are present, _resolve_auth returns the pair."""
+    monkeypatch.setenv("BICAMERAL_KEYRING_DISABLE", "1")
+    from secrets_store.store import _reset_for_tests
+
+    _reset_for_tests()
+    from secrets_store import put_secret
+
+    put_secret(source_id="jira", key="api_email", value="real@example.com")
+    put_secret(source_id="jira", key="api_token", value="real-token")
+
+    a = JiraAdapter()
+    email, token = a._resolve_auth()
+    assert email == "real@example.com"
+    assert token == "real-token"
+
+
+def test_resolve_auth_raises_when_only_email_present(monkeypatch):
+    """A partial config (email but no token) is still a hard failure."""
+    monkeypatch.setenv("BICAMERAL_KEYRING_DISABLE", "1")
+    from secrets_store.store import _reset_for_tests
+
+    _reset_for_tests()
+    from secrets_store import put_secret
+
+    put_secret(source_id="jira", key="api_email", value="real@example.com")
+
+    a = JiraAdapter()
+    with pytest.raises(RuntimeError, match="credentials not configured"):
+        a._resolve_auth()

--- a/tests/test_jira_adf.py
+++ b/tests/test_jira_adf.py
@@ -1,0 +1,343 @@
+"""Solitary unit tests for the ADF -> plain-text flattener (#337 Phase A).
+
+``flatten_adf`` is a pure function — no I/O, no collaborators — so
+solitary tests are correct here (per CLAUDE.md "solitary is correct for
+pure helpers"). There is nothing to seam: the inputs are plain dicts and
+the output is a string.
+
+Coverage: malformed roots (None, non-dict, non-doc, wrong version),
+every leaf inline node, nested lists, headings, code blocks, marks
+ignored, hardBreak, unknown node recursion, and a realistic multi-block
+issue description fixture.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from sources.jira.adf import flatten_adf
+
+
+def _doc(*content: dict) -> dict:
+    """Wrap block nodes in a valid ADF ``doc`` root."""
+    return {"version": 1, "type": "doc", "content": list(content)}
+
+
+def _para(*inline: dict) -> dict:
+    return {"type": "paragraph", "content": list(inline)}
+
+
+def _text(s: str, marks: list[dict] | None = None) -> dict:
+    node: dict = {"type": "text", "text": s}
+    if marks is not None:
+        node["marks"] = marks
+    return node
+
+
+# ── Malformed / empty roots → "" ────────────────────────────────────────────
+
+
+@pytest.mark.parametrize(
+    "bad",
+    [
+        None,
+        {},
+        [],
+        "a string",
+        42,
+        {"type": "paragraph", "content": []},  # non-doc root
+        {"version": 1, "type": "panel", "content": []},  # non-doc root
+        {"version": 2, "type": "doc", "content": []},  # wrong version
+        {"type": "doc", "content": []},  # missing version
+        {"version": "1", "type": "doc", "content": []},  # version is a string
+    ],
+)
+def test_flatten_adf_returns_empty_for_malformed_root(bad):
+    assert flatten_adf(bad) == ""
+
+
+def test_flatten_adf_empty_doc():
+    assert flatten_adf(_doc()) == ""
+
+
+def test_flatten_adf_doc_with_non_list_content():
+    assert flatten_adf({"version": 1, "type": "doc", "content": None}) == ""
+    assert flatten_adf({"version": 1, "type": "doc"}) == ""
+
+
+# ── Single block nodes ──────────────────────────────────────────────────────
+
+
+def test_single_paragraph():
+    doc = _doc(_para(_text("Ship the WARN posture.")))
+    assert flatten_adf(doc) == "Ship the WARN posture."
+
+
+def test_heading():
+    doc = _doc(
+        {"type": "heading", "attrs": {"level": 2}, "content": [_text("Decision")]},
+        _para(_text("We chose option B.")),
+    )
+    assert flatten_adf(doc) == "Decision\nWe chose option B."
+
+
+def test_two_paragraphs_separated_by_newline():
+    doc = _doc(_para(_text("First.")), _para(_text("Second.")))
+    assert flatten_adf(doc) == "First.\nSecond."
+
+
+# ── Marks ignored, text emitted unchanged ───────────────────────────────────
+
+
+def test_marks_are_ignored_text_emitted_unchanged():
+    doc = _doc(
+        _para(
+            _text("plain "),
+            _text("bold", [{"type": "strong"}]),
+            _text(" "),
+            _text("italic", [{"type": "em"}]),
+            _text(" "),
+            _text("mono", [{"type": "code"}]),
+        )
+    )
+    assert flatten_adf(doc) == "plain bold italic mono"
+
+
+def test_link_mark_text_emitted_without_href_v0():
+    # v0: the link href is NOT appended — the text is emitted unchanged.
+    doc = _doc(
+        _para(
+            _text(
+                "see the docs",
+                [{"type": "link", "attrs": {"href": "https://example.com"}}],
+            )
+        )
+    )
+    assert flatten_adf(doc) == "see the docs"
+
+
+# ── Lists ───────────────────────────────────────────────────────────────────
+
+
+def test_bullet_list():
+    doc = _doc(
+        {
+            "type": "bulletList",
+            "content": [
+                {"type": "listItem", "content": [_para(_text("alpha"))]},
+                {"type": "listItem", "content": [_para(_text("beta"))]},
+            ],
+        }
+    )
+    assert flatten_adf(doc) == "alpha\n\nbeta"
+
+
+def test_ordered_list():
+    doc = _doc(
+        {
+            "type": "orderedList",
+            "content": [
+                {"type": "listItem", "content": [_para(_text("one"))]},
+                {"type": "listItem", "content": [_para(_text("two"))]},
+            ],
+        }
+    )
+    assert flatten_adf(doc) == "one\n\ntwo"
+
+
+def test_nested_lists():
+    inner_list = {
+        "type": "bulletList",
+        "content": [
+            {"type": "listItem", "content": [_para(_text("child"))]},
+        ],
+    }
+    doc = _doc(
+        {
+            "type": "bulletList",
+            "content": [
+                {"type": "listItem", "content": [_para(_text("parent")), inner_list]},
+            ],
+        }
+    )
+    assert "parent" in flatten_adf(doc)
+    assert "child" in flatten_adf(doc)
+
+
+# ── codeBlock preserves inner text ──────────────────────────────────────────
+
+
+def test_code_block_preserves_inner_text():
+    doc = _doc(
+        {
+            "type": "codeBlock",
+            "attrs": {"language": "python"},
+            "content": [_text("print('hi')\nreturn 0")],
+        }
+    )
+    assert flatten_adf(doc) == "print('hi')\nreturn 0"
+
+
+# ── hardBreak → newline ─────────────────────────────────────────────────────
+
+
+def test_hard_break_becomes_newline():
+    doc = _doc(_para(_text("line one"), {"type": "hardBreak"}, _text("line two")))
+    assert flatten_adf(doc) == "line one\nline two"
+
+
+# ── Inline leaf nodes ───────────────────────────────────────────────────────
+
+
+def test_emoji_leaf_node():
+    doc = _doc(_para(_text("ship it "), {"type": "emoji", "attrs": {"text": "🚀"}}))
+    assert flatten_adf(doc) == "ship it 🚀"
+
+
+def test_mention_leaf_node():
+    doc = _doc(
+        _para(
+            {"type": "mention", "attrs": {"text": "@Dev", "id": "abc"}},
+            _text(" please review"),
+        )
+    )
+    assert flatten_adf(doc) == "@Dev please review"
+
+
+def test_status_leaf_node():
+    doc = _doc(_para({"type": "status", "attrs": {"text": "DONE", "color": "green"}}))
+    assert flatten_adf(doc) == "DONE"
+
+
+def test_inline_card_leaf_node():
+    doc = _doc(_para({"type": "inlineCard", "attrs": {"url": "https://example.com/x"}}))
+    assert flatten_adf(doc) == "https://example.com/x"
+
+
+def test_date_leaf_node_omitted():
+    doc = _doc(_para(_text("due "), {"type": "date", "attrs": {"timestamp": "1716200000000"}}))
+    assert flatten_adf(doc) == "due"
+
+
+def test_inline_leaf_missing_attrs_degrades_gracefully():
+    # attrs absent / non-dict / missing key → "", never a crash.
+    doc = _doc(
+        _para(
+            _text("a"),
+            {"type": "emoji"},
+            {"type": "mention", "attrs": None},
+            {"type": "status", "attrs": {}},
+            {"type": "inlineCard", "attrs": "not-a-dict"},
+            _text("b"),
+        )
+    )
+    assert flatten_adf(doc) == "ab"
+
+
+# ── Unknown node types recurse ──────────────────────────────────────────────
+
+
+def test_unknown_node_type_recurses_into_content():
+    doc = _doc(
+        {
+            "type": "someFutureNodeType",
+            "content": [_para(_text("still readable"))],
+        }
+    )
+    assert flatten_adf(doc) == "still readable"
+
+
+def test_non_dict_child_is_skipped():
+    doc = {
+        "version": 1,
+        "type": "doc",
+        "content": [_para(_text("kept")), None, "junk", 7],
+    }
+    assert flatten_adf(doc) == "kept"
+
+
+def test_text_node_with_non_string_text():
+    doc = _doc(_para({"type": "text", "text": None}, _text("real")))
+    assert flatten_adf(doc) == "real"
+
+
+# ── Realistic multi-block issue description fixture ──────────────────────────
+
+
+def test_realistic_multi_block_description():
+    doc = {
+        "version": 1,
+        "type": "doc",
+        "content": [
+            {
+                "type": "heading",
+                "attrs": {"level": 1},
+                "content": [_text("Context")],
+            },
+            _para(
+                _text("We need to decide the ingest gate posture for "),
+                _text("public sources", [{"type": "strong"}]),
+                _text("."),
+            ),
+            {
+                "type": "bulletList",
+                "content": [
+                    {"type": "listItem", "content": [_para(_text("Option A: hard fail"))]},
+                    {"type": "listItem", "content": [_para(_text("Option B: WARN + audit"))]},
+                ],
+            },
+            {
+                "type": "panel",
+                "attrs": {"panelType": "info"},
+                "content": [_para(_text("Decision: go with Option B."))],
+            },
+            {
+                "type": "codeBlock",
+                "attrs": {"language": "python"},
+                "content": [_text("gate = 'warn'")],
+            },
+        ],
+    }
+    out = flatten_adf(doc)
+    assert "Context" in out
+    assert "public sources" in out
+    assert "Option A: hard fail" in out
+    assert "Option B: WARN + audit" in out
+    assert "Decision: go with Option B." in out
+    assert "gate = 'warn'" in out
+    # No leading / trailing whitespace.
+    assert out == out.strip()
+
+
+def test_deeply_nested_adf_does_not_raise():
+    """A pathologically deep ADF tree (thousands of nested block nodes —
+    a few KB of JSON, well under the client's response-size cap) must NOT
+    raise RecursionError. The flattener caps recursion and drops the
+    subtree past the cap, honoring its documented "never raises" contract."""
+    doc: dict = {"type": "doc", "version": 1, "content": []}
+    node = doc
+    for _ in range(5000):
+        child: dict = {"type": "blockquote", "content": []}
+        node["content"].append(child)
+        node = child
+    node["content"].append(_text("buried payload"))
+
+    # Must not raise (RecursionError or anything else).
+    out = flatten_adf(doc)
+    assert isinstance(out, str)
+    # Content past the depth cap is dropped — the buried text does not surface.
+    assert "buried payload" not in out
+
+
+def test_shallow_nesting_within_cap_is_preserved():
+    """Nesting within the depth cap flattens normally — the guard does not
+    clip legitimately-structured (shallow) documents."""
+    doc: dict = {"type": "doc", "version": 1, "content": []}
+    node = doc
+    for _ in range(10):
+        child: dict = {"type": "blockquote", "content": []}
+        node["content"].append(child)
+        node = child
+    node["content"].append(_para(_text("reachable decision")))
+
+    assert "reachable decision" in flatten_adf(doc)


### PR DESCRIPTION
## Summary

First Jira code in the repo. **Phase A** of the Jira integration (#337) — the **active-ingest adapter**. Given a Jira issue URL, `JiraAdapter` fetches the issue via REST API v3 (HTTP Basic auth) and returns a normalized ingest-payload dict.

Built from the governed `/qor-research` brief (`docs/research-brief-jira-integration-2026-05-21.md`) and the local API grounding in `docs/vendor/jira/`.

## What ships — `sources/jira/`

- **`adf.py`** — `flatten_adf()`: a pure Atlassian Document Format → plain-text flattener. v3 issue `description` and comment bodies arrive as ADF nested JSON, not strings. Pure, defensive (`.get()` everywhere; `None`/non-`doc`/`version!=1` → `""`), **never raises** — recursion is depth-capped (100) so a pathologically nested hostile payload can't `RecursionError`.
- **`client.py`** — `get_issue()`: stdlib `urllib.request`, `Authorization: Basic base64(email:token)`, timeout, 8 MiB response cap. Errors carry HTTP status + URL, **never** the auth header.
- **`adapter.py`** — `JiraAdapter` (`source_id="jira"`, `can_handle_url`, `fetch_active`, `_resolve_auth`); URL parser for `<tenant>.atlassian.net/browse/<KEY>`; `normalize_issue_to_payload`. Conforms to the `sources/protocol.py` adapter protocol.

**Auth**: API-token + email HTTP Basic auth; two secrets (`api_email`, `api_token`) in the existing `secrets_store` under `source_id="jira"`. Jira Cloud only; REST v3; Phase-A decision artifacts = issue description + comment bodies (status transitions are Phase C).

## Scope boundary

Phase A ships **no operator-invocable surface** — no webhook, no CLI, no MCP tool. `JiraAdapter` is a library unit consumed by the future **Phase B** webhook receiver and **Phase E** poller — mirroring how `LinearAdapter` (#420 Phase 1a) shipped ahead of its BicameralAI/bicameral-mcp#433 poller. Phases B (webhook), C (status-transition ingest), D (CLI/setup), E (poller) are separate cycles.

## Governance

- Independent `architect-reviewer` plan audit: **PASS**, L2, no findings (first round).
- Adversarial `code-reviewer` pre-push pass: **SHIP** — 0 HIGH. The one MED (unbounded ADF recursion) was **fixed in this PR** via the depth cap + 2 new tests. Full token-flow trace confirmed the API token never reaches a log, exception, URL, or `repr`.

## Test plan

- [x] 69 tests — 34 solitary (the pure flattener, incl. deep-nesting no-crash) + 35 sociable (real `JiraAdapter` + real `flatten_adf` + real `normalize`, only the `urllib` network boundary seamed).
- [x] Explicit token-non-leak assertions.
- [x] `ruff check` + `ruff format --check` clean; `mypy` via CI.
- [x] `git diff --stat` — only new files under `sources/jira/` + `tests/test_jira_*`; no existing file edited.

🤖 Generated with [Claude Code](https://claude.com/claude-code)