### PR TITLE
feat(protocol): universal ingest/egress/grounding contracts (Phase 1)

### DIFF
--- a/protocol/__init__.py
+++ b/protocol/__init__.py
@@ -1,0 +1,64 @@
+"""Universal ingest/egress/grounding protocol.
+
+Public surface for adapters that talk to the bicameral-daemon. Today this
+module lives in-tree alongside the MCP server; in Phase 3 it is extracted to
+the public `bicameral-protocol` package so any integration (Linear, Notion,
+Slack, future grounders) can implement it without seeing MCP-internal code.
+
+The wire format is JSON-RPC 2.0 over a Unix domain socket. The daemon
+publishes the socket path in `~/.bicameral/daemon.json` at startup.
+"""
+
+from __future__ import annotations
+
+from .client import ProtocolClient
+from .contracts import (
+    PROTOCOL_VERSION,
+    AnalyzeRegionRequest,
+    BatchAnalyzeRequest,
+    CodeRegion,
+    DeliveryResult,
+    DriftResult,
+    EgressAdapter,
+    ExtractSymbolsRequest,
+    GetNeighborsRequest,
+    GroundingPort,
+    IngestAdapter,
+    IngestRequest,
+    IngestResult,
+    LinkCommitRequest,
+    LinkCommitResult,
+    Neighbor,
+    NotificationEvent,
+    ProtocolError,
+    ProtocolVersionError,
+    Symbol,
+    ValidateSymbolsRequest,
+)
+from .server import ProtocolServer
+
+__all__ = [
+    "PROTOCOL_VERSION",
+    "AnalyzeRegionRequest",
+    "BatchAnalyzeRequest",
+    "CodeRegion",
+    "DeliveryResult",
+    "DriftResult",
+    "EgressAdapter",
+    "ExtractSymbolsRequest",
+    "GetNeighborsRequest",
+    "GroundingPort",
+    "IngestAdapter",
+    "IngestRequest",
+    "IngestResult",
+    "LinkCommitRequest",
+    "LinkCommitResult",
+    "Neighbor",
+    "NotificationEvent",
+    "ProtocolClient",
+    "ProtocolError",
+    "ProtocolServer",
+    "ProtocolVersionError",
+    "Symbol",
+    "ValidateSymbolsRequest",
+]

