### PR TITLE
feat(notion): Notion integration — isolated feature branch [review only, do not merge]

### DIFF
--- a/cli/notion_pending_cli.py
+++ b/cli/notion_pending_cli.py
@@ -1,0 +1,183 @@
+"""CLI: ``bicameral-mcp notion-pending`` — operator-facing tool to
+retrieve pending Notion ``verification_token`` values.
+
+After ``webhooks/notion.py`` receives a verification handshake POST,
+the token is persisted in ``secrets_store`` under a fingerprint-keyed
+slot and the fingerprint (not the full token) is logged to stderr.
+The operator runs this command to retrieve the full token by
+fingerprint, then pastes it into Notion's UI to complete the
+subscription handshake.
+
+Usage::
+
+    bicameral-mcp notion-pending              # list all pending entries
+    bicameral-mcp notion-pending <fingerprint>  # print full token
+
+The list form prints fingerprint + received-at age, NOT the token,
+so it's safe to run in shared terminals. The retrieve form prints
+the full token to stdout — operator is responsible for not leaving
+that scrolled-back in a shared terminal.
+
+This is the user-facing half of cycle-8's F3 review fix: the token
+never appears in stderr / log pipelines; operators retrieve it via
+this explicit command instead.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import sys
+import time
+
+# Same prefix the webhook handler uses. Source of truth lives in
+# ``webhooks.notion``; keep these in sync.
+_PENDING_PREFIX = "pending_"
+_FINGERPRINT_RE = re.compile(r"^[0-9a-f]{16}$")
+# Cap the listing output to keep the CLI usable when the registry
+# has been spammed by attacker-driven verification POSTs. Matches
+# the webhook handler's ``_MAX_PENDING_ENTRIES`` cap (review LOW-2)
+# so a healthy registry never hits the truncation footer.
+_LIST_MAX_ROWS = 100
+
+
+def _build_argparser(subparser: argparse.ArgumentParser) -> None:
+    """Wire the subcommand's args. Called from ``server.py``'s argparse."""
+    subparser.add_argument(
+        "fingerprint",
+        nargs="?",
+        default=None,
+        help=(
+            "16-char hex fingerprint logged by the webhook receiver when "
+            "Notion's verification POST arrived. Omit to list all pending "
+            "entries (without revealing tokens)."
+        ),
+    )
+
+
+def main(args: argparse.Namespace) -> int:
+    """Entry point invoked from ``server.py``'s ``_dispatch``.
+
+    Returns 0 on success, 1 on no-matching-entry, 2 on
+    invalid-fingerprint, 3 on secrets_store error.
+    """
+    try:
+        from secrets_store import get_secret, list_keys
+    except Exception as exc:  # noqa: BLE001
+        print(f"[notion-pending] secrets_store unavailable: {exc}", file=sys.stderr)
+        return 3
+
+    if args.fingerprint is None:
+        return _list_pending(list_keys, get_secret)
+
+    fingerprint = args.fingerprint.strip().lower()
+    if not _FINGERPRINT_RE.match(fingerprint):
+        print(
+            f"[notion-pending] fingerprint must be 16 lowercase hex chars; got "
+            f"{args.fingerprint!r}",
+            file=sys.stderr,
+        )
+        return 2
+
+    return _retrieve_token(fingerprint, get_secret)
+
+
+def _list_pending(list_keys_fn, get_secret_fn) -> int:
+    """Print fingerprint + age for every pending entry. Never
+    prints token contents."""
+    try:
+        keys = list_keys_fn(source_id="notion")
+    except Exception as exc:  # noqa: BLE001
+        print(f"[notion-pending] list_keys failed: {exc}", file=sys.stderr)
+        return 3
+
+    pending_keys = sorted([k for k in keys if k.startswith(_PENDING_PREFIX)])
+    if not pending_keys:
+        print("No pending Notion verification entries.")
+        return 0
+
+    total = len(pending_keys)
+    truncated = total > _LIST_MAX_ROWS
+    visible = pending_keys[:_LIST_MAX_ROWS]
+
+    now = int(time.time())
+    print(f"{'FINGERPRINT':<18}{'AGE':<14}STATUS")
+    for key in visible:
+        fingerprint = key[len(_PENDING_PREFIX) :]
+        raw = get_secret_fn(source_id="notion", key=key)
+        if not raw:
+            print(f"{fingerprint:<18}{'?':<14}(value missing)")
+            continue
+        try:
+            entry = json.loads(raw)
+            received_at = int(entry.get("received_at") or 0)
+        except (json.JSONDecodeError, TypeError, ValueError):
+            print(f"{fingerprint:<18}{'?':<14}(malformed entry)")
+            continue
+        age_s = now - received_at
+        age = _format_age(age_s)
+        # 24h TTL on adoption (webhooks.notion._PENDING_TTL_SECONDS).
+        status = "stale" if age_s > 86400 else "active"
+        print(f"{fingerprint:<18}{age:<14}{status}")
+    if truncated:
+        print(
+            f"... and {total - _LIST_MAX_ROWS} more (showing first {_LIST_MAX_ROWS}). "
+            "Registry may be spammed; consider rotating the receiver URL."
+        )
+    return 0
+
+
+def _retrieve_token(fingerprint: str, get_secret_fn) -> int:
+    """Print the full token for one fingerprint to stdout. Operator
+    pastes this into Notion's UI."""
+    key = f"{_PENDING_PREFIX}{fingerprint}"
+    try:
+        raw = get_secret_fn(source_id="notion", key=key)
+    except Exception as exc:  # noqa: BLE001
+        print(f"[notion-pending] get_secret failed: {exc}", file=sys.stderr)
+        return 3
+
+    if not raw:
+        print(
+            f"[notion-pending] no pending entry for fingerprint {fingerprint!r}",
+            file=sys.stderr,
+        )
+        return 1
+
+    try:
+        entry = json.loads(raw)
+    except json.JSONDecodeError as exc:
+        print(
+            f"[notion-pending] entry for {fingerprint!r} is malformed: {exc}",
+            file=sys.stderr,
+        )
+        return 3
+
+    token = entry.get("token")
+    if not isinstance(token, str) or not token:
+        print(
+            f"[notion-pending] entry for {fingerprint!r} has no token field",
+            file=sys.stderr,
+        )
+        return 3
+
+    # Full token to stdout, not stderr — operator-driven retrieval
+    # is the safe surface (cycle 8 review F3). No trailing newline
+    # so the operator can pipe directly into a clipboard tool
+    # (``xclip``, ``pbcopy``, etc.) without spurious whitespace.
+    sys.stdout.write(token)
+    sys.stdout.flush()
+    return 0
+
+
+def _format_age(seconds: int) -> str:
+    """Render an age-in-seconds as a compact human-readable string."""
+    if seconds < 60:
+        return f"{seconds}s"
+    if seconds < 3600:
+        return f"{seconds // 60}m"
+    if seconds < 86400:
+        return f"{seconds // 3600}h"
+    days = seconds // 86400
+    return f"{days}d"

--- a/cli/source_list_cli.py
+++ b/cli/source_list_cli.py
@@ -22,7 +22,7 @@ import argparse
 import json
 import sys
 
-_DISCOVERABLE_SOURCES = ("github", "google_drive")
+_DISCOVERABLE_SOURCES = ("notion", "github", "google_drive")
 
 
 def _build_argparser(subparser: argparse.ArgumentParser) -> None:
@@ -47,6 +47,7 @@ def _build_argparser(subparser: argparse.ArgumentParser) -> None:
 def main(args: argparse.Namespace) -> int:
     """Entry point invoked from ``server.py::_dispatch``."""
     dispatch = {
+        "notion": _list_notion,
         "github": _list_github,
         "google_drive": _list_google_drive,
     }
@@ -75,6 +76,26 @@ class _AuthMissing(RuntimeError):
 
 class _APIError(RuntimeError):
     """Discovery API call failed."""
+
+
+def _list_notion() -> tuple[list[dict], list[str]]:
+    from secrets_store import get_secret
+
+    key = get_secret(source_id="notion", key="api_key")
+    if not key:
+        raise _AuthMissing(
+            "Notion integration token not configured. Store via put_secret "
+            "(source_id='notion', key='api_key'). The integration must "
+            "additionally be shared with each database via Notion's UI "
+            "(Share → Connections)."
+        )
+    from sources.notion.client import NotionAPIError, list_databases
+
+    try:
+        dbs = list_databases(api_key=key)
+    except NotionAPIError as exc:
+        raise _APIError(str(exc)) from exc
+    return dbs, ["title", "id"]
 
 
 def _list_github() -> tuple[list[dict], list[str]]:

--- a/events/sources/__init__.py
+++ b/events/sources/__init__.py
@@ -24,6 +24,7 @@ from .github import GitHubPollingAdapter
 from .google_drive import GoogleDriveFolderAdapter
 from .granola import GranolaAdapter, MissingApiKeyError
 from .local_directory import LocalDirectoryAdapter
+from .notion import NotionPollingAdapter
 
 
 @runtime_checkable
@@ -47,6 +48,7 @@ ADAPTERS: dict[str, type] = {
     "granola": GranolaAdapter,
     "local_directory": LocalDirectoryAdapter,
     "google_drive": GoogleDriveFolderAdapter,
+    "notion": NotionPollingAdapter,
     "github": GitHubPollingAdapter,
 }
 
@@ -58,5 +60,6 @@ __all__ = [
     "GranolaAdapter",
     "LocalDirectoryAdapter",
     "MissingApiKeyError",
+    "NotionPollingAdapter",
     "SourceAdapter",
 ]

