### PR TITLE
feat(slack): Slack integration — isolated feature branch [review only, do not merge]

### DIFF
--- a/cli/source_list_cli.py
+++ b/cli/source_list_cli.py
@@ -22,7 +22,7 @@ import argparse
 import json
 import sys
 
-_DISCOVERABLE_SOURCES = ("github", "google_drive")
+_DISCOVERABLE_SOURCES = ("slack", "github", "google_drive")
 
 
 def _build_argparser(subparser: argparse.ArgumentParser) -> None:
@@ -47,6 +47,7 @@ def _build_argparser(subparser: argparse.ArgumentParser) -> None:
 def main(args: argparse.Namespace) -> int:
     """Entry point invoked from ``server.py::_dispatch``."""
     dispatch = {
+        "slack": _list_slack,
         "github": _list_github,
         "google_drive": _list_google_drive,
     }
@@ -75,6 +76,25 @@ class _AuthMissing(RuntimeError):
 
 class _APIError(RuntimeError):
     """Discovery API call failed."""
+
+
+def _list_slack() -> tuple[list[dict], list[str]]:
+    from secrets_store import get_secret
+
+    token = get_secret(source_id="slack", key="api_key")
+    if not token:
+        raise _AuthMissing(
+            "Slack bot token not configured. Store it via put_secret "
+            "(source_id='slack', key='api_key'). See "
+            "docs/integrations-settings-inventory.md § Slack."
+        )
+    from sources.slack.client import SlackAPIError, list_channels
+
+    try:
+        channels = list_channels(token=token, include_private=True)
+    except SlackAPIError as exc:
+        raise _APIError(str(exc)) from exc
+    return channels, ["id", "name", "is_private", "is_member", "num_members"]
 
 
 def _list_github() -> tuple[list[dict], list[str]]:

--- a/events/sources/__init__.py
+++ b/events/sources/__init__.py
@@ -24,6 +24,7 @@ from .github import GitHubPollingAdapter
 from .google_drive import GoogleDriveFolderAdapter
 from .granola import GranolaAdapter, MissingApiKeyError
 from .local_directory import LocalDirectoryAdapter
+from .slack import SlackPollingAdapter
 
 
 @runtime_checkable
@@ -47,6 +48,7 @@ ADAPTERS: dict[str, type] = {
     "granola": GranolaAdapter,
     "local_directory": LocalDirectoryAdapter,
     "google_drive": GoogleDriveFolderAdapter,
+    "slack": SlackPollingAdapter,
     "github": GitHubPollingAdapter,
 }
 
@@ -58,5 +60,6 @@ __all__ = [
     "GranolaAdapter",
     "LocalDirectoryAdapter",
     "MissingApiKeyError",
+    "SlackPollingAdapter",
     "SourceAdapter",
 ]

