### PR TITLE
feat(dashboard): Project Pulse landing view (#437 Phase 3)

### DIFF
--- a/assets/dashboard.html
+++ b/assets/dashboard.html
@@ -81,6 +81,101 @@ body {
 /* ── MAIN ────────────────────────────────────────────────── */
 .main { max-width: 1000px; margin: 0 auto; padding: 24px 28px 80px; }
 
+/* ── PROJECT PULSE LANDING VIEW (#437 Phase 3) ─────────────── */
+.pulse { max-width: 1000px; margin: 0 auto; padding: 24px 28px 8px; }
+.pulse-loading, .pulse-error {
+  padding: 28px 0; text-align: center;
+  color: var(--text-dim); font-size: 12px;
+}
+.pulse-error { color: var(--amber); }
+.pulse-card {
+  background: var(--paper);
+  border: 1px solid var(--border);
+  border-radius: 4px;
+  padding: 18px 20px;
+}
+.pulse-title {
+  font-family: var(--serif);
+  font-size: 15px; font-weight: 700;
+  color: var(--accent);
+  letter-spacing: 0.02em;
+  margin-bottom: 4px;
+}
+.pulse-allclear {
+  font-size: 12px; color: var(--green);
+  background: var(--green-soft);
+  border: 1px solid var(--green);
+  border-radius: 3px;
+  padding: 10px 14px;
+  margin-bottom: 14px;
+  line-height: 1.7;
+}
+.pulse-section { margin-top: 16px; }
+.pulse-section:first-of-type { margin-top: 10px; }
+.pulse-section-name {
+  font-size: 10.5px; font-weight: 500;
+  color: var(--text-dim);
+  letter-spacing: 0.1em; text-transform: uppercase;
+  border-bottom: 1px solid var(--border);
+  padding-bottom: 4px; margin-bottom: 8px;
+}
+.pulse-health {
+  display: flex; flex-wrap: wrap; gap: 8px 18px;
+}
+.pulse-stat { display: flex; align-items: baseline; gap: 6px; }
+.pulse-stat-num {
+  font-size: 16px; font-weight: 500;
+  color: var(--accent);
+}
+.pulse-stat-num.drift { color: var(--amber); }
+.pulse-stat-label { font-size: 11px; color: var(--text-dim); }
+.pulse-sync {
+  font-size: 11px; color: var(--text-light);
+  margin-top: 8px;
+}
+.pulse-row {
+  display: flex; align-items: baseline; gap: 8px;
+  padding: 6px 0;
+  border-bottom: 1px dashed var(--border);
+  cursor: pointer;
+}
+.pulse-row:last-child { border-bottom: none; }
+.pulse-row:hover .pulse-row-summary { color: var(--accent); }
+.pulse-row-kind {
+  font-size: 9.5px; letter-spacing: 0.06em;
+  text-transform: uppercase;
+  color: var(--amber);
+  background: var(--amber-soft);
+  border: 1px solid var(--amber);
+  border-radius: 2px;
+  padding: 1px 6px; flex-shrink: 0;
+}
+.pulse-row-src {
+  font-size: 9.5px; letter-spacing: 0.04em;
+  color: var(--text-dim);
+  background: var(--accent-soft);
+  border-radius: 2px;
+  padding: 1px 6px; flex-shrink: 0;
+}
+.pulse-row-summary {
+  font-size: 12px; color: var(--text);
+  flex: 1; min-width: 0;
+}
+.pulse-row-meta {
+  font-size: 10.5px; color: var(--text-light);
+  flex-shrink: 0;
+}
+.pulse-empty {
+  font-size: 11px; color: var(--text-light);
+  font-style: italic; padding: 4px 0;
+}
+.pulse-next {
+  font-size: 12px; color: var(--text);
+  background: var(--accent-soft);
+  border-left: 2px solid var(--accent);
+  padding: 8px 12px;
+}
+
 .empty {
   padding: 72px 0; text-align: center;
   color: var(--text-dim); font-size: 12px; line-height: 2;
@@ -604,6 +699,16 @@ body {
   </label>
   <span id="tref" class="topbar-ref"></span>
 </header>
+
+<!-- ── PROJECT PULSE LANDING VIEW (#437 Phase 3) ──────────────── -->
+<!-- Populated by renderPulse() from GET /pulse. Every user-sourced
+     string (decision summary, source ref, signer, decision id) is
+     inserted via esc() — never raw innerHTML interpolation. The /pulse
+     fetch is independent of /history: a Pulse failure shows an inline
+     error here and the ledger table below still loads. -->
+<section id="pulse" class="pulse">
+  <div class="pulse-loading">Loading project pulse…</div>
+</section>
 
 <main class="main" id="root">
   <div class="empty">Loading decision ledger…</div>
@@ -1411,6 +1516,124 @@ function jumpToDecision(id) {
   row.scrollIntoView({behavior: 'smooth', block: 'center'});
 }
 
+// ── Project Pulse landing view (#437 Phase 3) ──────────────────
+// renderPulse builds the four ProjectPulseSummary sections into #pulse.
+// XSS discipline (load-bearing): EVERY user-sourced value — decision
+// summaries, source refs/types, signers, decision ids, last_sync — is
+// inserted via esc() (or fmtDate, which derives a fixed-shape string).
+// No raw user string is ever concatenated into innerHTML unescaped, and
+// every data-decision-id attribute is esc()'d.
+function pulseSignerLabel(signer) {
+  // The CLI renderer shows only the local-part of a signer email; mirror
+  // that here so the dashboard never prints a full address.
+  if (!signer) return '';
+  const s = String(signer);
+  const at = s.indexOf('@');
+  return at > 0 ? s.slice(0, at) : s;
+}
+
+function renderPulseHealth(health) {
+  const h = health || {};
+  const stat = (num, label, drift) =>
+    `<div class="pulse-stat">
+       <span class="pulse-stat-num${drift ? ' drift' : ''}">${esc(num ?? 0)}</span>
+       <span class="pulse-stat-label">${esc(label)}</span>
+     </div>`;
+  const sync = h.last_sync
+    ? `<div class="pulse-sync">Last sync: ${esc(fmtDate(h.last_sync))}</div>`
+    : `<div class="pulse-sync">Last sync: never</div>`;
+  return `
+<div class="pulse-section">
+  <div class="pulse-section-name">Health</div>
+  <div class="pulse-health">
+    ${stat(h.decisions_reflected, 'reflected')}
+    ${stat(h.decisions_drifted, 'drifted', (h.decisions_drifted || 0) > 0)}
+    ${stat(h.decisions_pending, 'pending')}
+    ${stat(h.decisions_ungrounded, 'ungrounded')}
+    ${stat(h.drifted_regions, 'drifted regions', (h.drifted_regions || 0) > 0)}
+  </div>
+  ${sync}
+</div>`;
+}
+
+function renderPulseNeedsAttention(items) {
+  const list = items || [];
+  let inner;
+  if (!list.length) {
+    inner = `<div class="pulse-empty">Nothing awaiting attention.</div>`;
+  } else {
+    inner = list.map(it => {
+      const kind = String(it.kind || '').replace(/_/g, ' ');
+      const signer = pulseSignerLabel(it.signer);
+      const meta = signer ? `<span class="pulse-row-meta">${esc(signer)}</span>` : '';
+      return `
+<div class="pulse-row" data-decision-id="${esc(it.decision_id)}">
+  <span class="pulse-row-kind">${esc(kind)}</span>
+  <span class="pulse-row-summary">${esc(it.summary)}</span>
+  ${meta}
+</div>`;
+    }).join('');
+  }
+  return `
+<div class="pulse-section">
+  <div class="pulse-section-name">Needs Attention</div>
+  ${inner}
+</div>`;
+}
+
+function renderPulseRecentlyLearned(items) {
+  const list = items || [];
+  let inner;
+  if (!list.length) {
+    inner = `<div class="pulse-empty">No decisions recorded yet.</div>`;
+  } else {
+    inner = list.map(it => {
+      const srcBits = [it.source_type, it.source_ref].filter(Boolean).join(' · ');
+      const src = srcBits
+        ? `<span class="pulse-row-src">${esc(srcBits)}</span>` : '';
+      const date = it.date
+        ? `<span class="pulse-row-meta">${esc(fmtDate(it.date))}</span>` : '';
+      return `
+<div class="pulse-row" data-decision-id="${esc(it.decision_id)}">
+  ${src}
+  <span class="pulse-row-summary">${esc(it.summary)}</span>
+  ${date}
+</div>`;
+    }).join('');
+  }
+  return `
+<div class="pulse-section">
+  <div class="pulse-section-name">Recently Learned</div>
+  ${inner}
+</div>`;
+}
+
+function renderPulse(summary) {
+  const el = document.getElementById('pulse');
+  if (!el) return;
+  if (!summary || summary.error) {
+    el.innerHTML =
+      `<div class="pulse-error">Project Pulse unavailable: ${esc((summary && summary.error) || 'no data')}</div>`;
+    return;
+  }
+  const allClear = summary.is_all_clear
+    ? `<div class="pulse-allclear">Bicameral checked project memory.<br>
+       No drift, no pending signoffs — memory is current.</div>`
+    : '';
+  el.innerHTML = `
+<div class="pulse-card">
+  <div class="pulse-title">Project Pulse</div>
+  ${allClear}
+  ${renderPulseHealth(summary.health)}
+  ${renderPulseNeedsAttention(summary.needs_attention)}
+  ${renderPulseRecentlyLearned(summary.recently_learned)}
+  <div class="pulse-section">
+    <div class="pulse-section-name">Suggested Next Move</div>
+    <div class="pulse-next">${esc(summary.suggested_next_move)}</div>
+  </div>
+</div>`;
+}
+
 // ── render ────────────────────────────────────────────────────
 let _lastFeaturesJson = null;
 
@@ -1531,7 +1754,24 @@ document.addEventListener('click', (ev) => {
   jumpToDecision(link.dataset.decisionId);
 });
 
+// #437 Phase 3 — delegated click for Project Pulse rows. Same discipline:
+// decision ids are carried in a data- attribute (esc()'d — `"` is escaped),
+// never interpolated into an inline onclick JS string (esc() does not escape
+// `'`, so an inline-onclick id would be a breakout vector).
+document.addEventListener('click', (ev) => {
+  const row = ev.target.closest('.pulse-row[data-decision-id]');
+  if (!row) return;
+  jumpToDecision(row.dataset.decisionId);
+});
+
 fetch('/history').then(r => r.json()).then(render).catch(() => {});
+// #437 Phase 3 — the Pulse fetch is independent of /history: a /pulse
+// failure shows an inline Pulse-section error and must NOT block the
+// ledger table above.
+fetch('/pulse').then(r => r.json()).then(renderPulse).catch(() => {
+  const el = document.getElementById('pulse');
+  if (el) el.innerHTML = '<div class="pulse-error">Project Pulse unavailable.</div>';
+});
 connect();
 </script>
 </body>

--- a/dashboard/server.py
+++ b/dashboard/server.py
@@ -7,6 +7,7 @@ Endpoints:
   GET /           → dashboard.html (self-contained HTML/JS bundle)
   GET /events     → SSE stream; each event is a full HistoryResponse JSON blob
   GET /history    → one-shot JSON dump (initial load fallback)
+  GET /pulse      → one-shot ProjectPulseSummary JSON (#437 Phase 3)
 
 The server is a module-level singleton started once when serve_stdio() runs.
 Write handlers (ingest, link_commit) call notify(ctx) to push updates.
@@ -131,6 +132,8 @@ class DashboardServer:
                 await self._serve_html(writer)
             elif method == "GET" and path == "/history":
                 await self._serve_history(writer)
+            elif method == "GET" and path == "/pulse":
+                await self._serve_pulse(writer)
             elif method == "GET" and path == "/events":
                 await self._serve_sse(writer)
             elif method == "POST" and path == "/admin/query":
@@ -169,6 +172,26 @@ class DashboardServer:
 
             response = await handle_history(ctx)
             body = json.dumps(response.model_dump(), default=str).encode()
+        except Exception as exc:
+            body = json.dumps({"error": str(exc)}).encode()
+        writer.write(_send_body(_HTTP_200_JSON, body))
+        await writer.drain()
+
+    async def _serve_pulse(self, writer: asyncio.StreamWriter) -> None:
+        """Serve a one-shot Project Pulse summary as JSON (#437 Phase 3).
+
+        Read-only — mirrors ``_serve_history``: builds a ``ProjectPulseSummary``
+        from the ledger via ``build_project_pulse`` and returns its
+        ``to_dict()`` shape. ``build_project_pulse`` is fail-soft per section;
+        a hard failure here surfaces an ``{"error": ...}`` body so the Pulse
+        section can show an error without crashing the dashboard server.
+        """
+        try:
+            ctx = self._ctx_factory()
+            from pulse.summary import build_project_pulse
+
+            summary = await build_project_pulse(ctx.ledger)
+            body = json.dumps(summary.to_dict(), default=str).encode()
         except Exception as exc:
             body = json.dumps({"error": str(exc)}).encode()
         writer.write(_send_body(_HTTP_200_JSON, body))

--- a/skills/bicameral-dashboard/SKILL.md
+++ b/skills/bicameral-dashboard/SKILL.md
@@ -1,6 +1,6 @@
 # bicameral-dashboard
 
-Launch the live decision dashboard — a local browser tab that shows every tracked decision grouped by feature area and pushes real-time updates whenever `bicameral.ingest` or `bicameral.link_commit` writes new data.
+Launch the live decision dashboard — a local browser tab that opens to a Project Pulse landing view (health, what needs attention, recently learned, suggested next move) above every tracked decision grouped by feature area, and pushes real-time updates whenever `bicameral.ingest` or `bicameral.link_commit` writes new data.
 
 ## Triggers
 

--- a/tests/test_dashboard_pulse.py
+++ b/tests/test_dashboard_pulse.py
@@ -1,0 +1,194 @@
+"""Sociable tests for the dashboard ``GET /pulse`` endpoint (#437 Phase 3).
+
+``DashboardServer._serve_pulse`` is exercised against a real
+``SurrealDBLedgerAdapter`` over ``memory://`` — no ``MagicMock`` for the
+ledger or the ``ctx``. The endpoint builds a ``ProjectPulseSummary`` via the
+real Phase 1 ``build_project_pulse`` and writes its ``to_dict()`` shape as the
+HTTP body; these tests assert that wire shape and the fail-soft error path.
+"""
+
+from __future__ import annotations
+
+import json
+from types import SimpleNamespace
+
+import pytest
+
+from dashboard.server import DashboardServer
+from ledger.adapter import SurrealDBLedgerAdapter
+from ledger.client import LedgerClient
+from ledger.schema import init_schema, migrate
+
+
+async def _fresh_adapter(suffix: str) -> tuple[SurrealDBLedgerAdapter, LedgerClient]:
+    """Real ``memory://`` ledger adapter — the sociable-test seam from
+    ``tests/test_codegenome_continuity_service.py::_fresh_adapter``.
+    """
+    c = LedgerClient(url="memory://", ns=f"pulse_dash_{suffix}", db="ledger_test")
+    await c.connect()
+    await init_schema(c)
+    await migrate(c, allow_destructive=True)
+    a = SurrealDBLedgerAdapter(url="memory://")
+    a._client = c
+    a._connected = True
+    return a, c
+
+
+class _FakeWriter:
+    """Minimal ``asyncio.StreamWriter`` stand-in — captures written bytes.
+
+    Solitary is correct here: a ``StreamWriter`` is a transport primitive, not
+    a collaborator we ship to the agent; capturing its bytes is the cleanest
+    way to assert the exact HTTP response ``_serve_pulse`` produces.
+    """
+
+    def __init__(self) -> None:
+        self.buffer = b""
+
+    def write(self, data: bytes) -> None:
+        self.buffer += data
+
+    async def drain(self) -> None:
+        return None
+
+
+def _parse_http_body(raw: bytes) -> dict:
+    """Split an HTTP/1.1 response into headers + JSON-decoded body."""
+    _, _, body = raw.partition(b"\r\n\r\n")
+    return json.loads(body.decode("utf-8"))
+
+
+async def _create_decision(client: LedgerClient, **fields: object) -> str:
+    """CREATE one decision row with the production schema; return its id."""
+    assignments = ", ".join(f"{k} = $f_{k}" for k in fields)
+    params = {f"f_{k}": v for k, v in fields.items()}
+    rows = await client.query(f"CREATE decision SET {assignments}", params)
+    return str(rows[0]["id"])
+
+
+def _server_for(adapter: SurrealDBLedgerAdapter) -> DashboardServer:
+    """A ``DashboardServer`` whose ``_ctx_factory`` yields a real-ledger ctx.
+
+    ``ctx`` is a ``SimpleNamespace`` (not ``MagicMock``) so a future required
+    ``ctx`` field fails the test honestly instead of being silently invented.
+    """
+    server = DashboardServer()
+    server._ctx_factory = lambda: SimpleNamespace(ledger=adapter, repo_path=".")
+    return server
+
+
+@pytest.mark.asyncio
+async def test_pulse_returns_to_dict_shape_for_populated_ledger() -> None:
+    """``GET /pulse`` returns the ``ProjectPulseSummary.to_dict()`` shape."""
+    adapter, client = await _fresh_adapter("populated")
+    try:
+        await _create_decision(
+            client,
+            description="Adopt JWT refresh tokens",
+            source_type="meeting",
+            source_ref="Sprint Planning",
+            status="reflected",
+            canonical_id="dec-jwt",
+        )
+        # A decision awaiting ratification → one needs_attention item.
+        await _create_decision(
+            client,
+            description="Switch checkout to Stripe",
+            source_type="slack",
+            source_ref="#payments",
+            status="pending",
+            signoff={"state": "proposed", "signer": "alice@example.com"},
+            canonical_id="dec-stripe",
+        )
+
+        server = _server_for(adapter)
+        writer = _FakeWriter()
+        await server._serve_pulse(writer)  # type: ignore[arg-type]
+
+        body = _parse_http_body(writer.buffer)
+        assert b"200 OK" in writer.buffer
+        assert b"application/json" in writer.buffer
+
+        # The four ProjectPulseSummary sections + the all-clear flag.
+        assert set(body) == {
+            "health",
+            "needs_attention",
+            "recently_learned",
+            "suggested_next_move",
+            "is_all_clear",
+        }
+        assert set(body["health"]) == {
+            "decisions_reflected",
+            "decisions_drifted",
+            "decisions_pending",
+            "decisions_ungrounded",
+            "drifted_regions",
+            "last_sync",
+        }
+        assert body["health"]["decisions_reflected"] == 1
+        assert body["health"]["decisions_pending"] == 1
+
+        # The proposed decision surfaces as a needs_attention item.
+        assert len(body["needs_attention"]) == 1
+        item = body["needs_attention"][0]
+        assert set(item) == {"kind", "decision_id", "summary", "signer"}
+        assert item["kind"] == "awaiting_ratification"
+        assert item["summary"] == "Switch checkout to Stripe"
+
+        # Both decisions are recently-learned items with the LearnedItem shape.
+        assert len(body["recently_learned"]) == 2
+        learned = body["recently_learned"][0]
+        assert set(learned) == {
+            "decision_id",
+            "summary",
+            "source_type",
+            "source_ref",
+            "date",
+        }
+
+        # A pending ratification → not all-clear.
+        assert body["is_all_clear"] is False
+        assert "ratification" in body["suggested_next_move"].lower()
+    finally:
+        await client.close()
+
+
+@pytest.mark.asyncio
+async def test_pulse_all_clear_for_empty_ledger() -> None:
+    """An empty ledger yields the explicit all-clear summary."""
+    adapter, client = await _fresh_adapter("empty")
+    try:
+        server = _server_for(adapter)
+        writer = _FakeWriter()
+        await server._serve_pulse(writer)  # type: ignore[arg-type]
+
+        body = _parse_http_body(writer.buffer)
+        assert body["is_all_clear"] is True
+        assert body["needs_attention"] == []
+        assert body["recently_learned"] == []
+        assert body["health"]["decisions_reflected"] == 0
+    finally:
+        await client.close()
+
+
+@pytest.mark.asyncio
+async def test_pulse_error_path_returns_error_body() -> None:
+    """A failing ``ctx_factory`` surfaces an ``{"error": ...}`` JSON body.
+
+    Mirrors ``_serve_history``'s fail-soft contract: ``/pulse`` must never
+    crash the dashboard server — a hard failure becomes an error body so the
+    Pulse section can render an inline error without blocking the ledger.
+    """
+
+    def _boom() -> SimpleNamespace:
+        raise RuntimeError("ledger unavailable")
+
+    server = DashboardServer()
+    server._ctx_factory = _boom
+    writer = _FakeWriter()
+    await server._serve_pulse(writer)  # type: ignore[arg-type]
+
+    body = _parse_http_body(writer.buffer)
+    assert b"200 OK" in writer.buffer
+    assert set(body) == {"error"}
+    assert "ledger unavailable" in body["error"]


### PR DESCRIPTION
## Summary
Phase 3 (final) of #437 — makes **Project Pulse** the dashboard landing view.

- New `GET /pulse` endpoint on the dashboard server returning `build_project_pulse(...).to_dict()` (mirrors `_serve_history`: read-only, localhost-bound, fail-soft `{"error": ...}` body).
- A Project Pulse `<section>` in `assets/dashboard.html` rendering the four summary sections — Health / Needs Attention / Recently Learned / Suggested Next Move — above the existing ledger table, plus the explicit friendly all-clear state.
- The `/pulse` fetch is independent of `/history`: a `/pulse` failure shows an inline Pulse-section error and the ledger table still loads.
- Builds on Phase 1 (`ProjectPulseSummary`, #461) and Phase 2 (`render_pulse_text`, #463) — one shared backend object, rendered three ways (CLI text, session-start hook, dashboard).

Completes #437 across its three phases.

## Security
- XSS discipline in `renderPulse()`: every user-sourced field (`summary`, `source_ref`, `signer`, `decision_id`, `last_sync`, …) is `esc()`'d before DOM insertion.
- Decision ids are carried in `data-decision-id` attributes and dispatched via a **delegated click handler** — never interpolated into an inline `onclick` JS string (`esc()` does not escape `'`, so an inline-onclick id would be a breakout vector). This matches the codebase's existing source-view discipline.
- Adversarial `code-reviewer` pass: one MED finding (inline-onclick id interpolation) — **fixed** before this push by switching to the delegated handler.

## Test plan
- [x] `pytest tests/test_dashboard_pulse.py` — 3 sociable tests (real `memory://` ledger), green.
- [x] `ruff check` + `ruff format --check` clean on `dashboard/server.py` + the test.
- [x] Live HTTP smoke test: `GET /` serves the bundle, `GET /pulse` returns the correct `to_dict()` shape against a seeded ledger.
- [x] Headless execution of the real `renderPulse()` JS — golden / all-clear / error states render; `<script>`/`<img onerror>`/`"`-breakout XSS payloads all entity-escaped; no `onclick` reintroduced.
- [ ] **Visual/CSS browser eyeball not performed** — the Chrome automation extension was not connected. Functional rendering + security are verified headlessly; the visual layout layer is the one item not eyeballed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)