--- a/events/sources/notion.py
+++ b/events/sources/notion.py
@@ -1,0 +1,196 @@
+"""Notion polling source adapter (#337 Phase 2b).
+
+Pull-based: enumerates pages in a Notion database that were last edited
+after the watermark, fetches each through Phase 2's active-ingest adapter
+for property + block-walk normalization, returns ingest-ready payloads.
+
+Config schema::
+
+    sources:
+      - type: notion
+        database_id: <Notion database ID>
+        source_type_label: decision-doc  # optional
+
+Auth: ``secrets_store source_id="notion", key="api_key"``. Operator
+stores the Notion integration token there; the integration must be
+shared with each database the adapter polls (Notion's share-per-database
+permission model — see plan-2-notion-active for caveats).
+
+Watermark: ``<watermark_dir>/notion.json`` with
+``{"last_edited_time": "<ISO8601>"}``. Corrupt / missing → epoch.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import sys
+from pathlib import Path
+
+logger = logging.getLogger(__name__)
+
+_WATERMARK_FILENAME = "notion.json"
+
+
+class NotionPollingAdapter:
+    """Source adapter conforming to ``events.sources.SourceAdapter``."""
+
+    name = "notion"
+
+    def __init__(self) -> None:
+        self._pending_watermark: str | None = None
+        self._watermark_path: Path | None = None
+
+    def pull(self, *, watermark_dir: Path, config: dict) -> list[dict]:
+        watermark_dir = Path(watermark_dir)
+        watermark_dir.mkdir(parents=True, exist_ok=True)
+        self._watermark_path = watermark_dir / _WATERMARK_FILENAME
+
+        database_id = (config.get("database_id") or "").strip()
+        if not database_id:
+            print(
+                "[notion] database_id is required in source config; skipping.",
+                file=sys.stderr,
+            )
+            self._pending_watermark = None
+            return []
+
+        last_watermark = _read_watermark(self._watermark_path)
+
+        try:
+            from secrets_store import get_secret
+            from sources.notion.poller import list_recently_edited_pages
+
+            api_key = get_secret(source_id="notion", key="api_key")
+            if not api_key:
+                print(
+                    "[notion] api_key not configured (secrets_store source_id=notion, "
+                    "key=api_key); skipping.",
+                    file=sys.stderr,
+                )
+                self._pending_watermark = None
+                return []
+            pages = list_recently_edited_pages(
+                api_key=api_key,
+                database_id=database_id,
+                edited_after=last_watermark,
+            )
+        except Exception as exc:  # noqa: BLE001 — never raise to _run_source
+            print(f"[notion] database query failed: {exc}", file=sys.stderr)
+            self._pending_watermark = None
+            return []
+
+        if not pages:
+            self._pending_watermark = None
+            return []
+
+        try:
+            from sources.notion.adapter import NotionAdapter
+        except ImportError as exc:
+            print(f"[notion] adapter import failed: {exc}", file=sys.stderr)
+            self._pending_watermark = None
+            return []
+
+        # #337 cycle 2: universal filter (source-level — Notion's
+        # database_id is the resource).
+        from filters import (
+            FilterSpec,
+            evaluate_filters,
+            get_max_bytes,
+            get_max_items,
+            payload_within_cap,
+        )
+
+        try:
+            source_spec = FilterSpec(**(config.get("filters") or {}))
+        except Exception as exc:  # noqa: BLE001
+            print(f"[notion] malformed filter block ignored: {exc}", file=sys.stderr)
+            source_spec = FilterSpec()
+
+        # cycle 4: per-source quota
+        max_items = get_max_items(config)
+        max_bytes = get_max_bytes(config)
+
+        active = NotionAdapter()
+        payloads: list[dict] = []
+        highest_edited = last_watermark or ""
+        for page in pages:
+            if max_items and len(payloads) >= max_items:
+                break
+            page_id = page.get("id") or ""
+            edited = page.get("last_edited_time") or ""
+            url = page.get("url") or ""
+            if not page_id or not url:
+                continue
+            try:
+                payload = active.fetch_active(url)
+            except Exception as exc:  # noqa: BLE001
+                print(
+                    f"[notion] page {page_id!r} fetch failed (skipped): {exc}",
+                    file=sys.stderr,
+                )
+                continue
+            text_bits = [
+                str(payload.get("query") or ""),
+                *(d.get("description", "") for d in (payload.get("decisions") or [])),
+            ]
+            participants = payload.get("participants") or []
+            candidate = {
+                "text": " ".join(text_bits),
+                "author": participants[0] if participants else "",
+                "timestamp": edited,
+            }
+            if not evaluate_filters(candidate, source_spec):
+                if edited > highest_edited:
+                    highest_edited = edited
+                continue
+            label = config.get("source_type_label")
+            if label:
+                payload = {**payload, "source": str(label)}
+            if not payload_within_cap(payload, max_bytes):
+                print(
+                    f"[notion] page {page_id!r} exceeds max_payload_bytes ({max_bytes}); skipped.",
+                    file=sys.stderr,
+                )
+                if edited > highest_edited:
+                    highest_edited = edited
+                continue
+            payloads.append(payload)
+            if edited > highest_edited:
+                highest_edited = edited
+
+        self._pending_watermark = highest_edited or None
+        return payloads
+
+    def confirm_watermark(self) -> None:
+        if self._watermark_path is None or self._pending_watermark is None:
+            return
+        try:
+            self._watermark_path.write_text(
+                json.dumps({"last_edited_time": self._pending_watermark}),
+                encoding="utf-8",
+            )
+        except OSError as exc:
+            logger.warning(
+                "[notion] watermark persistence failed (will re-pull next run): %s",
+                exc,
+            )
+        self._pending_watermark = None
+
+
+def _read_watermark(path: Path) -> str | None:
+    if not path.exists():
+        return None
+    try:
+        data = json.loads(path.read_text(encoding="utf-8"))
+    except (json.JSONDecodeError, OSError) as exc:
+        logger.warning(
+            "[notion] watermark file corrupt at %s, starting from epoch: %s",
+            path,
+            exc,
+        )
+        return None
+    value = data.get("last_edited_time") if isinstance(data, dict) else None
+    if not value or not isinstance(value, str):
+        return None
+    return value

--- a/server.py
+++ b/server.py
@@ -1473,6 +1473,16 @@ def _register_subparsers(parser: ArgumentParser, subparsers: Any) -> None:
     from cli.webhook_server_cli import _build_argparser as _ws_build
 
     _ws_build(webhook_server)
+    notion_pending = subparsers.add_parser(
+        "notion-pending",
+        help=(
+            "retrieve pending Notion verification_token by fingerprint, or list "
+            "all pending entries (#337 cycle 8b)"
+        ),
+    )
+    from cli.notion_pending_cli import _build_argparser as _np_build
+
+    _np_build(notion_pending)
     drive_watch = subparsers.add_parser(
         "drive-watch",
         help="start a Google Drive Push Notification channel for a file (#337 cycle 9b)",
@@ -1588,6 +1598,10 @@ def _dispatch(args: Any) -> int:
         from cli.webhook_server_cli import main as webhook_server_main
 
         return webhook_server_main(args)
+    if args.command == "notion-pending":
+        from cli.notion_pending_cli import main as notion_pending_main
+
+        return notion_pending_main(args)
     if args.command == "drive-watch":
         from cli.drive_watch_cli import main as drive_watch_main
 

--- a/sources/notion/__init__.py
+++ b/sources/notion/__init__.py
@@ -1,0 +1,14 @@
+"""Notion source adapter (#420 Phase 2 — active ingest).
+
+Public API: ``NotionAdapter`` (the SourceAdapter implementation) and
+``parse_notion_url`` (URL parsing helper, exposed for tests).
+
+Auth: persisted via ``secrets_store`` under ``source_id="notion"``,
+key ``"api_key"``. The Notion internal-integration token model means
+the operator creates an integration in Notion's admin UI, shares the
+specific page/database with it, then stores the token here.
+"""
+
+from sources.notion.adapter import NotionAdapter, parse_notion_url
+
+__all__ = ["NotionAdapter", "parse_notion_url"]

--- a/sources/notion/adapter.py
+++ b/sources/notion/adapter.py
@@ -1,0 +1,184 @@
+"""Notion source adapter (#420 Phase 2 — active ingest).
+
+URL → REST fetch → block walk → normalized ingest payload.
+
+Notion URL forms accepted:
+    https://www.notion.so/<workspace>/<slug>-<32hex>
+    https://www.notion.so/<32hex>
+    https://www.notion.so/<workspace>/<32hex>
+
+The trailing 32-hex page ID is the canonical identifier. Notion accepts
+both dashed (``...-...``) and undashed forms in API calls; the adapter
+normalizes to the dashed UUID form before the API call so the response
+is predictable.
+
+Block walker extracts text from common prose block types only:
+    paragraph, heading_1, heading_2, heading_3,
+    bulleted_list_item, numbered_list_item, to_do, quote, callout, code
+
+Other types (image, video, file, embed, child_database, child_page,
+table, divider) are skipped — they're not text-bearing for decision
+extraction purposes. Child pages are not recursed (out-of-scope per
+Phase 2 acceptance — operator passes specific pages).
+"""
+
+from __future__ import annotations
+
+import re
+
+_URL_RE = re.compile(
+    r"^https?://(?:www\.)?notion\.so/(?:[^/]+/)?(?:[^/]+-)?(?P<id>[0-9a-fA-F]{32})(?:[/?#].*)?$"
+)
+
+# Block types we extract text from.
+_PROSE_BLOCK_TYPES = frozenset(
+    {
+        "paragraph",
+        "heading_1",
+        "heading_2",
+        "heading_3",
+        "bulleted_list_item",
+        "numbered_list_item",
+        "to_do",
+        "quote",
+        "callout",
+        "code",
+    }
+)
+
+
+def parse_notion_url(url: str) -> str:
+    """Extract the 32-hex page ID and return the dashed UUID form.
+
+    Raises:
+        ValueError: URL doesn't match any accepted Notion shape.
+    """
+    m = _URL_RE.match(url.strip())
+    if not m:
+        raise ValueError(
+            f"not a recognized Notion URL: {url!r}. "
+            "Expected https://www.notion.so/<workspace>/<slug>-<32hex> or similar."
+        )
+    raw = m.group("id").lower()
+    # Normalize to dashed UUID form (8-4-4-4-12).
+    return f"{raw[0:8]}-{raw[8:12]}-{raw[12:16]}-{raw[16:20]}-{raw[20:32]}"
+
+
+def _extract_rich_text(rich_text: list[dict]) -> str:
+    """Concatenate Notion's rich_text array into a plain string."""
+    return "".join(item.get("plain_text", "") for item in rich_text or [])
+
+
+def _extract_block_text(block: dict) -> str:
+    """Return the plain-text content of a prose block, or empty string."""
+    btype = block.get("type")
+    if btype not in _PROSE_BLOCK_TYPES:
+        return ""
+    body = block.get(btype) or {}
+    rich_text = body.get("rich_text") or body.get("text") or []
+    text = _extract_rich_text(rich_text)
+    # Decorate by type so the ingest sees structural cues — important
+    # for the gap-judge chain that uses headings as topic anchors.
+    if btype == "heading_1":
+        return f"# {text}"
+    if btype == "heading_2":
+        return f"## {text}"
+    if btype == "heading_3":
+        return f"### {text}"
+    if btype == "bulleted_list_item":
+        return f"- {text}"
+    if btype == "numbered_list_item":
+        return f"1. {text}"
+    if btype == "to_do":
+        checked = body.get("checked", False)
+        return f"- [{'x' if checked else ' '}] {text}"
+    if btype == "quote":
+        return f"> {text}"
+    if btype == "callout":
+        return f"📌 {text}"  # Notion's own callout marker convention
+    if btype == "code":
+        lang = body.get("language") or ""
+        return f"```{lang}\n{text}\n```"
+    return text
+
+
+def _extract_page_title(page: dict) -> str:
+    """Pull the page title from properties.
+
+    Notion's property model varies — title lives under a property named
+    ``"title"`` or ``"Name"`` typically. Look for any property whose
+    ``type`` is ``"title"``.
+    """
+    properties = page.get("properties") or {}
+    for prop in properties.values():
+        if prop.get("type") == "title":
+            return _extract_rich_text(prop.get("title", []))
+    return ""
+
+
+def _extract_participants(page: dict) -> list[str]:
+    """Best-effort participant extraction.
+
+    Notion exposes ``created_by`` and ``last_edited_by`` as user objects
+    with at most a name; emails aren't available on the page-properties
+    surface for most workspaces. Returns names where present.
+    """
+    out: list[str] = []
+    seen: set[str] = set()
+    for key in ("created_by", "last_edited_by"):
+        user = page.get(key) or {}
+        name = user.get("name") or user.get("id")
+        if name and name not in seen:
+            seen.add(name)
+            out.append(name)
+    return out
+
+
+def normalize_page_to_payload(page: dict, blocks: list[dict], page_id: str) -> dict:
+    """Build the ingest payload from page metadata + child blocks."""
+    title = _extract_page_title(page) or page_id
+    block_texts = [t for b in blocks if (t := _extract_block_text(b))]
+    full_text = "\n".join(block_texts).strip()
+
+    decisions: list[dict] = []
+    if full_text:
+        decisions.append({"description": full_text, "title": title})
+
+    return {
+        "query": title,
+        "source": "notion",
+        "title": title,
+        "date": page.get("last_edited_time") or page.get("created_time") or "",
+        "participants": _extract_participants(page),
+        "decisions": decisions,
+    }
+
+
+class NotionAdapter:
+    """SourceAdapter implementation for Notion (active path)."""
+
+    source_id = "notion"
+
+    def can_handle_url(self, url: str) -> bool:
+        return bool(_URL_RE.match(url.strip()))
+
+    def fetch_active(self, url: str) -> dict:
+        page_id = parse_notion_url(url)
+        api_key = self._resolve_api_key()
+        from sources.notion.client import get_all_blocks, get_page
+
+        page = get_page(api_key=api_key, page_id=page_id)
+        blocks = get_all_blocks(api_key=api_key, page_id=page_id)
+        return normalize_page_to_payload(page, blocks, page_id)
+
+    def _resolve_api_key(self) -> str:
+        from secrets_store import get_secret
+
+        key = get_secret(source_id=self.source_id, key="api_key")
+        if not key:
+            raise RuntimeError(
+                "Notion API key not configured. Set it via:\n"
+                '  python -c "from secrets_store import put_secret; '
+                "put_secret(source_id='notion', key='api_key', value='secret_...')\""
+            )
+        return key

--- a/sources/notion/client.py
+++ b/sources/notion/client.py
@@ -1,0 +1,172 @@
+"""Thin Notion REST client (#420 Phase 2 — active ingest).
+
+Uses stdlib ``urllib.request`` for consistency with the Linear client.
+Two endpoints used today:
+    GET /v1/pages/{id}             — page metadata + properties
+    GET /v1/blocks/{id}/children    — paginated block list
+
+Notion requires a ``Notion-Version`` header — pinned to a stable version
+to avoid implicit upgrades silently breaking the block walker.
+
+Threat-model parity with the Linear client:
+- Token in Authorization header (never URL).
+- Response size capped at 4 MiB per call (Notion pages with megabytes of
+  blocks are misuse — operator should narrow the page scope).
+- Per-call 15s timeout.
+"""
+
+from __future__ import annotations
+
+import json
+import urllib.error
+import urllib.parse
+import urllib.request
+
+_API_BASE = "https://api.notion.com/v1"
+_NOTION_VERSION = "2022-06-28"
+_REQUEST_TIMEOUT_SECONDS = 15.0
+_MAX_RESPONSE_BYTES = 4 * 1024 * 1024
+_MAX_PAGINATION_PAGES = 20  # 20 * 100 blocks = 2000 — bounds large-page misuse
+
+
+class NotionAPIError(RuntimeError):
+    """Raised for any non-recoverable Notion API failure."""
+
+    def __init__(self, message: str, *, status_code: int | None = None) -> None:
+        self.status_code = status_code
+        super().__init__(message)
+
+
+def _get(*, api_key: str, path: str, params: dict | None = None) -> dict:
+    """GET ``{_API_BASE}{path}`` with optional query params; return parsed JSON."""
+    url = f"{_API_BASE}{path}"
+    if params:
+        url = url + "?" + urllib.parse.urlencode(params)
+    headers = {
+        "Authorization": f"Bearer {api_key}",
+        "Notion-Version": _NOTION_VERSION,
+        "User-Agent": "bicameral-mcp/source-notion",
+    }
+    req = urllib.request.Request(url, headers=headers, method="GET")
+    try:
+        with urllib.request.urlopen(req, timeout=_REQUEST_TIMEOUT_SECONDS) as resp:
+            raw = resp.read(_MAX_RESPONSE_BYTES + 1)
+            if len(raw) > _MAX_RESPONSE_BYTES:
+                raise NotionAPIError(
+                    f"Notion response exceeded {_MAX_RESPONSE_BYTES} bytes",
+                    status_code=resp.status,
+                )
+    except urllib.error.HTTPError as exc:
+        raise NotionAPIError(
+            f"Notion API HTTP {exc.code}: {exc.reason}",
+            status_code=exc.code,
+        ) from exc
+    except urllib.error.URLError as exc:
+        raise NotionAPIError(f"Notion API network error: {exc.reason}") from exc
+
+    try:
+        return json.loads(raw.decode("utf-8"))
+    except json.JSONDecodeError as exc:
+        raise NotionAPIError(f"Notion API returned non-JSON: {exc}") from exc
+
+
+def get_page(*, api_key: str, page_id: str) -> dict:
+    """Fetch a page's metadata + properties."""
+    return _get(api_key=api_key, path=f"/pages/{page_id}")
+
+
+def list_databases(*, api_key: str) -> list[dict]:
+    """Enumerate databases the Notion integration has been shared with.
+
+    Uses the `search` endpoint with `filter.value=database` since Notion's
+    integration-permission model doesn't expose a simple list-shared call.
+    Returns dicts shaped ``{"id", "title"}`` where title is the first
+    rich-text plain string of the database title.
+
+    Capped at 200 results (two pages) — operator workspaces with more
+    Notion databases shared with one integration than that are rare.
+    """
+    import urllib.error
+    import urllib.parse
+    import urllib.request
+
+    headers = {
+        "Authorization": f"Bearer {api_key}",
+        "Notion-Version": _NOTION_VERSION,
+        "Content-Type": "application/json",
+        "User-Agent": "bicameral-mcp/source-notion-discovery",
+    }
+    out: list[dict] = []
+    cursor: str | None = None
+    pages = 0
+    while True:
+        body: dict = {
+            "filter": {"value": "database", "property": "object"},
+            "page_size": 100,
+        }
+        if cursor is not None:
+            body["start_cursor"] = cursor
+        req = urllib.request.Request(
+            f"{_API_BASE}/search",
+            data=json.dumps(body).encode("utf-8"),
+            headers=headers,
+            method="POST",
+        )
+        try:
+            with urllib.request.urlopen(req, timeout=_REQUEST_TIMEOUT_SECONDS) as resp:
+                raw = resp.read(_MAX_RESPONSE_BYTES + 1)
+                if len(raw) > _MAX_RESPONSE_BYTES:
+                    raise NotionAPIError(
+                        f"Notion response exceeded {_MAX_RESPONSE_BYTES} bytes",
+                        status_code=resp.status,
+                    )
+        except urllib.error.HTTPError as exc:
+            raise NotionAPIError(
+                f"Notion search HTTP {exc.code}: {exc.reason}",
+                status_code=exc.code,
+            ) from exc
+        except urllib.error.URLError as exc:
+            raise NotionAPIError(f"Notion search network error: {exc.reason}") from exc
+
+        try:
+            data = json.loads(raw.decode("utf-8"))
+        except json.JSONDecodeError as exc:
+            raise NotionAPIError(f"Notion search returned non-JSON: {exc}") from exc
+
+        for db in data.get("results") or []:
+            title_rich = db.get("title") or []
+            title = "".join(t.get("plain_text", "") for t in title_rich) or "(untitled)"
+            out.append({"id": db.get("id") or "", "title": title})
+        pages += 1
+        if not data.get("has_more"):
+            break
+        cursor = data.get("next_cursor")
+        if not cursor or pages >= 2:
+            break
+    return out
+
+
+def get_all_blocks(*, api_key: str, page_id: str) -> list[dict]:
+    """Fetch every child block of ``page_id``, paginating until exhausted
+    or until the per-call page cap fires (misuse bound)."""
+    out: list[dict] = []
+    cursor: str | None = None
+    pages_fetched = 0
+    while True:
+        params: dict[str, str] = {"page_size": "100"}
+        if cursor is not None:
+            params["start_cursor"] = cursor
+        resp = _get(api_key=api_key, path=f"/blocks/{page_id}/children", params=params)
+        out.extend(resp.get("results", []))
+        pages_fetched += 1
+        if not resp.get("has_more"):
+            break
+        if pages_fetched >= _MAX_PAGINATION_PAGES:
+            raise NotionAPIError(
+                f"page has more than {_MAX_PAGINATION_PAGES * 100} blocks — "
+                "narrow the ingest scope to a sub-page"
+            )
+        cursor = resp.get("next_cursor")
+        if not cursor:
+            break
+    return out

--- a/sources/notion/poller.py
+++ b/sources/notion/poller.py
@@ -1,0 +1,119 @@
+"""Notion polling helper for Phase 2b passive ingest (#337).
+
+Wraps the Phase 2 REST client with a database query that returns pages
+edited strictly after the watermark. Notion shipped webhooks in 2024
+GA (see ``webhooks/notion.py`` and
+``docs/research-brief-notion-webhooks-2026-05-20.md``); passive ingest
+can now be either webhook-driven or poll-driven. Operators choose per
+subscription based on whether they can host an HTTPS endpoint.
+
+Pagination cap: 20 pages × 100 results = 2000 pages per pull. Mirrors
+the Phase 2 blocks pagination cap.
+"""
+
+from __future__ import annotations
+
+_PAGE_SIZE = 100
+_MAX_PAGES = 20
+
+
+def list_recently_edited_pages(
+    *,
+    api_key: str,
+    database_id: str,
+    edited_after: str | None = None,
+):
+    """Return database pages with ``last_edited_time > edited_after``.
+
+    Each result dict carries the full Notion page object (the polling
+    adapter pulls ``id``, ``last_edited_time``, and the URL from it).
+
+    Sorted ascending by ``last_edited_time`` via the Notion sort spec.
+
+    ``edited_after`` is an ISO 8601 timestamp string. ``None`` returns
+    every page in the database, oldest-edit first.
+
+    Raises ``RuntimeError`` on Notion API failure with a message the
+    polling adapter logs without advancing the watermark.
+    """
+    import json
+    import urllib.error
+    import urllib.request
+
+    from sources.notion.client import (
+        _API_BASE,
+        _MAX_RESPONSE_BYTES,
+        _NOTION_VERSION,
+        _REQUEST_TIMEOUT_SECONDS,
+        NotionAPIError,
+    )
+
+    headers = {
+        "Authorization": f"Bearer {api_key}",
+        "Notion-Version": _NOTION_VERSION,
+        "Content-Type": "application/json",
+        "User-Agent": "bicameral-mcp/source-notion-polling",
+    }
+
+    body: dict = {
+        "page_size": _PAGE_SIZE,
+        "sorts": [{"timestamp": "last_edited_time", "direction": "ascending"}],
+    }
+    if edited_after:
+        body["filter"] = {
+            "timestamp": "last_edited_time",
+            "last_edited_time": {"after": edited_after},
+        }
+
+    results: list[dict] = []
+    cursor: str | None = None
+    pages = 0
+    while True:
+        if cursor is not None:
+            body["start_cursor"] = cursor
+        elif "start_cursor" in body:
+            del body["start_cursor"]
+        req = urllib.request.Request(
+            f"{_API_BASE}/databases/{database_id}/query",
+            data=json.dumps(body).encode("utf-8"),
+            headers=headers,
+            method="POST",
+        )
+        try:
+            with urllib.request.urlopen(req, timeout=_REQUEST_TIMEOUT_SECONDS) as resp:
+                raw = resp.read(_MAX_RESPONSE_BYTES + 1)
+                if len(raw) > _MAX_RESPONSE_BYTES:
+                    raise NotionAPIError(
+                        f"Notion response exceeded {_MAX_RESPONSE_BYTES} bytes",
+                        status_code=resp.status,
+                    )
+        except urllib.error.HTTPError as exc:
+            raise RuntimeError(
+                f"Notion database query failed for database_id={database_id!r}: "
+                f"HTTP {exc.code} {exc.reason}"
+            ) from exc
+        except urllib.error.URLError as exc:
+            raise RuntimeError(f"Notion database query network error: {exc.reason}") from exc
+        except NotionAPIError as exc:
+            raise RuntimeError(f"Notion database query failed: {exc}") from exc
+
+        try:
+            data = json.loads(raw.decode("utf-8"))
+        except json.JSONDecodeError as exc:
+            raise RuntimeError(f"Notion database query returned non-JSON: {exc}") from exc
+
+        results.extend(data.get("results") or [])
+        pages += 1
+        if not data.get("has_more"):
+            break
+        cursor = data.get("next_cursor")
+        if not cursor:
+            break
+        if pages >= _MAX_PAGES:
+            raise RuntimeError(
+                f"Notion database {database_id!r} has more than "
+                f"{_MAX_PAGES * _PAGE_SIZE} edited pages since the watermark — "
+                "narrow the database or split the source config"
+            )
+
+    return results

--- a/tests/test_cli_notion_pending.py
+++ b/tests/test_cli_notion_pending.py
@@ -1,0 +1,173 @@
+"""Tests for the ``bicameral-mcp notion-pending`` CLI (#337 cycle 8b).
+
+Coverage:
+- _list_pending: empty registry, one pending entry, multiple entries,
+  malformed entry, missing value, stale-vs-active status
+- _retrieve_token: happy path, no matching entry, malformed entry,
+  missing token field
+- main: invalid fingerprint shape rejected with exit 2, secrets_store
+  unavailable returns exit 3
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import time
+
+import pytest
+
+from cli.notion_pending_cli import main as cli_main
+
+
+@pytest.fixture(autouse=True)
+def _disable_keyring(monkeypatch):
+    monkeypatch.setenv("BICAMERAL_KEYRING_DISABLE", "1")
+    from secrets_store.store import _reset_for_tests as _secrets_reset
+
+    _secrets_reset()
+    yield
+    _secrets_reset()
+
+
+def _put_pending(
+    fingerprint: str, token: str = "secret_xyz", received_at: int | None = None
+) -> None:
+    """Helper: store a pending entry in the shape the webhook receiver writes."""
+    from secrets_store import put_secret
+
+    entry = json.dumps(
+        {
+            "token": token,
+            "received_at": received_at if received_at is not None else int(time.time()),
+        }
+    )
+    put_secret(source_id="notion", key=f"pending_{fingerprint}", value=entry)
+
+
+def _args(fingerprint: str | None = None) -> argparse.Namespace:
+    return argparse.Namespace(fingerprint=fingerprint)
+
+
+# ── list mode ──────────────────────────────────────────────────────────────
+
+
+def test_list_empty_registry(capsys: pytest.CaptureFixture):
+    rc = cli_main(_args(None))
+    assert rc == 0
+    captured = capsys.readouterr()
+    assert "No pending Notion verification entries." in captured.out
+
+
+def test_list_one_entry_shows_fingerprint_not_token(capsys: pytest.CaptureFixture):
+    _put_pending("a" * 16, token="secret_should_not_appear")
+    rc = cli_main(_args(None))
+    assert rc == 0
+    captured = capsys.readouterr()
+    assert "a" * 16 in captured.out
+    assert "active" in captured.out
+    # Token must NOT appear in list-mode output (F3 review fix).
+    assert "secret_should_not_appear" not in captured.out
+
+
+def test_list_multiple_entries(capsys: pytest.CaptureFixture):
+    _put_pending("a" * 16)
+    _put_pending("b" * 16)
+    rc = cli_main(_args(None))
+    assert rc == 0
+    captured = capsys.readouterr()
+    assert "a" * 16 in captured.out
+    assert "b" * 16 in captured.out
+
+
+def test_list_stale_entry_flagged(capsys: pytest.CaptureFixture):
+    """Entries older than 24h are flagged as 'stale' (matching the
+    webhook handler's adoption-TTL cutoff)."""
+    _put_pending("c" * 16, received_at=0)  # epoch 1970
+    rc = cli_main(_args(None))
+    assert rc == 0
+    captured = capsys.readouterr()
+    assert "c" * 16 in captured.out
+    assert "stale" in captured.out
+
+
+def test_list_malformed_entry_does_not_crash(capsys: pytest.CaptureFixture):
+    """A pending key with a non-JSON value should print '(malformed entry)'
+    and continue rather than blowing up the whole listing."""
+    from secrets_store import put_secret
+
+    put_secret(source_id="notion", key="pending_" + "d" * 16, value="not-json")
+    _put_pending("e" * 16)
+    rc = cli_main(_args(None))
+    assert rc == 0
+    captured = capsys.readouterr()
+    assert "malformed entry" in captured.out
+    # Good entry still shown.
+    assert "e" * 16 in captured.out
+
+
+# ── retrieve mode ──────────────────────────────────────────────────────────
+
+
+def test_retrieve_token_happy_path(capsys: pytest.CaptureFixture):
+    _put_pending("a" * 16, token="secret_real_token_value")
+    rc = cli_main(_args("a" * 16))
+    assert rc == 0
+    captured = capsys.readouterr()
+    # Token to stdout, no trailing newline (so operator can pipe to
+    # clipboard tools without spurious whitespace).
+    assert captured.out == "secret_real_token_value"
+
+
+def test_retrieve_token_missing_returns_1(capsys: pytest.CaptureFixture):
+    rc = cli_main(_args("a" * 16))
+    assert rc == 1
+    captured = capsys.readouterr()
+    assert "no pending entry" in captured.err
+
+
+def test_retrieve_token_malformed_entry_returns_3(capsys: pytest.CaptureFixture):
+    from secrets_store import put_secret
+
+    put_secret(source_id="notion", key="pending_" + "a" * 16, value="not-json")
+    rc = cli_main(_args("a" * 16))
+    assert rc == 3
+    captured = capsys.readouterr()
+    assert "malformed" in captured.err
+
+
+def test_retrieve_token_no_token_field_returns_3(capsys: pytest.CaptureFixture):
+    from secrets_store import put_secret
+
+    put_secret(source_id="notion", key="pending_" + "a" * 16, value=json.dumps({"received_at": 1}))
+    rc = cli_main(_args("a" * 16))
+    assert rc == 3
+    captured = capsys.readouterr()
+    assert "no token field" in captured.err
+
+
+# ── input validation ──────────────────────────────────────────────────────
+
+
+def test_invalid_fingerprint_shape_rejected(capsys: pytest.CaptureFixture):
+    rc = cli_main(_args("NOT-HEX"))
+    assert rc == 2
+    captured = capsys.readouterr()
+    assert "16 lowercase hex" in captured.err
+
+
+def test_invalid_fingerprint_too_short(capsys: pytest.CaptureFixture):
+    rc = cli_main(_args("abc"))
+    assert rc == 2
+    captured = capsys.readouterr()
+    assert "16 lowercase hex" in captured.err
+
+
+def test_uppercase_fingerprint_normalized(capsys: pytest.CaptureFixture):
+    """Per the CLI's .lower() normalization — operators copy-pasting
+    from stderr shouldn't be tripped up by accidental capitalization."""
+    _put_pending("a" * 16, token="secret_lowercase_stored")
+    rc = cli_main(_args("A" * 16))
+    assert rc == 0
+    captured = capsys.readouterr()
+    assert captured.out == "secret_lowercase_stored"

--- a/tests/test_filters_per_adapter.py
+++ b/tests/test_filters_per_adapter.py
@@ -33,6 +33,37 @@ def _disable_keyring(monkeypatch):
 # ── Slack: keyword_include + per-resource override ──────────────────────────
 
 
+def test_notion_time_window_filter(tmp_path):
+    from events.sources.notion import NotionPollingAdapter
+    from secrets_store import put_secret
+
+    put_secret(source_id="notion", key="api_key", value="secret_t")
+
+    fake_pages = [
+        {"id": "p1", "url": "https://notion.so/p1", "last_edited_time": "2026-04-01T00:00:00Z"},
+        {"id": "p2", "url": "https://notion.so/p2", "last_edited_time": "2026-06-01T00:00:00Z"},
+    ]
+    fake_payload = {"query": "x", "decisions": [], "participants": []}
+
+    with (
+        patch("sources.notion.poller.list_recently_edited_pages", return_value=fake_pages),
+        patch("sources.notion.adapter.NotionAdapter.fetch_active", return_value=fake_payload),
+    ):
+        adapter = NotionPollingAdapter()
+        result = adapter.pull(
+            watermark_dir=tmp_path,
+            config={
+                "database_id": "db1",
+                "filters": {"time_window_after": "2026-05-01T00:00:00Z"},
+            },
+        )
+
+    assert len(result) == 1
+
+
+# ── GitHub: per-repo override ───────────────────────────────────────────────
+
+
 def test_github_per_repo_filter_override(tmp_path):
     from events.sources.github import GitHubPollingAdapter
     from secrets_store import put_secret

--- a/tests/test_filters_quota.py
+++ b/tests/test_filters_quota.py
@@ -93,6 +93,36 @@ def test_payload_within_cap_handles_malformed():
 # ── per-adapter wiring ──────────────────────────────────────────────────────
 
 
+def test_notion_caps_to_max_items(tmp_path):
+    from events.sources.notion import NotionPollingAdapter
+    from secrets_store import put_secret
+
+    put_secret(source_id="notion", key="api_key", value="secret_t")
+
+    fake_pages = [
+        {
+            "id": f"p{i}",
+            "url": f"https://notion.so/p{i}",
+            "last_edited_time": f"2026-05-{i:02d}T00:00:00Z",
+        }
+        for i in range(1, 6)
+    ]
+    payload = {"query": "x", "decisions": [], "participants": []}
+
+    with (
+        patch("sources.notion.poller.list_recently_edited_pages", return_value=fake_pages),
+        patch("sources.notion.adapter.NotionAdapter.fetch_active", return_value=payload),
+    ):
+        adapter = NotionPollingAdapter()
+        result = adapter.pull(
+            watermark_dir=tmp_path,
+            config={"database_id": "db1", "max_items_per_pull": 2},
+        )
+
+    assert len(result) == 2
+    assert adapter._pending_watermark == "2026-05-02T00:00:00Z"
+
+
 def test_github_caps_across_repos(tmp_path):
     """Cap is global across repos — once reached, no further repos are pulled."""
     from events.sources.github import GitHubPollingAdapter

--- a/tests/test_notion_adapter.py
+++ b/tests/test_notion_adapter.py
@@ -1,0 +1,261 @@
+"""Tests for the Notion source adapter (#420 Phase 2).
+
+Mirrors the Linear adapter test shape: mock urlopen at the boundary,
+exercise URL parse / block walk / normalization / error paths unmocked.
+"""
+
+from __future__ import annotations
+
+import io
+import json
+import urllib.error
+from unittest.mock import patch
+
+import pytest
+
+from sources.notion.adapter import (
+    NotionAdapter,
+    normalize_page_to_payload,
+    parse_notion_url,
+)
+from sources.notion.client import NotionAPIError, get_all_blocks, get_page
+
+# ── URL parsing ─────────────────────────────────────────────────────────────
+
+
+@pytest.mark.parametrize(
+    "url,expected_id",
+    [
+        (
+            "https://www.notion.so/myws/Decision-Doc-1234567890abcdef1234567890abcdef",
+            "12345678-90ab-cdef-1234-567890abcdef",
+        ),
+        (
+            "https://www.notion.so/1234567890abcdef1234567890abcdef",
+            "12345678-90ab-cdef-1234-567890abcdef",
+        ),
+        (
+            "https://notion.so/myws/1234567890ABCDEF1234567890ABCDEF",
+            "12345678-90ab-cdef-1234-567890abcdef",
+        ),
+        (
+            "https://www.notion.so/myws/some-page-1234567890abcdef1234567890abcdef?v=tab",
+            "12345678-90ab-cdef-1234-567890abcdef",
+        ),
+    ],
+)
+def test_parse_notion_url_accepts_valid(url, expected_id):
+    assert parse_notion_url(url) == expected_id
+
+
+@pytest.mark.parametrize(
+    "url",
+    [
+        "https://github.com/foo/bar",
+        "https://www.notion.so/",
+        "https://www.notion.so/myws/short-id-12345",
+        "",
+        "not-a-url",
+    ],
+)
+def test_parse_notion_url_rejects_invalid(url):
+    with pytest.raises(ValueError):
+        parse_notion_url(url)
+
+
+# ── Block text extraction + normalization ───────────────────────────────────
+
+
+def _block(btype: str, text: str, **extra) -> dict:
+    body = {"rich_text": [{"plain_text": text}]}
+    body.update(extra)
+    return {"type": btype, btype: body}
+
+
+def test_normalize_full_page_with_mixed_blocks():
+    page = {
+        "properties": {
+            "Name": {"type": "title", "title": [{"plain_text": "Decision Doc"}]},
+        },
+        "created_time": "2026-05-01T00:00:00Z",
+        "last_edited_time": "2026-05-19T20:00:00Z",
+        "created_by": {"name": "Alice", "id": "u1"},
+        "last_edited_by": {"name": "Bob", "id": "u2"},
+    }
+    blocks = [
+        _block("heading_1", "Context"),
+        _block("paragraph", "We decided to use the WARN posture."),
+        _block("heading_2", "Rationale"),
+        _block("bulleted_list_item", "Pollers can't fail-fast"),
+        _block("to_do", "Update docs", checked=False),
+        _block("code", "x = 1", language="python"),
+        {"type": "divider", "divider": {}},  # skipped
+        {"type": "image", "image": {}},  # skipped
+    ]
+
+    payload = normalize_page_to_payload(page, blocks, "page-id")
+
+    assert payload["source"] == "notion"
+    assert payload["title"] == "Decision Doc"
+    assert payload["query"] == "Decision Doc"
+    assert payload["date"] == "2026-05-19T20:00:00Z"
+    assert payload["participants"] == ["Alice", "Bob"]
+    assert len(payload["decisions"]) == 1
+    full_text = payload["decisions"][0]["description"]
+    assert "# Context" in full_text
+    assert "## Rationale" in full_text
+    assert "- Pollers can't fail-fast" in full_text
+    assert "- [ ] Update docs" in full_text
+    assert "```python" in full_text
+    # Divider and image are skipped, never appear.
+    assert "image" not in full_text.lower() or "image" not in payload["decisions"][0]["description"]
+
+
+def test_normalize_empty_page_drops_decision():
+    page = {
+        "properties": {"Name": {"type": "title", "title": []}},
+        "created_time": "2026-05-19T00:00:00Z",
+        "last_edited_time": "2026-05-19T00:00:00Z",
+    }
+    blocks = []
+    payload = normalize_page_to_payload(page, blocks, "page-id")
+    # No text → no decision row. Don't push empty decisions through.
+    assert payload["decisions"] == []
+    # But title falls back to the page_id when no title property is set.
+    assert payload["title"] == "page-id"
+
+
+def test_normalize_unchecked_vs_checked_todo():
+    page = {"properties": {}, "created_time": "", "last_edited_time": ""}
+    blocks = [
+        _block("to_do", "Done thing", checked=True),
+        _block("to_do", "Pending thing", checked=False),
+    ]
+    payload = normalize_page_to_payload(page, blocks, "p")
+    desc = payload["decisions"][0]["description"]
+    assert "- [x] Done thing" in desc
+    assert "- [ ] Pending thing" in desc
+
+
+def test_normalize_dedups_participants():
+    page = {
+        "properties": {"Name": {"type": "title", "title": [{"plain_text": "T"}]}},
+        "created_by": {"name": "Same", "id": "u"},
+        "last_edited_by": {"name": "Same", "id": "u"},
+        "created_time": "",
+        "last_edited_time": "",
+    }
+    payload = normalize_page_to_payload(page, [_block("paragraph", "x")], "p")
+    assert payload["participants"] == ["Same"]
+
+
+# ── REST client error handling ──────────────────────────────────────────────
+
+
+def _mock_response(body: dict, status: int = 200):
+    raw = json.dumps(body).encode("utf-8")
+    resp = io.BytesIO(raw)
+    resp.status = status  # type: ignore[attr-defined]
+
+    class _Ctx:
+        def __enter__(self):
+            return resp
+
+        def __exit__(self, *args):
+            return False
+
+    return _Ctx()
+
+
+def test_get_page_success():
+    expected = {"object": "page", "id": "p1"}
+    with patch("urllib.request.urlopen", return_value=_mock_response(expected)):
+        assert get_page(api_key="k", page_id="p1") == expected
+
+
+def test_get_page_raises_on_http_404():
+    err = urllib.error.HTTPError(
+        url="https://api.notion.com/v1/pages/x",
+        code=404,
+        msg="Not Found",
+        hdrs=None,
+        fp=io.BytesIO(b""),
+    )
+    with patch("urllib.request.urlopen", side_effect=err):
+        with pytest.raises(NotionAPIError) as exc_info:
+            get_page(api_key="k", page_id="x")
+    assert exc_info.value.status_code == 404
+
+
+def test_get_all_blocks_paginates_until_has_more_false():
+    page1 = {
+        "results": [_block("paragraph", "first")],
+        "has_more": True,
+        "next_cursor": "cursor-2",
+    }
+    page2 = {"results": [_block("paragraph", "second")], "has_more": False}
+
+    responses = [_mock_response(page1), _mock_response(page2)]
+    with patch("urllib.request.urlopen", side_effect=responses):
+        blocks = get_all_blocks(api_key="k", page_id="p1")
+    assert len(blocks) == 2
+
+
+def test_get_all_blocks_caps_pagination_pages():
+    """A page reporting has_more=True forever must hit the 20-page cap."""
+
+    def _infinite_page(*args, **kwargs):
+        # urlopen returns a context manager — each call needs its own.
+        return _mock_response(
+            {
+                "results": [_block("paragraph", "x")],
+                "has_more": True,
+                "next_cursor": "c",
+            }
+        )
+
+    with patch("urllib.request.urlopen", side_effect=_infinite_page):
+        with pytest.raises(NotionAPIError, match="more than 2000"):
+            get_all_blocks(api_key="k", page_id="p1")
+
+
+# ── Adapter integration ─────────────────────────────────────────────────────
+
+
+def test_adapter_can_handle_url():
+    a = NotionAdapter()
+    assert a.can_handle_url("https://www.notion.so/myws/page-1234567890abcdef1234567890abcdef")
+    assert not a.can_handle_url("https://linear.app/foo/issue/BIC-1")
+
+
+def test_adapter_fetch_active_round_trip(monkeypatch):
+    page_resp = {
+        "properties": {"Name": {"type": "title", "title": [{"plain_text": "T"}]}},
+        "created_time": "2026-05-19T00:00:00Z",
+        "last_edited_time": "2026-05-19T00:00:00Z",
+    }
+    blocks_resp = {
+        "results": [_block("paragraph", "Decision content")],
+        "has_more": False,
+    }
+    a = NotionAdapter()
+    monkeypatch.setattr(a, "_resolve_api_key", lambda: "secret_x")
+
+    responses = [_mock_response(page_resp), _mock_response(blocks_resp)]
+    with patch("urllib.request.urlopen", side_effect=responses):
+        result = a.fetch_active("https://www.notion.so/myws/T-1234567890abcdef1234567890abcdef")
+
+    assert result["source"] == "notion"
+    assert result["title"] == "T"
+    assert "Decision content" in result["decisions"][0]["description"]
+
+
+def test_adapter_raises_when_api_key_missing(monkeypatch):
+    monkeypatch.setenv("BICAMERAL_KEYRING_DISABLE", "1")
+    from secrets_store.store import _reset_for_tests
+
+    _reset_for_tests()
+
+    a = NotionAdapter()
+    with pytest.raises(RuntimeError, match="API key not configured"):
+        a.fetch_active("https://www.notion.so/myws/T-1234567890abcdef1234567890abcdef")

--- a/tests/test_notion_polling.py
+++ b/tests/test_notion_polling.py
@@ -1,0 +1,230 @@
+"""Tests for #337 Phase 2b — Notion polling adapter."""
+
+from __future__ import annotations
+
+import io
+import json
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+
+@pytest.fixture(autouse=True)
+def _disable_keyring(monkeypatch):
+    monkeypatch.setenv("BICAMERAL_KEYRING_DISABLE", "1")
+    from secrets_store.store import _reset_for_tests
+
+    _reset_for_tests()
+    yield
+    _reset_for_tests()
+
+
+def _mock_response(body: dict):
+    raw = json.dumps(body).encode("utf-8")
+    resp = io.BytesIO(raw)
+    resp.status = 200
+
+    class _Ctx:
+        def __enter__(self):
+            return resp
+
+        def __exit__(self, *args):
+            return False
+
+    return _Ctx()
+
+
+# ── poller.list_recently_edited_pages ───────────────────────────────────────
+
+
+def test_list_recently_edited_returns_results():
+    from sources.notion.poller import list_recently_edited_pages
+
+    pages = [
+        {"id": "p1", "last_edited_time": "2026-05-01T00:00:00Z", "url": "u1"},
+        {"id": "p2", "last_edited_time": "2026-05-02T00:00:00Z", "url": "u2"},
+    ]
+    with patch(
+        "urllib.request.urlopen",
+        return_value=_mock_response({"results": pages, "has_more": False}),
+    ):
+        result = list_recently_edited_pages(api_key="k", database_id="db1")
+    assert [p["id"] for p in result] == ["p1", "p2"]
+
+
+def test_list_recently_edited_paginates():
+    from sources.notion.poller import list_recently_edited_pages
+
+    page1 = {
+        "results": [{"id": "p1", "last_edited_time": "2026-05-01T00:00:00Z", "url": "u1"}],
+        "has_more": True,
+        "next_cursor": "c1",
+    }
+    page2 = {
+        "results": [{"id": "p2", "last_edited_time": "2026-05-02T00:00:00Z", "url": "u2"}],
+        "has_more": False,
+    }
+    with patch(
+        "urllib.request.urlopen",
+        side_effect=[_mock_response(page1), _mock_response(page2)],
+    ):
+        result = list_recently_edited_pages(api_key="k", database_id="db1")
+    assert len(result) == 2
+
+
+def test_list_recently_edited_includes_filter():
+    from sources.notion.poller import list_recently_edited_pages
+
+    captured: dict = {}
+
+    def _capture_request(req, timeout):
+        captured["body"] = json.loads(req.data.decode("utf-8"))
+        return _mock_response({"results": [], "has_more": False})
+
+    with patch("urllib.request.urlopen", side_effect=_capture_request):
+        list_recently_edited_pages(
+            api_key="k", database_id="db1", edited_after="2026-05-01T00:00:00Z"
+        )
+
+    assert captured["body"]["filter"]["last_edited_time"]["after"] == "2026-05-01T00:00:00Z"
+
+
+def test_list_recently_edited_raises_on_http_error():
+    import urllib.error
+
+    from sources.notion.poller import list_recently_edited_pages
+
+    err = urllib.error.HTTPError(
+        url="https://api.notion.com/v1/databases/db1/query",
+        code=403,
+        msg="Forbidden",
+        hdrs=None,
+        fp=io.BytesIO(b""),
+    )
+    with patch("urllib.request.urlopen", side_effect=err):
+        with pytest.raises(RuntimeError, match="database query failed"):
+            list_recently_edited_pages(api_key="k", database_id="db1")
+
+
+# ── NotionPollingAdapter.pull ───────────────────────────────────────────────
+
+
+def test_pull_returns_payloads_for_new_pages(tmp_path):
+    from events.sources.notion import NotionPollingAdapter
+    from secrets_store import put_secret
+
+    put_secret(source_id="notion", key="api_key", value="secret_x")
+
+    fake_pages = [
+        {"id": "p1", "url": "https://www.notion.so/p1", "last_edited_time": "2026-05-01T00:00:00Z"},
+        {"id": "p2", "url": "https://www.notion.so/p2", "last_edited_time": "2026-05-02T00:00:00Z"},
+    ]
+    fake_payload = {"source": "notion", "decisions": [], "title": "x"}
+
+    with (
+        patch(
+            "sources.notion.poller.list_recently_edited_pages",
+            return_value=fake_pages,
+        ),
+        patch(
+            "sources.notion.adapter.NotionAdapter.fetch_active",
+            return_value=fake_payload,
+        ),
+    ):
+        adapter = NotionPollingAdapter()
+        result = adapter.pull(watermark_dir=tmp_path, config={"database_id": "db1"})
+
+    assert len(result) == 2
+    assert adapter._pending_watermark == "2026-05-02T00:00:00Z"
+
+
+def test_pull_returns_empty_when_database_id_missing(tmp_path, capsys):
+    from events.sources.notion import NotionPollingAdapter
+
+    adapter = NotionPollingAdapter()
+    result = adapter.pull(watermark_dir=tmp_path, config={})
+    assert result == []
+    assert "database_id is required" in capsys.readouterr().err
+
+
+def test_pull_returns_empty_when_api_key_missing(tmp_path, capsys):
+    from events.sources.notion import NotionPollingAdapter
+
+    adapter = NotionPollingAdapter()
+    result = adapter.pull(watermark_dir=tmp_path, config={"database_id": "db1"})
+    assert result == []
+    assert "api_key not configured" in capsys.readouterr().err
+
+
+def test_pull_skips_individual_fetch_failures(tmp_path, capsys):
+    from events.sources.notion import NotionPollingAdapter
+    from secrets_store import put_secret
+
+    put_secret(source_id="notion", key="api_key", value="secret_x")
+    fake_pages = [
+        {"id": "p1", "url": "https://www.notion.so/p1", "last_edited_time": "2026-05-01T00:00:00Z"},
+        {"id": "p2", "url": "https://www.notion.so/p2", "last_edited_time": "2026-05-02T00:00:00Z"},
+    ]
+
+    def _flaky(self, url):
+        if "p1" in url:
+            raise RuntimeError("transient")
+        return {"source": "notion", "decisions": [], "title": "p2"}
+
+    with (
+        patch(
+            "sources.notion.poller.list_recently_edited_pages",
+            return_value=fake_pages,
+        ),
+        patch(
+            "sources.notion.adapter.NotionAdapter.fetch_active",
+            new=_flaky,
+        ),
+    ):
+        adapter = NotionPollingAdapter()
+        result = adapter.pull(watermark_dir=tmp_path, config={"database_id": "db1"})
+
+    assert len(result) == 1
+    assert "p1" in capsys.readouterr().err
+    assert adapter._pending_watermark == "2026-05-02T00:00:00Z"
+
+
+def test_pull_passes_watermark_to_poller(tmp_path):
+    from events.sources.notion import NotionPollingAdapter
+    from secrets_store import put_secret
+
+    put_secret(source_id="notion", key="api_key", value="secret_x")
+    (tmp_path / "notion.json").write_text(json.dumps({"last_edited_time": "2026-05-01T00:00:00Z"}))
+
+    captured: dict = {}
+
+    def _capture(*, api_key, database_id, edited_after=None):
+        captured["edited_after"] = edited_after
+        return []
+
+    with patch(
+        "sources.notion.poller.list_recently_edited_pages",
+        side_effect=_capture,
+    ):
+        adapter = NotionPollingAdapter()
+        adapter.pull(watermark_dir=tmp_path, config={"database_id": "db1"})
+
+    assert captured["edited_after"] == "2026-05-01T00:00:00Z"
+
+
+def test_confirm_watermark_persists(tmp_path):
+    from events.sources.notion import NotionPollingAdapter
+
+    adapter = NotionPollingAdapter()
+    adapter._watermark_path = tmp_path / "notion.json"
+    adapter._pending_watermark = "2026-05-19T00:00:00Z"
+    adapter.confirm_watermark()
+    data = json.loads((tmp_path / "notion.json").read_text())
+    assert data["last_edited_time"] == "2026-05-19T00:00:00Z"
+
+
+def test_registered_in_ADAPTERS():
+    from events.sources import ADAPTERS
+    from events.sources.notion import NotionPollingAdapter
+
+    assert ADAPTERS["notion"] is NotionPollingAdapter

--- a/tests/test_source_list_cli.py
+++ b/tests/test_source_list_cli.py
@@ -55,6 +55,32 @@ def _mock_resp(body):
 # ── Slack: list_channels ────────────────────────────────────────────────────
 
 
+def test_notion_list_databases():
+    from sources.notion.client import list_databases
+
+    body = {
+        "results": [
+            {
+                "id": "db-1",
+                "title": [{"plain_text": "Decision Log"}],
+            },
+            {
+                "id": "db-2",
+                "title": [{"plain_text": "Meeting "}, {"plain_text": "Notes"}],
+            },
+            # Untitled database — should fall back to "(untitled)".
+            {"id": "db-3", "title": []},
+        ],
+        "has_more": False,
+    }
+    with patch("urllib.request.urlopen", return_value=_mock_resp(body)):
+        result = list_databases(api_key="secret_x")
+    assert [d["title"] for d in result] == ["Decision Log", "Meeting Notes", "(untitled)"]
+
+
+# ── GitHub: list_repos ──────────────────────────────────────────────────────
+
+
 def test_github_list_repos_pat_returns_array():
     from sources.github.client import list_repos
 

--- a/tests/test_webhooks_notion.py
+++ b/tests/test_webhooks_notion.py
@@ -1,0 +1,865 @@
+"""Tests for the Notion webhook handler (#337 cycle 8).
+
+Coverage parity with the cycles 5-7 / 9 suites, scoped to Notion's
+two-mode contract (verification handshake + signed events):
+
+- verify_signature: missing header, missing token, missing prefix,
+  wrong digest length, mismatch, body-byte sensitivity, success
+- handle (verification path): non-JSON, non-object, missing token,
+  out-of-bounds length, success persists + logs the token
+- handle (event path): missing signature, missing subscription_id,
+  missing id, missing type, no registered token, signature mismatch,
+  happy path, dedup by id, attempt_number>1 logged, pending-token
+  adoption on first event for fresh subscription
+- Server route: /webhooks/notion routing (smoke test against the
+  dispatch tuple shape)
+"""
+
+from __future__ import annotations
+
+import hashlib
+import hmac
+import json
+
+import pytest
+
+from webhooks.notion import WebhookVerificationError, handle, verify_signature
+
+
+@pytest.fixture(autouse=True)
+def _disable_keyring_and_reset_dedup(monkeypatch):
+    monkeypatch.setenv("BICAMERAL_KEYRING_DISABLE", "1")
+    from secrets_store.store import _reset_for_tests as _secrets_reset
+    from webhooks.dedup import _reset_for_tests as _dedup_reset
+
+    _secrets_reset()
+    _dedup_reset()
+
+    # Cycle 8b: stub fetch_active by default so tests that don't
+    # explicitly care about the ingest path (most pre-cycle-8b
+    # tests, written when the handler was ack-only) don't fail
+    # when the default ``page.content_updated`` event triggers a
+    # fetch against ``https://www.notion.so/page1`` (a non-real
+    # URL). Individual tests that exercise the fetch/ingest
+    # failure paths override this stub.
+    def _default_fetch(self, url):
+        return {
+            "query": "stub-title",
+            "source": "notion",
+            "title": "stub-title",
+            "date": "",
+            "participants": [],
+            "decisions": [{"description": "stub", "title": "stub-title"}],
+        }
+
+    monkeypatch.setattr("sources.notion.adapter.NotionAdapter.fetch_active", _default_fetch)
+
+    # Default ingest stub — tests that care about the ingest call
+    # override with their own monkeypatch. The stub matches the
+    # signature handle_ingest exposes (async + keyword-only args).
+    async def _default_ingest(ctx, payload, *, source_scope, ingest_mode):
+        pass
+
+    monkeypatch.setattr("handlers.ingest.handle_ingest", _default_ingest)
+
+    from types import SimpleNamespace as _SN
+
+    monkeypatch.setattr("context.BicameralContext.from_env", classmethod(lambda cls: _SN()))
+
+    yield
+    _secrets_reset()
+    _dedup_reset()
+
+
+def _sign(token: str, body: bytes) -> str:
+    return (
+        "sha256=" + hmac.new(token.encode("utf-8"), msg=body, digestmod=hashlib.sha256).hexdigest()
+    )
+
+
+def _put_token(subscription_id: str, token: str = "secret_abc") -> None:
+    from secrets_store import put_secret
+
+    put_secret(source_id="notion", key=f"subscription_{subscription_id}", value=token)
+
+
+def _event_body(
+    *,
+    subscription_id: str = "sub-1",
+    event_id: str = "evt-1",
+    event_type: str = "page.content_updated",
+    attempt_number: int = 1,
+) -> bytes:
+    return json.dumps(
+        {
+            "id": event_id,
+            "timestamp": "2026-05-20T12:00:00.000Z",
+            "workspace_id": "ws-1",
+            "subscription_id": subscription_id,
+            "integration_id": "int-1",
+            "type": event_type,
+            "authors": [{"id": "u-1", "type": "person"}],
+            "accessible_by": [{"id": "u-1", "type": "person"}],
+            "attempt_number": attempt_number,
+            "entity": {"id": "page-1", "type": "page"},
+            "data": {},
+        }
+    ).encode("utf-8")
+
+
+# ── verify_signature ────────────────────────────────────────────────────────
+
+
+def test_verify_signature_success():
+    body = b'{"ok":true}'
+    token = "secret_xyz"
+    verify_signature(
+        body=body, signature_header=_sign(token, body), verification_token=token
+    )  # does not raise
+
+
+def test_verify_signature_missing_header_raises():
+    with pytest.raises(WebhookVerificationError, match="Signature"):
+        verify_signature(body=b"x", signature_header=None, verification_token="t")
+
+
+def test_verify_signature_missing_token_raises():
+    with pytest.raises(WebhookVerificationError, match="verification_token"):
+        verify_signature(body=b"x", signature_header="sha256=" + "a" * 64, verification_token="")
+
+
+def test_verify_signature_missing_prefix_raises():
+    body = b"x"
+    sig_without_prefix = hmac.new(b"t", msg=body, digestmod=hashlib.sha256).hexdigest()
+    with pytest.raises(WebhookVerificationError, match="sha256="):
+        verify_signature(body=body, signature_header=sig_without_prefix, verification_token="t")
+
+
+def test_verify_signature_wrong_digest_length():
+    with pytest.raises(WebhookVerificationError, match="64 hex"):
+        verify_signature(body=b"x", signature_header="sha256=abcdef", verification_token="t")
+
+
+def test_verify_signature_mismatch():
+    with pytest.raises(WebhookVerificationError, match="mismatch"):
+        verify_signature(
+            body=b"x",
+            signature_header="sha256=" + "0" * 64,
+            verification_token="t",
+        )
+
+
+def test_verify_signature_body_byte_sensitivity():
+    """Single-byte change in body invalidates the signature."""
+    token = "secret_xyz"
+    sig = _sign(token, b"original")
+    with pytest.raises(WebhookVerificationError, match="mismatch"):
+        verify_signature(body=b"originaL", signature_header=sig, verification_token=token)
+
+
+def test_verify_signature_uppercase_hex_accepted():
+    """Defensive: accept uppercase hex even though Notion sends lowercase."""
+    body = b"x"
+    token = "secret_xyz"
+    sig = _sign(token, body)
+    # Uppercase the hex portion only.
+    upper_sig = "sha256=" + sig[len("sha256=") :].upper()
+    verify_signature(body=body, signature_header=upper_sig, verification_token=token)
+
+
+# ── handle: verification handshake ─────────────────────────────────────────
+
+
+def test_handle_invalid_json_returns_400():
+    status, msg = handle(body=b"not-json", signature_header=None)
+    assert status == 400
+    assert "JSON" in msg
+
+
+def test_handle_non_object_body_returns_400():
+    status, msg = handle(body=b'["array", "not", "object"]', signature_header=None)
+    assert status == 400
+
+
+def test_handle_verification_success_persists_and_logs(
+    capsys: pytest.CaptureFixture,
+):
+    """Verification POST: extract token, persist under fingerprint
+    slot, log fingerprint (NOT full token) to stderr for operator
+    retrieval. F3 review fix: token must NOT appear in stderr."""
+    import hashlib
+
+    token = "secret_abcdefghij"
+    expected_fp = hashlib.sha256(token.encode("utf-8")).hexdigest()[:16]
+    body = json.dumps({"verification_token": token}).encode("utf-8")
+    status, msg = handle(body=body, signature_header=None)
+    assert status == 200
+    assert expected_fp in msg
+
+    captured = capsys.readouterr()
+    # Fingerprint logged, full token must NOT be in stderr.
+    assert expected_fp in captured.err
+    assert token not in captured.err
+    assert "paste" in captured.err.lower()
+
+    # Confirm the token was persisted under the fingerprint slot.
+    from secrets_store import get_secret
+
+    raw = get_secret(source_id="notion", key=f"pending_{expected_fp}")
+    assert raw is not None
+    entry = json.loads(raw)
+    assert entry["token"] == token
+    assert isinstance(entry["received_at"], int)
+
+
+def test_handle_verification_missing_token_returns_400():
+    body = json.dumps({"verification_token": None}).encode("utf-8")
+    status, msg = handle(body=body, signature_header=None)
+    assert status == 400
+    assert "verification_token" in msg
+
+
+def test_handle_verification_token_too_short_rejected():
+    body = json.dumps({"verification_token": "tiny"}).encode("utf-8")
+    status, msg = handle(body=body, signature_header=None)
+    assert status == 400
+    assert "length" in msg
+
+
+def test_handle_verification_token_too_long_rejected():
+    body = json.dumps({"verification_token": "x" * 257}).encode("utf-8")
+    status, msg = handle(body=body, signature_header=None)
+    assert status == 400
+    assert "length" in msg
+
+
+def test_handle_verification_pending_cap_rejects_new_fingerprint(
+    capsys: pytest.CaptureFixture, monkeypatch: pytest.MonkeyPatch
+):
+    """LOW-2 review fix: when the pending-entries set is at the cap,
+    NEW fingerprints are rejected with 429. Idempotent re-receipt
+    of an existing fingerprint still works."""
+    import webhooks.notion as _notion_mod
+
+    # Shrink the cap for testability.
+    monkeypatch.setattr(_notion_mod, "_MAX_PENDING_ENTRIES", 2)
+
+    from secrets_store import put_secret
+
+    put_secret(
+        source_id="notion",
+        key="pending_" + "a" * 16,
+        value=json.dumps({"token": "tok_a", "received_at": 1}),
+    )
+    put_secret(
+        source_id="notion",
+        key="pending_" + "b" * 16,
+        value=json.dumps({"token": "tok_b", "received_at": 1}),
+    )
+
+    body = json.dumps({"verification_token": "secret_third_attempt"}).encode("utf-8")
+    status, msg = handle(body=body, signature_header=None)
+    assert status == 429
+    assert "cap" in msg
+    err = capsys.readouterr().err
+    assert "cap reached" in err
+
+
+def test_handle_verification_pending_cap_allows_idempotent_resend(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    """LOW-2 review fix: re-receiving a verification POST with the
+    SAME token (same fingerprint) is allowed even at the cap. Notion
+    may retry the verification POST during operator setup."""
+    import webhooks.notion as _notion_mod
+
+    monkeypatch.setattr(_notion_mod, "_MAX_PENDING_ENTRIES", 2)
+
+    import hashlib
+
+    from secrets_store import get_secret, put_secret
+
+    existing_token = "secret_already_pending"
+    existing_fp = hashlib.sha256(existing_token.encode()).hexdigest()[:16]
+    put_secret(
+        source_id="notion",
+        key=f"pending_{existing_fp}",
+        value=json.dumps({"token": existing_token, "received_at": 1}),
+    )
+    put_secret(
+        source_id="notion",
+        key="pending_" + "f" * 16,
+        value=json.dumps({"token": "filler", "received_at": 1}),
+    )
+    # Now at cap (2). Re-send the verification for `existing_token`.
+    body = json.dumps({"verification_token": existing_token}).encode("utf-8")
+    status, _ = handle(body=body, signature_header=None)
+    assert status == 200
+    # received_at was refreshed.
+    raw = get_secret(source_id="notion", key=f"pending_{existing_fp}")
+    entry = json.loads(raw)
+    assert entry["received_at"] != 1
+
+
+def test_handle_verification_token_in_event_body_does_not_clobber():
+    """Structural marker safety: if an attacker smuggles
+    verification_token INTO an event payload (with `type` set), we
+    must NOT treat it as a verification handshake. Discriminator is
+    'verification_token present AND type absent'."""
+    body = json.dumps(
+        {
+            "verification_token": "secret_attacker_chosen",
+            "type": "page.content_updated",
+            "id": "evt-malicious",
+            "subscription_id": "sub-1",
+        }
+    ).encode("utf-8")
+    status, _ = handle(body=body, signature_header=None)
+    # Event path: missing signature → 401 (not 200/verification).
+    assert status == 401
+
+    # And no pending entries were created.
+    from secrets_store import list_keys
+
+    pending_keys = [k for k in list_keys(source_id="notion") if k.startswith("pending_")]
+    assert pending_keys == []
+
+
+# ── handle: event delivery ─────────────────────────────────────────────────
+
+
+def test_handle_event_missing_signature_returns_401():
+    _put_token("sub-1")
+    body = _event_body()
+    status, msg = handle(body=body, signature_header=None)
+    assert status == 401
+
+
+def test_handle_event_missing_subscription_id_returns_400():
+    body = json.dumps({"id": "evt", "type": "page.content_updated"}).encode("utf-8")
+    status, msg = handle(body=body, signature_header="sha256=" + "0" * 64)
+    assert status == 400
+    assert "subscription_id" in msg
+
+
+def test_handle_event_missing_id_returns_400():
+    body = json.dumps({"subscription_id": "sub-1", "type": "page.content_updated"}).encode("utf-8")
+    status, msg = handle(body=body, signature_header="sha256=" + "0" * 64)
+    assert status == 400
+    assert msg.endswith("missing id")
+
+
+def test_handle_event_missing_type_returns_400():
+    body = json.dumps({"subscription_id": "sub-1", "id": "evt"}).encode("utf-8")
+    status, msg = handle(body=body, signature_header="sha256=" + "0" * 64)
+    assert status == 400
+    assert "type" in msg
+
+
+def test_handle_event_no_registered_token_returns_401(
+    capsys: pytest.CaptureFixture,
+):
+    """No verification_token for the subscription → 401. Notion will
+    not retry on 401 (gives up after backoff envelope); operator
+    must re-run the handshake."""
+    body = _event_body(subscription_id="sub-unknown")
+    status, msg = handle(body=body, signature_header="sha256=" + "0" * 64)
+    assert status == 401
+    assert "verification_token" in msg
+
+
+def test_handle_event_signature_mismatch_returns_401():
+    _put_token("sub-1", token="correct-token")
+    body = _event_body()
+    bad_sig = _sign("WRONG-token", body)
+    status, msg = handle(body=body, signature_header=bad_sig)
+    assert status == 401
+    assert "mismatch" in msg or "verification" in msg
+
+
+def test_handle_event_happy_path():
+    _put_token("sub-1", token="secret_token")
+    body = _event_body()
+    status, msg = handle(body=body, signature_header=_sign("secret_token", body))
+    assert status == 200
+    assert "evt-1" in msg
+    assert "page.content_updated" in msg
+
+
+def test_handle_event_dedup_by_id():
+    _put_token("sub-1", token="secret_token")
+    body = _event_body(event_id="evt-dup")
+    sig = _sign("secret_token", body)
+    s1, _ = handle(body=body, signature_header=sig)
+    s2, msg2 = handle(body=body, signature_header=sig)
+    assert s1 == 200
+    assert s2 == 200
+    assert "duplicate" in msg2
+
+
+def test_handle_event_page_created_triggers_ingest(monkeypatch):
+    """Cycle 8b: page.created with a non-empty entity.id fetches the
+    page via NotionAdapter and pipes through handle_ingest."""
+    _put_token("sub-1", token="secret_token")
+
+    captured: dict = {}
+
+    # LOW-5 review fix: patch fetch_active on the real adapter
+    # class (narrower seam) rather than swapping the whole class.
+    # Catches constructor / _resolve_api_key regressions that a
+    # class-level swap would silently mask.
+    def _fake_fetch(self, url):
+        captured["fetch_url"] = url
+        return {
+            "query": "fetched-title",
+            "source": "notion",
+            "title": "fetched-title",
+            "date": "2026-05-20",
+            "participants": [],
+            "decisions": [{"description": "fetched-decision", "title": "fetched-title"}],
+        }
+
+    monkeypatch.setattr("sources.notion.adapter.NotionAdapter.fetch_active", _fake_fetch)
+
+    async def _fake_handle_ingest(ctx, payload, *, source_scope, ingest_mode):
+        captured["scope"] = source_scope
+        captured["mode"] = ingest_mode
+        captured["payload"] = payload
+
+    monkeypatch.setattr("handlers.ingest.handle_ingest", _fake_handle_ingest)
+    from types import SimpleNamespace as _SN
+
+    monkeypatch.setattr("context.BicameralContext.from_env", classmethod(lambda cls: _SN()))
+
+    body = _event_body(event_type="page.created")
+    status, msg = handle(body=body, signature_header=_sign("secret_token", body))
+    assert status == 200
+    assert "ingested" in msg
+    assert captured["scope"] == "notion"
+    assert captured["mode"] == "passive"
+    assert captured["payload"]["decisions"][0]["description"] == "fetched-decision"
+    # The fetch URL is built from entity.id with dashes stripped
+    # (handler normalizes to Notion's undashed UUID form). Test
+    # fixture entity.id is "page-1" → URL contains "page1".
+    assert "page1" in captured["fetch_url"]
+    assert "notion.so" in captured["fetch_url"]
+
+
+def test_handle_event_page_content_updated_triggers_ingest(monkeypatch):
+    """Same flow as page.created — pin that update events also
+    trigger fetch+ingest, not just create events."""
+    _put_token("sub-1", token="secret_token")
+
+    captured: dict = {}
+
+    def _fake_fetch(self, url):
+        return {
+            "query": "x",
+            "source": "notion",
+            "title": "x",
+            "date": "",
+            "participants": [],
+            "decisions": [{"description": "x", "title": "x"}],
+        }
+
+    monkeypatch.setattr("sources.notion.adapter.NotionAdapter.fetch_active", _fake_fetch)
+
+    async def _fake(ctx, payload, *, source_scope, ingest_mode):
+        captured["called"] = True
+
+    monkeypatch.setattr("handlers.ingest.handle_ingest", _fake)
+    from types import SimpleNamespace as _SN
+
+    monkeypatch.setattr("context.BicameralContext.from_env", classmethod(lambda cls: _SN()))
+
+    body = _event_body(event_type="page.content_updated")
+    status, _ = handle(body=body, signature_header=_sign("secret_token", body))
+    assert status == 200
+    assert captured.get("called") is True
+
+
+def test_handle_event_page_deleted_does_not_trigger_ingest(monkeypatch):
+    """page.deleted is acked but NOT fetched/ingested — same posture
+    as Linear's Issue.remove path (append-only contract)."""
+    _put_token("sub-1", token="secret_token")
+    fetch_called = []
+    ingest_called = []
+
+    def _fake_fetch(self, url):
+        fetch_called.append(url)
+        return {}
+
+    async def _fake(ctx, payload, *, source_scope, ingest_mode):
+        ingest_called.append(payload)
+
+    monkeypatch.setattr("sources.notion.adapter.NotionAdapter.fetch_active", _fake_fetch)
+    monkeypatch.setattr("handlers.ingest.handle_ingest", _fake)
+
+    body = _event_body(event_type="page.deleted")
+    status, msg = handle(body=body, signature_header=_sign("secret_token", body))
+    assert status == 200
+    assert "no ingest" in msg or "acknowledged" in msg
+    assert fetch_called == []
+    assert ingest_called == []
+
+
+def test_handle_event_page_event_missing_entity_id_skips_ingest(
+    monkeypatch, capsys: pytest.CaptureFixture
+):
+    """Defensive: page.* events with a missing entity.id are 200-acked
+    with a log but do NOT attempt to fetch (would otherwise hit the
+    Notion API with garbage)."""
+    _put_token("sub-1", token="secret_token")
+    fetch_called = []
+
+    def _fake_fetch(self, url):
+        fetch_called.append(url)
+        return {}
+
+    monkeypatch.setattr("sources.notion.adapter.NotionAdapter.fetch_active", _fake_fetch)
+
+    body = json.dumps(
+        {
+            "id": "evt-noent",
+            "timestamp": "2026-05-20T12:00:00.000Z",
+            "subscription_id": "sub-1",
+            "type": "page.content_updated",
+            "entity": {"type": "page"},  # NO id
+            "data": {},
+        }
+    ).encode("utf-8")
+    status, msg = handle(body=body, signature_header=_sign("secret_token", body))
+    assert status == 200
+    assert "entity.id" in msg or "acknowledged" in msg
+    assert fetch_called == []
+
+
+def test_handle_event_fetch_failure_acks_200_no_retry_amplification(
+    monkeypatch, capsys: pytest.CaptureFixture
+):
+    """Fetch failure is logged + 200-acked. Returning 5xx would cause
+    Notion to retry 8 times over 24h, amplifying transient fetch
+    failures into log spam. The audit log on stderr is the operator's
+    signal."""
+    _put_token("sub-1", token="secret_token")
+
+    # MED-1 fix: non-NotionAPIError exceptions (unclassified) now
+    # return 500 (transient default) so operator gets retry-storm
+    # visibility instead of silent loss. Pin the new posture.
+    def _broken_fetch(self, url):
+        raise RuntimeError("simulated transport failure")
+
+    monkeypatch.setattr("sources.notion.adapter.NotionAdapter.fetch_active", _broken_fetch)
+
+    body = _event_body(event_type="page.created")
+    status, msg = handle(body=body, signature_header=_sign("secret_token", body))
+    assert status == 500
+    assert "transient" in msg or "retry" in msg
+    err = capsys.readouterr().err
+    assert "simulated transport failure" in err
+
+
+def test_handle_event_fetch_5xx_returns_500_for_retry(monkeypatch, capsys: pytest.CaptureFixture):
+    """MED-1 fix: NotionAPIError with 5xx status → 500 so Notion's
+    8-retry envelope is the right backpressure mechanism."""
+    _put_token("sub-1", token="secret_token")
+
+    from sources.notion.client import NotionAPIError
+
+    def _fetch_503(self, url):
+        raise NotionAPIError("Service Unavailable", status_code=503)
+
+    monkeypatch.setattr("sources.notion.adapter.NotionAdapter.fetch_active", _fetch_503)
+
+    body = _event_body(event_type="page.created")
+    status, msg = handle(body=body, signature_header=_sign("secret_token", body))
+    assert status == 500
+    assert "transient" in msg
+    err = capsys.readouterr().err
+    assert "transient=True" in err
+
+
+def test_handle_event_fetch_429_returns_500_for_retry(monkeypatch, capsys: pytest.CaptureFixture):
+    """MED-1 fix: NotionAPIError with 429 (rate limit) → 500 so
+    Notion's retry envelope acts as the backoff."""
+    _put_token("sub-1", token="secret_token")
+
+    from sources.notion.client import NotionAPIError
+
+    def _fetch_429(self, url):
+        raise NotionAPIError("Rate limited", status_code=429)
+
+    monkeypatch.setattr("sources.notion.adapter.NotionAdapter.fetch_active", _fetch_429)
+
+    body = _event_body(event_type="page.created")
+    status, _ = handle(body=body, signature_header=_sign("secret_token", body))
+    assert status == 500
+
+
+def test_handle_event_fetch_404_returns_200_no_retry(monkeypatch, capsys: pytest.CaptureFixture):
+    """MED-1 fix: NotionAPIError with 4xx-not-429 (page deleted,
+    permission revoked) is deterministic → 200 ack. Retry would
+    amplify the deterministic failure."""
+    _put_token("sub-1", token="secret_token")
+
+    from sources.notion.client import NotionAPIError
+
+    def _fetch_404(self, url):
+        raise NotionAPIError("Not Found", status_code=404)
+
+    monkeypatch.setattr("sources.notion.adapter.NotionAdapter.fetch_active", _fetch_404)
+
+    body = _event_body(event_type="page.created")
+    status, msg = handle(body=body, signature_header=_sign("secret_token", body))
+    assert status == 200
+    assert "fetch failed" in msg
+    err = capsys.readouterr().err
+    assert "transient=False" in err
+
+
+def test_handle_event_ingest_hard_gate_refusal_acks_200(monkeypatch):
+    """Hard-gate refusal (e.g. PHI detected): _IngestRefused → 200 ack
+    (NOT 422 like the cycle-5/6/7 receivers). Reason: Notion retries
+    on ALL non-2xx (not just 5xx), and we don't want 8 retries of a
+    payload that the gate already rejected for compliance reasons.
+    Operator visibility via the gate's own audit-log emit."""
+    _put_token("sub-1", token="secret_token")
+
+    def _fake_fetch(self, url):
+        return {
+            "query": "x",
+            "source": "notion",
+            "title": "x",
+            "date": "",
+            "participants": [],
+            "decisions": [{"description": "x", "title": "x"}],
+        }
+
+    monkeypatch.setattr("sources.notion.adapter.NotionAdapter.fetch_active", _fake_fetch)
+
+    from handlers.ingest import _IngestRefused
+
+    async def _refuse(ctx, payload, *, source_scope, ingest_mode):
+        raise _IngestRefused(reason="sensitive_data:phi")
+
+    monkeypatch.setattr("handlers.ingest.handle_ingest", _refuse)
+    from types import SimpleNamespace as _SN
+
+    monkeypatch.setattr("context.BicameralContext.from_env", classmethod(lambda cls: _SN()))
+
+    body = _event_body(event_type="page.created")
+    status, msg = handle(body=body, signature_header=_sign("secret_token", body))
+    assert status == 200
+    assert "refused" in msg
+    assert "phi" in msg
+
+
+def test_handle_event_comment_created_does_not_fetch(monkeypatch):
+    """v0 scope: comment.* events ack-only; comment fetching requires
+    a Notion API path the adapter doesn't yet expose. Defer to a
+    later cycle. Pin that no fetch attempt happens."""
+    _put_token("sub-1", token="secret_token")
+    fetch_called = []
+
+    def _fake_fetch(self, url):
+        fetch_called.append(url)
+        return {}
+
+    monkeypatch.setattr("sources.notion.adapter.NotionAdapter.fetch_active", _fake_fetch)
+
+    body = _event_body(event_type="comment.created")
+    status, _ = handle(body=body, signature_header=_sign("secret_token", body))
+    assert status == 200
+    assert fetch_called == []
+
+
+def test_handle_event_attempt_number_4_logged(capsys: pytest.CaptureFixture):
+    """F7 fix: log attempt_number only when >= 4 (halfway through
+    the 8-retry envelope — real signal, not transient noise)."""
+    _put_token("sub-1", token="secret_token")
+    body = _event_body(attempt_number=4)
+    status, _ = handle(body=body, signature_header=_sign("secret_token", body))
+    assert status == 200
+    captured = capsys.readouterr()
+    assert "attempt_number=4" in captured.err
+    assert "retrying" in captured.err
+
+
+def test_handle_event_adopts_pending_token_by_hmac_match(
+    capsys: pytest.CaptureFixture,
+):
+    """First event for a fresh subscription: enumerate pending
+    entries (keyed by token fingerprint, F2 fix), try each as the
+    HMAC key, adopt the one whose signature matches the body. On
+    adoption, the pending entry is DELETED and the subscription-
+    specific key is created."""
+    import hashlib
+    import time as _t
+
+    from secrets_store import get_secret, put_secret
+
+    token = "secret_pending"
+    fingerprint = hashlib.sha256(token.encode("utf-8")).hexdigest()[:16]
+    entry = json.dumps({"token": token, "received_at": int(_t.time())})
+    put_secret(source_id="notion", key=f"pending_{fingerprint}", value=entry)
+    assert get_secret(source_id="notion", key="subscription_sub-fresh") is None
+
+    body = _event_body(subscription_id="sub-fresh")
+    status, _ = handle(body=body, signature_header=_sign(token, body))
+    assert status == 200
+
+    # Adopted: subscription-specific slot now holds the token.
+    assert get_secret(source_id="notion", key="subscription_sub-fresh") == token
+    # Pending slot was consumed.
+    assert get_secret(source_id="notion", key=f"pending_{fingerprint}") is None
+    captured = capsys.readouterr()
+    assert "adopted pending" in captured.err
+
+
+def test_handle_event_multiple_pending_only_matching_adopted(
+    capsys: pytest.CaptureFixture,
+):
+    """F2 fix in action: two concurrent verifications produce two
+    pending entries. An event signed with TOKEN_A adopts only the
+    A entry; B's entry remains untouched."""
+    import hashlib
+    import time as _t
+
+    from secrets_store import get_secret, put_secret
+
+    token_a = "secret_for_sub_a"
+    token_b = "secret_for_sub_b"
+    fp_a = hashlib.sha256(token_a.encode("utf-8")).hexdigest()[:16]
+    fp_b = hashlib.sha256(token_b.encode("utf-8")).hexdigest()[:16]
+    now = int(_t.time())
+    put_secret(
+        source_id="notion",
+        key=f"pending_{fp_a}",
+        value=json.dumps({"token": token_a, "received_at": now}),
+    )
+    put_secret(
+        source_id="notion",
+        key=f"pending_{fp_b}",
+        value=json.dumps({"token": token_b, "received_at": now}),
+    )
+
+    body = _event_body(subscription_id="sub-a")
+    status, _ = handle(body=body, signature_header=_sign(token_a, body))
+    assert status == 200
+
+    # A was adopted + consumed; B is untouched.
+    assert get_secret(source_id="notion", key="subscription_sub-a") == token_a
+    assert get_secret(source_id="notion", key=f"pending_{fp_a}") is None
+    assert get_secret(source_id="notion", key=f"pending_{fp_b}") is not None
+
+
+def test_handle_event_stale_pending_entry_dropped(capsys: pytest.CaptureFixture):
+    """F9 fix: pending entries older than 24h are deleted and not
+    adoptable, even if the HMAC would otherwise match. Bounds the
+    attacker-DoS window from forever to 24h."""
+    import hashlib
+
+    from secrets_store import get_secret, put_secret
+
+    token = "secret_old"
+    fingerprint = hashlib.sha256(token.encode("utf-8")).hexdigest()[:16]
+    stale_ts = 0  # epoch 1970 — well past 24h
+    put_secret(
+        source_id="notion",
+        key=f"pending_{fingerprint}",
+        value=json.dumps({"token": token, "received_at": stale_ts}),
+    )
+
+    body = _event_body(subscription_id="sub-stale")
+    status, _ = handle(body=body, signature_header=_sign(token, body))
+    # No adoption — falls through to "no verification_token registered".
+    assert status == 401
+
+    # Stale entry was deleted as a side effect.
+    assert get_secret(source_id="notion", key=f"pending_{fingerprint}") is None
+    captured = capsys.readouterr()
+    assert "stale pending entry" in captured.err
+
+
+def test_handle_event_attacker_pending_does_not_poison_legit_event():
+    """F2c fix: attacker POSTs a fake verification_token, creating
+    a pending entry under their token's fingerprint. A legitimate
+    event from Notion (signed with the real token, which we don't
+    yet have) lands; we enumerate pendings, the attacker's HMAC
+    does NOT match the legitimate body, so we do NOT adopt the
+    attacker entry. Event returns 401 (no matching pending), but
+    the attacker entry is NOT promoted to subscription-specific."""
+    import hashlib
+    import time as _t
+
+    from secrets_store import get_secret, put_secret
+
+    attacker_token = "secret_attacker"
+    fp_attacker = hashlib.sha256(attacker_token.encode("utf-8")).hexdigest()[:16]
+    put_secret(
+        source_id="notion",
+        key=f"pending_{fp_attacker}",
+        value=json.dumps({"token": attacker_token, "received_at": int(_t.time())}),
+    )
+
+    # Legitimate body signed with a DIFFERENT, legitimate token
+    # that we never received a verification for.
+    legitimate_token = "secret_real_from_notion"
+    body = _event_body(subscription_id="sub-real")
+    status, _ = handle(body=body, signature_header=_sign(legitimate_token, body))
+    assert status == 401
+
+    # Attacker entry is still pending (HMAC didn't match, no
+    # adoption happened) but it was NOT promoted to
+    # subscription_sub-real.
+    assert get_secret(source_id="notion", key="subscription_sub-real") is None
+    assert get_secret(source_id="notion", key=f"pending_{fp_attacker}") is not None
+
+
+def test_handle_event_subscription_specific_token_overrides_pending():
+    """If a subscription-specific token exists, the pending fallback
+    is NOT used — pin that the per-subscription token wins."""
+    import hashlib
+    import time as _t
+
+    from secrets_store import put_secret
+
+    put_secret(
+        source_id="notion",
+        key=f"pending_{hashlib.sha256(b'WRONG').hexdigest()[:16]}",
+        value=json.dumps({"token": "WRONG", "received_at": int(_t.time())}),
+    )
+    put_secret(source_id="notion", key="subscription_sub-1", value="correct-token")
+
+    body = _event_body(subscription_id="sub-1")
+    status, _ = handle(body=body, signature_header=_sign("correct-token", body))
+    assert status == 200
+
+
+def test_handle_event_subscription_id_with_invalid_chars_rejected():
+    """Review nice-to-have: invalid subscription_id (chars outside
+    [A-Za-z0-9._-]) returns 400, not 500 from secrets_store key
+    validation."""
+    body = json.dumps(
+        {
+            "subscription_id": "../malicious",  # path traversal attempt
+            "id": "evt-1",
+            "type": "page.content_updated",
+        }
+    ).encode("utf-8")
+    status, msg = handle(body=body, signature_header="sha256=" + "0" * 64)
+    assert status == 400
+    assert "subscription_id" in msg
+
+
+def test_handle_event_attempt_number_2_does_not_log_noise(
+    capsys: pytest.CaptureFixture,
+):
+    """F7 nice-to-have: attempt_number==2 is almost always a
+    transient self-heal; don't log noise. Only log at >= 4."""
+    _put_token("sub-1", token="secret_token")
+    body = _event_body(attempt_number=2)
+    status, _ = handle(body=body, signature_header=_sign("secret_token", body))
+    assert status == 200
+    captured = capsys.readouterr()
+    assert "attempt_number=2" not in captured.err

--- a/webhooks/notion.py
+++ b/webhooks/notion.py
@@ -1,0 +1,587 @@
+"""Notion webhook handler (#337 cycle 8).
+
+Notion's webhook contract:
+
+- Header ``X-Notion-Signature: sha256=<hex>`` — HMAC-SHA256 of the
+  raw request body, keyed by the ``verification_token``. Same
+  pattern as GitHub's ``X-Hub-Signature-256``.
+- Body envelope (post-handshake events): ``{id, timestamp,
+  workspace_id, subscription_id, integration_id, type, authors,
+  accessible_by, attempt_number, entity, data}``. ``id`` is the
+  canonical dedup key.
+- Verification handshake (one-time, at subscription setup):
+  Notion POSTs ``{"verification_token": "<token>"}`` with NO
+  signature header. We extract the token, persist it via
+  ``secrets_store``, and surface it to stderr so the operator can
+  paste it into Notion's UI to activate the subscription.
+
+The same ``verification_token`` doubles as the long-term HMAC
+secret for every subsequent event delivery on that subscription.
+
+## Replay defense
+
+Notion does NOT send a timestamp header. Body-side ``timestamp``
+exists but staleness-gating would conflict with aggregated
+``page.content_updated`` deliveries (Notion batches edits within a
+short window per their docs). We rely on body-side ``id`` for
+dedup via the shared :mod:`webhooks.dedup` LRU. The 24h TTL on
+that cache (raised post-cycle-5 review) covers Notion's full
+8-retry / 24h delivery envelope.
+
+## Event coverage (cycle 8 minimum)
+
+- ``page.created``, ``page.content_updated``, ``page.properties_updated``,
+  ``page.deleted``, ``page.locked``, ``page.unlocked``, ``page.moved``,
+  ``page.undeleted``
+- ``data_source.content_updated``, ``data_source.schema_updated``,
+  ``data_source.created``, ``data_source.deleted``, etc.
+- ``database.*`` (lifecycle only — ``database.schema_updated`` was
+  deprecated post-2022-06-28; we don't subscribe)
+- ``comment.created``, ``comment.updated``, ``comment.deleted``
+
+v0 ack-only on the event-dispatch path: cycle 8b adds the actual
+``handle_ingest`` invocations once we've validated the wire on
+real-operator deliveries. Returning 200 + a logged "dirty" marker
+is the same posture as cycle 9's Drive handler.
+
+See ``docs/research-brief-notion-webhooks-2026-05-20.md`` for the
+full design rationale.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import hmac
+import json
+import re
+import sys
+import time
+
+
+class WebhookVerificationError(Exception):
+    """Raised when signature verification fails."""
+
+
+# Cycle 8 review F2 fix: pending tokens are now keyed by token
+# FINGERPRINT (sha256 prefix), not by a single shared
+# ``pending_verification_token`` slot. This prevents:
+#   - F2a: concurrent verifications clobbering each other's tokens
+#   - F2b: cross-binding when multiple first-events race
+#   - F2c: attacker DoS via fake-verification POSTs poisoning the
+#     single pending slot
+# On first event for a subscription, we enumerate pending entries
+# and adopt the one whose HMAC matches the signature on the
+# incoming body. ``secrets_store.list_keys`` (source_id="notion")
+# gives us the enumeration primitive.
+#
+# Each pending entry stores ``{"token": "...", "received_at":
+# <epoch>}`` as JSON. Adoption is rejected for entries older than
+# 24h (F9 fix: bounds the attacker-DoS window).
+
+_PENDING_PREFIX = "pending_"
+_SUBSCRIPTION_PREFIX = "subscription_"
+_PENDING_TTL_SECONDS = 24 * 60 * 60
+# LOW-2 review fix: cap the number of pending entries to bound the
+# memory cost of attacker-driven fake-verification POSTs. At ~120
+# bytes per JSON entry, 100 entries ≈ 12 KiB — well within the
+# dict-fallback memory budget. New verifications past the cap are
+# rejected with 429 (operator can investigate via
+# ``bicameral-mcp notion-pending``).
+_MAX_PENDING_ENTRIES = 100
+# secrets_store keys must match [A-Za-z0-9._-]+; subscription_id
+# from Notion is a UUID but we validate defensively in case the
+# body is attacker-crafted.
+_SUBSCRIPTION_ID_RE = re.compile(r"^[A-Za-z0-9._-]+$")
+
+
+def _secret_key(subscription_id: str) -> str:
+    """Build the keyring key for a verified subscription's token."""
+    return f"{_SUBSCRIPTION_PREFIX}{subscription_id}"
+
+
+def _fingerprint(token: str) -> str:
+    """16-hex-char prefix of sha256(token). Collision-resistant for
+    the small N of pending tokens at any one operator's site."""
+    return hashlib.sha256(token.encode("utf-8")).hexdigest()[:16]
+
+
+def _pending_key(fingerprint: str) -> str:
+    return f"{_PENDING_PREFIX}{fingerprint}"
+
+
+def verify_signature(
+    *,
+    body: bytes,
+    signature_header: str | None,
+    verification_token: str,
+) -> None:
+    """Verify the X-Notion-Signature header against the body.
+
+    Direct adaptation of :func:`webhooks.github.verify_signature` —
+    the schemes are functionally identical apart from the header
+    name (``X-Notion-Signature`` vs ``X-Hub-Signature-256``).
+
+    Order:
+    1. Missing signature header or verification_token → reject.
+    2. Header must start with ``sha256=`` literal.
+    3. Hex digest after the prefix must be exactly 64 chars.
+    4. HMAC-SHA256(verification_token, body) compared constant-time
+       against the digest via :func:`hmac.compare_digest`.
+
+    Raises:
+        WebhookVerificationError: every failure mode.
+    """
+    if not signature_header:
+        raise WebhookVerificationError("missing X-Notion-Signature header")
+    if not verification_token:
+        raise WebhookVerificationError("no verification_token registered for this subscription")
+    if not signature_header.startswith("sha256="):
+        raise WebhookVerificationError(
+            f"X-Notion-Signature missing 'sha256=' prefix: {signature_header[:32]!r}"
+        )
+    provided_hex = signature_header[len("sha256=") :]
+    if len(provided_hex) != 64:
+        raise WebhookVerificationError(
+            f"X-Notion-Signature digest not 64 hex chars: got {len(provided_hex)}"
+        )
+    expected_hex = hmac.new(
+        verification_token.encode("utf-8"), msg=body, digestmod=hashlib.sha256
+    ).hexdigest()
+    if not hmac.compare_digest(provided_hex.lower(), expected_hex):
+        raise WebhookVerificationError("signature mismatch")
+
+
+def handle(
+    *,
+    body: bytes,
+    signature_header: str | None,
+) -> tuple[int, str]:
+    """Process one Notion webhook delivery.
+
+    Two structurally distinct payload shapes can arrive on this
+    route:
+
+    1. **Verification handshake** (one-time per subscription, no
+       signature header): body is ``{"verification_token":
+       "secret_..."}``. We persist the token via ``secrets_store``
+       and log it to stderr so the operator can complete the
+       handshake in Notion's UI.
+    2. **Event delivery** (recurring): full envelope with
+       ``subscription_id``, ``id``, ``type``, etc. We HMAC-verify
+       against the registered verification_token for that
+       subscription, dedup on ``id``, and ack.
+
+    Returns ``(http_status, response_body)``. Notion does not
+    require a JSON response shape; plain text suffices.
+    """
+    # Body parse comes BEFORE verify because we need to inspect the
+    # body shape to distinguish verification from event. This is
+    # the same posture Drive uses (no body signature on the
+    # verification path), and it's safer than the cycle-7 Linear
+    # pattern that verified first — Notion's verification body
+    # legitimately has no signature, so a verify-first design would
+    # require special-casing the missing header anyway.
+    try:
+        payload = json.loads(body.decode("utf-8"))
+    except Exception as exc:  # noqa: BLE001
+        print(f"[notion-webhook] body not JSON-decodable: {exc}", file=sys.stderr)
+        return 400, f"body not JSON: {exc}"
+
+    if not isinstance(payload, dict):
+        return 400, "body not a JSON object"
+
+    # ── Verification handshake ───────────────────────────────────
+    if "verification_token" in payload and "type" not in payload:
+        # Distinguish by structural marker: verification payloads
+        # have exactly one key (verification_token); event payloads
+        # always have type + id + subscription_id. We additionally
+        # require ``type`` to be ABSENT (rather than just check
+        # verification_token presence) so an attacker can't smuggle
+        # a verification_token into a normal event payload to trick
+        # us into clobbering the registered token.
+        return _handle_verification(payload)
+
+    # ── Event delivery ───────────────────────────────────────────
+    return _handle_event(body, payload, signature_header)
+
+
+def _handle_verification(payload: dict) -> tuple[int, str]:
+    """Handle Notion's one-time subscription verification POST.
+
+    Notion POSTs ``{"verification_token": "secret_..."}`` to our
+    callback URL. We persist the token under a fingerprint-keyed
+    pending slot and surface the fingerprint (NOT the full token)
+    to stderr. The full token is retrievable via
+    ``secrets_store.get_secret(source_id="notion",
+    key=f"pending_<fingerprint>")`` — cycle 8b's CLI tool reads it
+    and shows the operator the value to paste back into Notion's UI.
+
+    Each verification gets its own pending slot (keyed by token
+    fingerprint), so concurrent verifications don't clobber each
+    other (cycle 8 review F2 fix).
+
+    Threat-model note: an attacker who can reach this endpoint can
+    POST a fake ``{"verification_token": ...}`` to create a junk
+    pending entry. The damage is bounded — the entry is keyed by
+    the attacker's own token fingerprint, so it can NOT clobber a
+    legitimate pending token (different fingerprints → different
+    slots). Worst case is keyring bloat, capped by the 24h TTL on
+    adoption (review F9 fix).
+    """
+    token = payload.get("verification_token")
+    if not token or not isinstance(token, str):
+        return 400, "verification_token missing or non-string"
+
+    # Length sanity — Notion's documented format is "secret_<base64-ish>"
+    # at ~50 chars. Reject anything obviously off so we don't store
+    # garbage from random attackers.
+    if len(token) < 10 or len(token) > 256:
+        print(
+            f"[notion-webhook] verification_token length {len(token)} outside "
+            "[10, 256] — rejecting",
+            file=sys.stderr,
+        )
+        return 400, "verification_token length out of bounds"
+
+    fingerprint = _fingerprint(token)
+    entry = json.dumps({"token": token, "received_at": int(time.time())})
+
+    try:
+        from secrets_store import list_keys, put_secret
+
+        # LOW-2 review fix: bound the pending-entries set. Idempotent
+        # re-receipt of the same fingerprint (Notion retrying the
+        # verification POST itself, or operator-side retry) is
+        # ALLOWED — it overwrites the existing entry and doesn't
+        # count against the cap. Only NEW fingerprints past the cap
+        # are rejected.
+        existing = [k for k in list_keys(source_id="notion") if k.startswith(_PENDING_PREFIX)]
+        is_new = _pending_key(fingerprint) not in existing
+        if is_new and len(existing) >= _MAX_PENDING_ENTRIES:
+            print(
+                f"[notion-webhook] pending-entries cap reached "
+                f"({len(existing)} >= {_MAX_PENDING_ENTRIES}); rejecting new "
+                f"fingerprint={fingerprint!r}. Use `bicameral-mcp notion-pending` "
+                "to inspect and clean up stale entries.",
+                file=sys.stderr,
+            )
+            return 429, f"pending-entries cap reached ({_MAX_PENDING_ENTRIES})"
+
+        put_secret(source_id="notion", key=_pending_key(fingerprint), value=entry)
+    except Exception as exc:  # noqa: BLE001
+        print(
+            f"[notion-webhook] failed to persist verification entry: {exc}",
+            file=sys.stderr,
+        )
+        return 500, f"failed to persist verification entry: {exc}"
+
+    # F3 fix: log the fingerprint, not the full token. Operator
+    # retrieves the full token via `bicameral-mcp notion-pending
+    # <fingerprint>` (cycle 8b CLI). Until that CLI ships, operators
+    # can read the keyring entry directly via the OS keyring tool of
+    # their choice — same surface they already use for OAuth tokens.
+    print(
+        f"[notion-webhook] verification handshake received "
+        f"(fingerprint={fingerprint!r}). Retrieve the full token from "
+        f"secrets_store source_id='notion' key='{_pending_key(fingerprint)}' "
+        "and paste it into Notion's webhook verification form.",
+        file=sys.stderr,
+    )
+
+    return 200, f"verification received (fingerprint={fingerprint})"
+
+
+def _try_adopt_pending(
+    body: bytes, signature_header: str | None, subscription_id: str
+) -> str | None:
+    """Try each pending token; on HMAC match, adopt it for this
+    subscription and return the token. Returns None if no pending
+    token matches.
+
+    Stale entries (older than 24h per F9 fix) are skipped AND
+    deleted in the same pass.
+    """
+    if not signature_header or not signature_header.startswith("sha256="):
+        return None
+    provided_hex = signature_header[len("sha256=") :].lower()
+    if len(provided_hex) != 64:
+        return None
+
+    try:
+        from secrets_store import delete_secret, get_secret, list_keys, put_secret
+    except Exception as exc:  # noqa: BLE001
+        print(f"[notion-webhook] secrets_store import failed: {exc}", file=sys.stderr)
+        return None
+
+    keys = list_keys(source_id="notion")
+    pending_keys = [k for k in keys if k.startswith(_PENDING_PREFIX)]
+    now = int(time.time())
+
+    for key in pending_keys:
+        raw = get_secret(source_id="notion", key=key)
+        if not raw:
+            continue
+        try:
+            entry = json.loads(raw)
+        except Exception:  # noqa: BLE001
+            # Malformed entry — delete it and keep going.
+            try:
+                delete_secret(source_id="notion", key=key)
+            except Exception:  # noqa: BLE001
+                pass
+            continue
+        token = entry.get("token")
+        received_at = entry.get("received_at")
+        if not isinstance(token, str) or not isinstance(received_at, (int, float)):
+            try:
+                delete_secret(source_id="notion", key=key)
+            except Exception:  # noqa: BLE001
+                pass
+            continue
+        # F9 fix: reject + clean up stale pending entries.
+        if now - received_at > _PENDING_TTL_SECONDS:
+            print(
+                f"[notion-webhook] dropping stale pending entry {key!r} "
+                f"(age {now - int(received_at)}s > {_PENDING_TTL_SECONDS}s)",
+                file=sys.stderr,
+            )
+            try:
+                delete_secret(source_id="notion", key=key)
+            except Exception:  # noqa: BLE001
+                pass
+            continue
+
+        expected_hex = hmac.new(
+            token.encode("utf-8"), msg=body, digestmod=hashlib.sha256
+        ).hexdigest()
+        if hmac.compare_digest(provided_hex, expected_hex):
+            # Match — adopt under the subscription-specific key and
+            # delete the pending entry. This is the moment the
+            # subscription becomes "verified" from our side.
+            try:
+                put_secret(
+                    source_id="notion",
+                    key=_secret_key(subscription_id),
+                    value=token,
+                )
+                delete_secret(source_id="notion", key=key)
+            except Exception as exc:  # noqa: BLE001
+                print(
+                    f"[notion-webhook] failed to adopt pending entry {key!r}: {exc}",
+                    file=sys.stderr,
+                )
+                return None
+            print(
+                f"[notion-webhook] adopted pending verification (fingerprint="
+                f"{key[len(_PENDING_PREFIX) :]!r}) for subscription_id="
+                f"{subscription_id!r}",
+                file=sys.stderr,
+            )
+            return token
+    return None
+
+
+def _handle_event(body: bytes, payload: dict, signature_header: str | None) -> tuple[int, str]:
+    """Handle a post-handshake event delivery."""
+    subscription_id = payload.get("subscription_id")
+    if not subscription_id or not isinstance(subscription_id, str):
+        return 400, "event missing subscription_id"
+    # Validate subscription_id shape: secrets_store keys must match
+    # [A-Za-z0-9._-]+, and an attacker-supplied value with other
+    # characters would otherwise surface as a 500 from
+    # `_validate_identifier` (review nice-to-have: return 400
+    # instead).
+    if not _SUBSCRIPTION_ID_RE.match(subscription_id):
+        return 400, "subscription_id has invalid characters"
+
+    event_id = payload.get("id")
+    if not event_id or not isinstance(event_id, str):
+        return 400, "event missing id"
+
+    event_type = (payload.get("type") or "").strip()
+    if not event_type:
+        return 400, "event missing type"
+
+    # Look up the verification_token for this subscription. On the
+    # FIRST event delivery for a freshly verified subscription, the
+    # subscription-specific key won't exist yet — enumerate the
+    # pending entries (one per verification handshake we've
+    # received) and try to adopt one whose HMAC matches the
+    # incoming signature. Fingerprint-keyed pending entries
+    # (review F2 fix) prevent concurrent verifications from
+    # clobbering each other.
+    try:
+        from secrets_store import get_secret
+
+        token = get_secret(source_id="notion", key=_secret_key(subscription_id))
+        if not token:
+            token = _try_adopt_pending(body, signature_header, subscription_id)
+    except Exception as exc:  # noqa: BLE001
+        print(f"[notion-webhook] secret lookup failed: {exc}", file=sys.stderr)
+        return 500, f"secret lookup failed: {exc}"
+
+    if not token:
+        print(
+            f"[notion-webhook] no verification_token for subscription_id="
+            f"{subscription_id!r}; rejecting",
+            file=sys.stderr,
+        )
+        return 401, f"no verification_token registered for subscription {subscription_id!r}"
+
+    try:
+        verify_signature(body=body, signature_header=signature_header, verification_token=token)
+    except WebhookVerificationError as exc:
+        print(f"[notion-webhook] verification failed: {exc}", file=sys.stderr)
+        return 401, f"verification failed: {exc}"
+
+    # Dedup on event id. Notion's 8-retry / 24h envelope is fully
+    # covered by the shared 24h dedup TTL (raised post-cycle-5).
+    from webhooks.dedup import get_dedup_cache
+
+    cache = get_dedup_cache()
+    if cache.is_duplicate("notion", event_id):
+        print(
+            f"[notion-webhook] duplicate event_id {event_id!r} ignored",
+            file=sys.stderr,
+        )
+        return 200, "duplicate"
+    cache.mark_seen("notion", event_id)
+
+    attempt_number = payload.get("attempt_number")
+    # Review F7 nice-to-have: only log attempt_number when it's
+    # actually actionable. attempt_number==2 is almost always a
+    # transient that self-healed; attempt_number>=4 (halfway
+    # through the envelope) is a real signal worth surfacing.
+    if isinstance(attempt_number, int) and attempt_number >= 4:
+        print(
+            f"[notion-webhook] event_id={event_id!r} attempt_number="
+            f"{attempt_number} (Notion retrying — investigate prior 200 misses)",
+            file=sys.stderr,
+        )
+
+    # Cycle 8b: actually ingest decision-bearing events. The
+    # webhook is the trigger; the canonical content still flows
+    # through ``sources/notion/adapter.py:fetch_active`` so the
+    # passive and active paths land identical payloads.
+    #
+    # ``page.*`` events with a non-deleted entity → fetch + ingest.
+    # ``page.deleted`` → ack only (append-only contract, same
+    # posture as Linear's Issue/Comment remove path).
+    # ``comment.*``, ``data_source.*``, ``database.*`` → ack only;
+    # later cycles add comment fetching, schema-change handling.
+    if event_type in {"page.created", "page.content_updated", "page.properties_updated"}:
+        entity = payload.get("entity") or {}
+        page_id = entity.get("id")
+        if not page_id or not isinstance(page_id, str):
+            print(
+                f"[notion-webhook] event_id={event_id!r} type={event_type!r} "
+                f"missing entity.id; skipping ingest",
+                file=sys.stderr,
+            )
+            return 200, f"event id={event_id!r} type={event_type!r} acknowledged (no entity.id)"
+        return _ingest_page(event_id, event_type, page_id)
+
+    # Acknowledged, no ingest. Cycle 8c-or-later will add comment
+    # fetching (needs a new Notion API path beyond the existing
+    # adapter) and decide whether schema / data_source events get
+    # any treatment.
+    print(
+        f"[notion-webhook] event_id={event_id!r} type={event_type!r} "
+        f"subscription_id={subscription_id!r} (no ingest for this event type)",
+        file=sys.stderr,
+    )
+    return 200, f"event id={event_id!r} type={event_type!r} acknowledged"
+
+
+def _ingest_page(event_id: str, event_type: str, page_id: str) -> tuple[int, str]:
+    """Fetch a Notion page via the active adapter and pipe through
+    ``handle_ingest`` in passive mode.
+
+    Mirrors the GitHub/Slack/Linear webhook → handle_ingest path:
+    ``asyncio.run()`` inside the to_thread worker. Cycle 9 review
+    M3 flagged this nested-loop pattern as a latent reliability
+    issue (per-request loop create/teardown overhead); a follow-up
+    cycle will revisit by making handle() itself async. Until
+    then, the pattern matches the rest of the chain.
+
+    Failure posture: ALL failures (fetch error, refusal, generic
+    ingest error) return 200 to Notion. Notion retries on every
+    non-2xx (not just 5xx like Drive), and we do NOT want 8 retries
+    of a payload that's already failed for a deterministic reason.
+    Operator visibility is via stderr + the gate's own audit-log
+    emit. This deviates from cycles 5/6/7 (which return 422 on
+    refusal) — the deviation is documented in the
+    research-brief-notion §5 retry-policy analysis.
+    """
+    try:
+        from sources.notion.adapter import NotionAdapter
+        from sources.notion.client import NotionAPIError
+
+        adapter = NotionAdapter()
+        # Build a canonical Notion URL from the page_id. The
+        # adapter accepts both dashed and undashed UUIDs; the
+        # webhook payload provides the undashed form.
+        page_url = f"https://www.notion.so/{page_id.replace('-', '')}"
+        ingest_payload = adapter.fetch_active(page_url)
+    except NotionAPIError as exc:
+        # MED-1 fix: split transient from deterministic fetch
+        # failures. 5xx + 429 are exactly the cases where Notion's
+        # 8-retry / 24h envelope is the right backpressure — return
+        # 500 so the provider retries and the operator sees the
+        # storm in their network metrics. 4xx-not-429 (page gone,
+        # permission revoked, malformed page_id) is genuinely
+        # deterministic; 200-ack with stderr so we don't amplify.
+        status_code = exc.status_code
+        is_transient = status_code is None or status_code == 429 or status_code >= 500
+        print(
+            f"[notion-webhook] page fetch failed for {page_id!r} "
+            f"(event_id={event_id!r}, http_status={status_code}, "
+            f"transient={is_transient}): {exc}",
+            file=sys.stderr,
+        )
+        if is_transient:
+            return 500, (
+                f"event id={event_id!r} fetch failed (transient http={status_code}); "
+                "Notion will retry"
+            )
+        return 200, f"event id={event_id!r} type={event_type!r} acknowledged (fetch failed)"
+    except Exception as exc:  # noqa: BLE001
+        # Non-NotionAPIError exceptions (e.g. malformed URL parse,
+        # adapter import failure, transport-layer bugs we haven't
+        # classified). Treat as transient by default — operator
+        # visibility via the retry storm is more useful than silent
+        # loss.
+        print(
+            f"[notion-webhook] page fetch raised non-API exception for {page_id!r} "
+            f"(event_id={event_id!r}): {type(exc).__name__}: {exc}",
+            file=sys.stderr,
+        )
+        return 500, f"event id={event_id!r} fetch failed (unclassified); Notion will retry"
+
+    try:
+        import asyncio
+
+        from context import BicameralContext
+        from handlers.ingest import _IngestRefused, handle_ingest
+
+        ctx = BicameralContext.from_env()
+
+        async def _ingest() -> None:
+            await handle_ingest(ctx, ingest_payload, source_scope="notion", ingest_mode="passive")
+
+        asyncio.run(_ingest())
+    except _IngestRefused as exc:
+        print(
+            f"[notion-webhook] hard-gate refusal for page {page_id!r} "
+            f"(event_id={event_id!r}): {exc.reason}",
+            file=sys.stderr,
+        )
+        return 200, f"event id={event_id!r} acknowledged (refused: {exc.reason})"
+    except Exception as exc:  # noqa: BLE001
+        print(
+            f"[notion-webhook] ingest failed for page {page_id!r} (event_id={event_id!r}): {exc}",
+            file=sys.stderr,
+        )
+        return 200, f"event id={event_id!r} acknowledged (ingest failed)"
+
+    return 200, f"event id={event_id!r} type={event_type!r} ingested page {page_id!r}"

--- a/webhooks/server.py
+++ b/webhooks/server.py
@@ -11,6 +11,7 @@ NOT terminate TLS ourselves.
 
 Routes:
 - ``POST /webhooks/github``         → ``webhooks.github.handle``
+- ``POST /webhooks/notion``         → ``webhooks.notion.handle``
 - ``POST /webhooks/google-drive``   → ``webhooks.google_drive.handle``
 - ``GET /health``                   → 200 ack (for load-balancer health checks)
 
@@ -206,6 +207,13 @@ async def _process_request(reader: asyncio.StreamReader, writer: asyncio.StreamW
         await _respond(writer, status, message)
         return
 
+    if path == "/webhooks/notion":
+        status, message = await asyncio.to_thread(
+            _dispatch_notion, body, MappingProxyType(dict(headers))
+        )
+        await _respond(writer, status, message)
+        return
+
     await _respond(writer, 404, "not found")
 
 
@@ -240,6 +248,16 @@ def _dispatch_google_drive(body: bytes, headers) -> tuple[int, str]:
         resource_id=headers.get("x-goog-resource-id"),
         resource_state=headers.get("x-goog-resource-state"),
         message_number=headers.get("x-goog-message-number"),
+    )
+
+
+def _dispatch_notion(body: bytes, headers) -> tuple[int, str]:
+    """Sync entrypoint into the Notion handler (called via to_thread)."""
+    from webhooks.notion import handle
+
+    return handle(
+        body=body,
+        signature_header=headers.get("x-notion-signature"),
     )
 
 


### PR DESCRIPTION
## Review only — do not merge

This is a **review / preservation PR** for the `feat/notion` branch, opened for visibility per the per-feature-branch rule. It is **draft / do-not-merge** — the Notion integration is kept on its own long-lived branch, not merged into `dev`.

## Content

The **Notion** integration (active + passive ingest, webhook receiver, notion-pending CLI), backed out of `dev` by BicameralAI/bicameral-mcp#479 and preserved here in isolation.

## Note on the diff

This branch was cut from the integration-free `dev` base. Once **#479** (the back-out) merges into `dev`, this PR's diff resolves to exactly the Notion integration and nothing else — clean-isolated. Until then the diff also shows the other integrations being removed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)