--- a/protocol/client.py
+++ b/protocol/client.py
@@ -1,0 +1,192 @@
+"""Typed RPC client for the universal ingest/egress/grounding surface.
+
+Reads the daemon socket path from ``~/.bicameral/daemon.json`` (unless
+overridden via the constructor). A single connection multiplexes calls;
+requests are matched to responses by ``id``.
+
+Today this lives in-tree alongside the MCP server. Phase 3 extracts it to
+``bicameral-protocol`` so any adapter (Linear, Notion, future grounders)
+imports the same client without dragging in MCP code.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import itertools
+import json
+from pathlib import Path
+from typing import Any
+
+from .contracts import (
+    PROTOCOL_VERSION,
+    AnalyzeRegionRequest,
+    BatchAnalyzeRequest,
+    DriftResult,
+    ExtractSymbolsRequest,
+    GetNeighborsRequest,
+    IngestRequest,
+    IngestResult,
+    LinkCommitRequest,
+    LinkCommitResult,
+    Neighbor,
+    NotificationEvent,
+    DeliveryResult,
+    ProtocolError,
+    ProtocolVersionError,
+    Symbol,
+    ValidateSymbolsRequest,
+)
+from .transport import make_request, read_message, write_message
+
+
+def _parse_major(version: str) -> int:
+    return int(version.split(".", 1)[0])
+
+
+def _default_socket_path() -> Path:
+    return Path.home() / ".bicameral" / "daemon.sock"
+
+
+class ProtocolClient:
+    """Async RPC client for the bicameral daemon.
+
+    Usage::
+
+        client = ProtocolClient()
+        await client.connect()
+        symbols = await client.validate_symbols(req)
+        await client.close()
+    """
+
+    def __init__(self, socket_path: Path | None = None) -> None:
+        self._socket_path = socket_path or self._read_daemon_socket()
+        self._reader: asyncio.StreamReader | None = None
+        self._writer: asyncio.StreamWriter | None = None
+        self._id_iter = itertools.count(1)
+        self._pending: dict[int, asyncio.Future[Any]] = {}
+        self._reader_task: asyncio.Task[None] | None = None
+        self._closed = False
+
+    @staticmethod
+    def _read_daemon_socket() -> Path:
+        config = Path.home() / ".bicameral" / "daemon.json"
+        if not config.exists():
+            return _default_socket_path()
+        data = json.loads(config.read_text(encoding="utf-8"))
+        return Path(data["socket_path"])
+
+    async def connect(self) -> None:
+        self._reader, self._writer = await asyncio.open_unix_connection(
+            str(self._socket_path)
+        )
+        self._reader_task = asyncio.create_task(self._read_loop())
+        await self._verify_version()
+
+    async def _verify_version(self) -> None:
+        server_version = await self._call("system.version", {})
+        if not isinstance(server_version, str):
+            raise ProtocolError("system.version did not return a string")
+        if _parse_major(server_version) != _parse_major(PROTOCOL_VERSION):
+            raise ProtocolVersionError(
+                f"client {PROTOCOL_VERSION} incompatible with server {server_version}"
+            )
+
+    async def _read_loop(self) -> None:
+        assert self._reader is not None
+        try:
+            while not self._closed:
+                msg = await read_message(self._reader)
+                self._dispatch_response(msg)
+        except ProtocolError:
+            self._fail_pending(ProtocolError("connection closed"))
+        except asyncio.CancelledError:
+            self._fail_pending(ProtocolError("client cancelled"))
+            raise
+
+    def _dispatch_response(self, msg: dict[str, Any]) -> None:
+        req_id = msg.get("id")
+        if not isinstance(req_id, int):
+            return
+        future = self._pending.pop(req_id, None)
+        if future is None or future.done():
+            return
+        if "error" in msg:
+            future.set_exception(ProtocolError(msg["error"].get("message", "error")))
+        else:
+            future.set_result(msg.get("result"))
+
+    def _fail_pending(self, exc: Exception) -> None:
+        for future in self._pending.values():
+            if not future.done():
+                future.set_exception(exc)
+        self._pending.clear()
+
+    async def _call(self, method: str, params: dict[str, Any]) -> Any:
+        if self._writer is None:
+            raise ProtocolError("client not connected")
+        req_id = next(self._id_iter)
+        future: asyncio.Future[Any] = asyncio.get_event_loop().create_future()
+        self._pending[req_id] = future
+        await write_message(self._writer, make_request(req_id, method, params))
+        return await future
+
+    async def close(self) -> None:
+        self._closed = True
+        if self._writer is not None:
+            self._writer.close()
+            try:
+                await self._writer.wait_closed()
+            except Exception:
+                pass
+        if self._reader_task is not None:
+            self._reader_task.cancel()
+            try:
+                await self._reader_task
+            except (asyncio.CancelledError, ProtocolError):
+                pass
+
+    # ── Typed adapter facade ─────────────────────────────────────────
+
+    async def ingest(self, req: IngestRequest) -> IngestResult:
+        result = await self._call("ingest.ingest", req.model_dump())
+        return IngestResult.model_validate(result)
+
+    async def link_commit(self, req: LinkCommitRequest) -> LinkCommitResult:
+        result = await self._call("ingest.link_commit", req.model_dump())
+        return LinkCommitResult.model_validate(result)
+
+    async def deliver(self, event: NotificationEvent) -> DeliveryResult:
+        result = await self._call("egress.deliver", event.model_dump())
+        return DeliveryResult.model_validate(result)
+
+    async def validate_symbols(
+        self, req: ValidateSymbolsRequest
+    ) -> list[Symbol]:
+        result = await self._call("grounding.validate_symbols", req.model_dump())
+        return [Symbol.model_validate(item) for item in result]
+
+    async def extract_symbols(
+        self, req: ExtractSymbolsRequest
+    ) -> list[Symbol]:
+        result = await self._call("grounding.extract_symbols", req.model_dump())
+        return [Symbol.model_validate(item) for item in result]
+
+    async def get_neighbors(
+        self, req: GetNeighborsRequest
+    ) -> list[Neighbor]:
+        result = await self._call("grounding.get_neighbors", req.model_dump())
+        return [Neighbor.model_validate(item) for item in result]
+
+    async def analyze_region(
+        self, req: AnalyzeRegionRequest
+    ) -> DriftResult:
+        result = await self._call("grounding.analyze_region", req.model_dump())
+        return DriftResult.model_validate(result)
+
+    async def batch_analyze_regions(
+        self, req: BatchAnalyzeRequest
+    ) -> list[DriftResult]:
+        result = await self._call(
+            "grounding.batch_analyze_regions", req.model_dump()
+        )
+        return [DriftResult.model_validate(item) for item in result]

--- a/protocol/conformance.py
+++ b/protocol/conformance.py
@@ -1,0 +1,29 @@
+"""Conformance harness skeleton.
+
+Phase 3 publishes the full test suite as part of ``bicameral-protocol``;
+Phase 1 ships only the entry surface so adapters can declare conformance
+without depending on the eventual import path. The fleshed-out suite ships
+in the per-adapter implementation plans (Linear, Notion, Slack, …).
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any
+
+
+@dataclass
+class ConformanceReport:
+    passed: int = 0
+    failed: int = 0
+    failures: list[str] = field(default_factory=list)
+
+
+async def run_suite(_adapter: Any) -> ConformanceReport:
+    """Placeholder until Phase 3 lands the published conformance suite.
+
+    Returns an empty report so callers wiring up CI today get a no-op
+    baseline. Phase 3 replaces the body; the signature is the public
+    contract.
+    """
+    return ConformanceReport()

