### PR TITLE
docs(jira): operator setup guide — Jira integration Phase D

### DIFF
--- a/docs/integrations-settings-inventory.md
+++ b/docs/integrations-settings-inventory.md
@@ -163,6 +163,21 @@ consumes this inventory as its spec.
 | DM policy | **SHIPPED** | Channel-only enforced at URL parser (active) + ID-prefix filter (passive) |
 | Rate / quota | **PARTIAL** | Pagination capped at 2000 messages/cycle |
 
+### 8. `jira` — issue / comment / status-transition ingest (Phases A / B / C)
+
+| Field | State | Detail |
+|---|---|---|
+| Auth | **SHIPPED** | HTTP Basic (API token + account email) for active ingest; HMAC shared secret for the webhook. Three `secrets_store` keys under `source_id="jira"`: `api_email`, `api_token`, `webhook_secret`. Jira **Cloud** only. |
+| Discovery | **TBD** | No `source-list jira` enumerator; the operator names projects directly (the webhook JQL filter and `jira.status_transitions`) |
+| Selection — active | URL paste | Operator pastes a `…atlassian.net/browse/<KEY>-<N>` issue URL |
+| Selection — passive | **SHIPPED** | Admin-UI webhook (Phase B). The operator's Jira-side **JQL filter** scopes which issues fire it |
+| Filtering | **SHIPPED** (Jira-side) | The webhook's JQL filter is the passive selection criteria. The universal `FilterSpec` / `eval_hook` are a `sync-and-brief` pull-adapter mechanism — **N/A** on Jira's webhook path |
+| Status-transition heuristic | **SHIPPED** | Phase C — `.bicameral/config.yaml` `jira.status_transitions`: per-project terminal-status map (map keys = project allowlist; case-insensitive; fail-closed). A transition into a configured terminal status ingests as a decision |
+| Content eval hook | **N/A** | `eval_hook` is a pull-adapter primitive; Jira passive ingest is webhook-based |
+| Active/passive toggle | Both | Active = issue-URL paste; passive = admin-UI webhook |
+| Webhook receiver | **SHIPPED** | `webhooks/jira.py` (Phase B) — HMAC-SHA256 `X-Hub-Signature` verify, `X-Atlassian-Webhook-Identifier` dedup. Operator setup: `docs/jira-integration-setup.md` |
+| Rate / quota | **PARTIAL** | Inherits the global `handle_ingest` ingest gates; no per-source override |
+
 ---
 
 ## Patterns + gaps