--- a/events/sources/slack.py
+++ b/events/sources/slack.py
@@ -1,0 +1,283 @@
+"""Slack polling source adapter (#337 Phase 4b).
+
+Pull-based: enumerates new messages in configured channels via
+``conversations.history`` since the last watermark, fetches each
+top-level message's thread (if any), and returns ingest-ready payloads.
+
+A "decision" in Slack is most often the originating message of a
+thread — replies are commentary. Phase 4b ingests **top-level messages
+only** by default; full thread context per message is reserved for a
+future cycle (the active path at Phase 4a already fetches threads on
+demand for operator-pasted URLs).
+
+Config schema::
+
+    sources:
+      - type: slack
+        channels: ["C01ABC123", "C02DEF456"]
+        source_type_label: slack-message  # optional
+
+Auth: bot token in ``secrets_store source_id="slack", key="api_key"``.
+Same store as the active-ingest path (Phase 4a #438) — one token works
+for both.
+
+Watermark: per-channel. ``<watermark_dir>/slack.json`` stores
+``{"C01ABC123": "1700000000.123456", ...}`` so a busy channel doesn't
+strand a quiet one.
+
+Policy: channel-only — config entries that look like DM IDs (``D…``)
+or multi-party IM IDs (``G…`` — Slack uses ``G`` for private groups,
+which DO include private channels, so the check is permissive: only
+``D`` is explicitly rejected) are skipped with a stderr warning.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import sys
+from pathlib import Path
+
+logger = logging.getLogger(__name__)
+
+_WATERMARK_FILENAME = "slack.json"
+
+
+class SlackPollingAdapter:
+    """Source adapter conforming to ``events.sources.SourceAdapter``."""
+
+    name = "slack"
+
+    def __init__(self) -> None:
+        self._pending_watermarks: dict[str, str] = {}
+        self._watermark_path: Path | None = None
+
+    def pull(self, *, watermark_dir: Path, config: dict) -> list[dict]:
+        watermark_dir = Path(watermark_dir)
+        watermark_dir.mkdir(parents=True, exist_ok=True)
+        self._watermark_path = watermark_dir / _WATERMARK_FILENAME
+
+        # #337 foundations cycle 2: parse source-level filters + per-resource
+        # entries. ``channels`` accepts either bare strings (legacy: inherit
+        # source-level filter, no overrides) or dicts of shape
+        # ``{id: "C…", filters: {...}}`` (per-resource filter overrides).
+        from filters import (
+            FilterSpec,
+            evaluate_filters,
+            get_max_bytes,
+            get_max_items,
+            merge_specs,
+            payload_within_cap,
+        )
+
+        # cycle 4: per-source quota (applies across all channels in this pull)
+        max_items = get_max_items(config)
+        max_bytes = get_max_bytes(config)
+
+        source_level_filter = _parse_filter_block(config.get("filters") or {})
+        channels_raw = config.get("channels") or []
+        # Each entry becomes (channel_id, effective_filter_spec).
+        channel_specs: list[tuple[str, FilterSpec]] = []
+        for entry in channels_raw:
+            if isinstance(entry, str):
+                cid = entry.strip()
+                spec = source_level_filter
+            elif isinstance(entry, dict):
+                cid = str(entry.get("id") or "").strip()
+                res_spec = _parse_filter_block(entry.get("filters") or {})
+                spec = merge_specs(source_level_filter, res_spec)
+            else:
+                continue
+            if not cid or cid.upper().startswith("D"):
+                continue
+            channel_specs.append((cid, spec))
+
+        channels = [c for c, _ in channel_specs]
+        if not channels:
+            print(
+                "[slack] at least one channel ID is required in source.channels; "
+                "skipping. (DM IDs starting with 'D' are filtered by policy.)",
+                file=sys.stderr,
+            )
+            self._pending_watermarks = {}
+            return []
+
+        try:
+            from secrets_store import get_secret
+
+            token = get_secret(source_id="slack", key="api_key")
+            if not token:
+                print(
+                    "[slack] api_key not configured (secrets_store source_id=slack, "
+                    "key=api_key); skipping.",
+                    file=sys.stderr,
+                )
+                self._pending_watermarks = {}
+                return []
+        except Exception as exc:  # noqa: BLE001
+            print(f"[slack] secret lookup failed: {exc}", file=sys.stderr)
+            self._pending_watermarks = {}
+            return []
+
+        all_watermarks = _read_watermarks(self._watermark_path)
+        new_watermarks: dict[str, str] = dict(all_watermarks)
+
+        try:
+            from sources.slack.adapter import (
+                _is_decision_bearing,
+                normalize_thread_to_payload,
+            )
+            from sources.slack.client import get_user_info
+            from sources.slack.poller import list_new_messages
+        except ImportError as exc:
+            print(f"[slack] adapter import failed: {exc}", file=sys.stderr)
+            self._pending_watermarks = {}
+            return []
+
+        payloads: list[dict] = []
+        # Local cache so users.info is hit once per user per pull.
+        user_cache: dict[str, dict] = {}
+
+        def _resolver(user_id: str) -> dict:
+            if user_id in user_cache:
+                return user_cache[user_id]
+            try:
+                profile = get_user_info(token=token, user_id=user_id)
+            except Exception:  # noqa: BLE001 — resolver is best-effort
+                profile = {}
+            user_cache[user_id] = profile
+            return profile
+
+        for channel_id, channel_spec in channel_specs:
+            # cycle 4: cap stops processing further channels too.
+            if max_items and len(payloads) >= max_items:
+                break
+            last_ts = all_watermarks.get(channel_id)
+            try:
+                messages = list_new_messages(token=token, channel=channel_id, oldest=last_ts)
+            except Exception as exc:  # noqa: BLE001
+                print(
+                    f"[slack] {channel_id} history fetch failed: {exc}",
+                    file=sys.stderr,
+                )
+                continue
+
+            highest_ts = last_ts or ""
+            for msg in messages:
+                if max_items and len(payloads) >= max_items:
+                    break
+                msg_ts = msg.get("ts") or ""
+                # Only top-level messages — replies don't have parent_user_id
+                # and don't carry thread_ts == ts? Actually Slack sets
+                # ``thread_ts == ts`` for thread roots, and ``thread_ts``
+                # differing from ``ts`` for replies. Skip replies.
+                if msg.get("thread_ts") and msg.get("thread_ts") != msg_ts:
+                    if msg_ts > highest_ts:
+                        highest_ts = msg_ts
+                    continue
+                if not _is_decision_bearing(msg):
+                    if msg_ts > highest_ts:
+                        highest_ts = msg_ts
+                    continue
+                # #337 cycle 2: universal-filter gate. Slack candidate
+                # shape: text from message body, author from user_id
+                # (email resolution happens in normalize, but for filter
+                # eval we use the raw user ID — operators can configure
+                # author_include with user IDs OR delegate to extensions
+                # in a future cycle).
+                candidate = {
+                    "text": msg.get("text") or "",
+                    "author": msg.get("user") or "",
+                    "timestamp": _slack_ts_to_iso_safe(msg_ts),
+                }
+                if not evaluate_filters(candidate, channel_spec):
+                    if msg_ts > highest_ts:
+                        highest_ts = msg_ts
+                    continue
+                payload = normalize_thread_to_payload(
+                    [msg],
+                    channel=channel_id,
+                    thread_url=f"slack://{channel_id}/{msg_ts}",
+                    user_resolver=_resolver,
+                )
+                label = config.get("source_type_label")
+                if label:
+                    payload = {**payload, "source": str(label)}
+                if not payload_within_cap(payload, max_bytes):
+                    print(
+                        f"[slack] {channel_id}#{msg_ts} exceeds "
+                        f"max_payload_bytes ({max_bytes}); skipped.",
+                        file=sys.stderr,
+                    )
+                    if msg_ts > highest_ts:
+                        highest_ts = msg_ts
+                    continue
+                payloads.append(payload)
+                if msg_ts > highest_ts:
+                    highest_ts = msg_ts
+
+            if highest_ts:
+                new_watermarks[channel_id] = highest_ts
+
+        self._pending_watermarks = new_watermarks
+        return payloads
+
+    def confirm_watermark(self) -> None:
+        if self._watermark_path is None or not self._pending_watermarks:
+            return
+        try:
+            self._watermark_path.write_text(
+                json.dumps(self._pending_watermarks),
+                encoding="utf-8",
+            )
+        except OSError as exc:
+            logger.warning(
+                "[slack] watermark persistence failed (will re-pull next run): %s",
+                exc,
+            )
+        self._pending_watermarks = {}
+
+
+def _parse_filter_block(raw: dict | None):
+    """Coerce a YAML filter block into a FilterSpec, never raises.
+
+    Malformed filter config logs to stderr and falls through to the
+    no-filter default — operator gets stderr feedback but the poller
+    doesn't halt on a typo.
+    """
+    from filters import FilterSpec
+
+    if not raw or not isinstance(raw, dict):
+        return FilterSpec()
+    try:
+        return FilterSpec(**raw)
+    except Exception as exc:  # noqa: BLE001 — surface, don't halt
+        print(f"[slack] malformed filter block ignored: {exc}", file=sys.stderr)
+        return FilterSpec()
+
+
+def _slack_ts_to_iso_safe(ts: str) -> str:
+    """Slack ts → ISO 8601 for filter time-window comparison. Empty on parse failure."""
+    try:
+        from datetime import UTC, datetime
+
+        return datetime.fromtimestamp(float(ts), tz=UTC).isoformat()
+    except (ValueError, OSError, OverflowError):
+        return ""
+
+
+def _read_watermarks(path: Path) -> dict[str, str]:
+    if not path.exists():
+        return {}
+    try:
+        data = json.loads(path.read_text(encoding="utf-8"))
+    except (json.JSONDecodeError, OSError) as exc:
+        logger.warning(
+            "[slack] watermark file corrupt at %s, starting from epoch: %s",
+            path,
+            exc,
+        )
+        return {}
+    if not isinstance(data, dict):
+        return {}
+    return {str(k): str(v) for k, v in data.items() if isinstance(v, str)}

--- a/sources/slack/__init__.py
+++ b/sources/slack/__init__.py
@@ -1,0 +1,15 @@
+"""Slack source adapter (#337 Phase 4a — active ingest).
+
+Public API: ``SlackAdapter`` and ``parse_slack_url``.
+
+Auth: bot token persisted via ``secrets_store`` under
+``source_id="slack"``, key ``"api_key"``. Operator creates a Slack app
+at api.slack.com, grants ``channels:history`` + ``groups:history``
+scopes (and ``mpim:history`` / ``im:history`` only if intentionally
+ingesting DMs — Bicameral's policy is channel-only by default per
+#337's "no DMs" rule).
+"""
+
+from sources.slack.adapter import SlackAdapter, parse_slack_url
+
+__all__ = ["SlackAdapter", "parse_slack_url"]

--- a/sources/slack/adapter.py
+++ b/sources/slack/adapter.py
@@ -1,0 +1,220 @@
+"""Slack source adapter (#337 Phase 4a — active ingest).
+
+Active path: operator pastes a Slack thread URL → adapter fetches the
+thread + replies → normalizes to an IngestPayload. Passive (channel
+polling) is Phase 4b.
+
+URL forms accepted:
+    https://<workspace>.slack.com/archives/<channel_id>/p<ts_no_dot>
+    https://<workspace>.slack.com/archives/<channel_id>/p<ts_no_dot>?thread_ts=<root>
+
+The ``p<ts>`` segment encodes the message timestamp by stripping the
+decimal: ``p1700000000123456`` corresponds to Slack ``ts="1700000000.123456"``.
+When ``thread_ts`` is present it identifies the thread root; otherwise
+the message ``p<ts>`` IS the root.
+
+DM URLs (``/messages/<im_id>``) are rejected by design — Bicameral's
+ingest policy is channel-only per the parent tracker.
+"""
+
+from __future__ import annotations
+
+import re
+
+_THREAD_URL_RE = re.compile(
+    r"^https?://(?:[a-z0-9-]+\.)?slack\.com/archives/"
+    r"(?P<channel>[A-Z0-9]+)/p(?P<ts_compact>\d{16})"
+    r"(?:\?(?P<query>[^#]*))?(?:#.*)?$",
+    re.IGNORECASE,
+)
+
+
+class _ParsedSlackURL:
+    """URL parts used by the adapter."""
+
+    __slots__ = ("channel", "thread_ts", "url")
+
+    def __init__(self, *, channel: str, thread_ts: str, url: str) -> None:
+        self.channel = channel
+        self.thread_ts = thread_ts
+        self.url = url
+
+
+def parse_slack_url(url: str) -> _ParsedSlackURL:
+    """Extract channel_id + thread_ts from a Slack archive URL.
+
+    Returns a struct rather than a tuple so the call site reads cleanly
+    when both fields are referenced.
+
+    Raises:
+        ValueError: not a recognized Slack thread URL, or a DM URL
+            (DMs are out of scope by policy).
+    """
+    if "/messages/" in url.lower():
+        raise ValueError(f"DM URL not supported (Bicameral policy: channel-only): {url!r}")
+    m = _THREAD_URL_RE.match(url.strip())
+    if not m:
+        raise ValueError(
+            f"not a recognized Slack thread URL: {url!r}. "
+            "Expected slack.com/archives/<channel_id>/p<ts>."
+        )
+    channel = m.group("channel").upper()
+    ts_compact = m.group("ts_compact")
+    # p1700000000123456 → 1700000000.123456 (last 6 digits are microseconds).
+    message_ts = ts_compact[:-6] + "." + ts_compact[-6:]
+    # If the URL carries thread_ts=<root>, use that as the canonical
+    # thread anchor; otherwise the message itself is the root.
+    thread_ts = message_ts
+    query = m.group("query") or ""
+    for part in query.split("&"):
+        if part.startswith("thread_ts="):
+            thread_ts = part.split("=", 1)[1]
+            break
+    return _ParsedSlackURL(channel=channel, thread_ts=thread_ts, url=url.strip())
+
+
+def _is_decision_bearing(message: dict) -> bool:
+    """Filter out messages that aren't candidates for decision capture.
+
+    Out: bot messages (subtype set), channel-join/leave noise, empty text.
+    In: human messages with non-empty ``text`` or attachments.
+    """
+    if message.get("subtype") in {
+        "bot_message",
+        "channel_join",
+        "channel_leave",
+        "channel_topic",
+        "channel_purpose",
+        "channel_name",
+        "channel_archive",
+        "channel_unarchive",
+    }:
+        return False
+    text = (message.get("text") or "").strip()
+    if not text and not message.get("attachments"):
+        return False
+    return True
+
+
+def normalize_thread_to_payload(
+    messages: list[dict],
+    *,
+    channel: str,
+    thread_url: str,
+    user_resolver=None,
+) -> dict:
+    """Build the ingest payload from a Slack thread's messages.
+
+    ``user_resolver`` (optional) is a callable ``user_id -> dict`` that
+    returns a user-profile dict (``name``, ``profile.email``). When
+    supplied it's used to enrich ``participants``; when omitted the
+    Slack user IDs (``U…``) flow through unresolved.
+    """
+    decisions: list[dict] = []
+    participants: list[str] = []
+    seen_users: set[str] = set()
+
+    root_ts = messages[0].get("ts") if messages else ""
+    title = f"{channel}#{root_ts}"
+
+    for msg in messages:
+        if not _is_decision_bearing(msg):
+            continue
+        text = (msg.get("text") or "").strip()
+        if not text:
+            continue
+        msg_ts = msg.get("ts") or ""
+        decisions.append(
+            {
+                "description": text,
+                "title": f"{channel}#{msg_ts}" if msg_ts else title,
+            }
+        )
+        user_id = msg.get("user") or ""
+        if not user_id or user_id in seen_users:
+            continue
+        seen_users.add(user_id)
+        if user_resolver is not None:
+            try:
+                profile = user_resolver(user_id) or {}
+            except Exception:  # noqa: BLE001 — resolver is best-effort
+                profile = {}
+            email = ((profile.get("profile") or {}).get("email") or "").strip()
+            name = (profile.get("real_name") or profile.get("name") or "").strip()
+            participants.append(email or name or user_id)
+        else:
+            participants.append(user_id)
+
+    return {
+        "query": (decisions[0]["description"][:80] if decisions else title),
+        "source": "slack",
+        "title": title,
+        "date": _slack_ts_to_iso(root_ts) if root_ts else "",
+        "participants": participants,
+        "decisions": decisions,
+    }
+
+
+def _slack_ts_to_iso(ts: str) -> str:
+    """Convert Slack ``ts`` (epoch float as string) to ISO 8601.
+
+    Returns empty string on malformed input.
+    """
+    try:
+        from datetime import UTC, datetime
+
+        epoch = float(ts)
+        return datetime.fromtimestamp(epoch, tz=UTC).isoformat()
+    except (ValueError, OSError, OverflowError):
+        return ""
+
+
+class SlackAdapter:
+    """SourceAdapter implementation for Slack (active path)."""
+
+    source_id = "slack"
+
+    def can_handle_url(self, url: str) -> bool:
+        if "/messages/" in url.lower():
+            return False
+        return bool(_THREAD_URL_RE.match(url.strip()))
+
+    def fetch_active(self, url: str) -> dict:
+        parsed = parse_slack_url(url)
+        token = self._resolve_token()
+        from sources.slack.client import get_thread_replies
+
+        messages = get_thread_replies(
+            token=token, channel=parsed.channel, thread_ts=parsed.thread_ts
+        )
+        if not messages:
+            raise RuntimeError(
+                f"Slack returned no messages for {parsed.channel}#{parsed.thread_ts}. "
+                "Check that the bot is in the channel and has channels:history scope."
+            )
+
+        def _resolver(user_id: str) -> dict:
+            from sources.slack.client import get_user_info
+
+            return get_user_info(token=token, user_id=user_id)
+
+        return normalize_thread_to_payload(
+            messages,
+            channel=parsed.channel,
+            thread_url=parsed.url,
+            user_resolver=_resolver,
+        )
+
+    def _resolve_token(self) -> str:
+        from secrets_store import get_secret
+
+        token = get_secret(source_id=self.source_id, key="api_key")
+        if not token:
+            raise RuntimeError(
+                "Slack bot token not configured. Create a Slack app at "
+                "api.slack.com, grant channels:history + groups:history "
+                "scopes, then store the bot token (xoxb-...) via:\n"
+                '  python -c "from secrets_store import put_secret; '
+                "put_secret(source_id='slack', key='api_key', value='xoxb-...')\""
+            )
+        return token

--- a/sources/slack/client.py
+++ b/sources/slack/client.py
@@ -1,0 +1,200 @@
+"""Thin Slack Web API client (#337 Phase 4a — active ingest).
+
+stdlib ``urllib.request`` — same hardening as Linear/Notion/GitHub
+clients (15s timeout, 4 MiB response cap, Bearer in Authorization
+header). Endpoint: ``https://slack.com/api/<method>``.
+
+Slack's API returns 200 even on logical failures, with ``ok: false``
+in the JSON body. The client raises ``SlackAPIError`` on either HTTP
+non-2xx or ``ok=false`` responses so callers don't have to repeat the
+branch.
+"""
+
+from __future__ import annotations
+
+import json
+import urllib.error
+import urllib.parse
+import urllib.request
+
+_API_BASE = "https://slack.com/api"
+_REQUEST_TIMEOUT_SECONDS = 15.0
+_MAX_RESPONSE_BYTES = 4 * 1024 * 1024
+_MAX_PAGINATION_PAGES = 10  # 10 * 200 messages = 2000 per fetch
+
+
+class SlackAPIError(RuntimeError):
+    """Raised on Slack API failure (HTTP non-2xx OR ``ok=false`` in body)."""
+
+    def __init__(
+        self, message: str, *, status_code: int | None = None, slack_error: str | None = None
+    ) -> None:
+        self.status_code = status_code
+        self.slack_error = slack_error
+        super().__init__(message)
+
+
+def _get(*, token: str, method: str, params: dict | None = None) -> dict:
+    """GET ``slack.com/api/<method>`` with optional query params.
+
+    Returns the parsed JSON body on ``ok=true``. Raises ``SlackAPIError``
+    otherwise, surfacing Slack's ``error`` string when present.
+    """
+    url = f"{_API_BASE}/{method}"
+    if params:
+        url = url + "?" + urllib.parse.urlencode(params)
+    headers = {
+        "Authorization": f"Bearer {token}",
+        "Accept": "application/json",
+        "User-Agent": "bicameral-mcp/source-slack",
+    }
+    req = urllib.request.Request(url, headers=headers, method="GET")
+    try:
+        with urllib.request.urlopen(req, timeout=_REQUEST_TIMEOUT_SECONDS) as resp:
+            raw = resp.read(_MAX_RESPONSE_BYTES + 1)
+            if len(raw) > _MAX_RESPONSE_BYTES:
+                raise SlackAPIError(
+                    f"Slack response exceeded {_MAX_RESPONSE_BYTES} bytes",
+                    status_code=resp.status,
+                )
+    except urllib.error.HTTPError as exc:
+        raise SlackAPIError(
+            f"Slack API HTTP {exc.code}: {exc.reason}",
+            status_code=exc.code,
+        ) from exc
+    except urllib.error.URLError as exc:
+        raise SlackAPIError(f"Slack API network error: {exc.reason}") from exc
+
+    try:
+        data = json.loads(raw.decode("utf-8"))
+    except json.JSONDecodeError as exc:
+        raise SlackAPIError(f"Slack API returned non-JSON: {exc}") from exc
+
+    if not data.get("ok"):
+        slack_error = data.get("error") or "unknown_error"
+        raise SlackAPIError(
+            f"Slack API error: {slack_error}",
+            slack_error=slack_error,
+        )
+    return data
+
+
+def get_thread_replies(*, token: str, channel: str, thread_ts: str) -> list[dict]:
+    """Return all messages in a thread (root + replies), oldest first.
+
+    Paginates via Slack's ``next_cursor`` until exhausted or until the
+    page cap fires.
+    """
+    out: list[dict] = []
+    cursor: str | None = None
+    pages = 0
+    while True:
+        params: dict[str, str] = {
+            "channel": channel,
+            "ts": thread_ts,
+            "limit": "200",
+        }
+        if cursor is not None:
+            params["cursor"] = cursor
+        data = _get(token=token, method="conversations.replies", params=params)
+        out.extend(data.get("messages") or [])
+        pages += 1
+        cursor = (data.get("response_metadata") or {}).get("next_cursor")
+        if not cursor:
+            break
+        if pages >= _MAX_PAGINATION_PAGES:
+            raise SlackAPIError(
+                f"thread has more than {_MAX_PAGINATION_PAGES * 200} replies — "
+                "narrow the ingest target"
+            )
+    return out
+
+
+def get_user_info(*, token: str, user_id: str) -> dict:
+    """Fetch user profile metadata. Used to resolve names + emails for
+    participant attribution."""
+    data = _get(token=token, method="users.info", params={"user": user_id})
+    return data.get("user") or {}
+
+
+def list_channels(*, token: str, include_private: bool = True) -> list[dict]:
+    """Enumerate channels the bot has access to.
+
+    Returns dicts shaped ``{"id", "name", "is_private", "is_member",
+    "num_members"}``. Used by the ``bicameral-mcp source-list slack``
+    discovery primitive — operator picks channel IDs to add to
+    ``sources.channels`` config.
+
+    ``include_private`` toggles ``public_channel,private_channel``
+    types in the request. The bot must have ``groups:read`` scope
+    additionally for private channels; without it, Slack silently
+    returns only public ones.
+    """
+    types = "public_channel,private_channel" if include_private else "public_channel"
+    out: list[dict] = []
+    cursor: str | None = None
+    pages = 0
+    while True:
+        params: dict[str, str] = {"types": types, "limit": "200", "exclude_archived": "true"}
+        if cursor is not None:
+            params["cursor"] = cursor
+        data = _get(token=token, method="conversations.list", params=params)
+        for ch in data.get("channels") or []:
+            out.append(
+                {
+                    "id": ch.get("id") or "",
+                    "name": ch.get("name") or "",
+                    "is_private": bool(ch.get("is_private")),
+                    "is_member": bool(ch.get("is_member")),
+                    "num_members": int(ch.get("num_members") or 0),
+                }
+            )
+        pages += 1
+        cursor = (data.get("response_metadata") or {}).get("next_cursor")
+        if not cursor:
+            break
+        if pages >= _MAX_PAGINATION_PAGES:
+            raise SlackAPIError(
+                f"workspace has more than {_MAX_PAGINATION_PAGES * 200} channels — "
+                "narrow include_private or paginate manually"
+            )
+    return out
+
+
+def get_conversations_history(
+    *,
+    token: str,
+    channel: str,
+    oldest: str | None = None,
+    limit: int = 200,
+) -> list[dict]:
+    """Return recent messages in a channel since ``oldest`` (a Slack ``ts``).
+
+    Slack's ``conversations.history`` returns messages newest-first by
+    default. Caller is responsible for sorting / watermarking on ``ts``.
+    Paginates via ``next_cursor``.
+    """
+    out: list[dict] = []
+    cursor: str | None = None
+    pages = 0
+    while True:
+        params: dict[str, str] = {
+            "channel": channel,
+            "limit": str(limit),
+        }
+        if oldest:
+            params["oldest"] = oldest
+        if cursor is not None:
+            params["cursor"] = cursor
+        data = _get(token=token, method="conversations.history", params=params)
+        out.extend(data.get("messages") or [])
+        pages += 1
+        cursor = (data.get("response_metadata") or {}).get("next_cursor")
+        if not cursor:
+            break
+        if pages >= _MAX_PAGINATION_PAGES:
+            raise SlackAPIError(
+                f"channel has more than {_MAX_PAGINATION_PAGES * limit} messages "
+                "since the watermark — narrow the channel or shorten the watch window"
+            )
+    return out

--- a/sources/slack/poller.py
+++ b/sources/slack/poller.py
@@ -1,0 +1,39 @@
+"""Slack polling helper for Phase 4b passive ingest (#337).
+
+Wraps the Phase 4a client's ``conversations.history`` for per-channel
+incremental polling. Each channel has its own ``oldest`` cursor so a
+high-traffic channel doesn't re-pull because a low-traffic channel
+just advanced.
+
+Channels are passed in by ID (``C01ABC...``). The polling adapter
+resolves config-supplied IDs and maintains the per-channel watermark
+dict.
+"""
+
+from __future__ import annotations
+
+
+def list_new_messages(
+    *,
+    token: str,
+    channel: str,
+    oldest: str | None = None,
+):
+    """Return new messages in ``channel`` since the ``oldest`` Slack ts.
+
+    Slack's ``conversations.history`` returns newest-first; we re-sort
+    ascending so the polling adapter can watermark on the last item.
+
+    Raises ``RuntimeError`` on Slack API failure with the message the
+    polling adapter logs.
+    """
+    from sources.slack.client import SlackAPIError, get_conversations_history
+
+    try:
+        messages = get_conversations_history(token=token, channel=channel, oldest=oldest, limit=200)
+    except SlackAPIError as exc:
+        raise RuntimeError(f"Slack history fetch failed for channel {channel!r}: {exc}") from exc
+
+    # Slack returns newest-first; re-sort by ts ascending.
+    messages.sort(key=lambda m: m.get("ts") or "")
+    return messages

--- a/tests/test_filters_eval_hook.py
+++ b/tests/test_filters_eval_hook.py
@@ -175,3 +175,35 @@ def test_evaluate_filters_both_pass(fake_hooks_module):
 
 
 # ── Per-adapter wiring ──────────────────────────────────────────────────────
+
+
+def test_slack_adapter_uses_eval_hook(tmp_path, monkeypatch, fake_hooks_module):
+    from unittest.mock import patch
+
+    from events.sources.slack import SlackPollingAdapter
+    from secrets_store import put_secret
+    from secrets_store.store import _reset_for_tests
+
+    monkeypatch.setenv("BICAMERAL_KEYRING_DISABLE", "1")
+    _reset_for_tests()
+
+    put_secret(source_id="slack", key="api_key", value="xoxb-t")
+    fake_msgs = [
+        {"ts": "1700000001.000000", "user": "U1", "text": "urgent: ship it"},
+        {"ts": "1700000002.000000", "user": "U2", "text": "lunch?"},
+    ]
+    with (
+        patch("sources.slack.poller.list_new_messages", return_value=fake_msgs),
+        patch("sources.slack.client.get_user_info", return_value={}),
+    ):
+        adapter = SlackPollingAdapter()
+        result = adapter.pull(
+            watermark_dir=tmp_path,
+            config={
+                "channels": ["C01A"],
+                "filters": {"eval_hook": "fake_eval_hooks:contains_urgent"},
+            },
+        )
+
+    assert len(result) == 1
+    assert "urgent" in result[0].get("decisions", [{}])[0].get("description", "").lower()

--- a/tests/test_filters_per_adapter.py
+++ b/tests/test_filters_per_adapter.py
@@ -33,6 +33,98 @@ def _disable_keyring(monkeypatch):
 # ── Slack: keyword_include + per-resource override ──────────────────────────
 
 
+def test_slack_source_level_keyword_filter_drops_unmatched(tmp_path):
+    from events.sources.slack import SlackPollingAdapter
+    from secrets_store import put_secret
+
+    put_secret(source_id="slack", key="api_key", value="xoxb-t")
+
+    fake_msgs = [
+        {"ts": "1700000001.000000", "user": "U1", "text": "decided to ship"},
+        {"ts": "1700000002.000000", "user": "U2", "text": "lunch?"},
+    ]
+    with (
+        patch("sources.slack.poller.list_new_messages", return_value=fake_msgs),
+        patch("sources.slack.client.get_user_info", return_value={}),
+    ):
+        adapter = SlackPollingAdapter()
+        result = adapter.pull(
+            watermark_dir=tmp_path,
+            config={
+                "channels": ["C01A"],
+                "filters": {"keyword_include": ["decided"]},
+            },
+        )
+
+    assert len(result) == 1
+    # Watermark advances past the filtered-out message anyway.
+    assert adapter._pending_watermarks["C01A"] == "1700000002.000000"
+
+
+def test_slack_per_channel_override_takes_precedence(tmp_path):
+    from events.sources.slack import SlackPollingAdapter
+    from secrets_store import put_secret
+
+    put_secret(source_id="slack", key="api_key", value="xoxb-t")
+
+    # Same messages would be filtered by source-level filter, but
+    # the per-channel override clears it for C01B by widening
+    # the keyword_include list.
+    msgs_a = [{"ts": "1700000001.000000", "user": "U1", "text": "lunch?"}]
+    msgs_b = [{"ts": "1700000002.000000", "user": "U2", "text": "lunch?"}]
+
+    call_count = {"n": 0}
+
+    def _list(*, token, channel, oldest=None):
+        call_count["n"] += 1
+        return {"C01A": msgs_a, "C01B": msgs_b}[channel]
+
+    with (
+        patch("sources.slack.poller.list_new_messages", side_effect=_list),
+        patch("sources.slack.client.get_user_info", return_value={}),
+    ):
+        adapter = SlackPollingAdapter()
+        result = adapter.pull(
+            watermark_dir=tmp_path,
+            config={
+                "channels": [
+                    "C01A",  # inherits source-level filter — "lunch?" rejected
+                    {"id": "C01B", "filters": {"keyword_include": ["lunch"]}},
+                ],
+                "filters": {"keyword_include": ["decided"]},
+            },
+        )
+
+    # Only C01B's message survives.
+    assert len(result) == 1
+
+
+def test_slack_malformed_filter_falls_through(tmp_path, capsys):
+    from events.sources.slack import SlackPollingAdapter
+    from secrets_store import put_secret
+
+    put_secret(source_id="slack", key="api_key", value="xoxb-t")
+    fake_msgs = [{"ts": "1700000001.000000", "user": "U1", "text": "decided"}]
+    with (
+        patch("sources.slack.poller.list_new_messages", return_value=fake_msgs),
+        patch("sources.slack.client.get_user_info", return_value={}),
+    ):
+        adapter = SlackPollingAdapter()
+        result = adapter.pull(
+            watermark_dir=tmp_path,
+            # Typo'd field — pydantic rejects → no-filter fallback.
+            config={"channels": ["C01A"], "filters": {"keywords_include": ["x"]}},
+        )
+
+    err = capsys.readouterr().err
+    assert "malformed filter block" in err
+    # Items still flow through (no-filter fallback).
+    assert len(result) == 1
+
+
+# ── Linear: source-level keyword filter ─────────────────────────────────────
+
+
 def test_github_per_repo_filter_override(tmp_path):
     from events.sources.github import GitHubPollingAdapter
     from secrets_store import put_secret

--- a/tests/test_filters_quota.py
+++ b/tests/test_filters_quota.py
@@ -143,6 +143,37 @@ def test_github_caps_across_repos(tmp_path):
     assert "foo/baz" not in adapter._pending_watermarks
 
 
+def test_slack_caps_across_channels(tmp_path):
+    from events.sources.slack import SlackPollingAdapter
+    from secrets_store import put_secret
+
+    put_secret(source_id="slack", key="api_key", value="xoxb-t")
+
+    msgs_a = [{"ts": f"170000000{i}.000000", "user": "U1", "text": f"msg {i}"} for i in range(1, 4)]
+    msgs_b = [{"ts": "1700000099.000000", "user": "U2", "text": "later channel"}]
+
+    def _list(*, token, channel, oldest=None):
+        return {"C01A": msgs_a, "C01B": msgs_b}[channel]
+
+    with (
+        patch("sources.slack.poller.list_new_messages", side_effect=_list),
+        patch("sources.slack.client.get_user_info", return_value={}),
+    ):
+        adapter = SlackPollingAdapter()
+        result = adapter.pull(
+            watermark_dir=tmp_path,
+            config={
+                "channels": ["C01A", "C01B"],
+                "max_items_per_pull": 2,
+            },
+        )
+
+    assert len(result) == 2
+    # C01A's watermark advanced to second-msg ts; C01B never touched.
+    assert "C01A" in adapter._pending_watermarks
+    assert "C01B" not in adapter._pending_watermarks
+
+
 def test_google_drive_caps(tmp_path):
     from events.sources.google_drive import GoogleDriveFolderAdapter
 

--- a/tests/test_slack_adapter.py
+++ b/tests/test_slack_adapter.py
@@ -1,0 +1,306 @@
+"""Tests for #337 Phase 4a — Slack active-ingest adapter."""
+
+from __future__ import annotations
+
+import io
+import json
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+
+@pytest.fixture(autouse=True)
+def _disable_keyring(monkeypatch):
+    monkeypatch.setenv("BICAMERAL_KEYRING_DISABLE", "1")
+    from secrets_store.store import _reset_for_tests
+
+    _reset_for_tests()
+    yield
+    _reset_for_tests()
+
+
+def _mock_response(body):
+    raw = json.dumps(body).encode("utf-8")
+    resp = io.BytesIO(raw)
+    resp.status = 200
+
+    class _Ctx:
+        def __enter__(self):
+            return resp
+
+        def __exit__(self, *args):
+            return False
+
+    return _Ctx()
+
+
+# ── URL parsing ─────────────────────────────────────────────────────────────
+
+
+@pytest.mark.parametrize(
+    "url,channel,thread_ts",
+    [
+        (
+            "https://acme.slack.com/archives/C12345ABC/p1700000000123456",
+            "C12345ABC",
+            "1700000000.123456",
+        ),
+        (
+            "https://acme.slack.com/archives/C12345ABC/p1700000000999999?thread_ts=1699999999.000001",
+            "C12345ABC",
+            "1699999999.000001",
+        ),
+        (
+            "https://acme.slack.com/archives/c12345abc/p1700000000123456",
+            "C12345ABC",
+            "1700000000.123456",
+        ),
+    ],
+)
+def test_parse_slack_url_accepts_valid(url, channel, thread_ts):
+    from sources.slack.adapter import parse_slack_url
+
+    parsed = parse_slack_url(url)
+    assert parsed.channel == channel
+    assert parsed.thread_ts == thread_ts
+
+
+@pytest.mark.parametrize(
+    "url",
+    [
+        "https://github.com/foo/bar",
+        "https://acme.slack.com/messages/D12345ABC/p1700000000123456",  # DM
+        "https://acme.slack.com/archives/",
+        "https://acme.slack.com/archives/C12345/p12345",  # ts too short
+        "",
+    ],
+)
+def test_parse_slack_url_rejects_invalid(url):
+    from sources.slack.adapter import parse_slack_url
+
+    with pytest.raises(ValueError):
+        parse_slack_url(url)
+
+
+# ── Normalization ───────────────────────────────────────────────────────────
+
+
+def test_normalize_thread_filters_bot_and_join_messages():
+    from sources.slack.adapter import normalize_thread_to_payload
+
+    messages = [
+        {"ts": "1700000000.000001", "user": "U1", "text": "Real decision"},
+        {
+            "ts": "1700000001.000001",
+            "user": "USLACKBOT",
+            "text": "set channel topic",
+            "subtype": "channel_topic",
+        },
+        {
+            "ts": "1700000002.000001",
+            "user": "U2",
+            "text": "bot autoresponse",
+            "subtype": "bot_message",
+        },
+        {"ts": "1700000003.000001", "user": "U2", "text": "Counter-point"},
+    ]
+    payload = normalize_thread_to_payload(
+        messages,
+        channel="C12345ABC",
+        thread_url="https://acme.slack.com/archives/C12345ABC/p1700000000000001",
+    )
+    assert payload["source"] == "slack"
+    assert len(payload["decisions"]) == 2  # the two human messages
+    assert "Real decision" in payload["decisions"][0]["description"]
+    assert "Counter-point" in payload["decisions"][1]["description"]
+
+
+def test_normalize_thread_dedups_participants():
+    from sources.slack.adapter import normalize_thread_to_payload
+
+    messages = [
+        {"ts": "1700000000.000001", "user": "U1", "text": "first"},
+        {"ts": "1700000001.000001", "user": "U1", "text": "second from same user"},
+        {"ts": "1700000002.000001", "user": "U2", "text": "third"},
+    ]
+    payload = normalize_thread_to_payload(
+        messages,
+        channel="C12345ABC",
+        thread_url="https://acme.slack.com/archives/C12345ABC/p1700000000000001",
+    )
+    assert payload["participants"] == ["U1", "U2"]
+
+
+def test_normalize_thread_resolves_user_to_email_when_resolver_supplied():
+    from sources.slack.adapter import normalize_thread_to_payload
+
+    messages = [
+        {"ts": "1700000000.000001", "user": "U1", "text": "decision"},
+    ]
+    resolver = MagicMock(
+        return_value={
+            "real_name": "Alice",
+            "profile": {"email": "alice@example.com"},
+        }
+    )
+    payload = normalize_thread_to_payload(
+        messages,
+        channel="C12345ABC",
+        thread_url="https://acme.slack.com/archives/C12345ABC/p1700000000000001",
+        user_resolver=resolver,
+    )
+    assert payload["participants"] == ["alice@example.com"]
+
+
+def test_normalize_thread_falls_back_to_name_when_no_email():
+    from sources.slack.adapter import normalize_thread_to_payload
+
+    messages = [{"ts": "1700000000.000001", "user": "U1", "text": "x"}]
+    resolver = MagicMock(return_value={"real_name": "Alice", "profile": {}})
+    payload = normalize_thread_to_payload(
+        messages,
+        channel="C12345ABC",
+        thread_url="https://acme.slack.com/archives/C12345ABC/p1700000000000001",
+        user_resolver=resolver,
+    )
+    assert payload["participants"] == ["Alice"]
+
+
+def test_normalize_thread_falls_back_to_user_id_on_resolver_failure():
+    from sources.slack.adapter import normalize_thread_to_payload
+
+    messages = [{"ts": "1700000000.000001", "user": "U1", "text": "x"}]
+
+    def _failing(_):
+        raise RuntimeError("transient")
+
+    payload = normalize_thread_to_payload(
+        messages,
+        channel="C12345ABC",
+        thread_url="https://acme.slack.com/archives/C12345ABC/p1700000000000001",
+        user_resolver=_failing,
+    )
+    assert payload["participants"] == ["U1"]
+
+
+def test_normalize_thread_date_uses_root_ts_iso():
+    from sources.slack.adapter import normalize_thread_to_payload
+
+    messages = [{"ts": "1700000000.123456", "user": "U1", "text": "x"}]
+    payload = normalize_thread_to_payload(
+        messages,
+        channel="C12345ABC",
+        thread_url="https://acme.slack.com/archives/C12345ABC/p1700000000123456",
+    )
+    # 1700000000 epoch == 2023-11-14T22:13:20Z. Just assert the ISO shape +
+    # that the date field is non-empty.
+    assert payload["date"].startswith("2023-")
+
+
+# ── Client + Adapter integration ────────────────────────────────────────────
+
+
+def test_client_raises_on_ok_false():
+    from sources.slack.client import SlackAPIError, _get
+
+    with patch(
+        "urllib.request.urlopen",
+        return_value=_mock_response({"ok": False, "error": "invalid_auth"}),
+    ):
+        with pytest.raises(SlackAPIError) as exc_info:
+            _get(token="bad", method="conversations.replies")
+    assert exc_info.value.slack_error == "invalid_auth"
+
+
+def test_client_get_thread_replies_paginates():
+    from sources.slack.client import get_thread_replies
+
+    page1 = {
+        "ok": True,
+        "messages": [{"ts": "1700000000.000001", "user": "U1", "text": "a"}],
+        "response_metadata": {"next_cursor": "cursor-1"},
+    }
+    page2 = {
+        "ok": True,
+        "messages": [{"ts": "1700000001.000001", "user": "U1", "text": "b"}],
+        "response_metadata": {"next_cursor": ""},
+    }
+    with patch(
+        "urllib.request.urlopen",
+        side_effect=[_mock_response(page1), _mock_response(page2)],
+    ):
+        msgs = get_thread_replies(token="xoxb-t", channel="C1", thread_ts="1700000000.000001")
+    assert len(msgs) == 2
+
+
+def test_adapter_can_handle_url():
+    from sources.slack.adapter import SlackAdapter
+
+    a = SlackAdapter()
+    assert a.can_handle_url("https://acme.slack.com/archives/C12345ABC/p1700000000123456")
+    assert not a.can_handle_url("https://github.com/foo/bar")
+    assert not a.can_handle_url("https://acme.slack.com/messages/D12345/p1700000000123456")
+
+
+def test_adapter_fetch_active_round_trip(monkeypatch):
+    from secrets_store import put_secret
+    from sources.slack.adapter import SlackAdapter
+
+    put_secret(source_id="slack", key="api_key", value="xoxb-test")
+
+    thread_replies = {
+        "ok": True,
+        "messages": [
+            {"ts": "1700000000.000001", "user": "U1", "text": "Decision A"},
+            {"ts": "1700000001.000001", "user": "U2", "text": "Counter B"},
+        ],
+        "response_metadata": {"next_cursor": ""},
+    }
+    user_u1 = {
+        "ok": True,
+        "user": {"real_name": "Alice", "profile": {"email": "alice@example.com"}},
+    }
+    user_u2 = {
+        "ok": True,
+        "user": {"real_name": "Bob", "profile": {"email": "bob@example.com"}},
+    }
+
+    with patch(
+        "urllib.request.urlopen",
+        side_effect=[
+            _mock_response(thread_replies),
+            _mock_response(user_u1),
+            _mock_response(user_u2),
+        ],
+    ):
+        adapter = SlackAdapter()
+        result = adapter.fetch_active("https://acme.slack.com/archives/C12345ABC/p1700000000000001")
+
+    assert result["source"] == "slack"
+    assert len(result["decisions"]) == 2
+    assert result["participants"] == ["alice@example.com", "bob@example.com"]
+
+
+def test_adapter_raises_when_token_missing():
+    from sources.slack.adapter import SlackAdapter
+
+    a = SlackAdapter()
+    with pytest.raises(RuntimeError, match="bot token not configured"):
+        a.fetch_active("https://acme.slack.com/archives/C12345ABC/p1700000000000001")
+
+
+def test_adapter_raises_on_empty_thread(monkeypatch):
+    from secrets_store import put_secret
+    from sources.slack.adapter import SlackAdapter
+
+    put_secret(source_id="slack", key="api_key", value="xoxb-test")
+
+    with patch(
+        "urllib.request.urlopen",
+        return_value=_mock_response(
+            {"ok": True, "messages": [], "response_metadata": {"next_cursor": ""}}
+        ),
+    ):
+        adapter = SlackAdapter()
+        with pytest.raises(RuntimeError, match="no messages"):
+            adapter.fetch_active("https://acme.slack.com/archives/C12345ABC/p1700000000000001")

--- a/tests/test_slack_polling.py
+++ b/tests/test_slack_polling.py
@@ -1,0 +1,287 @@
+"""Tests for #337 Phase 4b — Slack polling adapter."""
+
+from __future__ import annotations
+
+import io
+import json
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+
+@pytest.fixture(autouse=True)
+def _disable_keyring(monkeypatch):
+    monkeypatch.setenv("BICAMERAL_KEYRING_DISABLE", "1")
+    from secrets_store.store import _reset_for_tests
+
+    _reset_for_tests()
+    yield
+    _reset_for_tests()
+
+
+def _mock_resp(body):
+    raw = json.dumps(body).encode("utf-8")
+    resp = io.BytesIO(raw)
+    resp.status = 200
+
+    class _Ctx:
+        def __enter__(self):
+            return resp
+
+        def __exit__(self, *args):
+            return False
+
+    return _Ctx()
+
+
+# ── poller.list_new_messages ────────────────────────────────────────────────
+
+
+def test_list_new_messages_sorts_ascending_by_ts():
+    """Slack returns newest-first; the poller normalizes to ascending."""
+    from sources.slack.poller import list_new_messages
+
+    body = {
+        "ok": True,
+        "messages": [
+            {"ts": "1700000003.000000", "user": "U1", "text": "third"},
+            {"ts": "1700000001.000000", "user": "U1", "text": "first"},
+            {"ts": "1700000002.000000", "user": "U1", "text": "second"},
+        ],
+        "response_metadata": {"next_cursor": ""},
+    }
+    with patch("urllib.request.urlopen", return_value=_mock_resp(body)):
+        result = list_new_messages(token="xoxb-t", channel="C1", oldest=None)
+    assert [m["ts"] for m in result] == [
+        "1700000001.000000",
+        "1700000002.000000",
+        "1700000003.000000",
+    ]
+
+
+def test_list_new_messages_raises_on_api_error():
+    from sources.slack.poller import list_new_messages
+
+    with patch(
+        "urllib.request.urlopen",
+        return_value=_mock_resp({"ok": False, "error": "channel_not_found"}),
+    ):
+        with pytest.raises(RuntimeError, match="history fetch failed"):
+            list_new_messages(token="xoxb-t", channel="C1")
+
+
+# ── SlackPollingAdapter.pull ────────────────────────────────────────────────
+
+
+def _make_messages(*tuples):
+    """Build a Slack history response. Each tuple is (ts, text, opt user, opt thread_ts)."""
+    msgs = []
+    for t in tuples:
+        ts, text = t[0], t[1]
+        user = t[2] if len(t) > 2 else "U1"
+        msg = {"ts": ts, "user": user, "text": text}
+        if len(t) > 3 and t[3]:
+            msg["thread_ts"] = t[3]
+        msgs.append(msg)
+    return msgs
+
+
+def test_pull_returns_payloads_for_new_top_level_messages(tmp_path):
+    from events.sources.slack import SlackPollingAdapter
+    from secrets_store import put_secret
+
+    put_secret(source_id="slack", key="api_key", value="xoxb-t")
+
+    fake_msgs = _make_messages(
+        ("1700000001.000000", "Decision A", "U1"),
+        ("1700000002.000000", "Decision B", "U2"),
+    )
+
+    with (
+        patch(
+            "sources.slack.poller.list_new_messages",
+            return_value=fake_msgs,
+        ),
+        patch("sources.slack.client.get_user_info", return_value={}),
+    ):
+        adapter = SlackPollingAdapter()
+        result = adapter.pull(watermark_dir=tmp_path, config={"channels": ["C01ABC"]})
+
+    assert len(result) == 2
+    # Per-channel watermark advances to the latest ts.
+    assert adapter._pending_watermarks["C01ABC"] == "1700000002.000000"
+
+
+def test_pull_skips_thread_replies(tmp_path):
+    """A message with thread_ts != ts is a reply — skip; we only ingest
+    top-level / thread-root messages in the polling path."""
+    from events.sources.slack import SlackPollingAdapter
+    from secrets_store import put_secret
+
+    put_secret(source_id="slack", key="api_key", value="xoxb-t")
+
+    fake_msgs = _make_messages(
+        # Root message (thread_ts == ts, here we omit thread_ts entirely):
+        ("1700000001.000000", "Root decision", "U1"),
+        # Reply: thread_ts differs from ts. SKIP.
+        ("1700000002.000000", "reply chatter", "U2", "1700000001.000000"),
+    )
+
+    with (
+        patch("sources.slack.poller.list_new_messages", return_value=fake_msgs),
+        patch("sources.slack.client.get_user_info", return_value={}),
+    ):
+        adapter = SlackPollingAdapter()
+        result = adapter.pull(watermark_dir=tmp_path, config={"channels": ["C01ABC"]})
+
+    assert len(result) == 1
+    # Watermark still advances past the skipped reply so we don't re-pull it.
+    assert adapter._pending_watermarks["C01ABC"] == "1700000002.000000"
+
+
+def test_pull_returns_empty_when_channels_missing(tmp_path, capsys):
+    from events.sources.slack import SlackPollingAdapter
+
+    adapter = SlackPollingAdapter()
+    result = adapter.pull(watermark_dir=tmp_path, config={})
+    assert result == []
+    assert "at least one channel ID" in capsys.readouterr().err
+
+
+def test_pull_filters_dm_channel_ids(tmp_path, capsys):
+    """Config entries starting with 'D' are DM IDs — policy says skip."""
+    from events.sources.slack import SlackPollingAdapter
+    from secrets_store import put_secret
+
+    put_secret(source_id="slack", key="api_key", value="xoxb-t")
+
+    with patch("sources.slack.poller.list_new_messages", return_value=[]):
+        adapter = SlackPollingAdapter()
+        adapter.pull(
+            watermark_dir=tmp_path,
+            config={"channels": ["D01DM", "C01CHAN"]},
+        )
+    # No assert on captured — purely behavioral: D01DM never reached the API.
+    # We verify by checking get_secret happened (key present) and by ensuring
+    # the test didn't blow up on a missing channel.
+
+
+def test_pull_returns_empty_when_token_missing(tmp_path, capsys):
+    from events.sources.slack import SlackPollingAdapter
+
+    adapter = SlackPollingAdapter()
+    result = adapter.pull(watermark_dir=tmp_path, config={"channels": ["C01ABC"]})
+    assert result == []
+    assert "api_key not configured" in capsys.readouterr().err
+
+
+def test_pull_per_channel_watermark_isolation(tmp_path):
+    from events.sources.slack import SlackPollingAdapter
+    from secrets_store import put_secret
+
+    put_secret(source_id="slack", key="api_key", value="xoxb-t")
+
+    # Seed one channel's watermark.
+    wm = tmp_path / "slack.json"
+    wm.write_text(json.dumps({"C01FAST": "1700000000.000000"}))
+
+    captured: list = []
+
+    def _capture(*, token, channel, oldest=None):
+        captured.append((channel, oldest))
+        return []
+
+    with patch(
+        "sources.slack.poller.list_new_messages",
+        side_effect=_capture,
+    ):
+        adapter = SlackPollingAdapter()
+        adapter.pull(
+            watermark_dir=tmp_path,
+            config={"channels": ["C01FAST", "C01SLOW"]},
+        )
+
+    by_channel = dict(captured)
+    assert by_channel["C01FAST"] == "1700000000.000000"
+    assert by_channel["C01SLOW"] is None
+
+
+def test_pull_individual_channel_failures_are_isolated(tmp_path, capsys):
+    from events.sources.slack import SlackPollingAdapter
+    from secrets_store import put_secret
+
+    put_secret(source_id="slack", key="api_key", value="xoxb-t")
+
+    def _flaky(*, token, channel, oldest=None):
+        if channel == "C01FAIL":
+            raise RuntimeError("channel_not_found")
+        return _make_messages(("1700000001.000000", "decision", "U1"))
+
+    with (
+        patch("sources.slack.poller.list_new_messages", side_effect=_flaky),
+        patch("sources.slack.client.get_user_info", return_value={}),
+    ):
+        adapter = SlackPollingAdapter()
+        result = adapter.pull(
+            watermark_dir=tmp_path,
+            config={"channels": ["C01FAIL", "C01OK"]},
+        )
+
+    assert len(result) == 1
+    err = capsys.readouterr().err
+    assert "C01FAIL" in err
+    # Failed channel doesn't advance its watermark.
+    assert "C01FAIL" not in adapter._pending_watermarks
+    assert adapter._pending_watermarks["C01OK"] == "1700000001.000000"
+
+
+def test_pull_filters_bot_subtype_messages(tmp_path):
+    from events.sources.slack import SlackPollingAdapter
+    from secrets_store import put_secret
+
+    put_secret(source_id="slack", key="api_key", value="xoxb-t")
+
+    fake_msgs = [
+        {"ts": "1700000001.000000", "user": "U1", "text": "real decision"},
+        {
+            "ts": "1700000002.000000",
+            "user": "USLACKBOT",
+            "text": "topic update",
+            "subtype": "channel_topic",
+        },
+    ]
+
+    with (
+        patch("sources.slack.poller.list_new_messages", return_value=fake_msgs),
+        patch("sources.slack.client.get_user_info", return_value={}),
+    ):
+        adapter = SlackPollingAdapter()
+        result = adapter.pull(watermark_dir=tmp_path, config={"channels": ["C01ABC"]})
+
+    assert len(result) == 1
+    # Watermark still advances past the filtered bot message.
+    assert adapter._pending_watermarks["C01ABC"] == "1700000002.000000"
+
+
+def test_confirm_watermark_persists_per_channel(tmp_path):
+    from events.sources.slack import SlackPollingAdapter
+
+    adapter = SlackPollingAdapter()
+    adapter._watermark_path = tmp_path / "slack.json"
+    adapter._pending_watermarks = {
+        "C01A": "1700000001.000000",
+        "C01B": "1700000002.000000",
+    }
+    adapter.confirm_watermark()
+    data = json.loads((tmp_path / "slack.json").read_text())
+    assert data == {
+        "C01A": "1700000001.000000",
+        "C01B": "1700000002.000000",
+    }
+
+
+def test_registered_in_ADAPTERS():
+    from events.sources import ADAPTERS
+    from events.sources.slack import SlackPollingAdapter
+
+    assert ADAPTERS["slack"] is SlackPollingAdapter

--- a/tests/test_source_list_cli.py
+++ b/tests/test_source_list_cli.py
@@ -55,6 +55,61 @@ def _mock_resp(body):
 # ── Slack: list_channels ────────────────────────────────────────────────────
 
 
+def test_slack_list_channels_returns_normalized_dicts():
+    from sources.slack.client import list_channels
+
+    body = {
+        "ok": True,
+        "channels": [
+            {
+                "id": "C1",
+                "name": "general",
+                "is_private": False,
+                "is_member": True,
+                "num_members": 42,
+            },
+            {
+                "id": "C2",
+                "name": "private-thing",
+                "is_private": True,
+                "is_member": False,
+                "num_members": 5,
+            },
+        ],
+        "response_metadata": {"next_cursor": ""},
+    }
+    with patch("urllib.request.urlopen", return_value=_mock_resp(body)):
+        result = list_channels(token="xoxb-t")
+    assert [c["id"] for c in result] == ["C1", "C2"]
+    assert result[0]["is_private"] is False
+    assert result[1]["is_private"] is True
+
+
+def test_slack_list_channels_paginates():
+    from sources.slack.client import list_channels
+
+    page1 = {
+        "ok": True,
+        "channels": [
+            {"id": "C1", "name": "a", "is_private": False, "is_member": True, "num_members": 1}
+        ],
+        "response_metadata": {"next_cursor": "cur"},
+    }
+    page2 = {
+        "ok": True,
+        "channels": [
+            {"id": "C2", "name": "b", "is_private": False, "is_member": True, "num_members": 2}
+        ],
+        "response_metadata": {"next_cursor": ""},
+    }
+    with patch("urllib.request.urlopen", side_effect=[_mock_resp(page1), _mock_resp(page2)]):
+        result = list_channels(token="xoxb-t")
+    assert len(result) == 2
+
+
+# ── Linear: list_teams ──────────────────────────────────────────────────────
+
+
 def test_github_list_repos_pat_returns_array():
     from sources.github.client import list_repos
 
@@ -117,3 +172,88 @@ def test_gdrive_list_folders():
 
 
 # ── CLI dispatch ────────────────────────────────────────────────────────────
+
+
+def test_cli_returns_1_when_slack_token_missing(capsys):
+    from cli.source_list_cli import main
+
+    exit_code = main(SimpleNamespace(source="slack", format="table"))
+    assert exit_code == 1
+    assert "not configured" in capsys.readouterr().err.lower()
+
+
+def test_cli_returns_0_on_slack_success(capsys, monkeypatch):
+    from cli.source_list_cli import main
+    from secrets_store import put_secret
+
+    put_secret(source_id="slack", key="api_key", value="xoxb-x")
+    body = {
+        "ok": True,
+        "channels": [
+            {
+                "id": "C1",
+                "name": "general",
+                "is_private": False,
+                "is_member": True,
+                "num_members": 7,
+            },
+        ],
+        "response_metadata": {"next_cursor": ""},
+    }
+    with patch("urllib.request.urlopen", return_value=_mock_resp(body)):
+        exit_code = main(SimpleNamespace(source="slack", format="table"))
+    assert exit_code == 0
+    out = capsys.readouterr().out
+    assert "C1" in out
+    assert "general" in out
+
+
+def test_cli_json_format_emits_array(capsys):
+    from cli.source_list_cli import main
+    from secrets_store import put_secret
+
+    put_secret(source_id="slack", key="api_key", value="xoxb-x")
+    body = {
+        "ok": True,
+        "channels": [
+            {
+                "id": "C1",
+                "name": "general",
+                "is_private": False,
+                "is_member": True,
+                "num_members": 7,
+            },
+        ],
+        "response_metadata": {"next_cursor": ""},
+    }
+    with patch("urllib.request.urlopen", return_value=_mock_resp(body)):
+        main(SimpleNamespace(source="slack", format="json"))
+    parsed = json.loads(capsys.readouterr().out)
+    assert isinstance(parsed, list)
+    assert parsed[0]["id"] == "C1"
+
+
+def test_cli_returns_3_on_api_error(capsys):
+    from cli.source_list_cli import main
+    from secrets_store import put_secret
+
+    put_secret(source_id="slack", key="api_key", value="xoxb-x")
+    with patch(
+        "urllib.request.urlopen",
+        return_value=_mock_resp({"ok": False, "error": "invalid_auth"}),
+    ):
+        exit_code = main(SimpleNamespace(source="slack", format="table"))
+    assert exit_code == 3
+    assert "API error" in capsys.readouterr().err
+
+
+def test_cli_empty_result_renders_friendly_message(capsys):
+    from cli.source_list_cli import main
+    from secrets_store import put_secret
+
+    put_secret(source_id="slack", key="api_key", value="xoxb-x")
+    body = {"ok": True, "channels": [], "response_metadata": {"next_cursor": ""}}
+    with patch("urllib.request.urlopen", return_value=_mock_resp(body)):
+        exit_code = main(SimpleNamespace(source="slack", format="table"))
+    assert exit_code == 0
+    assert "no results" in capsys.readouterr().out.lower()

--- a/tests/test_webhooks_slack.py
+++ b/tests/test_webhooks_slack.py
@@ -1,0 +1,668 @@
+"""Tests for the Slack Events API webhook handler.
+
+Coverage:
+- verify_signature: missing timestamp/signature/secret, stale timestamp,
+  non-integer timestamp, malformed signature prefix, mismatch, success,
+  constant-time comparison pin, body-byte sensitivity
+- handle: missing signature → 401, invalid JSON → 400, url_verification
+  echoes challenge, event_callback message → ingest, bot/topic messages
+  → ignored, dedup by event_id, hard-gate refusal → 422
+- Server route: Slack URL-verification handshake returns
+  application/json with the challenge bytes echoed verbatim
+"""
+
+from __future__ import annotations
+
+import asyncio
+import hashlib
+import hmac
+import io
+import json
+import time
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from webhooks.slack import WebhookVerificationError, handle, verify_signature
+
+
+@pytest.fixture(autouse=True)
+def _disable_keyring_and_reset_dedup(monkeypatch):
+    monkeypatch.setenv("BICAMERAL_KEYRING_DISABLE", "1")
+    from secrets_store.store import _reset_for_tests as _secrets_reset
+    from webhooks.dedup import _reset_for_tests as _dedup_reset
+
+    _secrets_reset()
+    _dedup_reset()
+    yield
+    _secrets_reset()
+    _dedup_reset()
+
+
+def _sign(secret: str, timestamp: str, body: bytes) -> str:
+    """Compute the v0 signature Slack would send for ``body`` at ``timestamp``."""
+    base = b"v0:" + timestamp.encode("ascii") + b":" + body
+    return "v0=" + hmac.new(secret.encode("utf-8"), msg=base, digestmod=hashlib.sha256).hexdigest()
+
+
+# ── verify_signature ────────────────────────────────────────────────────────
+
+
+def test_verify_signature_success():
+    body = b'{"ok":true}'
+    secret = "s3cr3t"
+    ts = str(int(time.time()))
+    sig = _sign(secret, ts, body)
+    verify_signature(
+        body=body,
+        timestamp_header=ts,
+        signature_header=sig,
+        secret=secret,
+    )  # does not raise
+
+
+def test_verify_signature_missing_timestamp_raises():
+    with pytest.raises(WebhookVerificationError, match="Timestamp"):
+        verify_signature(
+            body=b"x",
+            timestamp_header=None,
+            signature_header="v0=abc",
+            secret="s",
+        )
+
+
+def test_verify_signature_missing_signature_raises():
+    with pytest.raises(WebhookVerificationError, match="Signature"):
+        verify_signature(
+            body=b"x",
+            timestamp_header="1700000000",
+            signature_header=None,
+            secret="s",
+        )
+
+
+def test_verify_signature_missing_secret_raises():
+    with pytest.raises(WebhookVerificationError, match="webhook_secret"):
+        verify_signature(
+            body=b"x",
+            timestamp_header="1700000000",
+            signature_header="v0=abc",
+            secret="",
+        )
+
+
+def test_verify_signature_stale_timestamp_rejected():
+    """Replay defense: anything more than 5 minutes off is rejected
+    BEFORE the HMAC is even computed — protects against constant-time
+    probing against very old timestamps."""
+    secret = "s"
+    body = b"x"
+    stale_ts = "1700000000"  # 2023; definitely > 5 min from "now"
+    sig = _sign(secret, stale_ts, body)
+    with pytest.raises(WebhookVerificationError, match="stale"):
+        verify_signature(
+            body=body,
+            timestamp_header=stale_ts,
+            signature_header=sig,
+            secret=secret,
+            now=time.time(),  # use real current time
+        )
+
+
+def test_verify_signature_future_timestamp_rejected():
+    """Defense in depth: a clock-skew attacker submitting a timestamp
+    far in the future is also rejected (same 5-min gate)."""
+    secret = "s"
+    body = b"x"
+    future_ts = str(int(time.time()) + 3600)  # 1 hour ahead
+    sig = _sign(secret, future_ts, body)
+    with pytest.raises(WebhookVerificationError, match="stale"):
+        verify_signature(
+            body=body,
+            timestamp_header=future_ts,
+            signature_header=sig,
+            secret=secret,
+        )
+
+
+def test_verify_signature_non_integer_timestamp_rejected():
+    with pytest.raises(WebhookVerificationError, match="decimal"):
+        verify_signature(
+            body=b"x",
+            timestamp_header="not-a-number",
+            signature_header="v0=abc",
+            secret="s",
+        )
+
+
+def test_verify_signature_malformed_prefix_rejected():
+    """A future Slack version might ship v1 / v2 — for now we reject
+    anything not v0=. Documented intentional friction."""
+    ts = str(int(time.time()))
+    with pytest.raises(WebhookVerificationError, match="malformed"):
+        verify_signature(
+            body=b"x",
+            timestamp_header=ts,
+            signature_header="v1=" + "0" * 64,
+            secret="s",
+        )
+
+
+def test_verify_signature_mismatch_rejected():
+    secret = "right"
+    body = b"x"
+    ts = str(int(time.time()))
+    sig = _sign(secret, ts, body)
+    with pytest.raises(WebhookVerificationError, match="mismatch"):
+        verify_signature(
+            body=body,
+            timestamp_header=ts,
+            signature_header=sig,
+            secret="wrong",
+        )
+
+
+def test_verify_signature_uses_compare_digest():
+    import hmac as _hmac
+
+    secret = "s"
+    body = b"x"
+    ts = str(int(time.time()))
+    sig = _sign(secret, ts, body)
+    with patch.object(_hmac, "compare_digest", wraps=_hmac.compare_digest) as spy:
+        verify_signature(
+            body=body,
+            timestamp_header=ts,
+            signature_header=sig,
+            secret=secret,
+        )
+    assert spy.called
+
+
+def test_verify_signature_body_byte_sensitive():
+    """Even a single trailing space in the body invalidates the signature."""
+    secret = "s"
+    body = b'{"a":1}'
+    ts = str(int(time.time()))
+    sig = _sign(secret, ts, body)
+    with pytest.raises(WebhookVerificationError, match="mismatch"):
+        verify_signature(
+            body=b'{"a":1} ',  # one extra byte
+            timestamp_header=ts,
+            signature_header=sig,
+            secret=secret,
+        )
+
+
+def test_verify_signature_includes_timestamp_in_basestring():
+    """Slack's basestring is ``v0:{ts}:{body}`` — different ts must
+    produce different signature even with the same body. Pins against
+    accidentally signing only the body."""
+    secret = "s"
+    body = b"x"
+    ts_a = str(int(time.time()))
+    ts_b = str(int(time.time()) + 1)
+    sig_a = _sign(secret, ts_a, body)
+    # Same signature with the wrong timestamp must fail.
+    with pytest.raises(WebhookVerificationError, match="mismatch"):
+        verify_signature(
+            body=body,
+            timestamp_header=ts_b,
+            signature_header=sig_a,
+            secret=secret,
+        )
+
+
+# ── handle: dispatch ────────────────────────────────────────────────────────
+
+
+def _fresh_ts() -> str:
+    return str(int(time.time()))
+
+
+def test_handle_url_verification_echoes_challenge():
+    """The handshake response must echo the challenge field verbatim."""
+    from secrets_store import put_secret
+
+    put_secret(source_id="slack", key="webhook_secret", value="s")
+    body = json.dumps({"type": "url_verification", "challenge": "abc123"}).encode("utf-8")
+    ts = _fresh_ts()
+    status, response, content_type = handle(
+        body=body,
+        timestamp_header=ts,
+        signature_header=_sign("s", ts, body),
+    )
+    assert status == 200
+    assert content_type == "application/json"
+    parsed = json.loads(response)
+    assert parsed["challenge"] == "abc123"
+
+
+def test_handle_url_verification_missing_challenge_rejected():
+    from secrets_store import put_secret
+
+    put_secret(source_id="slack", key="webhook_secret", value="s")
+    body = json.dumps({"type": "url_verification"}).encode("utf-8")
+    ts = _fresh_ts()
+    status, _, _ = handle(
+        body=body,
+        timestamp_header=ts,
+        signature_header=_sign("s", ts, body),
+    )
+    assert status == 400
+
+
+def test_handle_missing_signature_returns_401():
+    from secrets_store import put_secret
+
+    put_secret(source_id="slack", key="webhook_secret", value="s")
+    status, _, _ = handle(
+        body=b"{}",
+        timestamp_header=_fresh_ts(),
+        signature_header=None,
+    )
+    assert status == 401
+
+
+def test_handle_invalid_json_returns_400():
+    from secrets_store import put_secret
+
+    put_secret(source_id="slack", key="webhook_secret", value="s")
+    body = b"not json"
+    ts = _fresh_ts()
+    status, _, _ = handle(
+        body=body,
+        timestamp_header=ts,
+        signature_header=_sign("s", ts, body),
+    )
+    assert status == 400
+
+
+def test_handle_message_event_ingests():
+    from secrets_store import put_secret
+
+    put_secret(source_id="slack", key="webhook_secret", value="s")
+    body = json.dumps(
+        {
+            "type": "event_callback",
+            "event_id": "Ev01",
+            "event": {
+                "type": "message",
+                "channel": "C01A",
+                "ts": "1700000000.000001",
+                "user": "U1",
+                "text": "decided to ship",
+            },
+        }
+    ).encode("utf-8")
+    ts = _fresh_ts()
+
+    async def _fake_ingest(*args, **kwargs):
+        return None
+
+    with (
+        patch("handlers.ingest.handle_ingest", new=_fake_ingest),
+        patch("context.BicameralContext.from_env", return_value=MagicMock()),
+    ):
+        status, msg, _ = handle(
+            body=body,
+            timestamp_header=ts,
+            signature_header=_sign("s", ts, body),
+        )
+    assert status == 200
+    assert "ingested" in msg
+
+
+def test_handle_thread_reply_ignored():
+    """thread_ts present and different from ts → reply, skip (matches the
+    polling adapter's behavior)."""
+    from secrets_store import put_secret
+
+    put_secret(source_id="slack", key="webhook_secret", value="s")
+    body = json.dumps(
+        {
+            "type": "event_callback",
+            "event_id": "Ev02",
+            "event": {
+                "type": "message",
+                "channel": "C01A",
+                "ts": "1700000002.000001",
+                "user": "U1",
+                "text": "reply text",
+                "thread_ts": "1700000001.000001",  # different from ts → reply
+            },
+        }
+    ).encode("utf-8")
+    ts = _fresh_ts()
+    status, msg, _ = handle(
+        body=body,
+        timestamp_header=ts,
+        signature_header=_sign("s", ts, body),
+    )
+    assert status == 200
+    assert "thread reply" in msg
+
+
+def test_handle_bot_message_subtype_ignored():
+    from secrets_store import put_secret
+
+    put_secret(source_id="slack", key="webhook_secret", value="s")
+    body = json.dumps(
+        {
+            "type": "event_callback",
+            "event_id": "Ev03",
+            "event": {
+                "type": "message",
+                "channel": "C01A",
+                "ts": "1700000000.000001",
+                "user": "USLACKBOT",
+                "text": "channel topic was set",
+                "subtype": "channel_topic",
+            },
+        }
+    ).encode("utf-8")
+    ts = _fresh_ts()
+    status, msg, _ = handle(
+        body=body,
+        timestamp_header=ts,
+        signature_header=_sign("s", ts, body),
+    )
+    assert status == 200
+    assert "decision-bearing" in msg
+
+
+def test_handle_dedup_on_event_id():
+    """Slack retries failed deliveries — second arrival with same
+    event_id must not re-ingest."""
+    from secrets_store import put_secret
+
+    put_secret(source_id="slack", key="webhook_secret", value="s")
+    body = json.dumps(
+        {
+            "type": "event_callback",
+            "event_id": "Ev-dup",
+            "event": {
+                "type": "message",
+                "channel": "C01A",
+                "ts": "1700000000.000001",
+                "user": "U1",
+                "text": "decided",
+            },
+        }
+    ).encode("utf-8")
+    ts = _fresh_ts()
+    sig = _sign("s", ts, body)
+
+    async def _fake_ingest(*args, **kwargs):
+        return None
+
+    with (
+        patch("handlers.ingest.handle_ingest", new=_fake_ingest),
+        patch("context.BicameralContext.from_env", return_value=MagicMock()),
+    ):
+        status1, _, _ = handle(body=body, timestamp_header=ts, signature_header=sig)
+        status2, msg2, _ = handle(body=body, timestamp_header=ts, signature_header=sig)
+    assert status1 == 200
+    assert status2 == 200
+    assert "duplicate" in msg2
+
+
+def test_handle_hard_gate_refusal_returns_422():
+    """_IngestRefused → 422 not 500. Slack retries 5xx 3× over 1 hour;
+    we don't want to re-process payloads with secret/PHI in them."""
+    from handlers.ingest import _IngestRefused
+    from secrets_store import put_secret
+
+    put_secret(source_id="slack", key="webhook_secret", value="s")
+    body = json.dumps(
+        {
+            "type": "event_callback",
+            "event_id": "Ev-secret",
+            "event": {
+                "type": "message",
+                "channel": "C01A",
+                "ts": "1700000000.000001",
+                "user": "U1",
+                "text": "AKIAIOSFODNN7EXAMPLE",
+            },
+        }
+    ).encode("utf-8")
+    ts = _fresh_ts()
+
+    async def _refuse(*args, **kwargs):
+        raise _IngestRefused("sensitive_data:secret")
+
+    with (
+        patch("handlers.ingest.handle_ingest", new=_refuse),
+        patch("context.BicameralContext.from_env", return_value=MagicMock()),
+    ):
+        status, msg, _ = handle(
+            body=body,
+            timestamp_header=ts,
+            signature_header=_sign("s", ts, body),
+        )
+    assert status == 422
+    assert "refused" in msg.lower()
+
+
+def test_handle_event_callback_without_event_id_rejected():
+    """B1 review finding: event_callback envelope missing event_id is
+    rejected with 400. Absence would skip the dedup cache entirely,
+    enabling unbounded replay within the 5-min timestamp window."""
+    from secrets_store import put_secret
+
+    put_secret(source_id="slack", key="webhook_secret", value="s")
+    body = json.dumps(
+        {
+            "type": "event_callback",
+            # NO event_id
+            "event": {"type": "message", "channel": "C01A", "ts": "1.0", "user": "U", "text": "x"},
+        }
+    ).encode("utf-8")
+    ts = _fresh_ts()
+    status, msg, _ = handle(
+        body=body,
+        timestamp_header=ts,
+        signature_header=_sign("s", ts, body),
+    )
+    assert status == 400
+    assert "event_id" in msg
+
+
+def test_handle_dm_channel_type_rejected():
+    """H2 review finding: channel_type 'im' (DM) ignored per the
+    channel-only policy that already applies to the polling adapter."""
+    from secrets_store import put_secret
+
+    put_secret(source_id="slack", key="webhook_secret", value="s")
+    body = json.dumps(
+        {
+            "type": "event_callback",
+            "event_id": "Ev-dm",
+            "event": {
+                "type": "message",
+                "channel": "C01A",
+                "channel_type": "im",
+                "ts": "1.0",
+                "user": "U",
+                "text": "private chat",
+            },
+        }
+    ).encode("utf-8")
+    ts = _fresh_ts()
+    status, msg, _ = handle(
+        body=body,
+        timestamp_header=ts,
+        signature_header=_sign("s", ts, body),
+    )
+    assert status == 200
+    assert "DM" in msg
+
+
+def test_handle_d_prefix_channel_id_rejected():
+    """H2 review finding: defense-in-depth — even if channel_type is
+    missing or wrong, a D-prefix channel ID is rejected."""
+    from secrets_store import put_secret
+
+    put_secret(source_id="slack", key="webhook_secret", value="s")
+    body = json.dumps(
+        {
+            "type": "event_callback",
+            "event_id": "Ev-dprefix",
+            "event": {
+                "type": "message",
+                "channel": "D01XYZ",  # D-prefix → DM
+                "ts": "1.0",
+                "user": "U",
+                "text": "x",
+            },
+        }
+    ).encode("utf-8")
+    ts = _fresh_ts()
+    status, msg, _ = handle(
+        body=body,
+        timestamp_header=ts,
+        signature_header=_sign("s", ts, body),
+    )
+    assert status == 200
+    assert "DM" in msg
+
+
+def test_handle_single_message_normalize_produces_non_empty_decisions():
+    """M2 review finding: regression pin against future adapter
+    refactors that would make single-message normalize produce empty
+    decisions (which would land a junk row in the ledger)."""
+    from secrets_store import put_secret
+    from sources.slack.adapter import normalize_thread_to_payload
+
+    put_secret(source_id="slack", key="webhook_secret", value="s")
+
+    event = {
+        "type": "message",
+        "channel": "C01A",
+        "ts": "1700000000.000001",
+        "user": "U1",
+        "text": "real decision text",
+    }
+    # Direct call to the normalize function as the webhook uses it.
+    payload = normalize_thread_to_payload(
+        [event],
+        channel="C01A",
+        thread_url="slack://C01A/1700000000.000001",
+    )
+    assert len(payload.get("decisions") or []) >= 1
+    assert payload["decisions"][0]["description"] == "real decision text"
+
+
+def test_verify_signature_rejects_timestamp_with_leading_plus():
+    """M1 review finding: strict digit-only timestamp parse rejects
+    `+1700000000` and similar non-canonical forms before int()."""
+    secret = "s"
+    body = b"x"
+    bad_ts = "+1700000000"  # int() would accept, isdigit() rejects
+    sig = _sign(secret, bad_ts, body)
+    with pytest.raises(WebhookVerificationError, match="strict decimal"):
+        verify_signature(
+            body=body,
+            timestamp_header=bad_ts,
+            signature_header=sig,
+            secret=secret,
+        )
+
+
+def test_verify_signature_rejects_timestamp_with_whitespace():
+    """M1 corollary: leading/trailing whitespace rejected."""
+    secret = "s"
+    body = b"x"
+    bad_ts = " 1700000000 "
+    sig = _sign(secret, bad_ts.strip(), body)
+    with pytest.raises(WebhookVerificationError, match="strict decimal"):
+        verify_signature(
+            body=body,
+            timestamp_header=bad_ts,
+            signature_header=sig,
+            secret=secret,
+        )
+
+
+def test_handle_dedup_only_after_verification():
+    """Bogus signed payloads must NOT pollute the dedup cache —
+    same defense as GitHub."""
+    from secrets_store import put_secret
+    from webhooks.dedup import get_dedup_cache
+
+    put_secret(source_id="slack", key="webhook_secret", value="real")
+    body = json.dumps(
+        {
+            "type": "event_callback",
+            "event_id": "Ev-attack",
+            "event": {"type": "message", "channel": "C01A", "ts": "1.0", "user": "U", "text": "x"},
+        }
+    ).encode("utf-8")
+    ts = _fresh_ts()
+
+    # Attacker signs with wrong secret.
+    bogus_sig = _sign("attacker", ts, body)
+    handle(body=body, timestamp_header=ts, signature_header=bogus_sig)
+    assert get_dedup_cache().is_duplicate("slack", "Ev-attack") is False
+
+
+# ── Server route (HTTP layer) ───────────────────────────────────────────────
+
+
+def test_server_routes_slack_handshake_as_json():
+    """End-to-end through the asyncio server: URL verification returns
+    application/json with the challenge bytes."""
+    from secrets_store import put_secret
+    from webhooks import server as ws
+
+    put_secret(source_id="slack", key="webhook_secret", value="s")
+    body = json.dumps({"type": "url_verification", "challenge": "xyz"}).encode("utf-8")
+    ts = _fresh_ts()
+    sig = _sign("s", ts, body)
+    raw = (
+        b"POST /webhooks/slack HTTP/1.1\r\n"
+        + f"X-Slack-Request-Timestamp: {ts}\r\n".encode("ascii")
+        + f"X-Slack-Signature: {sig}\r\n".encode("ascii")
+        + f"Content-Length: {len(body)}\r\n\r\n".encode("ascii")
+        + body
+    )
+
+    class _Buf:
+        def __init__(self, data):
+            self._in = io.BytesIO(data)
+            self.out = bytearray()
+
+        async def readline(self):
+            return self._in.readline()
+
+        async def readexactly(self, n):
+            chunk = self._in.read(n)
+            if len(chunk) < n:
+                raise asyncio.IncompleteReadError(chunk, n)
+            return chunk
+
+        def write(self, d):
+            self.out.extend(d)
+
+        async def drain(self):
+            return None
+
+        def close(self):
+            pass
+
+        async def wait_closed(self):
+            return None
+
+    ws._request_semaphore = None  # reset
+    buf = _Buf(raw)
+    asyncio.run(ws.handle_client(buf, buf))
+
+    out = bytes(buf.out)
+    assert b"200 OK" in out
+    assert b"Content-Type: application/json" in out
+    # Body bytes contain the challenge JSON.
+    body_idx = out.index(b"\r\n\r\n") + 4
+    body_bytes = out[body_idx:]
+    parsed = json.loads(body_bytes)
+    assert parsed["challenge"] == "xyz"

--- a/webhooks/server.py
+++ b/webhooks/server.py
@@ -11,6 +11,7 @@ NOT terminate TLS ourselves.
 
 Routes:
 - ``POST /webhooks/github``         → ``webhooks.github.handle``
+- ``POST /webhooks/slack``          → ``webhooks.slack.handle``
 - ``POST /webhooks/google-drive``   → ``webhooks.google_drive.handle``
 - ``GET /health``                   → 200 ack (for load-balancer health checks)
 
@@ -206,6 +207,16 @@ async def _process_request(reader: asyncio.StreamReader, writer: asyncio.StreamW
         await _respond(writer, status, message)
         return
 
+    if path == "/webhooks/slack":
+        # Slack handler returns (status, body, content_type) — H1 review
+        # finding: server passes content type through verbatim instead of
+        # guessing by inspecting the body.
+        status, message, content_type = await asyncio.to_thread(
+            _dispatch_slack, body, MappingProxyType(dict(headers))
+        )
+        await _respond(writer, status, message, content_type=content_type)
+        return
+
     await _respond(writer, 404, "not found")
 
 
@@ -240,6 +251,23 @@ def _dispatch_google_drive(body: bytes, headers) -> tuple[int, str]:
         resource_id=headers.get("x-goog-resource-id"),
         resource_state=headers.get("x-goog-resource-state"),
         message_number=headers.get("x-goog-message-number"),
+    )
+
+
+def _dispatch_slack(body: bytes, headers) -> tuple[int, str, str]:
+    """Sync entrypoint into the Slack handler (called via to_thread).
+
+    Returns ``(status, body, content_type)`` — content type is explicit
+    rather than guessed from body shape (H1 review finding).
+    """
+    from webhooks.slack import handle
+
+    timestamp = headers.get("x-slack-request-timestamp")
+    signature = headers.get("x-slack-signature")
+    return handle(
+        body=body,
+        timestamp_header=timestamp,
+        signature_header=signature,
     )
 
 

--- a/webhooks/slack.py
+++ b/webhooks/slack.py
@@ -1,0 +1,283 @@
+"""Slack Events API webhook handler (#337 cycle 6).
+
+Slack's webhook contract differs from GitHub's:
+- Signature header: ``X-Slack-Signature`` of form ``v0=<hex>``
+- Timestamp header: ``X-Slack-Request-Timestamp`` (epoch seconds, str)
+- Signature payload: ``v0:{timestamp}:{raw_body}`` (NOT just the body)
+- Replay defense: timestamp-based, reject if > 5 minutes stale
+
+The timestamped signature is a stronger replay defense than GitHub's
+delivery-UUID dedup: an attacker who captures a signed payload can
+only replay it within the 5-minute window. We still dedup on the event
+ID for ``event_callback`` requests (Slack retries failed deliveries up
+to 3× over 1 hour; same envelope can arrive twice within the 5-min
+window).
+
+URL verification handshake: when an operator first registers the
+webhook URL in Slack's app config, Slack POSTs ``{"type":"url_verification",
+"challenge":"<random>"}``. We must echo ``{"challenge":"<random>"}``
+within 3 seconds. The challenge response is the ONLY non-trivial 200
+payload we emit — everything else is a status line.
+
+Event handling (cycle 6 minimum):
+- ``url_verification`` → 200 with ``{"challenge": <echo>}`` body
+- ``event_callback`` with ``event.type == "message"`` (and not a bot
+  subtype) → normalize via Phase 4a thread-fetch, ingest passively
+- Any other ``event_callback`` subtype → 200 + "ignored"
+- ``app_uninstalled`` / ``tokens_revoked`` → 200, log, no action
+  (operator-side problem, our auth token is now dead anyway)
+"""
+
+from __future__ import annotations
+
+import hashlib
+import hmac
+import json
+import sys
+import time
+
+# Slack: reject signed requests where the timestamp is more than this many
+# seconds stale (per Slack docs § Verifying requests). 5 minutes is the
+# canonical value — long enough for clock skew between Slack and operator,
+# tight enough to bound replay window.
+_MAX_TIMESTAMP_SKEW_SECONDS = 5 * 60
+
+
+class WebhookVerificationError(Exception):
+    """Raised when signature OR timestamp verification fails."""
+
+
+def verify_signature(
+    *,
+    body: bytes,
+    timestamp_header: str | None,
+    signature_header: str | None,
+    secret: str,
+    now: float | None = None,
+) -> None:
+    """Verify Slack's v0 signing scheme + reject stale timestamps.
+
+    Order:
+    1. Missing timestamp / signature header → reject (no replay window
+       to verify against).
+    2. Timestamp parses as int.
+    3. Timestamp not stale (|now - ts| <= 5 minutes). Done BEFORE HMAC so
+       a constant-time-attacker can't probe the secret against an
+       arbitrarily-old timestamp.
+    4. Signature header has ``v0=`` prefix.
+    5. HMAC-SHA256(secret, ``v0:{timestamp}:{body}``).
+    6. Constant-time hex compare via ``hmac.compare_digest``.
+
+    ``now`` is injectable for tests; defaults to ``time.time()``.
+
+    Raises:
+        WebhookVerificationError: every failure mode. Operator-facing
+            detail is in the exception message; HTTP layer responds 401.
+    """
+    if not timestamp_header:
+        raise WebhookVerificationError("missing X-Slack-Request-Timestamp header")
+    if not signature_header:
+        raise WebhookVerificationError("missing X-Slack-Signature header")
+    if not secret:
+        raise WebhookVerificationError("no webhook_secret configured for this source")
+    # M1: strict digit-only parse — rejects whitespace, +, -, leading zeros
+    # via the digit check before int() so future code that relies on the
+    # parsed int form sees only canonical-shaped input.
+    if not timestamp_header.isdigit():
+        raise WebhookVerificationError(
+            f"X-Slack-Request-Timestamp not strict decimal: {timestamp_header[:32]!r}"
+        )
+    ts = int(timestamp_header)
+    current = time.time() if now is None else now
+    if abs(current - ts) > _MAX_TIMESTAMP_SKEW_SECONDS:
+        raise WebhookVerificationError(
+            f"timestamp stale: |now - {ts}| > {_MAX_TIMESTAMP_SKEW_SECONDS}s"
+        )
+    if not signature_header.startswith("v0="):
+        raise WebhookVerificationError(
+            f"signature header malformed: expected 'v0=<hex>', got {signature_header[:32]!r}"
+        )
+    provided_hex = signature_header[len("v0=") :]
+    # Slack's signature basestring concatenates the version tag, the
+    # timestamp, and the raw request body, separated by colons.
+    basestring = b"v0:" + timestamp_header.encode("ascii") + b":" + body
+    expected_hex = hmac.new(
+        secret.encode("utf-8"), msg=basestring, digestmod=hashlib.sha256
+    ).hexdigest()
+    if not hmac.compare_digest(provided_hex, expected_hex):
+        raise WebhookVerificationError("signature mismatch")
+
+
+def handle(
+    *,
+    body: bytes,
+    timestamp_header: str | None,
+    signature_header: str | None,
+) -> tuple[int, str, str]:
+    """Process one Slack Events API delivery.
+
+    Returns ``(http_status, response_body, content_type)`` — content type
+    is explicit (H1 review finding) so the server doesn't have to guess
+    by inspecting the body. Most responses are ``text/plain``; URL
+    verification handshake is ``application/json``.
+
+    Slack expects the URL-verification response (the challenge echo)
+    within 3 seconds of the POST.
+    """
+    _TEXT = "text/plain; charset=utf-8"
+    _JSON = "application/json"
+
+    try:
+        from secrets_store import get_secret
+
+        secret = get_secret(source_id="slack", key="webhook_secret") or ""
+    except Exception as exc:  # noqa: BLE001
+        print(f"[slack-webhook] secret lookup failed: {exc}", file=sys.stderr)
+        return 500, f"secret lookup failed: {exc}", _TEXT
+
+    try:
+        verify_signature(
+            body=body,
+            timestamp_header=timestamp_header,
+            signature_header=signature_header,
+            secret=secret,
+        )
+    except WebhookVerificationError as exc:
+        print(f"[slack-webhook] verification failed: {exc}", file=sys.stderr)
+        return 401, f"verification failed: {exc}", _TEXT
+
+    # Body parse only AFTER verification.
+    try:
+        payload = json.loads(body.decode("utf-8"))
+    except Exception as exc:  # noqa: BLE001
+        print(f"[slack-webhook] body not JSON-decodable: {exc}", file=sys.stderr)
+        return 400, f"body not JSON: {exc}", _TEXT
+
+    envelope_type = payload.get("type") or ""
+
+    # URL verification handshake: Slack expects {"challenge": <echo>}.
+    # Confirmed harmless to replay within the 5-min window — challenge is
+    # operator-chosen by Slack at app-config time and surfaced in their
+    # admin UI. Replays just yield the same 200 echo.
+    if envelope_type == "url_verification":
+        challenge = payload.get("challenge") or ""
+        if not challenge or not isinstance(challenge, str):
+            return 400, "url_verification missing 'challenge' field", _TEXT
+        # Echo back as JSON. Byte-exact: Slack literally byte-matches the
+        # challenge against the response body.
+        return 200, json.dumps({"challenge": challenge}), _JSON
+
+    if envelope_type == "event_callback":
+        # B1: Slack always sends event_id on event_callback. Absence is
+        # either a provider bug or an attacker stripping the field to
+        # bypass dedup — reject explicitly.
+        # TODO(multi-tenant): when multi-workspace support lands, namespace
+        # the dedup key as ("slack", team_id, event_id) — M3 from review.
+        event_id = payload.get("event_id")
+        if not event_id or not isinstance(event_id, str):
+            print(
+                "[slack-webhook] event_callback missing event_id (replay-defense gate); rejecting.",
+                file=sys.stderr,
+            )
+            return 400, "event_callback missing event_id", _TEXT
+
+        # Replay defense layer 2: Slack retries failed deliveries up to 3×
+        # over 1 hour. Combined with the timestamp gate (5-min window),
+        # any retry within the window must come through dedup.
+        from webhooks.dedup import get_dedup_cache
+
+        cache = get_dedup_cache()
+        if cache.is_duplicate("slack", event_id):
+            print(
+                f"[slack-webhook] duplicate event_id {event_id!r} ignored",
+                file=sys.stderr,
+            )
+            return 200, "duplicate", _TEXT
+        cache.mark_seen("slack", event_id)
+
+        event = payload.get("event") or {}
+        event_type = event.get("type") or ""
+
+        if event_type == "message":
+            status, msg = _ingest_message(event)
+            return status, msg, _TEXT
+
+        return 200, f"event.type={event_type!r} ignored", _TEXT
+
+    # tokens_revoked / app_uninstalled / etc. — Slack-side state changes
+    # we acknowledge but don't ingest.
+    return 200, f"envelope type={envelope_type!r} acknowledged", _TEXT
+
+
+def _ingest_message(event: dict) -> tuple[int, str]:
+    """Normalize a Slack message event + push through handle_ingest."""
+    # Drop messages that aren't decision-bearing (bot, channel-meta, etc.)
+    # by reusing the Phase 4a filter so active + passive + webhook paths
+    # share the same definition.
+    try:
+        from sources.slack.adapter import _is_decision_bearing, normalize_thread_to_payload
+    except ImportError as exc:
+        print(f"[slack-webhook] adapter import failed: {exc}", file=sys.stderr)
+        return 500, "adapter import failed"
+
+    # H2: channel-only policy parity with the polling adapter. Reject DMs
+    # (channel_type 'im'/'mpim') AND D-prefix channel IDs. Private channels
+    # ('group' channel_type, G-prefix IDs) remain permitted — operator is
+    # responsible for which channels the bot is invited to.
+    channel_type = event.get("channel_type") or ""
+    if channel_type in {"im", "mpim"}:
+        return 200, "DM channel type; ignored (channel-only policy)"
+
+    channel = event.get("channel") or ""
+    msg_ts = event.get("ts") or ""
+    if not channel or not msg_ts:
+        return 200, "message missing channel/ts; ignored"
+    if channel.upper().startswith("D"):
+        return 200, "DM channel ID; ignored (channel-only policy)"
+
+    if not _is_decision_bearing(event):
+        return 200, "message not decision-bearing; ignored"
+
+    # Skip thread replies (Slack semantics: thread_ts present and != ts);
+    # mirrors the polling adapter's behavior.
+    thread_ts = event.get("thread_ts") or ""
+    if thread_ts and thread_ts != msg_ts:
+        return 200, "thread reply; ignored (top-level + roots only)"
+
+    # M2: single-message list is intentional. normalize_thread_to_payload
+    # treats messages[0] as the thread root for title/date derivation;
+    # all decision-bearing messages in the list become decisions. For our
+    # one-message webhook path that's exactly the right shape.
+    payload = normalize_thread_to_payload(
+        [event],
+        channel=channel,
+        thread_url=f"slack://{channel}/{msg_ts}",
+    )
+
+    try:
+        import asyncio
+
+        from context import BicameralContext
+        from handlers.ingest import _IngestRefused, handle_ingest
+
+        ctx = BicameralContext.from_env()
+
+        async def _ingest() -> None:
+            await handle_ingest(ctx, payload, source_scope="slack", ingest_mode="passive")
+
+        asyncio.run(_ingest())
+    except _IngestRefused as exc:
+        # Same H2 fix as GitHub: hard-gate refusals → 422, no retry.
+        print(
+            f"[slack-webhook] hard-gate refusal for {channel}#{msg_ts}: {exc.reason}",
+            file=sys.stderr,
+        )
+        return 422, f"refused: {exc.reason}"
+    except Exception as exc:  # noqa: BLE001
+        print(
+            f"[slack-webhook] ingest failed for {channel}#{msg_ts}: {exc}",
+            file=sys.stderr,
+        )
+        return 500, f"ingest failed: {exc}"
+
+    return 200, f"ingested {channel}#{msg_ts}"


### PR DESCRIPTION
## Review only — do not merge

This is a **review / preservation PR** for the `feat/slack` branch, opened for visibility per the per-feature-branch rule. It is **draft / do-not-merge** — the Slack integration is kept on its own long-lived branch, not merged into `dev`.

## Content

The **Slack** integration (active + passive ingest, webhook receiver), backed out of `dev` by BicameralAI/bicameral-mcp#479 and preserved here in isolation.

## Note on the diff

This branch was cut from the integration-free `dev` base. Once **#479** (the back-out) merges into `dev`, this PR's diff resolves to exactly the Slack integration and nothing else — clean-isolated. Until then the diff also shows the other integrations being removed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)