--- a/protocol/contracts.py
+++ b/protocol/contracts.py
@@ -1,0 +1,198 @@
+"""Pydantic wire payloads + adapter Protocol classes.
+
+`PROTOCOL_VERSION` is semver. Minor bumps are additive (new optional fields,
+new methods); major bumps break wire compatibility and require coordinated
+daemon + adapter release. Every grounding-related request carries
+`(repo_id, ref)` because the daemon is user-scoped and repo-separated under
+`~/.bicameral/projects/<repo_id>/`.
+"""
+
+from __future__ import annotations
+
+from typing import Literal, Protocol, runtime_checkable
+
+from pydantic import BaseModel, ConfigDict, Field
+
+PROTOCOL_VERSION = "0.1.0"
+
+BATCH_REGION_LIMIT = 1000
+
+
+class ProtocolError(Exception):
+    """Wire-level protocol failure (malformed frame, unknown method)."""
+
+
+class ProtocolVersionError(ProtocolError):
+    """Raised when client and server disagree on major version."""
+
+
+# ── Ingest ──────────────────────────────────────────────────────────────
+
+
+class IngestRequest(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+    adapter_name: str
+    payload: str
+    source_id: str
+    source_ref: str
+    mode: Literal["active", "passive"] = "active"
+    repo_id: str | None = None
+
+
+class IngestResult(BaseModel):
+    # Server responses tolerate forward-additive fields; inputs stay strict.
+    model_config = ConfigDict(extra="ignore")
+    status: Literal["accepted", "refused", "duplicate"]
+    decision_ids: list[str] = Field(default_factory=list)
+    reason: str | None = None
+
+
+class LinkCommitRequest(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+    repo_id: str
+    commit_sha: str
+    ref: str = "HEAD"
+
+
+class LinkCommitResult(BaseModel):
+    model_config = ConfigDict(extra="ignore")
+    status: Literal["linked", "no_change", "refused"]
+    regions_updated: int = 0
+
+
+# ── Egress ──────────────────────────────────────────────────────────────
+
+
+class NotificationEvent(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+    event_type: str
+    decision_id: str | None = None
+    feature_area: str | None = None
+    summary: str = Field(max_length=200)
+    severity: Literal["info", "warn", "error"] = "info"
+    source_ref: str | None = None
+
+
+class DeliveryResult(BaseModel):
+    model_config = ConfigDict(extra="ignore")
+    status: Literal["delivered", "queued", "failed"]
+    detail: str | None = None
+
+
+# ── Grounding ──────────────────────────────────────────────────────────
+
+
+class ValidateSymbolsRequest(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+    repo_id: str
+    ref: str = "HEAD"
+    candidates: list[str]
+
+
+class Symbol(BaseModel):
+    model_config = ConfigDict(extra="ignore")
+    name: str
+    file: str
+    start_line: int
+    end_line: int
+
+
+class ExtractSymbolsRequest(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+    repo_id: str
+    ref: str = "HEAD"
+    file_path: str
+
+
+class GetNeighborsRequest(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+    repo_id: str
+    ref: str = "HEAD"
+    symbol_id: int
+
+
+class Neighbor(BaseModel):
+    model_config = ConfigDict(extra="ignore")
+    symbol_id: int
+    name: str
+    relation: Literal["calls", "called_by", "imports", "imported_by"]
+
+
+class CodeRegion(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+    file: str
+    symbol: str
+    start_line: int
+    end_line: int
+    stored_hash: str = ""
+
+
+class AnalyzeRegionRequest(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+    repo_id: str
+    ref: str = "HEAD"
+    region: CodeRegion
+    source_context: str = ""
+
+
+class DriftResult(BaseModel):
+    model_config = ConfigDict(extra="ignore")
+    status: Literal["reflected", "drifted", "pending", "ungrounded"]
+    content_hash: str
+    confidence: float = 1.0
+    explanation: str = ""
+
+
+class BatchAnalyzeRequest(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+    repo_id: str
+    ref: str = "HEAD"
+    regions: list[CodeRegion] = Field(max_length=BATCH_REGION_LIMIT)
+
+
+# ── Adapter Protocols ──────────────────────────────────────────────────
+
+
+@runtime_checkable
+class IngestAdapter(Protocol):
+    """Pulls intent + artifact events into the ledger."""
+
+    name: str
+
+    async def ingest(self, req: IngestRequest) -> IngestResult: ...
+
+    async def link_commit(self, req: LinkCommitRequest) -> LinkCommitResult: ...
+
+
+@runtime_checkable
+class EgressAdapter(Protocol):
+    """Delivers notification events to humans where they live."""
+
+    name: str
+
+    async def deliver(self, event: NotificationEvent) -> DeliveryResult: ...
+
+
+@runtime_checkable
+class GroundingPort(Protocol):
+    """Resolves symbols + analyzes drift against a `(repo_id, ref)` pair."""
+
+    async def validate_symbols(
+        self, req: ValidateSymbolsRequest
+    ) -> list[Symbol]: ...
+
+    async def extract_symbols(
+        self, req: ExtractSymbolsRequest
+    ) -> list[Symbol]: ...
+
+    async def get_neighbors(
+        self, req: GetNeighborsRequest
+    ) -> list[Neighbor]: ...
+
+    async def analyze_region(
+        self, req: AnalyzeRegionRequest
+    ) -> DriftResult: ...
+
+    async def batch_analyze_regions(
+        self, req: BatchAnalyzeRequest
+    ) -> list[DriftResult]: ...

--- a/protocol/server.py
+++ b/protocol/server.py
@@ -1,0 +1,96 @@
+"""UDS + JSON-RPC server stub for the universal protocol.
+
+Phase 1 ships the dispatch surface; Phase 2 wires concrete handlers
+(ingest/egress routers, grounding port) when the daemon process is
+extracted. The server today is only used by the conformance test suite and
+by the in-tree round-trip tests for the protocol package itself.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import inspect
+from pathlib import Path
+from typing import Any, Awaitable, Callable
+
+from .contracts import PROTOCOL_VERSION, ProtocolError
+from .transport import make_error, make_response, read_message, write_message
+
+Handler = Callable[[dict[str, Any]], Awaitable[Any]]
+
+
+class ProtocolServer:
+    """Asyncio UDS server with a JSON-RPC method-dispatch table.
+
+    Registered handlers receive the raw `params` dict and return any value
+    JSON-serializable. The built-in ``system.version`` method always
+    responds with the server's ``PROTOCOL_VERSION``.
+    """
+
+    def __init__(self, socket_path: Path) -> None:
+        self._socket_path = socket_path
+        self._methods: dict[str, Handler] = {}
+        self._server: asyncio.AbstractServer | None = None
+        self.register("system.version", self._handle_version)
+
+    @staticmethod
+    async def _handle_version(_: dict[str, Any]) -> str:
+        return PROTOCOL_VERSION
+
+    def register(self, method: str, handler: Handler) -> None:
+        self._methods[method] = handler
+
+    async def start(self) -> None:
+        # Defensive: remove a stale socket file from a previous run.
+        if self._socket_path.exists():
+            self._socket_path.unlink()
+        self._socket_path.parent.mkdir(parents=True, exist_ok=True)
+        self._server = await asyncio.start_unix_server(
+            self._handle_client, path=str(self._socket_path)
+        )
+
+    async def stop(self) -> None:
+        if self._server is not None:
+            self._server.close()
+            await self._server.wait_closed()
+        if self._socket_path.exists():
+            self._socket_path.unlink()
+
+    async def _handle_client(
+        self, reader: asyncio.StreamReader, writer: asyncio.StreamWriter
+    ) -> None:
+        try:
+            while True:
+                try:
+                    msg = await read_message(reader)
+                except ProtocolError:
+                    return
+                await self._handle_message(msg, writer)
+        finally:
+            writer.close()
+            try:
+                await writer.wait_closed()
+            except Exception:
+                pass
+
+    async def _handle_message(
+        self, msg: dict[str, Any], writer: asyncio.StreamWriter
+    ) -> None:
+        req_id = msg.get("id")
+        method = msg.get("method")
+        params = msg.get("params") or {}
+        if not isinstance(method, str):
+            await write_message(writer, make_error(req_id, -32600, "missing method"))
+            return
+        handler = self._methods.get(method)
+        if handler is None:
+            await write_message(writer, make_error(req_id, -32601, f"unknown method {method}"))
+            return
+        try:
+            result = handler(params)
+            if inspect.isawaitable(result):
+                result = await result
+        except Exception as exc:  # noqa: BLE001 — boundary serializes any handler error
+            await write_message(writer, make_error(req_id, -32000, str(exc)))
+            return
+        await write_message(writer, make_response(req_id, result))

--- a/protocol/transport.py
+++ b/protocol/transport.py
@@ -1,0 +1,68 @@
+"""Line-delimited JSON-RPC 2.0 framing over an asyncio stream.
+
+Each message is a single JSON object terminated by ``\n``. Frames are
+size-capped to defend against pathological payloads; oversized frames raise
+``ProtocolError`` and the connection is closed by the caller.
+
+This module does not own a socket — it only frames messages on a pair of
+``asyncio.StreamReader`` / ``asyncio.StreamWriter`` provided by the caller.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+from typing import Any
+
+from .contracts import ProtocolError
+
+MAX_FRAME_BYTES = 16 * 1024 * 1024  # 16 MiB hard cap per message
+
+
+async def read_message(reader: asyncio.StreamReader) -> dict[str, Any]:
+    """Read one JSON object terminated by newline.
+
+    Raises ProtocolError on connection close mid-frame or on malformed JSON.
+    """
+    raw = await reader.readline()
+    if not raw:
+        raise ProtocolError("connection closed")
+    if len(raw) > MAX_FRAME_BYTES:
+        raise ProtocolError(f"frame exceeds {MAX_FRAME_BYTES} bytes")
+    try:
+        obj = json.loads(raw)
+    except json.JSONDecodeError as exc:
+        raise ProtocolError(f"malformed JSON: {exc}") from exc
+    if not isinstance(obj, dict):
+        raise ProtocolError("frame is not a JSON object")
+    return obj
+
+
+async def write_message(
+    writer: asyncio.StreamWriter, payload: dict[str, Any]
+) -> None:
+    """Write one JSON object framed with a trailing newline."""
+    encoded = json.dumps(payload, separators=(",", ":")).encode("utf-8")
+    if len(encoded) > MAX_FRAME_BYTES:
+        raise ProtocolError(f"frame exceeds {MAX_FRAME_BYTES} bytes")
+    writer.write(encoded + b"\n")
+    await writer.drain()
+
+
+def make_request(req_id: int, method: str, params: dict[str, Any]) -> dict[str, Any]:
+    return {"jsonrpc": "2.0", "id": req_id, "method": method, "params": params}
+
+
+def make_response(req_id: int | str | None, result: Any) -> dict[str, Any]:
+    """Per JSON-RPC 2.0, the response id mirrors the request id; null if the
+    request was a notification (server still writes a response here for
+    diagnostics)."""
+    return {"jsonrpc": "2.0", "id": req_id, "result": result}
+
+
+def make_error(req_id: int | None, code: int, message: str) -> dict[str, Any]:
+    return {
+        "jsonrpc": "2.0",
+        "id": req_id,
+        "error": {"code": code, "message": message},
+    }

--- a/tests/test_protocol_serialization.py
+++ b/tests/test_protocol_serialization.py
@@ -1,0 +1,44 @@
+"""Phase 1 contracts: Pydantic serialization round-trip + size-cap enforcement.
+
+Per the audit-passed plan in
+``docs/Planning/plan-daemon-extract-universal-surface.md``.
+"""
+
+from __future__ import annotations
+
+import pytest
+from pydantic import ValidationError
+
+from protocol.contracts import (
+    BATCH_REGION_LIMIT,
+    BatchAnalyzeRequest,
+    CodeRegion,
+    IngestRequest,
+)
+
+
+def test_ingest_request_roundtrips_lossless() -> None:
+    """Serialization must not silently drop or coerce fields."""
+    original = IngestRequest(
+        adapter_name="mcp",
+        payload="we decided to use idempotency keys",
+        source_id="mcp:session_2026-05-19",
+        source_ref="session_2026-05-19",
+        mode="passive",
+        repo_id="bicameral-payments",
+    )
+    roundtripped = IngestRequest.model_validate(original.model_dump())
+    assert roundtripped == original
+
+
+def test_batch_request_rejects_over_thousand_regions() -> None:
+    """BATCH_REGION_LIMIT defends the daemon against flooded payloads."""
+    region = CodeRegion(
+        file="x.py", symbol="f", start_line=1, end_line=2, stored_hash="aaa"
+    )
+    with pytest.raises(ValidationError):
+        BatchAnalyzeRequest(
+            repo_id="repo",
+            ref="HEAD",
+            regions=[region] * (BATCH_REGION_LIMIT + 1),
+        )

--- a/tests/test_protocol_transport_uds.py
+++ b/tests/test_protocol_transport_uds.py
@@ -1,0 +1,88 @@
+"""Phase 1 transport: UDS+JSON-RPC client/server end-to-end + per-client isolation."""
+
+from __future__ import annotations
+
+import asyncio
+import shutil
+import tempfile
+from pathlib import Path
+
+import pytest
+
+from protocol.client import ProtocolClient
+from protocol.contracts import ValidateSymbolsRequest
+from protocol.server import ProtocolServer
+
+
+@pytest.fixture
+def short_socket_dir():
+    """macOS limits AF_UNIX paths to ~104 chars; pytest's tmp_path is too deep."""
+    base = Path(tempfile.mkdtemp(prefix="bm-", dir="/tmp"))
+    try:
+        yield base
+    finally:
+        shutil.rmtree(base, ignore_errors=True)
+
+
+@pytest.fixture
+async def running_server(short_socket_dir: Path):
+    """Boot a ProtocolServer with a fixture symbol handler bound."""
+    server = ProtocolServer(short_socket_dir / "d.sock")
+
+    async def handle_validate(params: dict) -> list[dict]:
+        names = params.get("candidates", [])
+        return [
+            {"name": name, "file": f"{name}.py", "start_line": 1, "end_line": 5}
+            for name in names
+        ]
+
+    server.register("grounding.validate_symbols", handle_validate)
+    await server.start()
+    try:
+        yield server, short_socket_dir / "d.sock"
+    finally:
+        await server.stop()
+
+
+async def test_client_rpc_returns_server_payload(running_server) -> None:
+    """Assertion is on the *list returned*, not on call presence."""
+    _server, socket_path = running_server
+    client = ProtocolClient(socket_path=socket_path)
+    await client.connect()
+    try:
+        result = await client.validate_symbols(
+            ValidateSymbolsRequest(
+                repo_id="r", ref="HEAD", candidates=["foo", "bar"]
+            )
+        )
+    finally:
+        await client.close()
+    assert [s.name for s in result] == ["foo", "bar"]
+    assert all(s.start_line == 1 and s.end_line == 5 for s in result)
+
+
+async def test_two_clients_no_response_interleave(running_server) -> None:
+    """Each client's responses come back in its own request order."""
+    _server, socket_path = running_server
+
+    async def run_client(label: str) -> list[list[str]]:
+        client = ProtocolClient(socket_path=socket_path)
+        await client.connect()
+        try:
+            results: list[list[str]] = []
+            for i in range(50):
+                req = ValidateSymbolsRequest(
+                    repo_id="r",
+                    ref="HEAD",
+                    candidates=[f"{label}_{i}"],
+                )
+                resp = await client.validate_symbols(req)
+                results.append([s.name for s in resp])
+            return results
+        finally:
+            await client.close()
+
+    a_results, b_results = await asyncio.gather(run_client("a"), run_client("b"))
+
+    assert [r[0] for r in a_results] == [f"a_{i}" for i in range(50)]
+    assert [r[0] for r in b_results] == [f"b_{i}" for i in range(50)]

--- a/tests/test_protocol_versioning.py
+++ b/tests/test_protocol_versioning.py
@@ -1,0 +1,83 @@
+"""Phase 1 versioning: minor-additive tolerance + major-bump rejection."""
+
+from __future__ import annotations
+
+import shutil
+import tempfile
+from pathlib import Path
+
+import pytest
+
+from protocol.client import ProtocolClient
+from protocol.contracts import IngestRequest, IngestResult, ProtocolVersionError
+from protocol.server import ProtocolServer
+
+
+@pytest.fixture
+def short_socket_dir():
+    """macOS AF_UNIX path is ~104-char capped; pytest tmp_path is too deep."""
+    base = Path(tempfile.mkdtemp(prefix="bm-", dir="/tmp"))
+    try:
+        yield base
+    finally:
+        shutil.rmtree(base, ignore_errors=True)
+
+
+async def test_v0_1_client_ignores_unknown_field_from_v0_2_server(
+    short_socket_dir: Path,
+) -> None:
+    """Server returns a payload with an extra field; v0.1 client tolerates it.
+
+    Minor-version bumps add optional fields. The wire layer must not choke
+    on unknown keys in a response; the typed client extracts only declared
+    fields and discards the rest.
+    """
+    server = ProtocolServer(short_socket_dir / "d.sock")
+
+    async def handle_ingest_with_extra_field(_params: dict) -> dict:
+        return {
+            "status": "accepted",
+            "decision_ids": ["d1"],
+            "reason": None,
+            "future_telemetry": {"latency_ms": 42},  # v0.2 addition
+        }
+
+    server.register("ingest.ingest", handle_ingest_with_extra_field)
+    await server.start()
+
+    client = ProtocolClient(socket_path=short_socket_dir / "d.sock")
+    try:
+        await client.connect()
+        result = await client.ingest(
+            IngestRequest(
+                adapter_name="mcp",
+                payload="x",
+                source_id="s",
+                source_ref="r",
+            )
+        )
+        assert isinstance(result, IngestResult)
+        assert result.status == "accepted"
+        assert result.decision_ids == ["d1"]
+    finally:
+        await client.close()
+        await server.stop()
+
+
+async def test_v0_1_client_rejects_major_bump_server(short_socket_dir: Path) -> None:
+    """Server advertises a future major version; client.connect() raises."""
+    server = ProtocolServer(short_socket_dir / "d.sock")
+
+    async def handle_version(_params: dict) -> str:
+        return "1.0.0"
+
+    server.register("system.version", handle_version)
+    await server.start()
+
+    client = ProtocolClient(socket_path=short_socket_dir / "d.sock")
+    try:
+        with pytest.raises(ProtocolVersionError):
+            await client.connect()
+    finally:
+        await client.close()
+        await server.stop()


### PR DESCRIPTION
## Summary

First phase of the daemon-extraction refactor — introduces `protocol/`, a transport-neutral universal surface that the MCP server (and future adapters: Linear, Notion, Slack, future grounders) will talk through to the daemon. In Phase 3 `protocol/` extracts to the public `bicameral-protocol` package; the universal surface reframes MCP as one integration among many.

**What's in this PR** (Phase 1 only — Phase 2 is daemon extraction in-tree, Phase 3 is the repo split):

- `protocol/contracts.py` — Pydantic models + three PEP 544 Protocols (`IngestAdapter`, `EgressAdapter`, `GroundingPort`). Inputs `extra="forbid"`, outputs `extra="ignore"` so minor-version-additive fields on responses don't break older clients.
- `protocol/transport.py` — line-delimited JSON-RPC 2.0 framing over an asyncio stream; 16 MiB frame cap.
- `protocol/client.py` — `ProtocolClient` over UDS; single multiplexed connection; matches responses to requests by `id`; performs a `system.version` major-version handshake on `connect()`.
- `protocol/server.py` — `ProtocolServer` with method-dispatch table; built-in `system.version`; registers adapter handlers at startup.
- `protocol/conformance.py` — empty harness skeleton; Phase 3 ships the published suite.
- 6 tests across `tests/test_protocol_{serialization,transport_uds,versioning}.py`.

**Surface choices worth flagging for review**:
- Transport: UDS + JSON-RPC 2.0. Streamlined for localhost. gRPC deferred until streaming-query benchmarks justify it.
- Every grounding request carries `(repo_id, ref)` because the daemon is user-scoped + repo-separated under `~/.bicameral/projects/<repo_id>/`. Parallel worktrees on different branches hit different cache slots.
- `BatchAnalyzeRequest` is capped at 1000 regions — defense + the IPC-latency budget for `bicameral.preflight`'s fan-out.
- `PROTOCOL_VERSION = "0.1.0"`. Minor bumps additive; major bumps require coordinated release.

## Plan / Audit / Seal

- **Plan**: `docs/Planning/plan-daemon-extract-universal-surface.md` (gitignored per qor convention)
  sha256:`c8678f36de684b1a57d60e87ba78d61a9fb3973bb792dda5f65b0df262a2ab1e`
- **Audit**: PASS — 2 `infrastructure-mismatch` findings caught + remediated in-pass
  report sha256:`3d4e03d3bca5a7a6b3c2397b37720994e845836be58e9c29bd118df4fb79adc1`
- **Seal**: pending merge to `dev`

## Test plan

- [x] `pytest tests/test_protocol_serialization.py -v` (2/2)
- [x] `pytest tests/test_protocol_transport_uds.py -v` (2/2)
- [x] `pytest tests/test_protocol_versioning.py -v` (2/2)
- [x] `mypy protocol/` — no issues
- [x] `python scripts/lint_plan_grounding.py docs/Planning/plan-daemon-extract-universal-surface.md` — clean

## What's NOT in this PR (and is coming)

- Phase 2 — daemon extraction in-tree (the actual BicameralAI/bicameral-mcp#301 fix, BicameralAI/bicameral-daemon#1's body). Moves `ledger/`, `dashboard/`, `governance/`, `audit_log.py`, the Drive sync worker, AND code-grounding (`code_locator/`, `codegenome/`, `ports.py`, `adapters/code_locator.py`, `adapters/codegenome.py`) into `daemon/`. Rewrites every handler to go through `ProtocolClient`. Implements `integrations/mcp_adapter/`.
- Phase 3 — repo split + issue migration. Promotes `protocol/` → public `BicameralAI/bicameral-protocol`; extracts `daemon/` → private `BicameralAI/bicameral-daemon`.

## Linked issues

Refs BicameralAI/bicameral-daemon#1 — sibling daemon issue, Phase 2 implements its acceptance criteria
Refs BicameralAI/bicameral-daemon#2 — ledger locator, prerequisite (already merged-to-dev)
Refs BicameralAI/bicameral-daemon#3 — unified ingest tracker, Phase 4 ships Linear/Notion/Slack adapters against this surface
Refs BicameralAI/bicameral-daemon#4 — notification hub, `EgressAdapter` is its contract
Refs BicameralAI/bicameral-daemon#5 — Dashboard v2 epic, frontend will consume TS bindings of these models in Phase 3
Refs BicameralAI/bicameral-mcp#301 — concurrent-writer revision errors, closes via Phase 2

🤖 Generated with [Claude Code](https://claude.com/claude-code)