### PR TITLE
feat(jira): status-transition heuristics — Jira integration Phase C

### DIFF
--- a/sources/jira/transition_config.py
+++ b/sources/jira/transition_config.py
@@ -1,0 +1,102 @@
+"""Jira status-transition config loader (#337 Jira Phase C).
+
+Phase C makes a Jira issue's transition into a "done-like" terminal status a
+decision-bearing event. Which statuses count is **operator config**, declared
+per project in ``.bicameral/config.yaml``:
+
+    jira:
+      status_transitions:
+        PROJ: ["Done", "Released"]
+        OPS:  ["Closed"]
+
+- ``jira.status_transitions`` is a map of **project key -> list of terminal
+  status display names**.
+- The map keys ARE the **project allowlist**: a project absent from the map
+  gets no transition-ingest at all.
+- Status-name and project-key matching is **case-insensitive** (casefolded),
+  so ``"done"`` and ``"Done"`` — and ``proj`` vs ``PROJ`` — match.
+- Absent or malformed config means transition-ingest is simply **off**
+  (`load_terminal_statuses` returns an empty map). It is never an error: a
+  config mistake must not crash the webhook receiver and must never be read
+  as "ingest every transition".
+
+The config file is resolved relative to ``REPO_PATH`` (default ``.``) — the
+same resolution ``context.py`` uses — so the server's CWD does not matter.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+from pathlib import Path
+
+logger = logging.getLogger(__name__)
+
+
+def _config_path(repo_path: str | None) -> Path:
+    """Resolve ``<repo>/.bicameral/config.yaml`` the way ``context.py`` does."""
+    base = repo_path if repo_path else os.getenv("REPO_PATH", ".")
+    return Path(base) / ".bicameral" / "config.yaml"
+
+
+def load_terminal_statuses(repo_path: str | None = None) -> dict[str, frozenset[str]]:
+    """Load the per-project terminal-status map — fail-closed.
+
+    Returns ``{casefolded_project_key: frozenset(casefolded status names)}``.
+    Any absent or malformed config yields an empty map (transition-ingest
+    off). This function **never raises** — a config error must not break
+    webhook delivery.
+
+    Loaded fresh on each call (no caching) so an operator's edit to
+    ``config.yaml`` takes effect with no restart; the v0 webhook volume
+    makes a per-delivery YAML read a non-issue.
+    """
+    path = _config_path(repo_path)
+    try:
+        raw = path.read_text(encoding="utf-8")
+    except OSError:
+        # File absent / unreadable — transition-ingest is simply off.
+        return {}
+
+    try:
+        import yaml
+
+        data = yaml.safe_load(raw)
+    except Exception as exc:  # noqa: BLE001 — any parse failure fails closed
+        logger.warning("[jira-transition-config] %s not parseable as YAML: %s", path, exc)
+        return {}
+
+    if not isinstance(data, dict):
+        return {}
+    jira = data.get("jira")
+    if not isinstance(jira, dict):
+        return {}
+    transitions = jira.get("status_transitions")
+    if transitions is None:
+        return {}
+    if not isinstance(transitions, dict):
+        logger.warning(
+            "[jira-transition-config] jira.status_transitions is %s, expected a "
+            "mapping of project-key -> status list; ignoring",
+            type(transitions).__name__,
+        )
+        return {}
+
+    out: dict[str, frozenset[str]] = {}
+    for project, statuses in transitions.items():
+        if not isinstance(project, str) or not project.strip():
+            logger.warning("[jira-transition-config] skipping non-string project key %r", project)
+            continue
+        if not isinstance(statuses, list):
+            logger.warning(
+                "[jira-transition-config] skipping project %r: statuses is %s, expected a list",
+                project,
+                type(statuses).__name__,
+            )
+            continue
+        names = frozenset(
+            s.strip().casefold() for s in statuses if isinstance(s, str) and s.strip()
+        )
+        if names:
+            out[project.strip().casefold()] = names
+    return out

--- a/tests/test_webhooks_jira_transitions.py
+++ b/tests/test_webhooks_jira_transitions.py
@@ -1,0 +1,268 @@
+"""Tests for Jira webhook status-transition heuristics (#337 Jira Phase C).
+
+Two layers:
+
+* **Solitary** unit tests for the two pure helpers — ``_status_transitions``
+  (the changelog parser) and ``load_terminal_statuses`` (the config loader).
+  Solitary is correct here: both are pure functions / a pure file read, with
+  no collaborator we ship to the agent (CLAUDE.md "solitary is correct for
+  pure helpers").
+* **Sociable** receiver tests that drive the real ``handle`` — real
+  ``verify_signature``, real ``DeliveryDedupCache``, real
+  ``normalize_issue_to_payload``, real ``_append_status_transition_decisions``,
+  and the real ``load_terminal_statuses`` reading a real temp ``config.yaml``.
+  The only seam is ``handle_ingest`` — the genuine ledger boundary — exactly
+  as the Phase B harness (``test_webhooks_jira.py``) documents and does; the
+  observable Phase C behaviour is the *payload* that reaches ``handle_ingest``.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import hmac
+import json
+from types import SimpleNamespace
+
+import pytest
+
+from sources.jira.transition_config import load_terminal_statuses
+from webhooks.jira import _status_transitions, handle
+
+_SECRET = "jira-webhook-shared-secret"
+
+
+@pytest.fixture(autouse=True)
+def _reset_dedup():
+    """Reset the process-local dedup singleton between tests."""
+    from webhooks.dedup import _reset_for_tests as _dedup_reset
+
+    _dedup_reset()
+    yield
+    _dedup_reset()
+
+
+def _sign(secret: str, body: bytes) -> str:
+    return "sha256=" + hmac.new(secret.encode(), msg=body, digestmod=hashlib.sha256).hexdigest()
+
+
+# ── Solitary: _status_transitions (the changelog parser) ────────────────────
+
+
+def test_status_transitions_extracts_status_item():
+    changelog = {
+        "id": "1001",
+        "items": [
+            {"field": "assignee", "fromString": "Ada", "toString": "Grace"},
+            {"field": "status", "fromString": "In Progress", "toString": "Done"},
+        ],
+    }
+    assert _status_transitions(changelog) == [("In Progress", "Done")]
+
+
+def test_status_transitions_preserves_item_order():
+    changelog = {
+        "items": [
+            {"field": "status", "fromString": "Open", "toString": "In Review"},
+            {"field": "status", "fromString": "In Review", "toString": "Done"},
+        ]
+    }
+    assert _status_transitions(changelog) == [("Open", "In Review"), ("In Review", "Done")]
+
+
+def test_status_transitions_missing_fromstring_yields_empty_str():
+    changelog = {"items": [{"field": "status", "toString": "Done"}]}
+    assert _status_transitions(changelog) == [("", "Done")]
+
+
+@pytest.mark.parametrize(
+    "changelog",
+    [None, "not-a-dict", 42, {}, {"items": "not-a-list"}, {"items": None}],
+)
+def test_status_transitions_malformed_changelog_yields_empty(changelog):
+    """A malformed/absent changelog yields no transition — never raises."""
+    assert _status_transitions(changelog) == []
+
+
+def test_status_transitions_skips_non_status_and_non_dict_items():
+    changelog = {"items": [{"field": "priority", "toString": "High"}, "junk", 7, None]}
+    assert _status_transitions(changelog) == []
+
+
+# ── Solitary: load_terminal_statuses (the config loader) ────────────────────
+
+
+def _write_config(tmp_path, text: str):
+    cfg_dir = tmp_path / ".bicameral"
+    cfg_dir.mkdir(parents=True, exist_ok=True)
+    (cfg_dir / "config.yaml").write_text(text, encoding="utf-8")
+
+
+def test_load_terminal_statuses_valid_config(tmp_path):
+    _write_config(
+        tmp_path,
+        "jira:\n  status_transitions:\n    PROJ: [Done, Released]\n    OPS: [Closed]\n",
+    )
+    result = load_terminal_statuses(repo_path=str(tmp_path))
+    assert result == {"proj": frozenset({"done", "released"}), "ops": frozenset({"closed"})}
+
+
+def test_load_terminal_statuses_casefolds_keys_and_statuses(tmp_path):
+    """Operator YAML casing must never silently miss — keys + statuses casefold."""
+    _write_config(tmp_path, "jira:\n  status_transitions:\n    Proj: ['DONE']\n")
+    result = load_terminal_statuses(repo_path=str(tmp_path))
+    assert result == {"proj": frozenset({"done"})}
+
+
+def test_load_terminal_statuses_missing_file_returns_empty(tmp_path):
+    assert load_terminal_statuses(repo_path=str(tmp_path)) == {}
+
+
+@pytest.mark.parametrize(
+    "text",
+    [
+        "jira: not-a-mapping",  # jira not a dict
+        "jira:\n  status_transitions: not-a-mapping",  # transitions not a dict
+        "not-a-mapping-at-all",  # top level not a dict
+        "{ broken: [unclosed",  # not valid YAML
+        "telemetry: true",  # no jira section
+    ],
+)
+def test_load_terminal_statuses_malformed_config_fails_closed(tmp_path, text):
+    """Every malformed shape fails closed to {} — never crashes, never
+    over-ingests."""
+    _write_config(tmp_path, text)
+    assert load_terminal_statuses(repo_path=str(tmp_path)) == {}
+
+
+def test_load_terminal_statuses_skips_bad_entry_keeps_good(tmp_path):
+    """A project whose value is not a list is skipped; valid siblings survive."""
+    _write_config(
+        tmp_path,
+        "jira:\n  status_transitions:\n    GOOD: [Done]\n    BAD: 123\n",
+    )
+    assert load_terminal_statuses(repo_path=str(tmp_path)) == {"good": frozenset({"done"})}
+
+
+# ── Sociable: handle() → transition decision in the ingest payload ──────────
+
+
+def _issue_updated_body(*, issue_key="PROJ-123", to_status="Done", from_status="In Progress"):
+    """A signed-ready jira:issue_updated body with a changelog status item."""
+    payload = {
+        "timestamp": 1716285600000,
+        "webhookEvent": "jira:issue_updated",
+        "issue": {
+            "key": issue_key,
+            "fields": {
+                "summary": "Ship the Jira integration",
+                "updated": "2026-05-21T12:00:00.000+0000",
+                "description": {
+                    "type": "doc",
+                    "version": 1,
+                    "content": [
+                        {"type": "paragraph", "content": [{"type": "text", "text": "Body."}]}
+                    ],
+                },
+            },
+        },
+        "changelog": {
+            "items": [{"field": "status", "fromString": from_status, "toString": to_status}]
+        },
+    }
+    return json.dumps(payload).encode("utf-8")
+
+
+def _capture_handle(monkeypatch, tmp_path, config_text: str) -> dict:
+    """Wire a real temp config + a capturing handle_ingest seam.
+
+    Returns a dict that ``["payload"]`` is filled into once handle_ingest is
+    reached. ``handle_ingest`` is the documented genuine ledger boundary —
+    seamed exactly as the Phase B receiver tests seam it.
+    """
+    _write_config(tmp_path, config_text)
+    monkeypatch.setenv("REPO_PATH", str(tmp_path))
+    captured: dict = {}
+
+    async def _fake_ingest(ctx, payload, *, source_scope, ingest_mode):
+        captured["payload"] = payload
+
+    monkeypatch.setattr("handlers.ingest.handle_ingest", _fake_ingest)
+    monkeypatch.setattr(
+        "context.BicameralContext.from_env", classmethod(lambda cls: SimpleNamespace())
+    )
+    return captured
+
+
+def _transition_decisions(payload: dict) -> list[dict]:
+    return [d for d in payload["decisions"] if d["title"].endswith("#status-Done")]
+
+
+def test_handle_configured_transition_appends_decision(monkeypatch, tmp_path):
+    """A status transition into a configured terminal status appends one
+    transition decision — alongside the Phase B description decision."""
+    captured = _capture_handle(
+        monkeypatch, tmp_path, "jira:\n  status_transitions:\n    PROJ: [Done]\n"
+    )
+    body = _issue_updated_body()
+    status, msg = handle(
+        body=body,
+        signature_header=_sign(_SECRET, body),
+        delivery_identifier="wh-c1",
+        secret_resolver=lambda: _SECRET,
+    )
+    assert status == 200
+    payload = captured["payload"]
+    transition = _transition_decisions(payload)
+    assert len(transition) == 1
+    assert transition[0]["title"] == "PROJ-123#status-Done"
+    assert "transitioned: In Progress -> Done" in transition[0]["description"]
+    # Phase B's description decision is still present — Phase C is additive.
+    assert any(d["title"] == "PROJ-123" for d in payload["decisions"])
+
+
+def test_handle_non_terminal_transition_appends_nothing(monkeypatch, tmp_path):
+    """A transition into a status NOT in the configured terminal set adds no
+    transition decision (Phase B description decision only)."""
+    captured = _capture_handle(
+        monkeypatch, tmp_path, "jira:\n  status_transitions:\n    PROJ: [Released]\n"
+    )
+    body = _issue_updated_body(to_status="Done")
+    handle(
+        body=body,
+        signature_header=_sign(_SECRET, body),
+        delivery_identifier="wh-c2",
+        secret_resolver=lambda: _SECRET,
+    )
+    assert _transition_decisions(captured["payload"]) == []
+
+
+def test_handle_unconfigured_project_appends_nothing(monkeypatch, tmp_path):
+    """An issue whose project key is not in the allowlist map gets no
+    transition decision — the map keys are the allowlist."""
+    captured = _capture_handle(
+        monkeypatch, tmp_path, "jira:\n  status_transitions:\n    OTHER: [Done]\n"
+    )
+    body = _issue_updated_body(issue_key="PROJ-7")
+    handle(
+        body=body,
+        signature_header=_sign(_SECRET, body),
+        delivery_identifier="wh-c3",
+        secret_resolver=lambda: _SECRET,
+    )
+    assert _transition_decisions(captured["payload"]) == []
+
+
+def test_handle_no_config_is_pure_phase_b(monkeypatch, tmp_path):
+    """With no jira config at all, behaviour is exactly Phase B — the issue
+    still ingests (description decision), no transition decision."""
+    captured = _capture_handle(monkeypatch, tmp_path, "telemetry: true\n")
+    body = _issue_updated_body()
+    status, _ = handle(
+        body=body,
+        signature_header=_sign(_SECRET, body),
+        delivery_identifier="wh-c4",
+        secret_resolver=lambda: _SECRET,
+    )
+    assert status == 200
+    assert _transition_decisions(captured["payload"]) == []
+    assert any(d["title"] == "PROJ-123" for d in captured["payload"]["decisions"])

--- a/webhooks/jira.py
+++ b/webhooks/jira.py
@@ -47,9 +47,13 @@ Mark-after-ack (the cycle-9d Drive precedent): the delivery is marked seen
 only once an acked outcome (a 200 or a 422) has been decided. A 500 path is
 left UNMARKED so Jira's retry re-dispatches the delivery.
 
-Event handling (Phase B):
+Event handling:
 - ``jira:issue_created`` / ``jira:issue_updated`` / ``comment_created`` /
   ``comment_updated`` → normalize the inline ``issue`` object and ingest.
+- ``jira:issue_updated`` additionally (Phase C): if the ``changelog`` shows a
+  status transition into a configured terminal status (``jira.status_transitions``
+  in ``.bicameral/config.yaml``), an extra status-transition decision is
+  appended to the ingest payload. Fail-closed — unconfigured → nothing added.
 - ``jira:issue_deleted`` / ``comment_deleted`` / every other ``webhookEvent``
   → 200 acknowledged, no ingest (append-only contract — deletes are not
   propagated to the ledger).
@@ -311,6 +315,19 @@ def _ingest_issue(payload: dict, event: str, delivery_identifier: str) -> tuple[
         )
         return 500, f"normalization failed for {issue_key!r}; Jira will retry"
 
+    # Phase C: a status transition into a configured terminal status is itself
+    # a decision — append it to the decisions Phase B built. Wrapped so a
+    # Phase C fault can never break Phase B's ingest path.
+    if event == "jira:issue_updated":
+        try:
+            _append_status_transition_decisions(payload, ingest_payload, issue_key)
+        except Exception as exc:  # noqa: BLE001
+            print(
+                f"[jira-webhook] status-transition detection failed for {issue_key!r} "
+                f"(delivery={delivery_identifier!r}): {type(exc).__name__}: {exc}",
+                file=sys.stderr,
+            )
+
     try:
         import asyncio
 
@@ -345,3 +362,85 @@ def _ingest_issue(payload: dict, event: str, delivery_identifier: str) -> tuple[
         return 500, f"ingest failed for {issue_key!r}; Jira will retry"
 
     return 200, f"event={event!r} ingested {issue_key}"
+
+
+def _status_transitions(changelog: object) -> list[tuple[str, str]]:
+    """Extract ``(from_status, to_status)`` pairs from a webhook ``changelog``.
+
+    The ``changelog`` (present only on ``jira:issue_updated``) carries an
+    ``items`` array; a status transition is an item with ``field == "status"``,
+    its ``fromString`` / ``toString`` the old / new status display names.
+
+    Defensive by design — ``docs/vendor/jira/webhooks.md`` §5 flags the nested
+    shape as best-effort, so anything unexpected yields no transition rather
+    than raising. Pairs are returned in ``items`` order (deterministic).
+    """
+    if not isinstance(changelog, dict):
+        return []
+    items = changelog.get("items")
+    if not isinstance(items, list):
+        return []
+    out: list[tuple[str, str]] = []
+    for item in items:
+        if not isinstance(item, dict) or item.get("field") != "status":
+            continue
+        from_s = item.get("fromString")
+        to_s = item.get("toString")
+        out.append(
+            (
+                from_s if isinstance(from_s, str) else "",
+                to_s if isinstance(to_s, str) else "",
+            )
+        )
+    return out
+
+
+def _append_status_transition_decisions(
+    payload: dict, ingest_payload: dict, issue_key: str
+) -> None:
+    """Append one decision per configured terminal-status transition.
+
+    Phase C — additive. For each ``changelog`` status transition whose target
+    status is in the issue's project's configured terminal-status set
+    (``.bicameral/config.yaml`` ``jira.status_transitions``), append a decision
+    to ``ingest_payload["decisions"]``. Fail-closed: an unconfigured project or
+    status, or an absent/malformed config, appends nothing. The downstream
+    caller-LLM / gap-judge chain decides whether the transition is a real
+    decision — same posture as comments.
+    """
+    from sources.jira.transition_config import load_terminal_statuses
+
+    terminal_by_project = load_terminal_statuses()
+    if not terminal_by_project:
+        return
+    project_key = issue_key.split("-", 1)[0].casefold()
+    terminal = terminal_by_project.get(project_key)
+    if not terminal:
+        return
+
+    transitions = _status_transitions(payload.get("changelog"))
+    if not transitions:
+        return
+
+    decisions = ingest_payload.get("decisions")
+    if not isinstance(decisions, list):
+        return
+
+    summary = ""
+    issue = payload.get("issue")
+    if isinstance(issue, dict):
+        fields = issue.get("fields")
+        if isinstance(fields, dict) and isinstance(fields.get("summary"), str):
+            summary = fields["summary"]
+
+    for from_s, to_s in transitions:
+        if not to_s or to_s.casefold() not in terminal:
+            continue
+        decisions.append(
+            {
+                "description": (
+                    f'{issue_key} ("{summary}") transitioned: {from_s or "(none)"} -> {to_s}'
+                ),
+                "title": f"{issue_key}#status-{to_s}",
+            }
+        )


### PR DESCRIPTION
## Summary
**Phase C of the Jira integration** (part of BicameralAI/bicameral-daemon#3; follows Phase A BicameralAI/bicameral-mcp#460 and Phase B BicameralAI/bicameral-mcp#462). Additive extension of the Phase B webhook receiver: a Jira issue's transition into an operator-configured "done-like" terminal status becomes a decision-bearing event.

- `sources/jira/transition_config.py` — NEW: fail-closed loader for the new `.bicameral/config.yaml` `jira.status_transitions` key.
- `webhooks/jira.py` — additive: `_status_transitions` (defensive `changelog` parser) + `_append_status_transition_decisions`, wired into `_ingest_issue` for `jira:issue_updated` behind a `try/except` so a Phase C fault cannot break Phase B ingest.
- `tests/test_webhooks_jira_transitions.py` — NEW: solitary tests for both pure helpers (every malformed branch) + sociable `handle()` coverage.

## Config surface
New `.bicameral/config.yaml` key — a per-project terminal-status map; map keys are the project allowlist; case-insensitive; **fail-closed** (absent/malformed → transition-ingest off, never a crash, never ingest-all):
```yaml
jira:
  status_transitions:
    PROJ: ["Done", "Released"]
```

## Governance
Independently audited — **PASS** (2 MAJOR + 3 MINOR conditions, all folded in). Adversarial review: **SHIP** — no HIGH/MED; fail-closed verified branch-by-branch, additive claim confirmed, no fabricated data.

## Test plan
- [x] 47 tests pass — 14 new Phase C (pure-helper malformed branches + sociable `handle()` path) + the Phase B suite, all green
- [x] `ruff check` + `ruff format --check` clean

Closes BicameralAI/bicameral-daemon#18

🤖 Generated with [Claude Code](https://claude.com/claude-code)