### PR TITLE
feat(jira): JQL poller — Jira integration Phase E

### DIFF
--- a/sources/jira/poller.py
+++ b/sources/jira/poller.py
@@ -1,0 +1,197 @@
+"""Jira JQL poller for #337 Jira Phase E — poll-based passive ingest.
+
+A poll alternative to the Phase B webhook receiver, for operators who
+cannot host an HTTPS webhook endpoint. Wraps the Phase A REST-client
+constants with a JQL bounded-search loop returning issues updated at/after
+a watermark.
+
+Structural twin of ``sources/notion/poller.py``: a *fetch* function — it
+holds no watermark and calls no ingest. Watermark persistence
+(``~/.bicameral/source-watermarks/``) and the ``handle_ingest`` call are
+the caller's job, exactly as the Notion poller leaves them to its caller.
+
+Targets ``POST /rest/api/3/search/jql`` — the token-based bounded-search
+API. The legacy offset ``POST /rest/api/3/search`` is being removed by
+Atlassian and is never called here (see
+``docs/vendor/jira/rest-api-v3-issues-comments.md``).
+
+Pagination cap: 20 pages x 100 issues = 2000 issues per pull (mirrors the
+Notion poller's cap).
+
+# TODO(#337 follow-on): wire into sync-and-brief. Phase E ships the poller
+# ahead of its consumer, gated on operator demand per the scope doc
+# (internal/jira-integration-scope.md Phase E).
+"""
+
+from __future__ import annotations
+
+import json
+import re
+import urllib.error
+import urllib.request
+
+_PAGE_SIZE = 100
+_MAX_PAGES = 20
+
+# The decision-bearing field set — same as the Phase A Get-issue client.
+_SEARCH_FIELDS = [
+    "summary",
+    "description",
+    "status",
+    "assignee",
+    "reporter",
+    "updated",
+    "created",
+    "comment",
+]
+
+# Matches the leading "YYYY-MM-DD" + ("T" or space) + "HH:MM" of a
+# timestamp; seconds / milliseconds / offset (if any) are dropped — JQL's
+# date comparator is minute-precision.
+_TS_PREFIX_RE = re.compile(r"^(\d{4}-\d{2}-\d{2})[T ](\d{2}:\d{2})")
+
+
+def _to_jql_datetime(value: str) -> str:
+    """Normalize a timestamp to JQL's ``yyyy-MM-dd HH:mm`` form.
+
+    Jira's ``updated`` field arrives as ISO-8601 with ``T`` / milliseconds /
+    a numeric offset (``2026-05-21T10:00:00.000+0000``); JQL's ``updated >=``
+    comparator wants minute precision with a space. A value already in
+    ``yyyy-MM-dd HH:mm`` form passes through unchanged.
+
+    Raises ``ValueError`` for an unrecognizable value — the caller must not
+    feed an unparseable string into a JQL query.
+    """
+    match = _TS_PREFIX_RE.match(value.strip())
+    if not match:
+        raise ValueError(
+            f"updated_after {value!r} is not a recognizable timestamp; "
+            "expected ISO-8601 or 'yyyy-MM-dd HH:mm'"
+        )
+    return f"{match.group(1)} {match.group(2)}"
+
+
+def _build_jql(scope_jql: str | None, updated_after: str | None) -> str:
+    """Compose the bounded-search JQL: scope + watermark + ascending sort.
+
+    ``scope_jql`` (operator config) and the watermark clause are joined with
+    ``AND``; the result is always ``ORDER BY updated ASC`` so the caller can
+    persist the last ``updated`` it saw as the next watermark.
+    """
+    clauses: list[str] = []
+    if scope_jql and scope_jql.strip():
+        clauses.append(f"({scope_jql.strip()})")
+    if updated_after:
+        clauses.append(f"updated >= '{_to_jql_datetime(updated_after)}'")
+    where = " AND ".join(clauses)
+    return f"{where} ORDER BY updated ASC" if where else "ORDER BY updated ASC"
+
+
+def search_issues_updated_since(
+    *,
+    base_url: str,
+    email: str,
+    token: str,
+    scope_jql: str | None = None,
+    updated_after: str | None = None,
+    fields: list[str] | None = None,
+) -> list[dict]:
+    """Return Jira issues updated at/after ``updated_after``, oldest first.
+
+    Paginates ``POST {base_url}/rest/api/3/search/jql`` using the token-based
+    ``nextPageToken`` until the last page, and returns the accumulated raw
+    issue dicts. The caller normalizes them (``normalize_issue_to_payload``)
+    and persists its own watermark — this function holds none.
+
+    Args:
+        base_url: tenant base, e.g. ``https://acme.atlassian.net``.
+        email: Atlassian account email (Basic-auth username).
+        token: Atlassian API token (Basic-auth password).
+        scope_jql: optional JQL scope clause, e.g. ``project in (PROJ, OPS)``
+            — operator-supplied config, composed into the query as-is.
+        updated_after: optional watermark; issues with ``updated`` at/after
+            this are returned. ISO-8601 or ``yyyy-MM-dd HH:mm``.
+        fields: issue fields to request; defaults to the decision-bearing set.
+
+    Returns:
+        The accumulated raw Jira issue objects, ascending by ``updated``.
+
+    Raises:
+        RuntimeError: any API / network / non-JSON failure, or the page cap
+            being exceeded. The caller logs it and does NOT advance its
+            watermark. The message carries the HTTP status + URL, never the
+            auth header.
+        ValueError: ``updated_after`` is not a recognizable timestamp.
+    """
+    from sources.jira.client import (
+        _MAX_RESPONSE_BYTES,
+        _REQUEST_TIMEOUT_SECONDS,
+        JiraAPIError,
+        _basic_auth_header,
+    )
+
+    jql = _build_jql(scope_jql, updated_after)
+    url = f"{base_url}/rest/api/3/search/jql"
+    headers = {
+        "Authorization": _basic_auth_header(email, token),
+        "Accept": "application/json",
+        "Content-Type": "application/json",
+        "User-Agent": "bicameral-mcp/source-jira-poller",
+    }
+
+    issues: list[dict] = []
+    next_token: str | None = None
+    pages = 0
+    while True:
+        body: dict = {
+            "jql": jql,
+            "fields": fields if fields is not None else _SEARCH_FIELDS,
+            "maxResults": _PAGE_SIZE,
+        }
+        if next_token:
+            body["nextPageToken"] = next_token
+        req = urllib.request.Request(
+            url,
+            data=json.dumps(body).encode("utf-8"),
+            headers=headers,
+            method="POST",
+        )
+        try:
+            with urllib.request.urlopen(req, timeout=_REQUEST_TIMEOUT_SECONDS) as resp:
+                raw = resp.read(_MAX_RESPONSE_BYTES + 1)
+                if len(raw) > _MAX_RESPONSE_BYTES:
+                    raise JiraAPIError(
+                        f"Jira search response exceeded {_MAX_RESPONSE_BYTES} bytes for {url}",
+                        status_code=resp.status,
+                    )
+        except urllib.error.HTTPError as exc:
+            raise RuntimeError(
+                f"Jira JQL search failed: HTTP {exc.code} {exc.reason} for {url}"
+            ) from exc
+        except urllib.error.URLError as exc:
+            raise RuntimeError(f"Jira JQL search network error for {url}: {exc.reason}") from exc
+        except JiraAPIError as exc:
+            raise RuntimeError(f"Jira JQL search failed: {exc}") from exc
+
+        try:
+            data = json.loads(raw.decode("utf-8"))
+        except json.JSONDecodeError as exc:
+            raise RuntimeError(f"Jira JQL search returned non-JSON for {url}: {exc}") from exc
+        if not isinstance(data, dict):
+            raise RuntimeError(f"Jira JQL search returned a non-object response for {url}")
+
+        page_issues = data.get("issues")
+        if isinstance(page_issues, list):
+            issues.extend(item for item in page_issues if isinstance(item, dict))
+        pages += 1
+
+        next_token = data.get("nextPageToken")
+        if data.get("isLast") or not next_token:
+            break
+        if pages >= _MAX_PAGES:
+            raise RuntimeError(
+                f"Jira JQL search exceeded {_MAX_PAGES * _PAGE_SIZE} issues since the "
+                "watermark — narrow the scope_jql filter or shorten the poll interval"
+            )
+
+    return issues

