### PR TITLE
docs: Dashboard v2 design spec + ADRs 0001-0005

### DIFF
--- a/docs/ARCHITECTURE_PLAN.md
+++ b/docs/ARCHITECTURE_PLAN.md
@@ -49,7 +49,7 @@ bicameral-mcp/                  (repo root, flat layout — no `bicameral/` pack
 │   ├── retrieval/              bm25s_client, sqlite_vec_client
 │   ├── fusion/                 RRF
 │   └── tools/                  validate_symbols, search_code, get_neighbors
-├── dashboard/                  optional web UI for ledger viewing
+├── dashboard/                  web UI — Dashboard v2 surface (on-demand; CLI output is primary)
 ├── skills/                     Claude skill definitions (.md)
 ├── docs/                       this directory; project DNA + design docs
 ├── tests/                      pytest suite (markers: phase1/phase2/phase3/alpha_flow/bench)

--- a/docs/architecture/adr-0001-dashboard-v2-information-architecture.md
+++ b/docs/architecture/adr-0001-dashboard-v2-information-architecture.md
@@ -1,0 +1,62 @@
+# ADR-0001: Dashboard v2 Information Architecture
+
+**Status:** Accepted for planning  
+**Date:** 2026-05-21  
+**Related:** `docs/design/dashboard-v2-comprehensive-design.md`
+
+## Context
+
+The current Bicameral dashboard exposes useful decision information but presents it primarily as a ledger-oriented operational view. Upstream work on Project Pulse establishes a stronger product direction: Bicameral should feel like the project memory is awake, surfacing health, needs attention, recently learned decisions, and suggested next actions.
+
+However, the existing ledger view remains valuable. It contains the detailed canonical decision history and should not be discarded.
+
+## Decision
+
+Adopt a multi-view dashboard information architecture:
+
+1. **Pulse**: default landing view for situational awareness.
+2. **Ledger**: canonical decision record retaining the existing detailed view.
+3. **Ratification**: workflow surface for approving, rejecting, requesting changes, and superseding decisions.
+4. **Drift**: implementation mismatch and evidence surface.
+5. **Sources**: ingest visibility grouped by connector/source type.
+6. **Audit**: operational and security event trail.
+7. **Integrations**: connection and source configuration center.
+8. **Settings**: profile, team sync, themes, accessibility, privacy, diagnostics, and advanced controls.
+
+## Rationale
+
+This structure separates distinct user jobs:
+
+- Pulse answers what needs attention.
+- Ledger answers what the canonical decision record contains.
+- Ratification answers what needs human judgment.
+- Drift answers where implementation diverged.
+- Sources answer where decisions are coming from.
+- Audit answers what the system did and why.
+- Integrations answer how sources are configured.
+- Settings answer how the product behaves for the local user and team.
+
+Combining these into one dashboard would create a dense, confusing UI. Replacing the Ledger would throw away an already useful audit-oriented view.
+
+## Consequences
+
+Positive:
+
+- Preserves existing functionality.
+- Gives new users a clearer landing experience.
+- Gives power users a detailed Ledger view.
+- Creates room for integrations, audit, and settings expansion.
+
+Tradeoffs:
+
+- Requires navigation and route structure.
+- Requires shared decision-detail components across Ledger, Ratification, and Drift.
+- Requires careful consistency between Pulse summary data and Ledger canonical data.
+
+## Acceptance Criteria
+
+- Pulse is default dashboard route.
+- Existing detailed decision view remains accessible as Ledger.
+- Ledger is explicitly described as the canonical decision record.
+- Ratification and Drift are separate views, not hidden filters inside Ledger.
+- Sources and Audit are separate concepts in the UI.

--- a/docs/architecture/adr-0002-drive-backed-team-sync-and-freshness.md
+++ b/docs/architecture/adr-0002-drive-backed-team-sync-and-freshness.md
@@ -1,0 +1,118 @@
+# ADR-0002: Google Drive-Backed Team Sync and Freshness Boundaries
+
+**Status:** Accepted for planning  
+**Date:** 2026-05-21  
+**Related:** `docs/design/dashboard-v2-comprehensive-design.md`
+
+## Context
+
+Current Bicameral team functions flow through a Google Drive file-share substrate. Team mode replicates shared decision events through files that live in a user-provisioned Drive folder. This is local-first and simple, but it is not the same as a real-time team server.
+
+The UI must therefore avoid implying that team state is always current. If Google Drive is disconnected, stale, or auth-expired, Bicameral can still operate locally, but shared team awareness may be incomplete.
+
+## Decision
+
+Model team sync as eventual consistency with explicit freshness states.
+
+Required states:
+
+```ts
+type TeamSyncState =
+  | "solo"
+  | "team_connected"
+  | "team_syncing"
+  | "team_stale"
+  | "team_offline"
+  | "team_auth_expired"
+  | "team_conflict"
+  | "team_read_only_fallback";
+```
+
+The UI must distinguish:
+
+1. Local state.
+2. Last confirmed team state from Google Drive.
+3. Potentially unknown remote changes while stale/offline.
+
+The UI must also distinguish **source freshness** from **team ledger freshness**. Example: Jira may be connected and recently checked while Google Drive team sync is stale.
+
+## Rationale
+
+Without freshness boundaries, users may believe ratification or integration changes are operating on current shared state when they are not. That creates ghost decisions, stale ratification, conflict risk, and audit ambiguity.
+
+Drive-backed sync should be presented honestly:
+
+> Local-first, team-aware, Drive-synchronized.
+
+## Action Policy
+
+Safe while stale/offline:
+
+- View Pulse from local state.
+- View Ledger.
+- View previously synced decisions.
+- Run local drift checks.
+- View local audit.
+- Edit personal preferences.
+- Draft local proposed decisions.
+
+Allowed but queued:
+
+- Create local proposed decisions.
+- Capture local ingest.
+- Add local notes.
+- Create local audit events.
+
+Paused while stale/offline:
+
+- Final shared ratification.
+- Reject or supersede shared decisions.
+- Team integration scope changes.
+- Shared credential changes.
+- Team access changes.
+- Shared reset/replay.
+- Conflict resolution.
+
+## UI Requirements
+
+- Global Team Sync status pill.
+- Freshness Boundary card when stale/offline.
+- Action-level disabled reasons.
+- Local queue count.
+- Last confirmed sync timestamp.
+- Manual sync action.
+- Reconnect Google Drive action.
+- Clear distinction between permission denial and freshness pause.
+
+Example copy:
+
+> Ratification paused until team memory is current.
+
+Do not use:
+
+> You do not have permission.
+
+unless the user truly lacks the role/capability.
+
+## Consequences
+
+Positive:
+
+- Preserves local-first usefulness.
+- Avoids false team certainty.
+- Makes Drive-backed eventual consistency understandable.
+- Supports future team-server or hosted deployment without rewriting the UI model.
+
+Tradeoffs:
+
+- Adds state complexity.
+- Requires capability checks to consider both role and freshness.
+- Requires conflict and queued-event visibility.
+
+## Acceptance Criteria
+
+- Team Sync state is globally visible.
+- Ledger and Pulse remain usable when Drive is stale/offline.
+- Shared ratification and team configuration actions are paused or queued appropriately.
+- Source freshness and team freshness are displayed separately.
+- Stale/offline states are text-described, not only color-coded.

--- a/docs/architecture/adr-0003-identity-capabilities-and-team-preferences.md
+++ b/docs/architecture/adr-0003-identity-capabilities-and-team-preferences.md
@@ -1,0 +1,149 @@
+# ADR-0003: Identity, Capabilities, Preferences, and Access Gating
+
+**Status:** Accepted for planning  
+**Date:** 2026-05-21  
+**Related:** `docs/design/dashboard-v2-comprehensive-design.md`
+
+## Context
+
+Bicameral is local-first. Solo mode should not require a hosted login because the operating-system user boundary is the local trust boundary. Team mode currently uses Google Drive as the shared substrate, which means identity may come from Google OAuth or team config rather than a Bicameral-hosted account system.
+
+However, incoming team workflows require different visibility and action rights. Ratification, integration configuration, credential revocation, team settings, audit access, and destructive operations cannot all be available to every user once shared team workflows exist.
+
+## Decision
+
+Design the UI around an `IdentityContext` and capability-based access model.
+
+Solo mode:
+
+- No Bicameral login required.
+- User is treated as `local_owner`.
+- Trust boundary is `os_user`.
+
+Team mode:
+
+- User identity comes from Google Drive OAuth or team config.
+- Roles/capabilities may be stored in shared team metadata.
+- Capabilities are affected by team freshness state.
+
+Future hosted/shared deployment:
+
+- Requires real auth shim before privileged shared operations.
+- UI model should already support hosted/session identity.
+
+## Roles
+
+Initial roles:
+
+- `local_owner`
+- `viewer`
+- `reviewer`
+- `decision_owner`
+- `integrator`
+- `admin`
+
+## Capabilities
+
+Use capabilities for UI gating and backend enforcement.
+
+```ts
+type Capability =
+  | "local.read"
+  | "local.write"
+  | "team.read"
+  | "team.propose"
+  | "team.ratify"
+  | "team.reject"
+  | "team.supersede"
+  | "team.configure_integrations"
+  | "team.manage_access"
+  | "team.danger.reset"
+  | "credential.write"
+  | "credential.revoke"
+  | "audit.read"
+  | "audit.security.read"
+  | "diagnostics.read";
+```
+
+## Identity Context
+
+```ts
+type BicameralMode = "solo" | "team" | "hosted";
+
+type UserIdentity = {
+  id: string;
+  displayName?: string;
+  email?: string;
+  source: "local_os" | "config" | "google_drive" | "github" | "linear" | "jira" | "hosted_auth";
+  timezone: "system" | string;
+  locale: string;
+};
+
+type IdentityContext = {
+  mode: BicameralMode;
+  user: UserIdentity;
+  roles: string[];
+  capabilities: Capability[];
+  trustBoundary: "os_user" | "provider_oauth" | "team_server_auth" | "hosted_session";
+};
+```
+
+## Preference Classes
+
+Personal preferences are local and always editable:
+
+- Theme.
+- High contrast.
+- Reduced motion.
+- Density.
+- Font scale.
+- Timezone.
+- Locale/language.
+- Date/time format.
+- First day of week.
+
+Team preferences are shared and Drive-sync-sensitive:
+
+- Source scopes.
+- Integration modes.
+- Passive ingest settings.
+- Team folder configuration.
+- Role/capability map.
+- Audit retention defaults.
+- DLQ retention defaults.
+- Shared rate/size limits.
+
+## Rationale
+
+A full hosted login is unnecessary for solo mode and would undermine the local-first posture. But role/capability modeling is needed now so team workflows do not require a later UI rewrite.
+
+Capability-based design avoids hard-coding everything to role names. It also lets the UI distinguish these cases:
+
+- User lacks permission.
+- User has permission, but Drive sync is stale.
+- User has permission, but credentials are expired.
+- User has permission, but action is unavailable in solo mode.
+
+## Consequences
+
+Positive:
+
+- Keeps solo mode simple.
+- Supports Drive-backed team workflows.
+- Prepares for hosted/shared deployment.
+- Enables clear action-level explanations.
+
+Tradeoffs:
+
+- Requires backend enforcement, not just UI hiding.
+- Requires shared metadata for team role/capability mapping.
+- Requires careful UX copy to distinguish permission denial from freshness pause.
+
+## Acceptance Criteria
+
+- Solo mode does not require login.
+- Team mode can show current identity from Google Drive or config.
+- UI gates actions by capability and freshness state.
+- Permission denial and stale-state pause are visually and textually distinct.
+- Personal preferences remain local and editable offline.
+- Team preferences are editable only when team sync is current and capability permits.

--- a/docs/architecture/adr-0004-dashboard-v2-frontend-build-architecture.md
+++ b/docs/architecture/adr-0004-dashboard-v2-frontend-build-architecture.md
@@ -1,0 +1,82 @@
+# ADR-0004: Dashboard v2 Frontend Build Architecture
+
+**Status:** Accepted for planning
+**Date:** 2026-05-21
+**Related:** `docs/design/dashboard-v2-comprehensive-design.md`, `docs/architecture/adr-0001-dashboard-v2-information-architecture.md`
+
+## Context
+
+The current dashboard is a single hand-maintained file, `assets/dashboard.html`
+(~1,538 lines of HTML, CSS, and JavaScript), served verbatim by
+`dashboard/server.py`. There is no build step: the file *is* the source and the
+artifact.
+
+Dashboard v2 specifies an eight-view application — Pulse, Ledger, Ratification,
+Drift, Sources, Audit, Integrations, Settings — decomposed into roughly fifty
+components, with TypeScript data contracts (`IdentityContext`,
+`IntegrationConfigSummary`, `AccessibilityPreferences`, and others), five
+themes, and WCAG 2.2 AA compliance.
+
+A single hand-maintained file cannot carry that surface without becoming
+unmaintainable, and the design's TypeScript data contracts cannot be enforced
+without a TypeScript compiler.
+
+## Decision
+
+Adopt a real frontend build toolchain for Dashboard v2.
+
+- **Build tool:** Vite.
+- **Language:** TypeScript — the design's data contracts become compiler-
+  enforced types rather than documentation.
+- **Component framework:** a JSX-based, React-compatible framework (React or
+  Preact). The final pick is deferred to the Milestone 1 plan; the component
+  model is JSX and matches the design's component tree.
+- **Output contract:** Vite produces a static bundle. `dashboard/server.py`
+  continues to serve a built artifact — the server's HTTP contract (`GET /`,
+  `/history`, `/events`, `/pulse`) is unchanged; only the *source form* of the
+  bundle changes.
+- **Shipped artifact:** the built bundle is shipped, so end users never need a
+  Node toolchain. The zero-config "just run the server" path is preserved.
+- **On-demand, not a daemon:** the dashboard is launched when the user wants it
+  and is not required to run continuously. Agent and CLI output remain the
+  primary delivery channel (design principle 2.7); the build architecture must
+  not assume an always-on server.
+- **Ledger preservation:** the existing `assets/dashboard.html` behaviour is
+  ported into the new architecture as `LedgerView` (and `PulseView`, from
+  #437), preserving current functionality as ADR-0001 mandates.
+
+## Rationale
+
+Roughly fifty components in a single vanilla file is untenable. The design's
+TypeScript contracts need a compiler to be real. Vite is the standard
+low-configuration choice for a TypeScript SPA. Serving a pre-built static
+bundle keeps `dashboard/server.py`'s existing "serve a bundle" contract intact,
+so the migration is contained to the frontend source tree and does not touch
+the MCP server, the ledger, or the HTTP endpoints.
+
+## Consequences
+
+Positive:
+
+- A real component model, scalable to the eight-view surface.
+- Type-safe, compiler-enforced data contracts.
+- Theming and accessibility become tractable instead of hand-rolled.
+- The server contract and end-user run path are unchanged.
+
+Tradeoffs:
+
+- Introduces a Node toolchain into a Python-first repository.
+- CI must build the frontend; the build must be reproducible.
+- Contributors who modify the dashboard need Node installed.
+- The existing `assets/dashboard.html` must be ported, not merely extended.
+
+## Acceptance Criteria
+
+- A Vite + TypeScript project exists for the dashboard frontend.
+- `dashboard/server.py` serves the built bundle; `GET /`, `/history`,
+  `/events`, and `/pulse` behave exactly as before.
+- The existing Ledger view's behaviour is preserved after the port.
+- The Project Pulse view (#437) is preserved after the port.
+- CI builds the frontend and the build is reproducible.
+- End users do not need a Node toolchain to run the dashboard — the built
+  artifact is shipped.

--- a/docs/architecture/adr-0004-three-layer-pm-em-dev-conceptual-model.md
+++ b/docs/architecture/adr-0004-three-layer-pm-em-dev-conceptual-model.md
@@ -1,0 +1,148 @@
+# ADR-0004: Three-Layer PM / EM / Dev Conceptual Model
+
+**Status:** Accepted for planning  
+**Date:** 2026-05-21  
+**Related:** `docs/design/dashboard-v2-comprehensive-design.md`, `docs/design/dashboard-v2-conceptual-architecture-amendment.md`
+
+## Context
+
+The Dashboard v2 design already defines an application information architecture: Pulse, Ledger, Ratification, Drift, Sources, Audit, Integrations, and Settings.
+
+A newer conceptual architecture diagram introduces a stronger product model:
+
+> Bicameral is the walkie-talkie for software teams.
+
+The diagram frames Bicameral as coordination infrastructure across three owners:
+
+- PM / Product Owner.
+- EM / Engineering Manager.
+- Dev / Developer.
+
+It also introduces three layers:
+
+- Decision Ledger.
+- Dependency Layer.
+- Grounding Layer.
+
+This model is strong enough to influence the Dashboard v2 design, role model, copy, and product documentation.
+
+## Decision
+
+Adopt the three-layer PM / EM / Dev conceptual model as the product mental model beneath Dashboard v2.
+
+The application navigation remains unchanged for MVP:
+
+```text
+Pulse
+Ledger
+Ratification
+Drift
+Sources
+Audit
+Integrations
+Settings
+```
+
+The conceptual model informs these views rather than replacing them.
+
+## Three Layers
+
+### Decision Ledger
+
+Owner lens: PM / Product Owner.
+
+Purpose:
+
+- Human signoff.
+- Decision authority.
+- Proposed / ratified / rejected / superseded state.
+- Artifact compliance state such as ungrounded, reflected, drifted.
+
+Corrected ownership language:
+
+> PM owns ratification authority over product decisions. Bicameral owns the canonical ledger. Sources and agents may propose entries, but human signoff determines decision authority.
+
+### Dependency Layer
+
+Owner lens: EM / Engineering Manager.
+
+Purpose:
+
+- Blast-radius detection.
+- Scope creep detection.
+- Requirement gap routing.
+- Dependency graph or K-hop awareness.
+- Routing surfaced issues between PM and Dev.
+
+### Grounding Layer
+
+Owner lens: Dev / Developer.
+
+Purpose:
+
+- Code and artifact grounding.
+- File/symbol/commit/PR evidence.
+- IDE plugin input.
+- Agent-session capture.
+- Preventing hallucinated implementation context.
+
+## Relationship To Dashboard Views
+
+| View | Conceptual support |
+|---|---|
+| Pulse | Summarizes decision, dependency, grounding, and team freshness state. |
+| Ledger | Canonical decision record and Decision Ledger layer. |
+| Ratification | PM/Product Owner decision authority workflow. |
+| Drift | Grounding and dependency mismatch evidence. |
+| Sources | Feeds into all layers. |
+| Audit | Operational and security event trail. |
+| Integrations | Source and ratification surface configuration. |
+| Settings | Identity, sync, preferences, themes, accessibility, credentials, diagnostics. |
+
+A future `Dependency Map` view may be added when the underlying data can support reliable dependency routing, impact analysis, and owner handoff visualization.
+
+## Rationale
+
+The three-layer model makes Bicameral easier to understand:
+
+- PMs need to know what decisions require product authority.
+- EMs need to know where decisions create dependency or scope risk.
+- Developers need grounded evidence tied to real code and artifacts.
+
+This model also gives the product a clearer market position than a generic decision ledger.
+
+## Consequences
+
+Positive:
+
+- Stronger product story.
+- Clearer owner lenses.
+- Better mapping from integrations to user value.
+- Better framing for Pulse and Drift.
+- More memorable brand language.
+
+Tradeoffs:
+
+- Must avoid over-literal walkie-talkie UI language.
+- Must avoid implying PM exclusively owns every ledger entry.
+- Must overlay Google Drive freshness state so ideal flows are not confused with current team certainty.
+- May eventually require a dedicated Dependency Map view.
+
+## UI Rules
+
+1. Use the walkie-talkie metaphor for positioning, onboarding, and explainers, not literal dashboard interaction labels.
+2. Keep the dashboard operational and calm.
+3. Show PM, EM, and Dev owner lenses where they clarify responsibility.
+4. Keep Ledger as the canonical record.
+5. Add dependency/blast-radius data into Pulse and Drift before creating a top-level Dependency Map route.
+6. Always display team freshness state where shared decisions or routing are involved.
+
+## Acceptance Criteria
+
+- Design documentation includes the three-layer model.
+- Design documentation maps PM, EM, and Dev to owner lenses.
+- Pulse requirements include decision, dependency, grounding, and team freshness state.
+- Ledger requirements include fixed, domain-agnostic decision record language.
+- Drift requirements distinguish product intent drift, dependency/scope drift, and grounding/artifact drift.
+- Integration settings can identify owner lens: PM, EM, Dev, or shared.
+- Team Memory State overlays the model when Google Drive sync is stale/offline.

--- a/docs/architecture/adr-0005-dashboard-v2-frontend-build-architecture.md
+++ b/docs/architecture/adr-0005-dashboard-v2-frontend-build-architecture.md
@@ -1,8 +1,12 @@
-# ADR-0004: Dashboard v2 Frontend Build Architecture
+# ADR-0005: Dashboard v2 Frontend Build Architecture
 
 **Status:** Accepted for planning
 **Date:** 2026-05-21
 **Related:** `docs/design/dashboard-v2-comprehensive-design.md`, `docs/architecture/adr-0001-dashboard-v2-information-architecture.md`
+
+> Renumbered from ADR-0004 → ADR-0005 to resolve a numbering collision with
+> `adr-0004-three-layer-pm-em-dev-conceptual-model.md` (the design author's
+> deliberately-numbered conceptual-model ADR, pulled from the design fork).
 
 ## Context
 

--- a/docs/design/dashboard-v2-comprehensive-design.md
+++ b/docs/design/dashboard-v2-comprehensive-design.md
@@ -1,0 +1,844 @@
+# Bicameral Dashboard v2 Comprehensive Design Specification
+
+**Repository:** `Knapp-Kevin/bicameral-mcp`  
+**Product:** Bicameral MCP  
+**Document type:** Product design and implementation specification  
+**Status:** Ready for planning and phased implementation  
+**Date:** 2026-05-21
+
+## 1. Executive Summary
+
+Bicameral MCP already has a functional local dashboard and a strong product thesis: AI agents ship code fast, but they forget what teams agreed. The dashboard now needs to evolve from a raw operational ledger into a product-grade decision operations surface.
+
+Dashboard v2 must preserve the existing ledger view, but reposition it as the **Ledger**: the canonical decision history and audit surface. The new default landing experience should be **Project Pulse**, a summary and triage view that makes Bicameral feel like the project memory is awake before confusion becomes expensive.
+
+The product must also support an expanding integrations roadmap: Linear, Jira, Notion, GitHub, Slack, Google Drive, local folders, and future providers. These integrations require a settings and configuration system that handles active/passive ingest modes, source scopes, credentials, audit trails, freshness, dead-letter queue visibility, privacy controls, and failure states.
+
+Team mode currently flows through a Google Drive file-share substrate. That means the UI must not pretend to be a real-time team server. It must clearly distinguish:
+
+1. Local knowledge.
+2. Last confirmed shared team knowledge.
+3. Potentially stale team awareness while disconnected from Google Drive.
+
+The design target is a local-first, team-aware, Drive-synchronized product that remains useful offline while honestly marking shared state as stale when appropriate.
+
+## 2. Product Principles
+
+### 2.1 Local-first continuity
+
+Bicameral must remain useful when disconnected. Local Project Pulse, Ledger, drift checks, local proposed decisions, diagnostics, and personal preferences should remain available without Google Drive.
+
+### 2.2 Team-awareness without false certainty
+
+When Google Drive is disconnected or stale, the UI must not imply shared team certainty. Team-affecting actions should either be queued locally or paused, depending on risk.
+
+### 2.3 Two-chamber product model
+
+Bicameral should visually and conceptually express its name.
+
+- **Intent Chamber:** decisions, requirements, PRDs, meetings, Slack threads, Jira/Linear tickets, open questions, and ratification.
+- **Execution Chamber:** code changes, commits, pull requests, agent actions, implementation evidence, and drift.
+- **Bicameral Bridge:** MCP preflight, decision ledger, active/passive ingest, ratification, sync, and drift detection.
+
+### 2.4 Ledger preservation
+
+The current ledger-oriented view is valuable and must not be discarded. It should become the dedicated **Ledger** view.
+
+### 2.5 Settings as product infrastructure
+
+Settings are not a later polish pass. Incoming integrations make settings, scopes, credentials, team sync, auditability, themes, and accessibility foundational.
+
+### 2.6 Accessibility by default
+
+WCAG accessibility must be designed into the first version of Dashboard v2. It cannot be bolted on later without turning the UI into a haunted checkbox museum.
+
+## 3. Primary Navigation Model
+
+Dashboard v2 should use this core navigation structure.
+
+| View | Purpose |
+|---|---|
+| Pulse | Default landing view for health, attention, freshness, recent learning, and suggested next action. |
+| Ledger | Canonical decision record, retaining the current detailed grouped decision UI. |
+| Ratification | Product-owner and decision-owner workflow for approving, rejecting, or superseding proposed decisions. |
+| Drift | Implementation mismatch view with evidence, affected files, symbols, commits, and next actions. |
+| Sources | Source ingest visibility by connector, source group, and capture channel. |
+| Audit | Operational and security audit trail, including source ingest attempts, auth events, refusals, and DLQ summaries. |
+| Integrations | Connection and configuration center for Linear, Jira, Notion, GitHub, Slack, Google Drive, and future sources. |
+| Settings | Profile, team sync, themes, accessibility, privacy, diagnostics, and advanced controls. |
+
+A compact sidebar is recommended for desktop. Mobile/tablet can collapse into a top-level menu with persistent sync status.
+
+## 4. Information Architecture
+
+### 4.1 Pulse
+
+Project Pulse is the landing experience. It answers:
+
+- Is project memory current?
+- What needs attention?
+- What did Bicameral recently learn?
+- Where is drift or implementation risk?
+- What should the user do next?
+- Is team awareness fresh, stale, offline, or conflicted?
+
+Recommended layout:
+
+1. Dashboard header.
+2. Team Sync status and freshness banner if needed.
+3. Two-Chamber Overview.
+4. Project Pulse summary.
+5. Needs Attention queue.
+6. Recently Learned queue.
+7. Suggested Next Move.
+8. Short activity timeline.
+9. Links into Ledger, Ratification, Drift, Sources, and Audit.
+
+### 4.2 Ledger
+
+The Ledger is the canonical decision record. It retains the existing ledger view and makes it intentional.
+
+Ledger answers:
+
+- What decisions exist?
+- What source did they come from?
+- What is their status?
+- Which decisions are ratified, proposed, rejected, superseded, reflected, or drifted?
+- Which feature/source group do they belong to?
+- What code references or commits are linked?
+
+Recommended Ledger subtitle:
+
+> Complete decision history, source groups, ratification state, implementation linkage, and drift indicators.
+
+Ledger must be available while offline or stale, with a visible freshness warning:
+
+> Ledger is showing local state plus the last confirmed team sync. Team updates may be missing until Google Drive reconnects.
+
+### 4.3 Ratification
+
+Ratification is the decision workflow surface. It must support PM-accessible approval and reject/supersede actions without requiring users to live inside Claude Code.
+
+Ratification items should show:
+
+- Decision statement.
+- Source evidence.
+- Source type and source reference.
+- Feature area.
+- Risk level.
+- Related code references.
+- Related decisions and supersession candidates.
+- Signer/actor metadata.
+- Current team freshness state.
+- Allowed actions.
+
+Actions:
+
+- Ratify.
+- Reject.
+- Request changes.
+- Supersede.
+- Open full context.
+- Copy source reference.
+
+### 4.4 Drift
+
+Drift is the implementation mismatch view.
+
+Drift items should show:
+
+- Original decision.
+- Expected behavior.
+- Observed implementation behavior.
+- Evidence location.
+- File, symbol, line range, commit, or PR.
+- Severity or level.
+- Suggested next action.
+- Whether the team ledger is current.
+
+Actions:
+
+- Open evidence.
+- Mark reviewed.
+- Create follow-up proposal.
+- Supersede decision.
+- Re-run drift check.
+
+### 4.5 Sources
+
+Sources provide ingest visibility and source-group history.
+
+Source categories:
+
+- Issue Trackers: Linear, Jira.
+- Documentation: Notion, Google Drive.
+- Communication: Slack.
+- Source Control: GitHub.
+- Local and Advanced: Local folder, transcript directory, manual paste.
+
+Each source group should show:
+
+- Source name.
+- Status.
+- Last checked.
+- Last accepted ingest.
+- Last refused ingest.
+- Active/passive mode.
+- Scope summary.
+- Decisions created.
+- Pending proposals.
+- Drifted decisions.
+- Audit link.
+
+### 4.6 Audit
+
+Audit is not the same as Ledger.
+
+Ledger is the product decision record. Audit is the operational/security event trail.
+
+Audit should include:
+
+- Source ingest attempts.
+- Source ingest accepted/refused.
+- Source auth granted/revoked.
+- Soft-gate WARN + DLQ events.
+- Hard-gate security refusals.
+- Team sync events.
+- Credential changes.
+- Configuration changes.
+- Ratification actions.
+- Reset/replay events.
+
+Audit must be filterable by source, event type, severity, actor, time range, and disposition.
+
+## 5. Dashboard Header
+
+The header must expose product identity, project context, and freshness.
+
+Required elements:
+
+- Bicameral wordmark/logo.
+- Current repository or project name.
+- Mode indicator: Solo or Team.
+- Team Sync pill.
+- Source freshness summary.
+- Active user identity, if available.
+- Settings entry point.
+- Theme-aware visual design.
+
+Example header states:
+
+- `Team Sync: Current`
+- `Team Sync: Stale`
+- `Team Sync: Offline`
+- `Team Sync: Auth Needed`
+- `Team Sync: Conflict`
+
+Clicking the Team Sync pill should open Team Sync detail.
+
+## 6. Team Sync and Google Drive Freshness
+
+### 6.1 Current team substrate
+
+All team functions currently flow through Google Drive file share. The UI must treat Drive as the shared event substrate, not as a real-time server.
+
+### 6.2 Team sync states
+
+```ts
+type TeamSyncState =
+  | "solo"
+  | "team_connected"
+  | "team_syncing"
+  | "team_stale"
+  | "team_offline"
+  | "team_auth_expired"
+  | "team_conflict"
+  | "team_read_only_fallback";
+```
+
+User-facing copy:
+
+| State | Copy |
+|---|---|
+| team_connected | Team memory is current. |
+| team_syncing | Checking Google Drive for team updates. |
+| team_stale | Local memory is usable, but team updates have not been confirmed since the last sync. |
+| team_offline | Google Drive is unavailable. Bicameral is using local memory until reconnect. |
+| team_auth_expired | Google Drive access needs to be refreshed before team updates can sync. |
+| team_conflict | Two or more team events need reconciliation. |
+| team_read_only_fallback | Team state is stale. Review is available, but team-affecting actions are paused. |
+
+### 6.3 Freshness Boundary
+
+Introduce **Freshness Boundary** as a visible concept.
+
+Recommended copy:
+
+> Bicameral can keep working locally, but it must not imply team certainty until Google Drive sync is current.
+
+Freshness card fields:
+
+- Team backend: Google Drive.
+- Last confirmed sync.
+- Local queued events.
+- Remote freshness state.
+- Last error.
+- Manual sync button.
+- Reconnect Google Drive button.
+
+### 6.4 Offline and stale behavior
+
+Safe while offline or stale:
+
+- View local Pulse.
+- View Ledger.
+- View previously synced decisions.
+- Run local drift checks.
+- View local audit.
+- Change personal preferences.
+- Draft proposed decisions locally.
+- Run preflight against local state with stale warning.
+
+Allowed offline but queued:
+
+- Create local proposed decisions.
+- Add local notes.
+- Capture local ingest.
+- Create pending ratification proposals.
+- Create local audit entries.
+
+Paused while stale/offline:
+
+- Final shared ratification.
+- Reject or supersede shared decisions.
+- Team integration scope changes.
+- Shared credential changes.
+- Team access changes.
+- Reset/replay shared ledger state.
+- Conflict resolution.
+
+## 7. Integrations and Sources
+
+### 7.1 Integration Center
+
+Integrations must be managed through a unified configuration center.
+
+Each integration card should include:
+
+- Name.
+- Category.
+- Connection status.
+- Active/passive mode.
+- Scope summary.
+- Credential status.
+- Last checked.
+- Last accepted ingest.
+- Last error.
+- Configure action.
+- Test connection action.
+- Audit action.
+- Revoke or disconnect action where allowed.
+
+### 7.2 Required source categories
+
+```text
+Sources
+  Issue Trackers
+    Linear
+    Jira
+
+  Documentation
+    Notion
+    Google Drive
+
+  Communication
+    Slack
+
+  Source Control
+    GitHub
+
+  Local / Advanced
+    Local Folder
+    Transcript Directory
+    Manual Paste
+```
+
+### 7.3 Source freshness vs team freshness
+
+Source freshness and team ledger freshness are different.
+
+Example:
+
+- Jira source freshness: `connected, last checked 2 minutes ago`.
+- Team ledger freshness: `stale, Google Drive last confirmed 1 hour ago`.
+
+The UI must not collapse these states.
+
+```ts
+type SourceFreshness = {
+  sourceId: string;
+  status: "connected" | "syncing" | "stale" | "offline" | "auth_expired" | "misconfigured";
+  lastCheckedAt?: string;
+  lastIngestedAt?: string;
+  lastError?: string;
+};
+
+type TeamLedgerFreshness = {
+  backend: "google_drive";
+  status: "current" | "syncing" | "stale" | "offline" | "auth_expired" | "conflict";
+  lastConfirmedAt?: string;
+  queuedLocalEvents: number;
+};
+```
+
+### 7.4 Jira design requirements
+
+Jira is now a first-class source.
+
+Jira supports:
+
+- Active ingest by issue URL or key.
+- Passive ingest by project, issue type, status transition, label, component, or JQL.
+- Comment capture.
+- Transition capture.
+- Linked PR capture.
+- Optional ratification command surface.
+
+Jira integration settings:
+
+```text
+Connection
+  Jira site URL
+  Auth method
+  Connected account
+  Test connection
+  Revoke credentials
+
+Scope
+  Projects
+  Issue types
+  Components
+  Labels
+  Status transitions
+  Advanced JQL
+
+Ingest Behavior
+  Active ingest
+  Passive ingest
+  Comment capture
+  Transition capture
+  Linked PR capture
+
+Ratification
+  Enable @bicameral commands
+  Allowed actions: ratify, reject, request changes, supersede
+  Identity mapping required
+  Unknown actor behavior: capture as proposal, do not finalize
+
+Audit
+  Last pull
+  Last accepted ingest
+  Last refused ingest
+  Last auth event
+  View source audit
+```
+
+JQL should be hidden under Advanced. Basic project/label/status controls should be the default.
+
+### 7.5 Linear and Jira shared pattern
+
+Do not design separate one-off UIs for Linear and Jira. Design an **Issue Tracker Source** pattern and instantiate both.
+
+Shared fields:
+
+- Workspace/site.
+- Project/team.
+- Issue type.
+- Labels/components.
+- Status transitions.
+- Comment capture.
+- Linked implementation references.
+- Ratification command configuration.
+- Active/passive mode.
+
+## 8. Settings
+
+### 8.1 Settings sections
+
+Settings should include:
+
+1. Profile and Preferences.
+2. Workspace / Project.
+3. Team Sync.
+4. Integrations.
+5. Source Scopes.
+6. Ratification Surfaces.
+7. Automation and Hooks.
+8. Privacy and Telemetry.
+9. Themes.
+10. Accessibility.
+11. Diagnostics.
+12. Advanced / Danger Zone.
+
+### 8.2 Profile and preferences
+
+Personal preferences are local and always editable.
+
+Required fields:
+
+- Display name.
+- Email, optional unless team identity requires it.
+- Timezone: system or fixed timezone.
+- Locale/language.
+- Date/time format.
+- First day of week.
+- Theme.
+- Density.
+- Font scale.
+- Reduced motion.
+- High contrast.
+
+Timezone must be implemented early because audit, ratification, source ingest, and Drive sync are time-sensitive. Store audit timestamps in UTC. Display them using the user's selected timezone.
+
+### 8.3 Team preferences
+
+Team preferences are Drive-backed and sync-sensitive.
+
+Examples:
+
+- Shared source scopes.
+- Shared integration modes.
+- Shared passive ingest settings.
+- Team folder config.
+- Role/capability mapping.
+- Shared audit retention policy.
+- DLQ retention defaults.
+- Shared rate/size limits.
+
+Team preferences should be editable only when Drive is connected and current.
+
+## 9. Identity, Roles, and Capabilities
+
+### 9.1 No full login for solo mode
+
+Solo mode should not require a Bicameral login. The trust boundary is the local OS user account.
+
+### 9.2 Team mode identity
+
+Team mode identity should come from Google Drive OAuth or explicit team config. The UI should show the current identity, but it should not imply Bicameral-hosted account authority.
+
+### 9.3 Hosted/shared future
+
+If hosted/shared deployment exists later, a real auth shim is required. The UI should be designed around identity context and capabilities so this future path does not require a rewrite.
+
+### 9.4 Roles
+
+Recommended roles:
+
+- Local Owner.
+- Viewer.
+- Reviewer.
+- Decision Owner.
+- Integrator.
+- Admin.
+
+### 9.5 Capabilities
+
+Use capabilities under the hood. The UI should check capabilities and the backend must enforce them.
+
+```ts
+type Capability =
+  | "local.read"
+  | "local.write"
+  | "team.read"
+  | "team.propose"
+  | "team.ratify"
+  | "team.reject"
+  | "team.supersede"
+  | "team.configure_integrations"
+  | "team.manage_access"
+  | "team.danger.reset"
+  | "credential.write"
+  | "credential.revoke"
+  | "audit.read"
+  | "audit.security.read"
+  | "diagnostics.read";
+```
+
+Capabilities should be conditional on team freshness.
+
+Example:
+
+> Ratification paused until team memory is current.
+
+This is different from:
+
+> You do not have permission.
+
+The UI must distinguish temporary freshness constraints from actual permission denial.
+
+## 10. Themes
+
+### 10.1 Minimum themes
+
+Required:
+
+- System.
+- Light.
+- Dark.
+- High contrast light.
+- High contrast dark.
+
+Optional branded themes:
+
+- Ledger Parchment.
+- Deep Navy.
+- Terminal Minimal.
+
+### 10.2 Theme controls
+
+- Theme mode.
+- Density: comfortable / compact.
+- Font scale: default / large / extra large.
+- Reduced motion.
+- Monochrome status indicators.
+
+### 10.3 Theme persistence
+
+Theme and accessibility preferences should persist locally and must not depend on Google Drive.
+
+## 11. Accessibility Requirements
+
+Target WCAG 2.2 AA.
+
+Requirements:
+
+- Status must not rely on color alone.
+- All status chips require visible text labels.
+- Keyboard access for all controls.
+- Clear focus states.
+- Dialogs/drawers must trap and restore focus.
+- Forms need explicit labels.
+- Errors must be text-described.
+- Tables/lists must preserve semantic structure.
+- UI must remain usable at 125%, 150%, and 200% zoom.
+- Reduced motion must disable nonessential animation.
+- High contrast themes must meet AA and aim for AAA where practical.
+
+## 12. Component Architecture
+
+Suggested component decomposition:
+
+```text
+DashboardApp
+  AppShell
+    SidebarNav
+    DashboardHeader
+    TeamSyncStatusPill
+    SourceFreshnessSummary
+  PulseView
+    ChamberOverview
+    ProjectPulseCard
+    NeedsAttentionQueue
+    RecentlyLearnedQueue
+    SuggestedNextMoveCard
+    ActivityTimeline
+  LedgerView
+    LedgerFilters
+    LedgerGroupList
+    LedgerDecisionRow
+    LedgerDecisionDetailDrawer
+  RatificationView
+    RatificationQueue
+    RatificationDecisionCard
+    RatificationDetailDrawer
+  DriftView
+    DriftSummary
+    DriftEvidenceCard
+    DriftDetailDrawer
+  SourcesView
+    SourceCategoryGroup
+    SourceStatusCard
+    SourceDetailDrawer
+  AuditView
+    AuditFilters
+    AuditEventTable
+    DlqSummaryPanel
+  IntegrationsView
+    IntegrationCategoryGroup
+    IntegrationCard
+    IntegrationDetailDrawer
+    ConnectionTestResult
+  SettingsView
+    ProfileSettingsPanel
+    WorkspaceSettingsPanel
+    TeamSyncSettingsPanel
+    ThemeSettingsPanel
+    AccessibilitySettingsPanel
+    PrivacyTelemetryPanel
+    DiagnosticsPanel
+    AdvancedDangerZone
+```
+
+## 13. Data Contracts
+
+### 13.1 Identity context
+
+```ts
+type BicameralMode = "solo" | "team" | "hosted";
+
+type UserIdentity = {
+  id: string;
+  displayName?: string;
+  email?: string;
+  source: "local_os" | "config" | "google_drive" | "github" | "linear" | "jira" | "hosted_auth";
+  timezone: "system" | string;
+  locale: string;
+};
+
+type IdentityContext = {
+  mode: BicameralMode;
+  user: UserIdentity;
+  roles: string[];
+  capabilities: Capability[];
+  trustBoundary: "os_user" | "provider_oauth" | "team_server_auth" | "hosted_session";
+};
+```
+
+### 13.2 Integration config summary
+
+```ts
+type IntegrationStatus =
+  | "connected"
+  | "not_connected"
+  | "misconfigured"
+  | "pending"
+  | "coming_soon"
+  | "auth_expired";
+
+type IntegrationConfigSummary = {
+  id: string;
+  name: string;
+  category: string;
+  status: IntegrationStatus;
+  description: string;
+  localFirst: boolean;
+  requiresCredentials: boolean;
+  supportsActiveIngest: boolean;
+  supportsPassiveIngest: boolean;
+  supportsRatificationSurface: boolean;
+  lastCheckAt?: string;
+  lastIngestedAt?: string;
+  lastError?: string;
+};
+```
+
+### 13.3 Accessibility preferences
+
+```ts
+type DensityMode = "comfortable" | "compact";
+
+type AccessibilityPreferences = {
+  reducedMotion: boolean;
+  highContrast: boolean;
+  fontScale: "default" | "large" | "extra_large";
+  density: DensityMode;
+  strongFocusRing: boolean;
+  monochromeStatusIndicators: boolean;
+};
+```
+
+## 14. Implementation Milestones
+
+### Milestone 1: Information architecture and navigation
+
+- Add navigation model.
+- Rename current dashboard/history table view to Ledger.
+- Preserve existing Ledger functionality.
+- Add Pulse as default landing view.
+- Add Team Sync status pill.
+
+### Milestone 2: Pulse visual redesign
+
+- Add two-chamber overview.
+- Improve Project Pulse hierarchy.
+- Add stale/offline freshness warnings.
+- Add activity timeline and next action cards.
+
+### Milestone 3: Ratification and Drift surfaces
+
+- Build Ratification view.
+- Build Drift view.
+- Add decision detail drawers.
+- Add capability and freshness-based disabled states.
+
+### Milestone 4: Integrations and Sources
+
+- Build Integration Center.
+- Add source categories.
+- Add Linear and Jira as Issue Tracker sources.
+- Add Notion, GitHub, Slack, Google Drive, local folder, and transcript directory placeholders or active configs as appropriate.
+- Add source freshness separation from team freshness.
+
+### Milestone 5: Settings, themes, and accessibility
+
+- Add Settings shell.
+- Add profile/preferences.
+- Add light/dark/system/high-contrast themes.
+- Add timezone/locale scaffolding.
+- Add accessibility preferences.
+- Persist preferences locally.
+
+### Milestone 6: Audit and diagnostics
+
+- Add Audit view.
+- Add DLQ summary visibility.
+- Add diagnostics view.
+- Add smoke test status, MCP registration status, hook status, sync status, and config parse status.
+
+### Milestone 7: WCAG and visual QA
+
+- Keyboard pass.
+- Screen reader label pass.
+- Focus management pass.
+- Contrast audit.
+- Zoom testing.
+- Reduced motion verification.
+- Stale/offline state review.
+
+## 15. Acceptance Criteria
+
+Dashboard v2 is complete when:
+
+1. Project Pulse is the default landing view.
+2. The existing detailed decision UI remains available as Ledger.
+3. Ledger clearly describes itself as the canonical decision record.
+4. Team Sync state is globally visible.
+5. Stale/offline Drive state clearly distinguishes local continuity from shared team certainty.
+6. Ratification has a dedicated workflow surface.
+7. Drift has a dedicated evidence surface.
+8. Sources and integrations are separated but connected.
+9. Jira is represented as a first-class source alongside Linear.
+10. Integration settings support active/passive modes, scopes, auth state, test connection, revoke, and audit.
+11. Source freshness and team ledger freshness are not collapsed.
+12. Personal preferences include theme, timezone, locale/language scaffold, density, font scale, and accessibility controls.
+13. Light, dark, system, high-contrast light, and high-contrast dark themes exist.
+14. WCAG 2.2 AA requirements are tested and documented.
+15. Role/capability and freshness constraints are represented in the UI.
+16. No team-affecting action silently succeeds while Drive state is stale or offline.
+17. Local-first behavior remains useful when disconnected.
+
+## 16. Non-Goals
+
+- Full Bicameral-hosted login for solo mode.
+- Enterprise RBAC in the first implementation slice.
+- Replacing the existing Ledger view.
+- Building a real-time team server UI before backend support exists.
+- Treating Google Drive sync as equivalent to live shared state.
+- Requiring cloud services for local dashboard use.
+
+## 17. Final Design Thesis
+
+Bicameral Dashboard v2 should feel like a calm project memory system, not a raw event table. It should show what the team decided, what the code now reflects, what needs human judgment, and whether shared team memory is current.
+
+The UI should preserve Bicameral's local-first posture while giving teams enough structure to trust it during real work.

--- a/docs/design/dashboard-v2-comprehensive-design.md
+++ b/docs/design/dashboard-v2-comprehensive-design.md
@@ -52,6 +52,10 @@ Settings are not a later polish pass. Incoming integrations make settings, scope
 
 WCAG accessibility must be designed into the first version of Dashboard v2. It cannot be bolted on later without turning the UI into a haunted checkbox museum.
 
+### 2.7 CLI-first delivery, on-demand UI
+
+The web dashboard is a significant product surface, but it is not the primary delivery channel and it is not required to run continuously. Direct agent and CLI output — MCP tool responses, the `brief` command, and the session-start brief — remain the prioritized path for delivering project memory to the user. The dashboard is a rich, on-demand view opened when the user wants depth; Bicameral must remain fully usable with the dashboard closed.
+
 ## 3. Primary Navigation Model
 
 Dashboard v2 should use this core navigation structure.

--- a/docs/design/dashboard-v2-conceptual-architecture-amendment.md
+++ b/docs/design/dashboard-v2-conceptual-architecture-amendment.md
@@ -1,0 +1,390 @@
+# Dashboard v2 Conceptual Architecture Amendment
+
+**Repository:** `Knapp-Kevin/bicameral-mcp`  
+**Product:** Bicameral MCP  
+**Parent document:** `docs/design/dashboard-v2-comprehensive-design.md`  
+**Status:** Accepted for planning  
+**Date:** 2026-05-21
+
+## 1. Purpose
+
+This amendment adds the stronger product mental model introduced by the latest architecture diagram:
+
+> Bicameral is the walkie-talkie for software teams.
+
+That phrase should not replace the Dashboard v2 application architecture. It should clarify the product story behind it.
+
+The dashboard still needs Pulse, Ledger, Ratification, Drift, Sources, Audit, Integrations, and Settings. This amendment defines the conceptual layer model and role-ownership model that should guide those views.
+
+In plainer terms: this document prevents the UI from becoming either a raw ledger table or a cute diagram with no controls. Two ways to lose, because software design apparently enjoys variety.
+
+## 2. Product Mental Model
+
+The new product metaphor is:
+
+> Bicameral keeps PM, EM, and Dev in sync when decisions move faster than the codebase.
+
+The dashboard should express this model through three layers and three owner roles.
+
+### 2.1 Three layers
+
+| Layer | Ownership | Purpose | Product meaning |
+|---|---|---|---|
+| Decision Ledger | PM / Product Owner | Human signoff, decision state, compliance artifact state | What was decided and whether it is ratified. |
+| Dependency Layer | EM / Engineering Manager | Blast-radius detection, scope creep detection, routing, dependency awareness | Who or what is affected by a decision or drift. |
+| Grounding Layer | Dev / Developer | Code and artifact grounding, implementation evidence, IDE/plugin/session input | Whether the implementation is tied to real artifacts rather than model imagination. |
+
+### 2.2 Owner roles
+
+The diagram introduces a more product-specific role model than generic RBAC labels.
+
+#### PM / Product Owner
+
+Owns:
+
+- Decision authority.
+- Ratification.
+- Rejection.
+- Supersession.
+- Requirements gaps.
+- Product source evidence.
+
+Does not exclusively own every ledger entry. Sources, agents, developers, and integrations may propose ledger entries. PM owns final decision authority for product-relevant decisions.
+
+#### EM / Engineering Manager
+
+Owns:
+
+- Dependency routing.
+- Blast-radius review.
+- Scope creep detection.
+- Cross-team visibility.
+- Risk routing between PM and Dev.
+- Determining whether a surfaced issue needs product clarification or technical investigation.
+
+#### Dev / Developer
+
+Owns:
+
+- Grounding evidence.
+- Affected files.
+- Symbols.
+- Commits.
+- Pull requests.
+- IDE/plugin input.
+- Implementation context.
+
+## 3. Corrected Ownership Language
+
+Do not say:
+
+> PM owns the ledger.
+
+That is too broad.
+
+Use:
+
+> PM owns ratification authority over product decisions. Bicameral owns the canonical ledger. Sources and agents may propose entries, but human signoff determines decision authority.
+
+Do not say:
+
+> Dev owns drift.
+
+Use:
+
+> Dev owns implementation evidence and grounding. Drift is a system-detected mismatch that may route to PM, EM, or Dev depending on whether the issue is product intent, dependency impact, or artifact grounding.
+
+Do not say:
+
+> EM owns all routing.
+
+Use:
+
+> EM owns dependency and blast-radius routing where cross-team or scope-impact decisions need management attention.
+
+## 4. Relationship To Existing Dashboard IA
+
+The existing Dashboard v2 IA remains valid. The conceptual model should map into it as follows.
+
+| Application View | Conceptual Layer Support |
+|---|---|
+| Pulse | Summary across Decision Ledger, Dependency Layer, Grounding Layer, and Team Freshness. |
+| Ledger | Decision Ledger layer. Canonical record of proposed, ratified, rejected, superseded, reflected, drifted, and ungrounded decisions. |
+| Ratification | PM / Product Owner decision authority workflow. |
+| Drift | Grounding and dependency mismatch evidence. |
+| Dependency Map | Future or embedded view for blast-radius and scope-creep routing. |
+| Sources | Feeds into all three layers. |
+| Audit | Operational and security event trail across layers. |
+| Integrations | Configuration for incoming feeds and ratification surfaces. |
+| Settings | Identity, team sync, preferences, accessibility, themes, credentials, and diagnostics. |
+
+## 5. Navigation Amendment
+
+The current recommended navigation remains:
+
+```text
+Pulse
+Ledger
+Ratification
+Drift
+Sources
+Audit
+Integrations
+Settings
+```
+
+This amendment adds one future candidate:
+
+```text
+Dependency Map
+```
+
+### 5.1 MVP treatment
+
+For the first implementation, do not add Dependency Map as a required top-level route unless the underlying data already supports it.
+
+Instead:
+
+- Include dependency/blast-radius cards inside Pulse.
+- Include dependency evidence inside Drift.
+- Include owner routing inside Ratification and Decision Detail.
+
+### 5.2 Later treatment
+
+Add `Dependency Map` as a top-level view when Bicameral can reliably show:
+
+- Decision-to-file impact.
+- Decision-to-team impact.
+- Decision-to-feature impact.
+- Scope creep signals.
+- Routing recommendations.
+- PM/EM/Dev owner handoffs.
+- K-hop dependency graph or equivalent dependency reasoning.
+
+## 6. Pulse Amendments
+
+Project Pulse should summarize the three-layer model.
+
+Recommended Pulse sections:
+
+1. **Team Memory State**
+   - Google Drive freshness.
+   - Local queue.
+   - Shared actions enabled/paused.
+
+2. **Decision Ledger Health**
+   - Proposed.
+   - Ratified.
+   - Rejected.
+   - Superseded.
+   - Ungrounded.
+   - Reflected.
+   - Drifted.
+
+3. **Dependency Pulse**
+   - Scope creep signals.
+   - Blast-radius warnings.
+   - Affected features or owners.
+   - EM-routed issues.
+
+4. **Grounding Pulse**
+   - Code/artifact links.
+   - Drift evidence.
+   - Ungrounded decisions.
+   - IDE/plugin/session sources.
+
+5. **Suggested Next Move**
+   - Review ratification.
+   - Inspect drift.
+   - Explain scope creep.
+   - Explore technical constraints.
+   - Reconnect Drive.
+
+## 7. Ledger Amendments
+
+The Ledger view should explicitly reflect the Decision Ledger layer from the diagram.
+
+Recommended Ledger description:
+
+> The Ledger is Bicameral's fixed, domain-agnostic decision record. It tracks human signoff and artifact compliance state across proposed, ratified, rejected, ungrounded, reflected, drifted, and superseded decisions.
+
+Ledger filters should include:
+
+- Signoff state: proposed, ratified, rejected, superseded.
+- Artifact state: ungrounded, reflected, drifted.
+- Source: Slack, PRD, transcript, Jira, Linear, GitHub, Notion, Google Drive, manual.
+- Owner lens: PM, EM, Dev, unassigned.
+- Level: L1/L2/L3.
+- Freshness: local-only, synced, queued, stale.
+
+## 8. Ratification Amendments
+
+Ratification should be framed as PM/Product Owner authority, while still allowing EM/Dev context.
+
+Decision cards should show:
+
+- Decision text.
+- Proposed source.
+- Required owner: PM, EM, Dev, or shared.
+- Why the owner is required.
+- Related dependency impact.
+- Related grounding evidence.
+- Team freshness state.
+- Actions available by capability and freshness.
+
+Recommended owner-action copy:
+
+- PM: `Ratify product intent`.
+- EM: `Route dependency impact`.
+- Dev: `Add grounding evidence`.
+
+## 9. Drift and Dependency Amendments
+
+Drift should not be only a code mismatch list. It should show whether the issue is:
+
+1. Product intent drift.
+2. Dependency/scope drift.
+3. Grounding/artifact drift.
+
+Recommended labels:
+
+- `Requirement gap surfaced`.
+- `Scope creep surfaced`.
+- `Implementation drift surfaced`.
+- `Grounding missing`.
+- `Artifact changed`.
+- `Router action required`.
+
+Each drift card should include:
+
+- Origin layer.
+- Destination owner.
+- Why the route was selected.
+- Evidence.
+- Suggested next action.
+
+## 10. Sources and Integrations Amendments
+
+The diagram groups incoming information as PM integrations and Dev integrations. The app should preserve the broader source category model while adding owner lens metadata.
+
+### 10.1 PM-facing sources
+
+Examples:
+
+- Transcript.
+- Slack / PRD.
+- Jira.
+- Linear.
+- Notion.
+- Google Drive Docs.
+
+### 10.2 Dev-facing sources
+
+Examples:
+
+- Agent session.
+- Git commit.
+- IDE plugin.
+- GitHub PR.
+- Local files.
+- Artifact locator / code grounding.
+
+### 10.3 EM-facing signals
+
+Examples:
+
+- Scope creep detection.
+- Blast-radius dependency graph.
+- Requirement gap surfaced.
+- Drift surfaced.
+- Router ownership.
+
+Integration configuration should support this owner lens:
+
+```ts
+type SourceOwnerLens = "pm" | "em" | "dev" | "shared";
+```
+
+## 11. Team Sync Overlay Requirement
+
+The diagram shows ideal active flows. The real product currently uses Google Drive as the team file-share substrate.
+
+Every layer must be overlaid with team freshness state.
+
+Required Team Memory State ribbon/card:
+
+```text
+Team Memory State
+Google Drive: current / stale / offline / auth needed / conflict
+Local queue: N events
+Shared actions: enabled / paused
+Last confirmed team sync: timestamp
+```
+
+When stale/offline:
+
+- Decision Ledger remains viewable from local state.
+- Dependency routing must be marked as local/stale if remote updates may be missing.
+- Grounding evidence remains locally useful.
+- Shared ratification is paused until Drive is current.
+- Local proposals may queue.
+
+## 12. Brand and Marketing Guidance
+
+`The Walkie-Talkie for Software Teams` is a strong product metaphor for external-facing material.
+
+Best uses:
+
+- Website hero.
+- README positioning.
+- Product onboarding.
+- Empty states.
+- Explainer diagrams.
+- Pitch deck.
+
+Use sparingly inside the dashboard.
+
+Good dashboard copy:
+
+> Bicameral keeps PM, EM, and Dev aligned when decisions move faster than the codebase.
+
+Avoid dashboard copy like:
+
+> Walkie-Talkie status: transmitting.
+
+The product should feel calm and operational, not like a toy radio got promoted to CTO.
+
+## 13. Accessibility and Diagram Translation
+
+If the conceptual diagram becomes part of the app or docs site, it must have a text equivalent.
+
+Required accessible description:
+
+> Bicameral has three layers. The Decision Ledger records human signoff and artifact compliance states. The Dependency Layer detects blast radius and scope creep, routing surfaced gaps through the EM. The Grounding Layer links implementation artifacts and code evidence through developer-owned integrations. PM integrations feed decisions into the ledger, Dev integrations feed grounding evidence into the grounding layer, and the EM router coordinates requirement gaps and drift between the two sides.
+
+Do not rely on arrows, colors, or layout alone.
+
+## 14. Acceptance Criteria Amendments
+
+Add these to the Dashboard v2 acceptance criteria:
+
+1. The UI or documentation includes the three-layer conceptual model: Decision Ledger, Dependency Layer, Grounding Layer.
+2. The UI distinguishes PM, EM, and Dev owner lenses.
+3. Pulse summarizes decision, dependency, grounding, and team freshness state.
+4. Ledger preserves the current detailed view and labels it as the fixed, domain-agnostic decision record.
+5. Drift distinguishes product intent drift, dependency/scope drift, and grounding/artifact drift.
+6. Integration settings can tag sources by owner lens: PM, EM, Dev, or shared.
+7. Team Memory State overlays the conceptual model so users do not confuse ideal flow with current Drive-backed freshness.
+8. The Walkie-Talkie metaphor is used for positioning, not as a literal dashboard interaction model.
+
+## 15. Final Amendment Thesis
+
+The dashboard should not merely show a list of decisions. It should show the operating system of team alignment:
+
+- PM controls decision authority.
+- EM controls dependency routing and blast-radius awareness.
+- Dev controls grounding evidence.
+- Bicameral preserves the ledger and routes drift between the layers.
+- Google Drive sync defines whether shared team memory is current or stale.
+
+That is the product story worth designing around.


### PR DESCRIPTION
## Summary
Lands the **Dashboard v2** design set — imported from the design fork and refined during a validation review against open issues, PRs, and the roadmap.

- `docs/design/dashboard-v2-comprehensive-design.md` — 8-view dashboard spec, 7 milestones, component plan, data contracts, acceptance criteria *(imported; authored by Kevin Knapp)*
- `adr-0001` information architecture · `adr-0002` Drive-backed team sync · `adr-0003` identity/capabilities *(imported)*
- `adr-0004` **frontend build architecture** — new; locks the Vite + TypeScript + React-compatible-framework decision
- design **principle 2.7** (CLI-first delivery, on-demand UI) — review refinement
- `ARCHITECTURE_PLAN.md` — corrects the stale "optional web UI for ledger viewing" line

## Reconciliations from the validation review
- **Solo mode retained** — #373 (deprecate solo mode) contradicted the design + ADR-0003; rejected and closed.
- **Google Drive confirmed** as the team-sync substrate — ADR-0002 stands as written.
- **#437 Project Pulse** = Dashboard v2 Milestone 1-2, shipped across all 3 phases; #437 closed.

## Test plan
- [x] Docs-only change — no code, no tests affected.
- [x] ADRs follow the established 0001-0003 format.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Closes #471