### PR TITLE
feat(pulse): ProjectPulseSummary backend object (#437 Phase 1)

### DIFF
--- a/pulse/__init__.py
+++ b/pulse/__init__.py
@@ -1,0 +1,28 @@
+"""Project Pulse — the shared backend summary object behind GitHub #437.
+
+This package ships the structured, read-only ``ProjectPulseSummary`` that
+future render surfaces (CLI ``bicameral-mcp brief``, the dashboard Project
+Pulse view, and future Slack/email channels) all consume. Phase 1 builds
+*only* the data object and its builder — no renderer, no CLI command, no
+dashboard view.
+
+See ``pulse/summary.py`` for the dataclasses and ``build_project_pulse``.
+"""
+
+from __future__ import annotations
+
+from pulse.summary import (
+    Health,
+    LearnedItem,
+    NeedsAttentionItem,
+    ProjectPulseSummary,
+    build_project_pulse,
+)
+
+__all__ = [
+    "Health",
+    "LearnedItem",
+    "NeedsAttentionItem",
+    "ProjectPulseSummary",
+    "build_project_pulse",
+]

--- a/pulse/summary.py
+++ b/pulse/summary.py
@@ -1,0 +1,336 @@
+"""``ProjectPulseSummary`` — the shared Project Pulse backend object (#437 Phase 1).
+
+A *Project Pulse* is the operator-facing summary of "what does project memory
+look like right now" — health counts, what needs attention, what was recently
+learned, and one suggested next move. ``ProjectPulseSummary`` is the structured,
+read-only data object behind that summary; ``build_project_pulse`` computes it
+once from the ledger.
+
+This module is **data, not presentation**. The object carries no markdown, no
+ANSI, no HTML — rendering is Phases 2/3 (CLI ``bicameral-mcp brief`` and the
+dashboard view). ``to_dict()`` gives #437's ``--json`` acceptance criterion
+directly.
+
+Design notes:
+
+* ``build_project_pulse`` is **read-only** — it issues only ``get_*`` queries
+  against the ledger adapter.
+* It is **fail-soft per section**: a failure computing one section degrades that
+  section (empty list / zeroed counts) and the summary still builds. The
+  all-clear state is a first-class result, not an error.
+* ``drift_findings`` and ``last_sync`` are **injected arguments**, not computed
+  here — drift computation is the caller's best-effort job (mirroring
+  ``cli/sync_and_brief_cli.py``), and ``last_sync`` comes from sync metadata
+  the renderer phases own. This keeps the object a pure assembler.
+"""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass, field
+from typing import Any
+
+logger = logging.getLogger(__name__)
+
+# Decision status enum — the eng-reflected (double-entry) axis. Confirmed at
+# ``ledger/adapter.py`` ``_STATUS_PRIORITY`` and the ``decision`` schema ASSERT.
+_HEALTH_STATUSES = ("reflected", "drifted", "pending", "ungrounded")
+
+# The friendly all-clear message (#437: "all-clear is a useful result").
+_ALL_CLEAR_MESSAGE = "Project memory is current — no drift, no pending signoffs."
+
+
+@dataclass
+class Health:
+    """Health counts for the Project Pulse summary.
+
+    ``decisions_reflected`` / ``_drifted`` / ``_pending`` / ``_ungrounded`` are
+    counts over the decision ``status`` enum. ``drifted_regions`` is the count
+    of drift findings supplied by the caller (drift analysis is best-effort and
+    not computed here). ``last_sync`` is an injected ISO timestamp string, or
+    ``None`` when no canonical sync watermark is available.
+    """
+
+    decisions_reflected: int = 0
+    decisions_drifted: int = 0
+    decisions_pending: int = 0
+    decisions_ungrounded: int = 0
+    drifted_regions: int = 0
+    last_sync: str | None = None
+
+    def to_dict(self) -> dict[str, Any]:
+        """Return a JSON-safe dict of the health counts."""
+        return {
+            "decisions_reflected": self.decisions_reflected,
+            "decisions_drifted": self.decisions_drifted,
+            "decisions_pending": self.decisions_pending,
+            "decisions_ungrounded": self.decisions_ungrounded,
+            "drifted_regions": self.drifted_regions,
+            "last_sync": self.last_sync,
+        }
+
+
+@dataclass
+class NeedsAttentionItem:
+    """One item in the ``needs_attention`` list.
+
+    ``kind`` is a discriminant literal — Phase 1 only emits
+    ``"awaiting_ratification"``, but the field exists so Phase 1b can add
+    ``context_pending`` / ``collision_pending`` / ``rejected_in_branch`` items
+    without changing the object's shape.
+    """
+
+    kind: str
+    decision_id: str
+    summary: str
+    signer: str | None = None
+
+    def to_dict(self) -> dict[str, Any]:
+        """Return a JSON-safe dict of the needs-attention item."""
+        return {
+            "kind": self.kind,
+            "decision_id": self.decision_id,
+            "summary": self.summary,
+            "signer": self.signer,
+        }
+
+
+@dataclass
+class LearnedItem:
+    """One recently-learned decision in the ``recently_learned`` list.
+
+    Carries only opaque, ledger-exposed fields — ``decision_id``, ``summary``
+    (the decision ``description``), ``source_type``, ``source_ref`` and a
+    ``date`` — the same data ``brief_renderer.py`` already renders. No raw
+    transcript text or signer emails are added.
+    """
+
+    decision_id: str
+    summary: str
+    source_type: str | None = None
+    source_ref: str | None = None
+    date: str | None = None
+
+    def to_dict(self) -> dict[str, Any]:
+        """Return a JSON-safe dict of the learned item."""
+        return {
+            "decision_id": self.decision_id,
+            "summary": self.summary,
+            "source_type": self.source_type,
+            "source_ref": self.source_ref,
+            "date": self.date,
+        }
+
+
+@dataclass
+class ProjectPulseSummary:
+    """The shared Project Pulse summary object (#437).
+
+    A structured, read-only snapshot of project memory: ``health`` counts,
+    ``needs_attention`` items, ``recently_learned`` decisions, one
+    ``suggested_next_move`` string, and an ``is_all_clear`` flag. ``to_dict()``
+    produces a recursive, JSON-safe representation — the foundation for #437's
+    ``--json`` output.
+    """
+
+    health: Health
+    needs_attention: list[NeedsAttentionItem] = field(default_factory=list)
+    recently_learned: list[LearnedItem] = field(default_factory=list)
+    suggested_next_move: str = _ALL_CLEAR_MESSAGE
+    is_all_clear: bool = True
+
+    def to_dict(self) -> dict[str, Any]:
+        """Return a recursive, JSON-safe dict of the whole summary."""
+        return {
+            "health": self.health.to_dict(),
+            "needs_attention": [item.to_dict() for item in self.needs_attention],
+            "recently_learned": [item.to_dict() for item in self.recently_learned],
+            "suggested_next_move": self.suggested_next_move,
+            "is_all_clear": self.is_all_clear,
+        }
+
+
+def _decision_sort_key(decision: dict[str, Any]) -> str:
+    """Recency sort key for a decision dict returned by ``get_all_decisions``.
+
+    ``get_all_decisions`` pops ``created_at`` and exposes it as the
+    ``ingested_at`` string (``ledger/queries.py``); ``meeting_date`` is the
+    fallback when present. A string compare on ISO timestamps is monotonic.
+    """
+    return str(decision.get("ingested_at") or decision.get("meeting_date") or "")
+
+
+def _is_awaiting_ratification(decision: dict[str, Any]) -> bool:
+    """True iff the decision is awaiting ratification.
+
+    A decision is awaiting ratification iff its ``signoff`` is a dict with
+    ``signoff.state == "proposed"`` — the post-v0.7.0 default a fresh ingest
+    writes while awaiting signoff (``ledger/schema.py``). This is the
+    ``signoff.state`` axis, orthogonal to the ``status`` enum, so
+    ``get_decisions_by_status`` cannot answer it.
+    """
+    signoff = decision.get("signoff")
+    return isinstance(signoff, dict) and signoff.get("state") == "proposed"
+
+
+async def _build_health(
+    ledger: Any,
+    *,
+    drift_findings: list[dict[str, Any]] | None,
+    last_sync: str | None,
+) -> Health:
+    """Compute the ``Health`` section — fail-soft.
+
+    Counts decisions by status via ``get_decisions_by_status``; the
+    ``drifted_regions`` count comes from the injected ``drift_findings``. A
+    ledger failure degrades the counts to zero rather than crashing the
+    summary.
+    """
+    health = Health(
+        drifted_regions=len(drift_findings or []),
+        last_sync=last_sync,
+    )
+    try:
+        rows = await ledger.get_decisions_by_status(list(_HEALTH_STATUSES))
+    except Exception as exc:  # noqa: BLE001 — fail-soft per section
+        logger.warning("[project-pulse] health counts failed: %s", exc)
+        return health
+
+    counts = {status: 0 for status in _HEALTH_STATUSES}
+    for row in rows or []:
+        status = row.get("status")
+        if status in counts:
+            counts[status] += 1
+    health.decisions_reflected = counts["reflected"]
+    health.decisions_drifted = counts["drifted"]
+    health.decisions_pending = counts["pending"]
+    health.decisions_ungrounded = counts["ungrounded"]
+    return health
+
+
+async def _build_needs_attention(ledger: Any) -> list[NeedsAttentionItem]:
+    """Compute the ``needs_attention`` section — fail-soft.
+
+    From ``get_all_decisions(filter="all")``, keeps decisions awaiting
+    ratification (``signoff.state == "proposed"``) and builds one
+    ``NeedsAttentionItem`` each. A ledger failure degrades the section to an
+    empty list.
+    """
+    try:
+        decisions = await ledger.get_all_decisions(filter="all")
+    except Exception as exc:  # noqa: BLE001 — fail-soft per section
+        logger.warning("[project-pulse] needs_attention fetch failed: %s", exc)
+        return []
+
+    items: list[NeedsAttentionItem] = []
+    for decision in decisions or []:
+        if not _is_awaiting_ratification(decision):
+            continue
+        signoff = decision.get("signoff") or {}
+        signer = signoff.get("signer")
+        items.append(
+            NeedsAttentionItem(
+                kind="awaiting_ratification",
+                decision_id=str(decision.get("decision_id") or ""),
+                summary=str(decision.get("description") or ""),
+                signer=str(signer) if signer else None,
+            )
+        )
+    return items
+
+
+async def _build_recently_learned(ledger: Any, *, recent_limit: int) -> list[LearnedItem]:
+    """Compute the ``recently_learned`` section — fail-soft.
+
+    Returns the most-recent ``recent_limit`` decisions (newest first) as
+    ``LearnedItem``s. A ledger failure degrades the section to an empty list.
+    """
+    try:
+        decisions = await ledger.get_all_decisions(filter="all")
+    except Exception as exc:  # noqa: BLE001 — fail-soft per section
+        logger.warning("[project-pulse] recently_learned fetch failed: %s", exc)
+        return []
+
+    ordered = sorted(decisions or [], key=_decision_sort_key, reverse=True)
+    items: list[LearnedItem] = []
+    for decision in ordered[: max(recent_limit, 0)]:
+        items.append(
+            LearnedItem(
+                decision_id=str(decision.get("decision_id") or ""),
+                summary=str(decision.get("description") or ""),
+                source_type=decision.get("source_type") or None,
+                source_ref=decision.get("source_ref") or None,
+                date=_decision_sort_key(decision) or None,
+            )
+        )
+    return items
+
+
+def _suggest_next_move(
+    *,
+    drifted_regions: int,
+    pending_count: int,
+) -> str:
+    """Deterministic priority ladder for ``suggested_next_move``.
+
+    drift present → review drift; else pending ratifications → review them;
+    else the explicit friendly all-clear. No model inference.
+    """
+    if drifted_regions > 0:
+        plural = "s" if drifted_regions != 1 else ""
+        return f"Review {drifted_regions} drifted region{plural} before further edits."
+    if pending_count > 0:
+        plural = "s" if pending_count != 1 else ""
+        return f"Review {pending_count} decision{plural} awaiting ratification."
+    return _ALL_CLEAR_MESSAGE
+
+
+async def build_project_pulse(
+    ledger: Any,
+    *,
+    recent_limit: int = 8,
+    drift_findings: list[dict[str, Any]] | None = None,
+    last_sync: str | None = None,
+) -> ProjectPulseSummary:
+    """Build the shared ``ProjectPulseSummary`` from the ledger — read-only.
+
+    Computes the four #437 sections (``health``, ``needs_attention``,
+    ``recently_learned``, ``suggested_next_move``) once. Each section is
+    computed fail-soft: a failure in one section degrades that section and the
+    summary still builds.
+
+    Args:
+        ledger: A ledger adapter exposing ``get_decisions_by_status`` and
+            ``get_all_decisions`` (e.g. ``SurrealDBLedgerAdapter``).
+        recent_limit: Cap for ``recently_learned`` — the configuration seam
+            Phase 2's ``--since`` flag will parameterize. Defaults to 8.
+        drift_findings: Best-effort drift findings supplied by the caller.
+            Drift computation is not done here. Defaults to ``None``.
+        last_sync: Injected ISO timestamp of the last sync, or ``None`` when no
+            canonical watermark is available. Defaults to ``None``.
+
+    Returns:
+        A fully-assembled ``ProjectPulseSummary``.
+    """
+    health = await _build_health(
+        ledger,
+        drift_findings=drift_findings,
+        last_sync=last_sync,
+    )
+    needs_attention = await _build_needs_attention(ledger)
+    recently_learned = await _build_recently_learned(ledger, recent_limit=recent_limit)
+
+    suggested_next_move = _suggest_next_move(
+        drifted_regions=health.drifted_regions,
+        pending_count=len(needs_attention),
+    )
+    is_all_clear = (
+        health.drifted_regions == 0 and health.decisions_drifted == 0 and len(needs_attention) == 0
+    )
+    return ProjectPulseSummary(
+        health=health,
+        needs_attention=needs_attention,
+        recently_learned=recently_learned,
+        suggested_next_move=suggested_next_move,
+        is_all_clear=is_all_clear,
+    )

--- a/tests/test_project_pulse_summary.py
+++ b/tests/test_project_pulse_summary.py
@@ -1,0 +1,295 @@
+"""Sociable tests for ``pulse.build_project_pulse`` (#437 Phase 1).
+
+Per CLAUDE.md's mandatory sociable-testing rule for anything that reads the
+ledger: every test instantiates a **real** ``SurrealDBLedgerAdapter`` over
+``memory://`` and seeds decision rows with the production schema (the
+``_fresh_adapter`` pattern from ``test_codegenome_continuity_service.py``).
+No ``MagicMock`` ledger — observable output is asserted, not call shapes.
+"""
+
+from __future__ import annotations
+
+import itertools
+import json
+
+from ledger.adapter import SurrealDBLedgerAdapter
+from ledger.client import LedgerClient
+from ledger.schema import init_schema, migrate
+from pulse import ProjectPulseSummary, build_project_pulse
+from pulse.summary import _ALL_CLEAR_MESSAGE
+
+
+async def _fresh_adapter(suffix: str) -> tuple[SurrealDBLedgerAdapter, LedgerClient]:
+    """Return a real ``SurrealDBLedgerAdapter`` over an isolated ``memory://`` ledger."""
+    client = LedgerClient(url="memory://", ns=f"pulse_{suffix}", db="ledger_test")
+    await client.connect()
+    await init_schema(client)
+    await migrate(client, allow_destructive=True)
+    adapter = SurrealDBLedgerAdapter(url="memory://")
+    adapter._client = client
+    adapter._connected = True
+    return adapter, client
+
+
+# ``idx_decision_canonical`` is UNIQUE over ``canonical_id`` and the field
+# defaults to ''; seeding multiple rows therefore needs a distinct value each.
+_canonical_counter = itertools.count()
+
+
+async def _seed_decision(
+    client: LedgerClient,
+    *,
+    description: str,
+    status: str = "ungrounded",
+    source_type: str = "manual",
+    source_ref: str = "",
+    signoff: dict | None = None,
+) -> str:
+    """Create one decision row with the production schema; return its id string."""
+    rows = await client.query(
+        "CREATE decision SET description = $d, status = $s, "
+        "source_type = $st, source_ref = $sr, signoff = $sig, canonical_id = $cid",
+        {
+            "d": description,
+            "s": status,
+            "st": source_type,
+            "sr": source_ref,
+            "sig": signoff,
+            "cid": f"pulse-test-{next(_canonical_counter)}",
+        },
+    )
+    return str(rows[0]["id"])
+
+
+# ── 1. all-clear state ────────────────────────────────────────────────────
+
+
+async def test_all_clear_state() -> None:
+    """Only reflected decisions, no drift, no pending → first-class all-clear."""
+    adapter, client = await _fresh_adapter("all_clear")
+    await _seed_decision(
+        client,
+        description="Use BM25 for code search",
+        status="reflected",
+        signoff={"state": "ratified", "signer": "jin"},
+    )
+
+    summary = await build_project_pulse(adapter)
+
+    assert isinstance(summary, ProjectPulseSummary)
+    assert summary.is_all_clear is True
+    assert summary.needs_attention == []
+    assert summary.suggested_next_move == _ALL_CLEAR_MESSAGE
+
+
+# ── 2. needs_attention lists pending ratifications ────────────────────────
+
+
+async def test_needs_attention_lists_pending_ratifications() -> None:
+    """Two decisions awaiting ratification → two needs_attention items."""
+    adapter, client = await _fresh_adapter("needs_attention")
+    id_a = await _seed_decision(
+        client,
+        description="Adopt feature flags",
+        signoff={"state": "proposed", "signer": "silong"},
+    )
+    id_b = await _seed_decision(
+        client,
+        description="Cache vocab lookups",
+        signoff={"state": "proposed"},
+    )
+    # A ratified decision must NOT appear in needs_attention.
+    await _seed_decision(
+        client,
+        description="Already ratified",
+        status="reflected",
+        signoff={"state": "ratified", "signer": "jin"},
+    )
+
+    summary = await build_project_pulse(adapter)
+
+    assert len(summary.needs_attention) == 2
+    ids = {item.decision_id for item in summary.needs_attention}
+    assert ids == {id_a, id_b}
+    for item in summary.needs_attention:
+        assert item.kind == "awaiting_ratification"
+        assert item.summary  # the decision description carries through
+    signers = {item.signer for item in summary.needs_attention}
+    assert "silong" in signers
+    assert None in signers  # the decision with no signer field
+
+
+# ── 3. health counts by status ────────────────────────────────────────────
+
+
+async def test_health_counts_by_status() -> None:
+    """A mix of statuses → exact per-status health counts."""
+    adapter, client = await _fresh_adapter("health_counts")
+    await _seed_decision(client, description="r1", status="reflected")
+    await _seed_decision(client, description="r2", status="reflected")
+    await _seed_decision(client, description="d1", status="drifted")
+    await _seed_decision(client, description="p1", status="pending")
+    await _seed_decision(client, description="u1", status="ungrounded")
+    await _seed_decision(client, description="u2", status="ungrounded")
+    await _seed_decision(client, description="u3", status="ungrounded")
+
+    summary = await build_project_pulse(adapter)
+
+    assert summary.health.decisions_reflected == 2
+    assert summary.health.decisions_drifted == 1
+    assert summary.health.decisions_pending == 1
+    assert summary.health.decisions_ungrounded == 3
+
+
+# ── 4. recently_learned respects limit + recency ──────────────────────────
+
+
+async def test_recently_learned_respects_limit_and_recency() -> None:
+    """Twelve decisions → recently_learned is capped to recent_limit, newest first."""
+    adapter, client = await _fresh_adapter("recently_learned")
+    for i in range(12):
+        await _seed_decision(
+            client,
+            description=f"decision-{i:02d}",
+            status="reflected",
+            source_type="meeting",
+            source_ref="Sprint Planning",
+        )
+
+    summary = await build_project_pulse(adapter, recent_limit=8)
+
+    assert len(summary.recently_learned) == 8
+    # Newest-first: created_at descending → decision-11 ahead of decision-04.
+    dates = [item.date for item in summary.recently_learned]
+    assert dates == sorted(dates, reverse=True)
+    first = summary.recently_learned[0]
+    assert first.source_type == "meeting"
+    assert first.source_ref == "Sprint Planning"
+
+
+# ── 5. suggested_next_move priority ladder ────────────────────────────────
+
+
+async def test_suggested_next_move_priority_ladder() -> None:
+    """Drift wins over pending; pending wins over all-clear; else friendly all-clear."""
+    # (a) drift present → drift suggestion takes priority even with pending.
+    adapter_a, client_a = await _fresh_adapter("ladder_drift")
+    await _seed_decision(
+        client_a,
+        description="pending one",
+        signoff={"state": "proposed"},
+    )
+    summary_a = await build_project_pulse(
+        adapter_a,
+        drift_findings=[{"region": "auth.py"}, {"region": "checkout.py"}],
+    )
+    assert "drifted region" in summary_a.suggested_next_move
+    assert summary_a.suggested_next_move.startswith("Review 2 drifted regions")
+
+    # (b) no drift + pending → ratification suggestion.
+    adapter_b, client_b = await _fresh_adapter("ladder_pending")
+    await _seed_decision(
+        client_b,
+        description="pending one",
+        signoff={"state": "proposed"},
+    )
+    summary_b = await build_project_pulse(adapter_b)
+    assert summary_b.suggested_next_move == "Review 1 decision awaiting ratification."
+
+    # (c) neither → friendly all-clear.
+    adapter_c, client_c = await _fresh_adapter("ladder_clear")
+    await _seed_decision(
+        client_c,
+        description="ratified one",
+        status="reflected",
+        signoff={"state": "ratified", "signer": "jin"},
+    )
+    summary_c = await build_project_pulse(adapter_c)
+    assert summary_c.suggested_next_move == _ALL_CLEAR_MESSAGE
+
+
+# ── 6. to_dict is JSON-serializable ───────────────────────────────────────
+
+
+async def test_to_dict_is_json_serializable() -> None:
+    """summary.to_dict() round-trips through json.dumps (#437 --json foundation)."""
+    adapter, client = await _fresh_adapter("to_dict")
+    await _seed_decision(
+        client,
+        description="proposed decision",
+        signoff={"state": "proposed", "signer": "silong"},
+    )
+    await _seed_decision(
+        client,
+        description="reflected decision",
+        status="reflected",
+        source_type="slack",
+        source_ref="#payments",
+        signoff={"state": "ratified", "signer": "jin"},
+    )
+
+    summary = await build_project_pulse(adapter, drift_findings=[{"region": "x.py"}])
+    payload = summary.to_dict()
+
+    encoded = json.dumps(payload)
+    decoded = json.loads(encoded)
+    assert decoded["is_all_clear"] is False
+    assert decoded["health"]["drifted_regions"] == 1
+    assert isinstance(decoded["needs_attention"], list)
+    assert isinstance(decoded["recently_learned"], list)
+    assert decoded["needs_attention"][0]["kind"] == "awaiting_ratification"
+
+
+# ── 7. drift_findings feeds health + suggestion ───────────────────────────
+
+
+async def test_drift_findings_argument_feeds_health_and_suggestion() -> None:
+    """Injected drift_findings drive drifted_regions count + the suggestion + not-all-clear."""
+    adapter, client = await _fresh_adapter("drift_arg")
+    await _seed_decision(
+        client,
+        description="reflected decision",
+        status="reflected",
+        signoff={"state": "ratified", "signer": "jin"},
+    )
+
+    summary = await build_project_pulse(
+        adapter,
+        drift_findings=[{"region": "a.py"}, {"region": "b.py"}, {"region": "c.py"}],
+    )
+
+    assert summary.health.drifted_regions == 3
+    assert summary.is_all_clear is False
+    assert summary.suggested_next_move.startswith("Review 3 drifted regions")
+
+
+# ── 8. fail-soft when a section errors ────────────────────────────────────
+
+
+async def test_build_does_not_crash_when_a_section_errors() -> None:
+    """A ledger query raising for one section degrades that section; summary still builds."""
+    adapter, client = await _fresh_adapter("fail_soft")
+    await _seed_decision(
+        client,
+        description="healthy decision",
+        status="reflected",
+        signoff={"state": "ratified", "signer": "jin"},
+    )
+
+    # Seam off only the failure mode: get_all_decisions raises, so the
+    # needs_attention + recently_learned sections must degrade — but health
+    # (which uses get_decisions_by_status) and the overall build still succeed.
+    async def _boom(*_args: object, **_kwargs: object) -> list[dict]:
+        raise RuntimeError("simulated ledger failure")
+
+    adapter.get_all_decisions = _boom  # type: ignore[method-assign]
+
+    summary = await build_project_pulse(adapter)
+
+    assert isinstance(summary, ProjectPulseSummary)
+    assert summary.needs_attention == []
+    assert summary.recently_learned == []
+    # Health still computed via the un-broken get_decisions_by_status path.
+    assert summary.health.decisions_reflected == 1
+    # to_dict still works on the degraded-but-built summary.
+    assert json.dumps(summary.to_dict())


### PR DESCRIPTION
## Summary

**Phase 1 of #437** (Bicameral Brief / Project Pulse). #437's design note is explicit: *"prefer one shared backend object, then render it three ways."* This PR ships that object — the CLI (Phase 2) and dashboard (Phase 3) render it. **No renderer or operator-facing surface in this PR.**

## What ships — new `pulse/` package

- **`ProjectPulseSummary`** + nested `Health` / `NeedsAttentionItem` / `LearnedItem` dataclasses — each with a recursive, JSON-safe `to_dict()` (the foundation for #437's `brief --json`).
- **`build_project_pulse(ledger, *, recent_limit=8, drift_findings=None, last_sync=None)`** — read-only; computes the four #437 sections once. **Fail-soft per section**: one section erroring degrades only that section; the summary still builds. The all-clear state is a first-class friendly result.

`needs_attention` = decisions awaiting ratification, defined precisely as `signoff` being a dict with `signoff.state == "proposed"`. The `NeedsAttentionItem.kind` discriminant lets Phase 1b add `context_pending` / `collision_pending` / rejected-in-branch kinds without a shape change. `suggested_next_move` is a deterministic priority ladder — no model inference.

## Scope boundary

Phase 1 ships the backend object only. **Phase 2** = the CLI renderer (`bicameral-mcp brief` + `--json/--since/--feature`, consolidating `cli/brief_renderer.py`). **Phase 3** = the dashboard Project Pulse landing view (the UI — which carries the functional + full-configuration-accountability DoD, browser-tested).

## Governance

- Independent `architect-reviewer` plan audit: **PASS**, L2 — 2 rounds. Round 1 VETO'd a wrong `needs_attention` data source (the plan had cited `signoff_state`, a non-existent field, and `get_decisions_by_status`, which filters the orthogonal `status` enum). The corrected `signoff.state == "proposed"` path was re-verified to trace to real code (`ledger/queries.py:244` selects `signoff`; passthrough confirmed).
- Read-only internal object, no attack surface (no public HTTP, no secrets) — the 2-round audit + sociable tests are the proportionate gate; no separate adversarial pass needed for this risk class.

## Test plan

- [x] 8 sociable tests against a real `SurrealDBLedgerAdapter` over `memory://` (per CLAUDE.md — no `MagicMock` ledger), seeding real decision rows: all-clear, needs-attention, health counts, recency limit, the suggestion ladder, JSON serializability, drift wiring, per-section fail-soft.
- [x] `ruff check` + `ruff format --check` clean; `mypy` via CI.
- [x] `git diff --stat` — only new `pulse/*` + the test file; no existing file edited.

🤖 Generated with [Claude Code](https://claude.com/claude-code)