--- a/tests/test_sources_jira_poller.py
+++ b/tests/test_sources_jira_poller.py
@@ -1,0 +1,192 @@
+"""Solitary tests for the Jira JQL poller (#337 Jira Phase E).
+
+The poller's only collaborator is the Jira REST API — an external HTTP
+boundary. Per CLAUDE.md ("solitary is correct for ... external boundaries
+we can't run"), these tests fake ``urllib.request.urlopen`` and assert the
+poller's observable behaviour: the JQL it composes, token pagination, the
+page cap, and the fail-without-auth-leak contract. Mirrors the harness of
+``tests/test_notion_polling.py``.
+"""
+
+from __future__ import annotations
+
+import json
+import urllib.error
+
+import pytest
+
+from sources.jira.poller import (
+    _build_jql,
+    _to_jql_datetime,
+    search_issues_updated_since,
+)
+
+_BASE = {"base_url": "https://acme.atlassian.net", "email": "e@example.com"}
+_SEARCH_URL = "https://acme.atlassian.net/rest/api/3/search/jql"
+
+
+class _FakeResp:
+    """Minimal urlopen return value — a context manager with read()/status."""
+
+    def __init__(self, body: bytes, status: int = 200) -> None:
+        self._body = body
+        self.status = status
+
+    def read(self, _n: int = -1) -> bytes:
+        return self._body
+
+    def __enter__(self) -> _FakeResp:
+        return self
+
+    def __exit__(self, *_a: object) -> bool:
+        return False
+
+
+def _install_urlopen(monkeypatch, outcomes: list) -> list[dict]:
+    """Patch urlopen with a scripted sequence of outcomes.
+
+    Each outcome is a dict (→ 200 JSON response), bytes (→ raw 200 body,
+    for the non-JSON case), or an Exception instance (→ raised). Returns a
+    list into which each request's parsed JSON body is recorded.
+    """
+    captured: list[dict] = []
+    seq = list(outcomes)
+
+    def _fake(req, timeout=None):  # noqa: ANN001, ARG001
+        captured.append(json.loads(req.data.decode("utf-8")))
+        outcome = seq.pop(0)
+        if isinstance(outcome, Exception):
+            raise outcome
+        if isinstance(outcome, bytes):
+            return _FakeResp(outcome)
+        return _FakeResp(json.dumps(outcome).encode("utf-8"))
+
+    monkeypatch.setattr("urllib.request.urlopen", _fake)
+    return captured
+
+
+# ── _to_jql_datetime ────────────────────────────────────────────────────────
+
+
+def test_to_jql_datetime_normalizes_iso8601():
+    """An ISO-8601 `updated` value (T / millis / offset) → minute precision."""
+    assert _to_jql_datetime("2026-05-21T10:30:45.123+0000") == "2026-05-21 10:30"
+
+
+def test_to_jql_datetime_passes_through_space_form():
+    assert _to_jql_datetime("2026-05-21 09:00") == "2026-05-21 09:00"
+
+
+def test_to_jql_datetime_rejects_unparseable():
+    with pytest.raises(ValueError, match="not a recognizable timestamp"):
+        _to_jql_datetime("last tuesday")
+
+
+# ── _build_jql ──────────────────────────────────────────────────────────────
+
+
+def test_build_jql_scope_and_watermark():
+    jql = _build_jql("project in (PROJ)", "2026-05-21T10:30:00.000+0000")
+    assert jql == "(project in (PROJ)) AND updated >= '2026-05-21 10:30' ORDER BY updated ASC"
+
+
+def test_build_jql_watermark_only():
+    assert _build_jql(None, "2026-05-20 00:00") == (
+        "updated >= '2026-05-20 00:00' ORDER BY updated ASC"
+    )
+
+
+def test_build_jql_empty_is_just_ordering():
+    assert _build_jql(None, None) == "ORDER BY updated ASC"
+
+
+# ── search_issues_updated_since ─────────────────────────────────────────────
+
+
+def test_search_single_page_returns_issues_and_composes_jql(monkeypatch):
+    captured = _install_urlopen(
+        monkeypatch,
+        [{"issues": [{"key": "PROJ-1"}, {"key": "PROJ-2"}], "isLast": True}],
+    )
+    result = search_issues_updated_since(
+        **_BASE, token="tok", scope_jql="project = PROJ", updated_after="2026-05-20 00:00"
+    )
+    assert [i["key"] for i in result] == ["PROJ-1", "PROJ-2"]
+    assert captured[0]["jql"] == (
+        "(project = PROJ) AND updated >= '2026-05-20 00:00' ORDER BY updated ASC"
+    )
+    assert "nextPageToken" not in captured[0]
+
+
+def test_search_paginates_with_next_page_token(monkeypatch):
+    """Page 1 hands back a nextPageToken; page 2 is isLast — both accumulate,
+    and page 2's request carries the token."""
+    captured = _install_urlopen(
+        monkeypatch,
+        [
+            {"issues": [{"key": "PROJ-1"}], "nextPageToken": "tok-2", "isLast": False},
+            {"issues": [{"key": "PROJ-2"}], "isLast": True},
+        ],
+    )
+    result = search_issues_updated_since(**_BASE, token="tok")
+    assert [i["key"] for i in result] == ["PROJ-1", "PROJ-2"]
+    assert "nextPageToken" not in captured[0]
+    assert captured[1]["nextPageToken"] == "tok-2"
+
+
+def test_search_stops_when_token_absent_even_without_isLast(monkeypatch):
+    """A page with no nextPageToken is the last page (isLast may be omitted)."""
+    _install_urlopen(monkeypatch, [{"issues": [{"key": "PROJ-1"}]}])
+    result = search_issues_updated_since(**_BASE, token="tok")
+    assert [i["key"] for i in result] == ["PROJ-1"]
+
+
+def test_search_page_cap_raises(monkeypatch):
+    """Every page claims more pages — the cap raises rather than looping."""
+    monkeypatch.setattr("sources.jira.poller._MAX_PAGES", 3)
+    _install_urlopen(
+        monkeypatch,
+        [
+            {"issues": [{"key": f"PROJ-{n}"}], "nextPageToken": f"t{n}", "isLast": False}
+            for n in range(10)
+        ],
+    )
+    with pytest.raises(RuntimeError, match="exceeded"):
+        search_issues_updated_since(**_BASE, token="tok")
+
+
+def test_search_http_error_raises_without_auth_leak(monkeypatch):
+    _install_urlopen(
+        monkeypatch,
+        [urllib.error.HTTPError(_SEARCH_URL, 403, "Forbidden", None, None)],
+    )
+    with pytest.raises(RuntimeError, match="HTTP 403") as excinfo:
+        search_issues_updated_since(**_BASE, token="super-secret-token")
+    # The exception must never carry the credential.
+    assert "super-secret-token" not in str(excinfo.value)
+
+
+def test_search_network_error_raises(monkeypatch):
+    _install_urlopen(monkeypatch, [urllib.error.URLError("connection refused")])
+    with pytest.raises(RuntimeError, match="network error"):
+        search_issues_updated_since(**_BASE, token="tok")
+
+
+def test_search_non_json_body_raises(monkeypatch):
+    _install_urlopen(monkeypatch, [b"<html>not json</html>"])
+    with pytest.raises(RuntimeError, match="non-JSON"):
+        search_issues_updated_since(**_BASE, token="tok")
+
+
+def test_search_unparseable_watermark_raises_value_error(monkeypatch):
+    """A bad updated_after fails before any HTTP call — never a malformed JQL."""
+    _install_urlopen(monkeypatch, [])
+    with pytest.raises(ValueError, match="not a recognizable timestamp"):
+        search_issues_updated_since(**_BASE, token="tok", updated_after="whenever")
+
+
+def test_search_non_object_json_raises(monkeypatch):
+    """A valid-JSON-but-non-object body (e.g. a bare list) → RuntimeError."""
+    _install_urlopen(monkeypatch, [[1, 2, 3]])
+    with pytest.raises(RuntimeError, match="non-object"):
+        search_issues_updated_since(**_BASE, token="tok")