--- a/docs/jira-integration-setup.md
+++ b/docs/jira-integration-setup.md
@@ -1,0 +1,160 @@
+# Jira Integration — Operator Setup
+
+How to connect a **Jira Cloud** site to Bicameral so that Jira issues,
+comments, and status transitions flow into the decision ledger.
+
+Bicameral ingests Jira two ways, and you can use either or both:
+
+- **Active** — paste a Jira issue URL into `bicameral.ingest` and it is
+  fetched on demand.
+- **Passive** — register a webhook in Jira; issue/comment events are
+  ingested as they happen, with no polling.
+
+This guide covers the **admin-UI webhook** path (you register the webhook
+once in Jira's own settings). It is the recommended setup: one-time, no
+OAuth, no token-renewal job. The OAuth / dynamic-webhook variant is out of
+scope for v0.
+
+> Jira **Cloud** only. Jira Server / Data Center is not supported.
+
+---
+
+## Prerequisites
+
+- A Jira Cloud site (`https://<your-tenant>.atlassian.net`).
+- A **Jira site admin** account — required to register the webhook
+  (Step 4). Active ingest alone (Steps 1–3) does not need admin.
+- Bicameral's webhook receiver reachable from the internet over **HTTPS**
+  (see the port note in Step 4). Jira Cloud only delivers to TLS endpoints.
+
+---
+
+## Step 1 — Create an Atlassian API token
+
+Active ingest authenticates with HTTP Basic auth — your account email plus
+an API token (not your password).
+
+1. Go to <https://id.atlassian.com/manage-profile/security/api-tokens>.
+2. **Create API token**, give it a label (e.g. `bicameral-mcp`), and copy
+   the value. You cannot retrieve it again later.
+
+The token's account needs **Browse projects** permission on every project
+you want to ingest from.
+
+---
+
+## Step 2 — Store the credentials
+
+Bicameral keeps all source credentials in the OS keyring via
+`secrets_store` — never in `.bicameral/config.yaml`. Jira uses three keys
+under `source_id="jira"`. Store each one (paste your own values):
+
+```bash
+python -c "from secrets_store import put_secret; put_secret(source_id='jira', key='api_email', value='you@example.com')"
+python -c "from secrets_store import put_secret; put_secret(source_id='jira', key='api_token', value='<your-api-token>')"
+```
+
+The third key — `webhook_secret` — is the shared HMAC secret for the
+passive webhook; you will generate and store it in Step 3.
+
+| Key | Used by | Purpose |
+|---|---|---|
+| `api_email` | active ingest | Basic-auth account email |
+| `api_token` | active ingest | Basic-auth API token (Step 1) |
+| `webhook_secret` | passive webhook | HMAC-SHA256 shared secret (Step 3) |
+
+If you only want active ingest, you can stop after this step.
+
+---
+
+## Step 3 — Generate and store the webhook secret
+
+The passive webhook is verified with an HMAC-SHA256 signature. Pick a
+strong random secret — you will paste the *same* value into Bicameral here
+and into Jira in Step 4.
+
+```bash
+python -c "import secrets; print(secrets.token_urlsafe(32))"   # generate one
+python -c "from secrets_store import put_secret; put_secret(source_id='jira', key='webhook_secret', value='<the-secret>')"
+```
+
+The webhook receiver **fails closed**: with no `webhook_secret` stored it
+refuses every delivery (HTTP 500 with setup guidance) rather than accepting
+unverifiable traffic. Keep the secret — Jira does not let you retrieve it
+again after the webhook is saved (Step 4); if lost, re-create the webhook.
+
+---
+
+## Step 4 — Register the webhook in Jira
+
+As a Jira site admin: **Jira Settings → System → WebHooks → Create a
+WebHook**.
+
+| Field | Value |
+|---|---|
+| **Name** | e.g. `Bicameral ingest` |
+| **URL** | your Bicameral receiver, path **`/webhooks/jira`** — e.g. `https://bicameral.example.com/webhooks/jira` |
+| **Secret** | the exact `webhook_secret` value from Step 3 (this enables `X-Hub-Signature` HMAC signing) |
+| **JQL filter** | optional — scopes which issues fire the webhook, e.g. `project in (PROJ, OPS)`. Leave empty to watch everything the webhook can see. |
+| **Events** | enable: **Issue created**, **Issue updated**, **Comment created**, **Comment updated** |
+
+**Callback port restriction.** Jira Cloud only delivers to these ports:
+`443`, `1880-1890`, `4044`, `6017`, `7990`, `8060`, `8080`, `8085`,
+`8089`, `8090`, `8443`, `8444`, `8900`, `9900`, `9420`, `9520`.
+**Port 80 is not allowed** — front the receiver with TLS on `443` (or one
+of the others).
+
+> Jira signs deliveries with the **`X-Hub-Signature`** header (note: *not*
+> GitHub's `X-Hub-Signature-256` — same algorithm, different header name).
+> You do not configure the header name anywhere; this is just so the
+> behaviour is not a surprise if you inspect deliveries.
+
+Save. Jira does not show the secret again after saving.
+
+---
+
+## Step 5 — (Optional) Status-transition ingest
+
+By default the webhook ingests issue descriptions and comments. You can
+*also* have a Jira issue's transition into a "done-like" status recorded as
+a decision — e.g. when `PROJ-123` moves to `Done`.
+
+This is **opt-in per project** in `.bicameral/config.yaml`:
+
+```yaml
+jira:
+  status_transitions:
+    PROJ: ["Done", "Released"]
+    OPS:  ["Closed"]
+```
+
+- A map of **project key → list of terminal status names**.
+- The map keys are the **allowlist**: a project not listed gets no
+  transition ingest.
+- Status names and project keys are matched **case-insensitively**.
+- **Fail-closed**: if this section is absent or malformed, transition
+  ingest is simply off — issue/comment ingest is unaffected.
+
+---
+
+## Verify it works
+
+- **Active** — paste a Jira issue URL
+  (`https://<tenant>.atlassian.net/browse/PROJ-123`) into `bicameral.ingest`.
+  The decision should appear in the ledger / dashboard.
+- **Passive** — edit an issue or add a comment in an in-scope project, then
+  check the dashboard. Jira's WebHooks admin page also shows recent
+  delivery attempts and their response codes (a `200` means accepted).
+
+---
+
+## Revoking access
+
+- **Stop passive ingest** — delete the webhook in Jira's WebHooks admin
+  page. (The receiver also rejects deliveries once the secrets no longer
+  match.)
+- **Remove stored credentials** —
+  `python -c "from secrets_store import delete_secret; delete_secret(source_id='jira', key='webhook_secret')"`
+  (repeat for `api_token` / `api_email`).
+- **Revoke the API token** at
+  <https://id.atlassian.com/manage-profile/security/api-tokens>.


### PR DESCRIPTION
## Summary
**Phase D of the Jira integration** (part of BicameralAI/bicameral-daemon#3; follows A BicameralAI/bicameral-mcp#460, B BicameralAI/bicameral-mcp#462, C BicameralAI/bicameral-daemon#18/#474). Operator setup documentation — the admin-UI-webhook variant.

> **Stacked on Phase C (#474)** — base is `feat/jira-phase-c` so the diff is the 2 doc files only. GitHub auto-retargets this to `dev` once BicameralAI/bicameral-mcp#474 merges.

- `docs/jira-integration-setup.md` — NEW: end-to-end operator guide — Atlassian API token → the three `secrets_store` secrets → admin-UI webhook registration (URL `/webhooks/jira`, events, the HMAC shared secret, the callback-port restriction) → the optional `jira.status_transitions` config → verify + revocation.
- `docs/integrations-settings-inventory.md` — adds Jira as the 8th source inventory entry (Phases A/B/C).

## Scope
**Docs-only.** No code, no CLI, no tests. No CLI setup helper — Jira is a static-key source and the house pattern (Linear/Notion/GitHub) is `secrets_store.put_secret` direct; `source_auth_cli.py` is OAuth-only.

## Governance
Independently audited — **PASS** (every technical claim fact-checked against the shipped Phase A/B/C code: secret keys, route, events, ports, config key — all confirmed). Adversarial doc-accuracy review run; its one HIGH finding was a branch-base artifact (Phase D was branched off `dev` before Phase C merged) — resolved by stacking Phase D on `feat/jira-phase-c` so `transition_config.py` is present and the docs match the code.

## Merge note
When merging BicameralAI/bicameral-mcp#474 (Phase C), do **not** delete `feat/jira-phase-c` while this PR is still open against it — that would auto-close this PR. Merge BicameralAI/bicameral-mcp#474 first; GitHub retargets this to `dev`; then merge this.

Closes BicameralAI/bicameral-daemon#19

🤖 Generated with [Claude Code](https://claude.com/claude-code)