### PR TITLE
feat(jira): webhook receiver — passive ingest entry point (#337 Jira Phase B)

### DIFF
--- a/tests/test_webhooks_jira.py
+++ b/tests/test_webhooks_jira.py
@@ -1,0 +1,541 @@
+"""Tests for the Jira Cloud webhook handler (#337 Phase B).
+
+Sociable: real ``handle``, real ``verify_signature``, the real
+``DeliveryDedupCache`` singleton (reset per test), and the real
+``JiraAdapter.normalize_issue_to_payload`` / ``flatten_adf``. The only
+seams are the genuine boundaries — the ``handle_ingest`` ledger call and
+the webhook-secret resolver — because running the real ledger / keyring
+inside a unit test would couple the receiver test to external state we
+don't need to exercise here.
+
+Coverage (the 11 cases from the Phase B plan's Test plan):
+1. verify_signature against Atlassian's documented test vector; tamper.
+2. missing X-Hub-Signature → 401; bad signature → 401.
+3. missing X-Atlassian-Webhook-Identifier → 400.
+4. malformed JSON body (signature valid) → 400.
+5. dedup: same identifier twice → second 200 "duplicate", ingest once.
+6. jira:issue_created / jira:issue_updated → ingest, scope="jira",
+   payload normalized (ADF description flattened).
+7. comment_created → ingest (normalizes the inline issue).
+8. jira:issue_deleted / unknown webhookEvent → 200, no ingest.
+9. issue missing key → 200 acknowledged, no ingest.
+10. _IngestRefused → 422; transient ingest Exception → 500; a 500 does
+    NOT mark_seen (retry re-dispatches).
+11. missing webhook secret → 500, message carries no secret value.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import hmac
+import json
+
+import pytest
+
+from webhooks.jira import WebhookVerificationError, handle, verify_signature
+
+# Atlassian's documented HMAC test vector (docs/vendor/jira/webhooks.md §2).
+_ATLASSIAN_SECRET = "It's a Secret to Everybody"
+_ATLASSIAN_BODY = b"Hello World!"
+_ATLASSIAN_EXPECTED = "sha256=a4771c39fbe90f317c7824e83ddef3caae9cb3d976c214ace1f2937e133263c9"
+
+# A non-secret value used for the handle()-level tests.
+_SECRET = "jira-webhook-shared-secret"
+
+
+@pytest.fixture(autouse=True)
+def _reset_dedup():
+    """The dedup cache is a process-local singleton; reset it between
+    tests so a delivery identifier from one test does not short-circuit
+    another (mirrors tests/test_webhooks_google_drive.py)."""
+    from webhooks.dedup import _reset_for_tests as _dedup_reset
+
+    _dedup_reset()
+    yield
+    _dedup_reset()
+
+
+def _sign(secret: str, body: bytes) -> str:
+    """Build a Jira-style X-Hub-Signature header value for ``body``."""
+    return (
+        "sha256=" + hmac.new(secret.encode("utf-8"), msg=body, digestmod=hashlib.sha256).hexdigest()
+    )
+
+
+def _issue_payload(
+    *,
+    event: str = "jira:issue_updated",
+    issue_key: str | None = "PROJ-123",
+    summary: str = "Investigate flaky webhook test",
+    description_text: str = "We decided to pin the retry budget at 5.",
+) -> dict:
+    """Build a Jira webhook payload with an inline ``issue`` object.
+
+    ``description`` is ADF JSON (Jira v3 wire shape) so the real
+    ``flatten_adf`` is exercised end-to-end by the ingest path.
+    """
+    issue: dict = {
+        "id": "10042",
+        "fields": {
+            "summary": summary,
+            "updated": "2026-05-21T12:00:00.000+0000",
+            "description": {
+                "type": "doc",
+                "version": 1,
+                "content": [
+                    {
+                        "type": "paragraph",
+                        "content": [{"type": "text", "text": description_text}],
+                    }
+                ],
+            },
+            "assignee": {"displayName": "Ada Lovelace"},
+            "reporter": {"displayName": "Grace Hopper"},
+        },
+    }
+    if issue_key is not None:
+        issue["key"] = issue_key
+    return {
+        "timestamp": 1716285600000,
+        "webhookEvent": event,
+        "issue_event_type_name": "issue_generic",
+        "issue": issue,
+    }
+
+
+def _body(payload: dict) -> bytes:
+    return json.dumps(payload).encode("utf-8")
+
+
+# ── 1. verify_signature: Atlassian test vector ──────────────────────────────
+
+
+def test_verify_signature_atlassian_test_vector_passes():
+    """The verifier must accept Atlassian's documented test vector
+    (docs/vendor/jira/webhooks.md §2) — the wire-protocol ground truth."""
+    verify_signature(
+        body=_ATLASSIAN_BODY,
+        signature_header=_ATLASSIAN_EXPECTED,
+        secret=_ATLASSIAN_SECRET,
+    )  # does not raise
+
+
+def test_verify_signature_tampered_body_raises():
+    """Atlassian's vector signature against a tampered body must fail —
+    pins the body-byte sensitivity of the HMAC."""
+    with pytest.raises(WebhookVerificationError, match="mismatch"):
+        verify_signature(
+            body=_ATLASSIAN_BODY + b" ",
+            signature_header=_ATLASSIAN_EXPECTED,
+            secret=_ATLASSIAN_SECRET,
+        )
+
+
+def test_verify_signature_uses_compare_digest():
+    """Constant-time comparison is load-bearing — pin that the verifier
+    routes through hmac.compare_digest, not ==."""
+    import hmac as _hmac
+    from unittest.mock import patch
+
+    with patch.object(_hmac, "compare_digest", wraps=_hmac.compare_digest) as spy:
+        verify_signature(
+            body=_ATLASSIAN_BODY,
+            signature_header=_ATLASSIAN_EXPECTED,
+            secret=_ATLASSIAN_SECRET,
+        )
+    assert spy.called
+
+
+def test_verify_signature_malformed_prefix_raises():
+    """A header that doesn't start with 'sha256=' is rejected before any
+    HMAC computation."""
+    with pytest.raises(WebhookVerificationError, match="malformed"):
+        verify_signature(body=b"x", signature_header="md5=" + "0" * 32, secret=_SECRET)
+
+
+def test_verify_signature_empty_hex_raises():
+    """The classic bypass attempt — the 'sha256=' prefix present but an empty
+    hex payload — fails closed: 0 chars vs the 64-char digest is a mismatch,
+    raising WebhookVerificationError (never silently accepted)."""
+    with pytest.raises(WebhookVerificationError, match="mismatch"):
+        verify_signature(body=b"x", signature_header="sha256=", secret=_SECRET)
+
+
+def test_verify_signature_non_ascii_header_raises_verification_error():
+    """A non-ASCII signature header fails closed as WebhookVerificationError
+    (→ 401), NOT a raw TypeError from hmac.compare_digest. Defense-in-depth
+    for a non-HTTP caller bypassing the server's header ASCII gate."""
+    with pytest.raises(WebhookVerificationError, match="non-ASCII"):
+        verify_signature(body=b"x", signature_header="sha256=café", secret=_SECRET)
+
+
+# ── 2. handle: signature failures → 401 ─────────────────────────────────────
+
+
+def test_handle_missing_signature_returns_401():
+    body = _body(_issue_payload())
+    status, msg = handle(
+        body=body,
+        signature_header=None,
+        delivery_identifier="wh-1",
+        secret_resolver=lambda: _SECRET,
+    )
+    assert status == 401
+    assert "verification" in msg
+
+
+def test_handle_bad_signature_returns_401():
+    """A valid-looking 'sha256=...' header signed with the wrong secret
+    must not get past verification."""
+    body = _body(_issue_payload())
+    status, msg = handle(
+        body=body,
+        signature_header=_sign("attacker-guess", body),
+        delivery_identifier="wh-1",
+        secret_resolver=lambda: _SECRET,
+    )
+    assert status == 401
+    assert "verification" in msg
+
+
+# ── 3. handle: missing delivery identifier → 400 ────────────────────────────
+
+
+def test_handle_missing_delivery_identifier_returns_400():
+    """Jira always sends X-Atlassian-Webhook-Identifier; an empty value
+    is rejected so a captured signed payload cannot bypass dedup."""
+    body = _body(_issue_payload())
+    status, msg = handle(
+        body=body,
+        signature_header=_sign(_SECRET, body),
+        delivery_identifier="",
+        secret_resolver=lambda: _SECRET,
+    )
+    assert status == 400
+    assert "X-Atlassian-Webhook-Identifier" in msg
+
+
+# ── 4. handle: malformed JSON body (signature valid) → 400 ──────────────────
+
+
+def test_handle_malformed_json_body_returns_400():
+    """A body that verifies but is not JSON-decodable → 400. Verification
+    runs over the raw bytes, so a valid signature over garbage still
+    reaches the json.loads boundary."""
+    body = b"not json at all"
+    status, msg = handle(
+        body=body,
+        signature_header=_sign(_SECRET, body),
+        delivery_identifier="wh-1",
+        secret_resolver=lambda: _SECRET,
+    )
+    assert status == 400
+    assert "JSON" in msg
+
+
+# ── 5. handle: dedup ────────────────────────────────────────────────────────
+
+
+def test_handle_duplicate_delivery_returns_200_ingest_once(monkeypatch):
+    """The same X-Atlassian-Webhook-Identifier twice → the second is
+    200 'duplicate' and handle_ingest is invoked exactly once."""
+    ingest_calls: list[str] = []
+
+    async def _fake_ingest(ctx, payload, *, source_scope, ingest_mode):
+        ingest_calls.append(source_scope)
+
+    monkeypatch.setattr("handlers.ingest.handle_ingest", _fake_ingest)
+    from types import SimpleNamespace as _SN
+
+    monkeypatch.setattr("context.BicameralContext.from_env", classmethod(lambda cls: _SN()))
+
+    body = _body(_issue_payload())
+    sig = _sign(_SECRET, body)
+
+    status1, msg1 = handle(
+        body=body,
+        signature_header=sig,
+        delivery_identifier="wh-dup",
+        secret_resolver=lambda: _SECRET,
+    )
+    status2, msg2 = handle(
+        body=body,
+        signature_header=sig,
+        delivery_identifier="wh-dup",
+        secret_resolver=lambda: _SECRET,
+    )
+    assert status1 == 200
+    assert status2 == 200
+    assert "ingested" in msg1
+    assert msg2 == "duplicate"
+    assert ingest_calls == ["jira"], f"ingest invoked {len(ingest_calls)} times; want 1"
+
+
+# ── 6. handle: issue_created / issue_updated → ingest ───────────────────────
+
+
+@pytest.mark.parametrize("event", ["jira:issue_created", "jira:issue_updated"])
+def test_handle_issue_events_ingest_with_normalized_payload(monkeypatch, event):
+    """jira:issue_created / jira:issue_updated → handle_ingest called with
+    source_scope='jira', ingest_mode='passive', and a payload whose ADF
+    description was flattened to plain text by the real adapter."""
+    captured: dict = {}
+
+    async def _fake_ingest(ctx, payload, *, source_scope, ingest_mode):
+        captured["payload"] = payload
+        captured["scope"] = source_scope
+        captured["mode"] = ingest_mode
+
+    monkeypatch.setattr("handlers.ingest.handle_ingest", _fake_ingest)
+    from types import SimpleNamespace as _SN
+
+    monkeypatch.setattr("context.BicameralContext.from_env", classmethod(lambda cls: _SN()))
+
+    body = _body(_issue_payload(event=event, description_text="Chose option B for the rollout."))
+    status, msg = handle(
+        body=body,
+        signature_header=_sign(_SECRET, body),
+        delivery_identifier=f"wh-{event}",
+        secret_resolver=lambda: _SECRET,
+    )
+    assert status == 200
+    assert "ingested" in msg
+    assert captured["scope"] == "jira"
+    assert captured["mode"] == "passive"
+    payload = captured["payload"]
+    assert payload["source"] == "jira"
+    assert payload["title"] == "PROJ-123"
+    # The ADF description was flattened to plain text (real flatten_adf).
+    assert payload["decisions"][0]["description"] == "Chose option B for the rollout."
+    assert "Ada Lovelace" in payload["participants"]
+
+
+# ── 7. handle: comment_created → ingest the inline issue ────────────────────
+
+
+def test_handle_comment_created_ingests_inline_issue(monkeypatch):
+    """comment_created carries the inline issue object too — Phase B
+    normalizes that same inline issue."""
+    captured: dict = {}
+
+    async def _fake_ingest(ctx, payload, *, source_scope, ingest_mode):
+        captured["payload"] = payload
+        captured["scope"] = source_scope
+
+    monkeypatch.setattr("handlers.ingest.handle_ingest", _fake_ingest)
+    from types import SimpleNamespace as _SN
+
+    monkeypatch.setattr("context.BicameralContext.from_env", classmethod(lambda cls: _SN()))
+
+    body = _body(
+        _issue_payload(event="comment_created", description_text="Comment-event issue body.")
+    )
+    status, msg = handle(
+        body=body,
+        signature_header=_sign(_SECRET, body),
+        delivery_identifier="wh-comment",
+        secret_resolver=lambda: _SECRET,
+    )
+    assert status == 200
+    assert "ingested" in msg
+    assert captured["scope"] == "jira"
+    assert captured["payload"]["title"] == "PROJ-123"
+
+
+# ── 8. handle: deletes / unknown events → 200, no ingest ────────────────────
+
+
+@pytest.mark.parametrize(
+    "event",
+    ["jira:issue_deleted", "comment_deleted", "worklog_created", "sprint_started"],
+)
+def test_handle_non_ingest_events_acked_no_ingest(monkeypatch, event):
+    """jira:issue_deleted, comment_deleted, and every other webhookEvent
+    → 200 acknowledged with no ingest (append-only contract)."""
+    ingest_calls: list[str] = []
+
+    async def _fake_ingest(ctx, payload, *, source_scope, ingest_mode):
+        ingest_calls.append(source_scope)
+
+    monkeypatch.setattr("handlers.ingest.handle_ingest", _fake_ingest)
+
+    body = _body(_issue_payload(event=event))
+    status, msg = handle(
+        body=body,
+        signature_header=_sign(_SECRET, body),
+        delivery_identifier=f"wh-{event}",
+        secret_resolver=lambda: _SECRET,
+    )
+    assert status == 200
+    assert "no ingest" in msg
+    assert ingest_calls == [], f"event {event!r} wrongly triggered ingest"
+
+
+# ── 9. handle: issue missing key → 200 acknowledged, no ingest ──────────────
+
+
+def test_handle_issue_missing_key_acked_no_ingest(monkeypatch):
+    """An ingest event whose inline issue has no 'key' → 200 acknowledged
+    without ingest (malformed payload, not worth a retry)."""
+    ingest_calls: list[str] = []
+
+    async def _fake_ingest(ctx, payload, *, source_scope, ingest_mode):
+        ingest_calls.append(source_scope)
+
+    monkeypatch.setattr("handlers.ingest.handle_ingest", _fake_ingest)
+
+    body = _body(_issue_payload(event="jira:issue_updated", issue_key=None))
+    status, msg = handle(
+        body=body,
+        signature_header=_sign(_SECRET, body),
+        delivery_identifier="wh-nokey",
+        secret_resolver=lambda: _SECRET,
+    )
+    assert status == 200
+    assert "key" in msg
+    assert ingest_calls == []
+
+
+# ── 10. handle: _IngestRefused → 422; transient → 500; 500 not marked ───────
+
+
+def test_handle_ingest_refused_returns_422(monkeypatch):
+    """_IngestRefused (hard gate — PHI/secret/PAN) → 422 so Jira does not
+    retry; the reason category surfaces but never the payload content."""
+    from handlers.ingest import _IngestRefused
+
+    async def _refuse(ctx, payload, *, source_scope, ingest_mode):
+        raise _IngestRefused("sensitive_data:secret")
+
+    monkeypatch.setattr("handlers.ingest.handle_ingest", _refuse)
+    from types import SimpleNamespace as _SN
+
+    monkeypatch.setattr("context.BicameralContext.from_env", classmethod(lambda cls: _SN()))
+
+    body = _body(_issue_payload())
+    status, msg = handle(
+        body=body,
+        signature_header=_sign(_SECRET, body),
+        delivery_identifier="wh-refused",
+        secret_resolver=lambda: _SECRET,
+    )
+    assert status == 422
+    assert "refused" in msg.lower()
+    assert "secret" in msg
+
+
+def test_handle_transient_ingest_failure_returns_500_and_does_not_mark(monkeypatch):
+    """A transient ingest Exception → 500, and the delivery is NOT
+    marked seen — Jira's retry of the same identifier must re-dispatch
+    (mark-after-ack). Proven by handle_ingest being invoked on both
+    back-to-back deliveries of the same identifier."""
+    ingest_calls: list[int] = []
+
+    async def _fail(ctx, payload, *, source_scope, ingest_mode):
+        ingest_calls.append(1)
+        raise RuntimeError("simulated ledger failure")
+
+    monkeypatch.setattr("handlers.ingest.handle_ingest", _fail)
+    from types import SimpleNamespace as _SN
+
+    monkeypatch.setattr("context.BicameralContext.from_env", classmethod(lambda cls: _SN()))
+
+    body = _body(_issue_payload())
+    sig = _sign(_SECRET, body)
+
+    status1, _ = handle(
+        body=body,
+        signature_header=sig,
+        delivery_identifier="wh-transient",
+        secret_resolver=lambda: _SECRET,
+    )
+    status2, _ = handle(
+        body=body,
+        signature_header=sig,
+        delivery_identifier="wh-transient",
+        secret_resolver=lambda: _SECRET,
+    )
+    assert status1 == 500
+    assert status2 == 500
+    assert len(ingest_calls) == 2, (
+        f"handle_ingest called {len(ingest_calls)} times; a 500 wrongly "
+        "marked the delivery seen and the retry was dedup-suppressed"
+    )
+
+
+def test_handle_ingest_refused_422_marks_dedup(monkeypatch):
+    """Mark-after-ack corollary: a 422 IS an acked outcome (Jira will not
+    retry it), so the delivery is marked — a replay is dedup-suppressed.
+    handle_ingest is invoked exactly once across two deliveries."""
+    from handlers.ingest import _IngestRefused
+
+    ingest_calls: list[int] = []
+
+    async def _refuse(ctx, payload, *, source_scope, ingest_mode):
+        ingest_calls.append(1)
+        raise _IngestRefused("sensitive_data:phi")
+
+    monkeypatch.setattr("handlers.ingest.handle_ingest", _refuse)
+    from types import SimpleNamespace as _SN
+
+    monkeypatch.setattr("context.BicameralContext.from_env", classmethod(lambda cls: _SN()))
+
+    body = _body(_issue_payload())
+    sig = _sign(_SECRET, body)
+
+    status1, _ = handle(
+        body=body,
+        signature_header=sig,
+        delivery_identifier="wh-refused-dup",
+        secret_resolver=lambda: _SECRET,
+    )
+    status2, msg2 = handle(
+        body=body,
+        signature_header=sig,
+        delivery_identifier="wh-refused-dup",
+        secret_resolver=lambda: _SECRET,
+    )
+    assert status1 == 422
+    assert status2 == 200
+    assert msg2 == "duplicate"
+    assert len(ingest_calls) == 1
+
+
+# ── 11. handle: missing webhook secret → 500, no secret leak ────────────────
+
+
+def test_handle_missing_secret_returns_500_no_secret_leak():
+    """A receiver with no configured secret cannot verify anything — it
+    fails closed with 500. The message must carry setup guidance only,
+    never a secret value."""
+    body = _body(_issue_payload())
+    status, msg = handle(
+        body=body,
+        signature_header=_sign(_SECRET, body),
+        delivery_identifier="wh-1",
+        secret_resolver=lambda: "",
+    )
+    assert status == 500
+    assert "webhook_secret" in msg
+    # The message names the key, not any value — pin that no plausible
+    # secret value leaked into the operator-facing message.
+    assert _SECRET not in msg
+
+
+def test_handle_secret_resolver_exception_returns_500():
+    """If the secret resolver itself raises, the receiver returns 500
+    (transient — Jira retries) and the exception is not a secret."""
+
+    def _boom() -> str:
+        raise RuntimeError("keyring backend unavailable")
+
+    body = _body(_issue_payload())
+    status, msg = handle(
+        body=body,
+        signature_header=_sign(_SECRET, body),
+        delivery_identifier="wh-1",
+        secret_resolver=_boom,
+    )
+    assert status == 500
+    assert "secret lookup failed" in msg
+    assert _SECRET not in msg

--- a/webhooks/jira.py
+++ b/webhooks/jira.py
@@ -1,0 +1,347 @@
+"""Jira Cloud webhook handler (#337 Phase B).
+
+Jira's webhook contract (admin-UI registration path — Jira Settings →
+System → WebHooks, with a shared secret):
+
+- POST request with a JSON body.
+- ``X-Hub-Signature`` header: ``sha256=<hex>`` HMAC-SHA256(secret, raw_body).
+  **Note the header name is** ``X-Hub-Signature`` — *not* GitHub's
+  ``X-Hub-Signature-256``. Same algorithm, different header name
+  (Jira follows the WebSub ``method=signature`` convention).
+- ``X-Atlassian-Webhook-Identifier`` header: an identifier unique within a
+  Jira Cloud tenant and stable across retries — the idempotency key for
+  duplicate-delivery filtering.
+- ``webhookEvent`` body field: the event id (``jira:issue_created`` etc.).
+
+The webhook secret (the third Jira ``secrets_store`` key alongside Phase A's
+``api_email`` / ``api_token``) is referred to as the ``webhook_secret``. It
+is read via ``secrets_store.get_secret(source_id="jira", key="webhook_secret")``,
+is NEVER logged, and never appears in an exception or HTTP-response message.
+
+Verification order (mirrors ``webhooks/github.py``):
+1. Resolve the webhook secret. A receiver with no configured secret cannot
+   verify anything, so it fails CLOSED — missing secret → 500 with a
+   setup-guidance message that carries no secret value.
+2. Verify the HMAC signature over the **exact raw request bytes** — never a
+   re-serialized body (re-encoding changes whitespace / key order and breaks
+   the digest). Missing / malformed / mismatched → 401 (Jira does not retry
+   a 401).
+3. Require ``X-Atlassian-Webhook-Identifier``. Missing/empty → 400 (Jira does
+   not retry a 400; an empty delivery id would also let a captured payload
+   bypass dedup).
+4. Dedup on the delivery identifier — single bucket (the identifier is
+   globally unique per tenant, so no per-channel partition is needed).
+   Dedup runs AFTER verification so an unverified delivery cannot poison the
+   cache.
+5. JSON-parse the body (verification already confirmed the bytes), dispatch
+   on ``webhookEvent``.
+
+Self-contained payload: unlike the GitHub / Drive receivers, a Jira
+issue/comment webhook carries the full ``issue`` object inline (the same
+shape the REST API returns with no expand params). Phase B normalizes that
+inline object via Phase A's ``sources.jira.adapter.normalize_issue_to_payload``
+(a module-level function — the ``JiraAdapter`` class calls it internally on
+the active path) — there is no network round-trip and no SSRF surface.
+
+Mark-after-ack (the cycle-9d Drive precedent): the delivery is marked seen
+only once an acked outcome (a 200 or a 422) has been decided. A 500 path is
+left UNMARKED so Jira's retry re-dispatches the delivery.
+
+Event handling (Phase B):
+- ``jira:issue_created`` / ``jira:issue_updated`` / ``comment_created`` /
+  ``comment_updated`` → normalize the inline ``issue`` object and ingest.
+- ``jira:issue_deleted`` / ``comment_deleted`` / every other ``webhookEvent``
+  → 200 acknowledged, no ingest (append-only contract — deletes are not
+  propagated to the ledger).
+
+Status-code contract (``docs/vendor/jira/webhooks.md`` §4):
+- 200 — ack (success / dedup hit / ignored event / deterministic ingest
+  failure). Jira will not retry a 2xx.
+- 401 — signature verification failed. Jira does not retry a 401.
+- 400 — missing/empty ``X-Atlassian-Webhook-Identifier`` or a body that is
+  not JSON. Jira does not retry a 400.
+- 422 — hard-gate refusal (``_IngestRefused`` — PHI/secret/PAN). Jira does
+  not retry a 422.
+- 500 — transient receiver failure (secret lookup error, transient ingest
+  failure). Jira WILL retry, which is desired.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import hmac
+import json
+import sys
+
+
+class WebhookVerificationError(Exception):
+    """Raised when signature verification fails. Caller maps to HTTP 401."""
+
+
+def verify_signature(*, body: bytes, signature_header: str | None, secret: str) -> None:
+    """Verify the Jira HMAC-SHA256 signature against ``body``.
+
+    Jira signs with the ``X-Hub-Signature`` header, value ``sha256=<hex>``,
+    HMAC-SHA256 over the raw request body keyed by the webhook secret.
+
+    Raises ``WebhookVerificationError`` on any failure mode (missing
+    header, malformed format, missing secret, digest mismatch). The
+    exception message is operator-facing only — it never carries the
+    secret value, and the HTTP layer responds with a generic 401.
+
+    Comparison uses ``hmac.compare_digest`` for constant-time equality —
+    no timing oracle on the secret.
+    """
+    if not signature_header:
+        raise WebhookVerificationError("missing X-Hub-Signature header")
+    if not signature_header.isascii():
+        # Defense-in-depth (mirrors webhooks/google_drive.py's ASCII gate):
+        # the HTTP layer already rejects non-ASCII headers, but a non-ASCII
+        # provided-hex would make hmac.compare_digest raise TypeError rather
+        # than failing closed as a WebhookVerificationError. Reject here so a
+        # non-HTTP caller (a future CLI replay tool) still fails closed → 401.
+        raise WebhookVerificationError("non-ASCII X-Hub-Signature header")
+    if not signature_header.startswith("sha256="):
+        raise WebhookVerificationError(
+            f"signature header malformed: expected 'sha256=<hex>', got {signature_header[:32]!r}"
+        )
+    provided_hex = signature_header[len("sha256=") :]
+    if not secret:
+        # Defensive: operator-config bug. Refuse rather than silently
+        # accept anything signed with an empty key.
+        raise WebhookVerificationError("no webhook_secret configured for this source")
+    expected_hex = hmac.new(secret.encode("utf-8"), msg=body, digestmod=hashlib.sha256).hexdigest()
+    # Both sides hex-encoded — same length, ASCII-safe for compare_digest.
+    if not hmac.compare_digest(provided_hex.lower(), expected_hex):
+        raise WebhookVerificationError("signature mismatch")
+
+
+# Events that carry a decision-bearing inline ``issue`` object and trigger
+# ingest. Comment events also carry the inline ``issue`` (the comment lives
+# on the issue's comment page) — Phase B normalizes the same inline object
+# for all four; comment-event-specific shaping is a Phase C refinement.
+_INGEST_EVENTS = frozenset(
+    {
+        "jira:issue_created",
+        "jira:issue_updated",
+        "comment_created",
+        "comment_updated",
+    }
+)
+
+
+def _resolve_secret() -> str:
+    """Default webhook-secret resolver — reads from ``secrets_store``.
+
+    Returns the secret string ("" when unset). Kept as a module function
+    so ``handle`` can inject a test stub without monkeypatching the
+    ``secrets_store`` module at import time.
+    """
+    from secrets_store import get_secret
+
+    return get_secret(source_id="jira", key="webhook_secret") or ""
+
+
+def handle(
+    *,
+    body: bytes,
+    signature_header: str | None,
+    delivery_identifier: str | None,
+    secret_resolver=None,
+) -> tuple[int, str]:
+    """Process one Jira webhook delivery.
+
+    Returns ``(http_status, log_message)``. The HTTP server lifts the
+    status into the response and prints the log message.
+
+    ``secret_resolver`` is an injectable zero-arg callable returning the
+    webhook secret string; it defaults to :func:`_resolve_secret`
+    (``secrets_store``). Tests pass a stub to avoid touching the keyring.
+
+    The function is sync; the HTTP server calls it via
+    ``asyncio.to_thread`` so the ingest path does not block the event
+    loop — same pattern as the peer receivers.
+    """
+    resolver = secret_resolver if secret_resolver is not None else _resolve_secret
+    try:
+        secret = resolver() or ""
+    except Exception as exc:  # noqa: BLE001 — never break the HTTP layer
+        # Note: the secret value itself never reaches this branch — only
+        # the lookup-failure exception, which carries no secret.
+        print(f"[jira-webhook] secret lookup failed: {exc}", file=sys.stderr)
+        return 500, f"secret lookup failed: {exc}"
+
+    if not secret:
+        # Fail closed: a receiver with no configured secret cannot verify
+        # any delivery. Surface setup guidance — never a secret value.
+        print(
+            "[jira-webhook] no webhook_secret configured for source 'jira'; "
+            "refusing to accept unverifiable deliveries. Configure it via "
+            "secrets_store source_id='jira' key='webhook_secret' to match the "
+            "secret set in Jira's webhook configuration.",
+            file=sys.stderr,
+        )
+        return 500, "webhook_secret not configured for source 'jira'"
+
+    # Verify the signature over the exact raw bytes BEFORE any json.loads.
+    try:
+        verify_signature(body=body, signature_header=signature_header, secret=secret)
+    except WebhookVerificationError as exc:
+        # Verification failure logs detail server-side, returns generic 401.
+        print(f"[jira-webhook] verification failed: {exc}", file=sys.stderr)
+        return 401, f"verification failed: {exc}"
+
+    # Jira always sends X-Atlassian-Webhook-Identifier. Absence is a
+    # provider bug or an attack trying to bypass dedup — accepting an
+    # empty identifier would let a captured signed payload replay
+    # infinitely under the dedup radar.
+    if not delivery_identifier:
+        print(
+            "[jira-webhook] missing X-Atlassian-Webhook-Identifier header "
+            "(replay-defense gate); rejecting.",
+            file=sys.stderr,
+        )
+        return 400, "missing X-Atlassian-Webhook-Identifier"
+
+    # Dedup AFTER verification so an attacker cannot poison the cache with
+    # unverified delivery identifiers. Single bucket — the identifier is
+    # globally unique per tenant, no per-channel partition.
+    from webhooks.dedup import get_dedup_cache
+
+    cache = get_dedup_cache()
+    if cache.is_duplicate("jira", delivery_identifier):
+        print(
+            f"[jira-webhook] duplicate delivery {delivery_identifier!r} ignored",
+            file=sys.stderr,
+        )
+        return 200, "duplicate"
+
+    # Parse the JSON body. Verification already confirmed the bytes are
+    # what Jira signed, but the bytes might still not be JSON-decodable.
+    try:
+        payload = json.loads(body.decode("utf-8"))
+    except Exception as exc:  # noqa: BLE001
+        print(f"[jira-webhook] body not JSON-decodable: {exc}", file=sys.stderr)
+        # 400, not marked seen — a malformed body is deterministic, but a
+        # mark here is harmless either way; consistency with mark-after-ack
+        # keeps the rule simple: only 200/422 mark.
+        return 400, f"body not JSON: {exc}"
+
+    if not isinstance(payload, dict):
+        return 400, "body not a JSON object"
+
+    event = ""
+    raw_event = payload.get("webhookEvent")
+    if isinstance(raw_event, str):
+        event = raw_event.strip()
+
+    if event in _INGEST_EVENTS:
+        result = _ingest_issue(payload, event, delivery_identifier)
+    else:
+        # jira:issue_deleted / comment_deleted / any other event →
+        # acknowledged, no ingest (append-only contract).
+        print(
+            f"[jira-webhook] delivery {delivery_identifier!r} event "
+            f"{event!r} acknowledged (no ingest)",
+            file=sys.stderr,
+        )
+        result = (200, f"event={event!r} acknowledged (no ingest)")
+
+    # Mark-after-ack: mark the delivery seen only once an acked outcome
+    # (200 or 422 — Jira will not retry either) is decided. A 500 path is
+    # left unmarked so Jira's retry re-dispatches the delivery.
+    if result[0] in (200, 422):
+        cache.mark_seen("jira", delivery_identifier)
+    return result
+
+
+def _ingest_issue(payload: dict, event: str, delivery_identifier: str) -> tuple[int, str]:
+    """Normalize the webhook payload's inline ``issue`` object and ingest.
+
+    The Jira issue/comment webhook carries the full ``issue`` object inline
+    (REST shape, no expand), so Phase B normalizes it directly — no network
+    round-trip. ``comment_*`` events carry the same inline ``issue`` (the
+    comment lives on the issue's comment page).
+
+    Failure posture:
+    - missing/empty ``issue`` or its ``key`` → 200 acknowledged, no ingest
+      (a malformed payload — not worth a retry).
+    - ``_IngestRefused`` (hard gate: PHI/secret/PAN) → 422 (Jira does not
+      retry; the gate's own audit-log emit is the operator-visibility
+      surface — the payload content is not echoed).
+    - any other ``Exception`` (transient ledger error, etc.) → 500 so Jira
+      retries; the operator's environment recovers if the failure was
+      transient.
+    """
+    issue = payload.get("issue")
+    if not isinstance(issue, dict) or not issue:
+        print(
+            f"[jira-webhook] delivery {delivery_identifier!r} event {event!r} "
+            "missing inline 'issue' object; acking without ingest",
+            file=sys.stderr,
+        )
+        return 200, f"event={event!r} acknowledged (no issue object)"
+
+    issue_key = issue.get("key")
+    if not isinstance(issue_key, str) or not issue_key.strip():
+        print(
+            f"[jira-webhook] delivery {delivery_identifier!r} event {event!r} "
+            "issue payload missing 'key'; acking without ingest",
+            file=sys.stderr,
+        )
+        return 200, f"event={event!r} acknowledged (issue missing key)"
+    issue_key = issue_key.strip()
+
+    try:
+        # Phase A ships ``normalize_issue_to_payload`` as a module-level
+        # function in ``sources/jira/adapter.py`` (the ``JiraAdapter``
+        # class calls it internally). Phase B reuses it directly on the
+        # webhook's inline ``issue`` object — no network, no ``fetch_active``.
+        from sources.jira.adapter import normalize_issue_to_payload
+
+        ingest_payload = normalize_issue_to_payload(issue, issue_key)
+    except Exception as exc:  # noqa: BLE001
+        # Normalization is pure (no network); a failure here is a payload-
+        # shape surprise. Treat as transient — operator visibility via the
+        # retry storm beats silent loss.
+        print(
+            f"[jira-webhook] payload normalization failed for {issue_key!r} "
+            f"(delivery={delivery_identifier!r}): {type(exc).__name__}: {exc}",
+            file=sys.stderr,
+        )
+        return 500, f"normalization failed for {issue_key!r}; Jira will retry"
+
+    try:
+        import asyncio
+
+        from context import BicameralContext
+        from handlers.ingest import _IngestRefused, handle_ingest
+
+        ctx = BicameralContext.from_env()
+
+        async def _ingest() -> None:
+            await handle_ingest(ctx, ingest_payload, source_scope="jira", ingest_mode="passive")
+
+        asyncio.run(_ingest())
+    except _IngestRefused as exc:
+        # Hard-gate refusal (secret / PHI / PAN). Don't echo the payload
+        # content into the HTTP response — only the reason category. The
+        # gate's own audit-log emit captured the detail. 422 → Jira does
+        # not retry, so the offending content does not linger in retry logs.
+        print(
+            f"[jira-webhook] hard-gate refusal for {issue_key!r} "
+            f"(delivery={delivery_identifier!r}): {exc.reason}",
+            file=sys.stderr,
+        )
+        return 422, f"refused: {exc.reason}"
+    except Exception as exc:  # noqa: BLE001
+        # Generic post-normalize ingest failure (ledger error, etc.).
+        # 500 so Jira retries — a transient failure self-heals.
+        print(
+            f"[jira-webhook] ingest failed for {issue_key!r} "
+            f"(delivery={delivery_identifier!r}): {type(exc).__name__}: {exc}",
+            file=sys.stderr,
+        )
+        return 500, f"ingest failed for {issue_key!r}; Jira will retry"
+
+    return 200, f"event={event!r} ingested {issue_key}"

--- a/webhooks/server.py
+++ b/webhooks/server.py
@@ -15,6 +15,7 @@ Routes:
 - ``POST /webhooks/linear``         → ``webhooks.linear.handle``
 - ``POST /webhooks/google-drive``   → ``webhooks.google_drive.handle``
 - ``POST /webhooks/notion``         → ``webhooks.notion.handle``
+- ``POST /webhooks/jira``           → ``webhooks.jira.handle``
 - ``GET /health``                   → 200 ack (for load-balancer health checks)
 
 ## Hardening (post code-review)
@@ -233,6 +234,13 @@ async def _process_request(reader: asyncio.StreamReader, writer: asyncio.StreamW
         await _respond(writer, status, message)
         return
 
+    if path == "/webhooks/jira":
+        status, message = await asyncio.to_thread(
+            _dispatch_jira, body, MappingProxyType(dict(headers))
+        )
+        await _respond(writer, status, message)
+        return
+
     await _respond(writer, 404, "not found")
 
 
@@ -289,6 +297,22 @@ def _dispatch_google_drive(body: bytes, headers) -> tuple[int, str]:
         resource_id=headers.get("x-goog-resource-id"),
         resource_state=headers.get("x-goog-resource-state"),
         message_number=headers.get("x-goog-message-number"),
+    )
+
+
+def _dispatch_jira(body: bytes, headers) -> tuple[int, str]:
+    """Sync entrypoint into the Jira handler (called via to_thread).
+
+    Pulls the HMAC signature (``X-Hub-Signature`` — note: not GitHub's
+    ``X-Hub-Signature-256``) and the per-tenant delivery identifier
+    (``X-Atlassian-Webhook-Identifier``) used for dedup.
+    """
+    from webhooks.jira import handle
+
+    return handle(
+        body=body,
+        signature_header=headers.get("x-hub-signature"),
+        delivery_identifier=headers.get("x-atlassian-webhook-identifier"),
     )
 
 


### PR DESCRIPTION
## Summary

**Phase B of the Jira integration (#337).** Ships `webhooks/jira.py` — the Jira Cloud **webhook receiver** — and its `webhooks/server.py` route. This is the passive-ingest entry point that makes Phase A's `JiraAdapter` reachable: a webhook delivery is signature-verified → dedup'd → normalized → `handle_ingest`.

## Security posture (admin-UI webhook model, shared secret)

- **HMAC-SHA256 over the exact raw request bytes**, `X-Hub-Signature` header (`sha256=<hex>` — note: *not* GitHub's `X-Hub-Signature-256`), `hmac.compare_digest`. Verified **before** any `json.loads`.
- **Fail-closed**: a receiver with no configured `webhook_secret` accepts nothing (→ 500). The secret never reaches a log, exception, or HTTP response.
- **Dedup after verification** (an unverified delivery can't poison the cache) on `X-Atlassian-Webhook-Identifier` — single bucket; the identifier is globally unique per tenant.
- **Status-code contract** per Jira's documented retry triggers: 401 sig-fail, 400 missing-id/bad-JSON, 422 hard-gate refusal, 500 transient (Jira retries), 200 ack.
- **Mark-after-ack**: a delivery is marked seen only on 200/422; a 500 is left unmarked so Jira's retry re-dispatches.

The webhook payload carries the full `issue` object inline (REST shape), so Phase B reuses Phase A's `normalize_issue_to_payload` + `flatten_adf` directly — **no network round-trip, no `fetch_active`, no SSRF surface**.

## Scope

Handled events: `jira:issue_created/updated`, `comment_created/updated`. Deletes + other events → acked without ingest (append-only contract). Status-transition/`changelog` decision detection is Phase C; admin-UI setup helper is Phase D; poller is Phase E.

## Governance

- Independent `architect-reviewer` plan audit: **PASS**, L2, no findings (first round).
- Adversarial `code-reviewer` pre-push pass: **SHIP** — 0 HIGH, 0 MED, 2 LOW, **both fixed in this PR** (a defense-in-depth non-ASCII signature-header guard so `verify_signature` always fails closed as `WebhookVerificationError`, mirroring the Drive handler's ASCII gate; + the empty-hex bypass-attempt test). The reviewer's full signature-bypass trace confirmed no path lets a forged or unsigned delivery reach `json.loads` or `handle_ingest`.

## Test plan

- [x] 24 sociable tests — real `handle` / `verify_signature` / `DeliveryDedupCache` / `normalize_issue_to_payload`; `handle_ingest` seamed. Uses **Atlassian's documented HMAC test vector**. Covers: signature pass/fail/missing/malformed/empty-hex/non-ASCII, missing-identifier, dedup replay, issue + comment ingest, delete/unknown events, hard-gate 422, transient 500 (and that 500 does not mark).
- [x] `pytest tests/test_webhooks_*.py` → 96+ green (peer regression unaffected).
- [x] `ruff check` + `ruff format --check` clean; `mypy` via CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)