### PR DESCRIPTION
## Summary
**Phase E (final) of the Jira integration** (part of BicameralAI/bicameral-daemon#3; follows A BicameralAI/bicameral-mcp#460, B BicameralAI/bicameral-mcp#462, C BicameralAI/bicameral-daemon#18/#474, D BicameralAI/bicameral-daemon#19/#476).

A poll-based alternative to the Phase B webhook receiver, for operators who cannot host an HTTPS webhook endpoint.

- `sources/jira/poller.py` — `search_issues_updated_since`: paginates `POST /rest/api/3/search/jql` (the token-based bounded-search API — the removed offset `POST /rest/api/3/search` is never called) and returns Jira issues updated since a watermark.
- Structural twin of `sources/notion/poller.py` — a library **fetch** function: it holds no watermark and calls no ingest. Watermark persistence + ingest belong to a future `sync-and-brief` wiring, gated on operator demand per the scope doc (a `# TODO(#337 follow-on)` marker records this).

## Discipline
Read-path only — no inbound/attack surface. Auth header never logged; `RuntimeError` on every failure (so a caller never advances a watermark on a failed pull); a 2000-issue page cap; the watermark is normalized to JQL's `yyyy-MM-dd HH:mm` form. No change to `sources/jira/client.py` (the poller reuses its constants). No new dependency — stdlib `urllib` only.

## Governance
Independently audited — **PASS** (the `/rest/api/3/search/jql` contract and Notion-poller parity verified). Adversarial review: **SHIP** — no HIGH/MED; JQL composition, the fail contract, token pagination, and no-auth-leak all cleared.

## Test plan
- [x] 15 solitary tests (faked HTTP boundary, per CLAUDE.md for external boundaries) — JQL composition, token pagination, page cap, and every failure mode
- [x] `ruff check` + `ruff format --check` clean

This completes the Jira integration's planned phases A–E.

Closes BicameralAI/bicameral-mcp#477

🤖 Generated with [Claude Code](https://claude.com/claude-code)