### PR TITLE
feat(daemon): supervisor + adapter registry skeleton (Phase 2a)

### DIFF
--- a/daemon/__init__.py
+++ b/daemon/__init__.py
@@ -1,0 +1,29 @@
+"""bicameral-daemon — user-scoped, repo-separated process owning the ledger,
+grounding, dashboard, sync, and audit/governance state.
+
+Phase 2a (this commit): scaffolding only. The daemon supervises its own
+lifecycle and hosts the ProtocolServer surface from Phase 1; registered
+adapters provide ingest/egress behavior. Code moves into ``daemon/*`` —
+ledger, dashboard, grounding, sync — land in Phase 2c. The supervisor
+gains real surreal-child spawning + LaunchAgent install in Phase 2c.
+
+Phase 3 extracts this package to the private ``bicameral-daemon`` repo.
+"""
+
+from __future__ import annotations
+
+from .registry import AdapterRegistry, AdapterRegistryError
+from .runtime import Runtime
+from .supervisor import Supervisor, SupervisorError, SupervisorStatus
+
+DAEMON_VERSION = "0.1.0"
+
+__all__ = [
+    "AdapterRegistry",
+    "AdapterRegistryError",
+    "DAEMON_VERSION",
+    "Runtime",
+    "Supervisor",
+    "SupervisorError",
+    "SupervisorStatus",
+]

--- a/daemon/registry.py
+++ b/daemon/registry.py
@@ -1,0 +1,58 @@
+"""Adapter registry — keyed lookup of IngestAdapter / EgressAdapter
+instances by ``adapter.name``.
+
+Adapters register themselves on daemon startup; the protocol router uses
+this map to dispatch ``ingest.ingest(adapter_name="mcp", ...)`` and
+``egress.deliver(channel="slack", ...)`` calls to the right backend.
+
+The registry is *opinionated about uniqueness*: registering two adapters
+with the same name raises rather than silently shadowing. Daemons that
+need multiple instances of the same adapter type must give them distinct
+names (``"linear-eng"`` vs ``"linear-product"``).
+"""
+
+from __future__ import annotations
+
+from protocol.contracts import EgressAdapter, IngestAdapter
+
+
+class AdapterRegistryError(Exception):
+    """Raised on duplicate registration or unknown lookup."""
+
+
+class AdapterRegistry:
+    def __init__(self) -> None:
+        self._ingest: dict[str, IngestAdapter] = {}
+        self._egress: dict[str, EgressAdapter] = {}
+
+    def register_ingest(self, adapter: IngestAdapter) -> None:
+        if adapter.name in self._ingest:
+            raise AdapterRegistryError(
+                f"ingest adapter '{adapter.name}' already registered"
+            )
+        self._ingest[adapter.name] = adapter
+
+    def register_egress(self, adapter: EgressAdapter) -> None:
+        if adapter.name in self._egress:
+            raise AdapterRegistryError(
+                f"egress adapter '{adapter.name}' already registered"
+            )
+        self._egress[adapter.name] = adapter
+
+    def lookup_ingest(self, name: str) -> IngestAdapter:
+        try:
+            return self._ingest[name]
+        except KeyError as exc:
+            raise AdapterRegistryError(f"unknown ingest adapter '{name}'") from exc
+
+    def lookup_egress(self, name: str) -> EgressAdapter:
+        try:
+            return self._egress[name]
+        except KeyError as exc:
+            raise AdapterRegistryError(f"unknown egress adapter '{name}'") from exc
+
+    def ingest_names(self) -> list[str]:
+        return sorted(self._ingest.keys())
+
+    def egress_names(self) -> list[str]:
+        return sorted(self._egress.keys())

--- a/daemon/runtime.py
+++ b/daemon/runtime.py
@@ -1,0 +1,80 @@
+"""In-process runtime: hosts the ProtocolServer + AdapterRegistry.
+
+The runtime is the *thing inside* the daemon process. It registers all
+default RPC methods (`ingest.*`, `egress.*`, `grounding.*`, `system.*`)
+against the registry, then runs the server until ``stop()`` is called.
+
+In Phase 2c the runtime also spawns + supervises the surreal child
+process; today it only hosts the protocol surface.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+from protocol.contracts import (
+    IngestRequest,
+    LinkCommitRequest,
+    NotificationEvent,
+)
+from protocol.server import ProtocolServer
+
+from .registry import AdapterRegistry
+
+
+class Runtime:
+    def __init__(self, socket_path: Path, registry: AdapterRegistry) -> None:
+        self._registry = registry
+        self._server = ProtocolServer(socket_path)
+        self._register_default_methods()
+
+    @property
+    def server(self) -> ProtocolServer:
+        return self._server
+
+    @property
+    def registry(self) -> AdapterRegistry:
+        return self._registry
+
+    def _register_default_methods(self) -> None:
+        self._server.register("ingest.ingest", self._handle_ingest)
+        self._server.register("ingest.link_commit", self._handle_link_commit)
+        self._server.register("egress.deliver", self._handle_deliver)
+        # grounding.* methods land in Phase 2c when the code-locator + drift
+        # analyzer move into daemon/grounding/. system.version is already
+        # registered by ProtocolServer itself.
+
+    async def _handle_ingest(self, params: dict[str, Any]) -> dict[str, Any]:
+        req = IngestRequest.model_validate(params)
+        adapter = self._registry.lookup_ingest(req.adapter_name)
+        result = await adapter.ingest(req)
+        return result.model_dump()
+
+    async def _handle_link_commit(self, params: dict[str, Any]) -> dict[str, Any]:
+        req = LinkCommitRequest.model_validate(params)
+        # link_commit dispatches to ANY ingest adapter that opted into commit
+        # binding — for v0.1 we route by repo_id convention; the active MCP
+        # adapter handles all commits in its repo. Phase 2c generalizes.
+        ingest_names = self._registry.ingest_names()
+        if not ingest_names:
+            raise RuntimeError("no ingest adapters registered for link_commit")
+        adapter = self._registry.lookup_ingest(ingest_names[0])
+        result = await adapter.link_commit(req)
+        return result.model_dump()
+
+    async def _handle_deliver(self, params: dict[str, Any]) -> dict[str, Any]:
+        # The egress channel is selected by the embedded channel name.
+        channel = params.pop("channel", None)
+        if not isinstance(channel, str):
+            raise ValueError("egress.deliver requires a 'channel' string")
+        event = NotificationEvent.model_validate(params)
+        adapter = self._registry.lookup_egress(channel)
+        result = await adapter.deliver(event)
+        return result.model_dump()
+
+    async def start(self) -> None:
+        await self._server.start()
+
+    async def stop(self) -> None:
+        await self._server.stop()

--- a/daemon/supervisor.py
+++ b/daemon/supervisor.py
@@ -1,0 +1,124 @@
+"""Supervisor — in-process lifecycle controller for the daemon Runtime.
+
+Writes ``~/.bicameral/daemon.json`` so ProtocolClients can discover the
+socket without coordinating out-of-band. ``start()`` is idempotent — a
+second call returns the same status.
+
+Phase 2c wires this up to a real OS-level process (LaunchAgent on macOS,
+systemd-user on Linux, TBD on Windows) so the daemon survives shell
+sessions. Today the supervisor only manages the runtime *within the
+calling process* — which is enough to test the protocol contract end-to-
+end and is also exactly what MCP needs when no system daemon is yet
+installed.
+"""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+from enum import Enum
+from pathlib import Path
+
+from .registry import AdapterRegistry
+from .runtime import Runtime
+
+
+class SupervisorError(Exception):
+    """Raised on lifecycle violations (e.g., stop before start)."""
+
+
+class SupervisorStatus(str, Enum):
+    STOPPED = "stopped"
+    RUNNING = "running"
+
+
+@dataclass
+class _DaemonDescriptor:
+    """Wire format for ``~/.bicameral/daemon.json``."""
+
+    socket_path: str
+    pid: int
+
+    def to_json(self) -> str:
+        return json.dumps({"socket_path": self.socket_path, "pid": self.pid})
+
+
+def default_state_dir() -> Path:
+    return Path.home() / ".bicameral"
+
+
+def default_socket_path() -> Path:
+    return default_state_dir() / "daemon.sock"
+
+
+def default_descriptor_path() -> Path:
+    return default_state_dir() / "daemon.json"
+
+
+class Supervisor:
+    def __init__(
+        self,
+        registry: AdapterRegistry | None = None,
+        socket_path: Path | None = None,
+        descriptor_path: Path | None = None,
+    ) -> None:
+        self._registry = registry or AdapterRegistry()
+        self._socket_path = socket_path or default_socket_path()
+        self._descriptor_path = descriptor_path or default_descriptor_path()
+        self._runtime: Runtime | None = None
+        self._status: SupervisorStatus = SupervisorStatus.STOPPED
+
+    @property
+    def registry(self) -> AdapterRegistry:
+        return self._registry
+
+    @property
+    def runtime(self) -> Runtime | None:
+        return self._runtime
+
+    @property
+    def status(self) -> SupervisorStatus:
+        return self._status
+
+    @property
+    def socket_path(self) -> Path:
+        return self._socket_path
+
+    async def start(self) -> SupervisorStatus:
+        if self._status == SupervisorStatus.RUNNING:
+            return self._status
+        runtime = Runtime(self._socket_path, self._registry)
+        await runtime.start()
+        self._runtime = runtime
+        self._write_descriptor()
+        self._status = SupervisorStatus.RUNNING
+        return self._status
+
+    async def stop(self) -> SupervisorStatus:
+        if self._status == SupervisorStatus.STOPPED:
+            return self._status
+        assert self._runtime is not None  # invariant: RUNNING ⇒ runtime exists
+        await self._runtime.stop()
+        self._runtime = None
+        self._remove_descriptor()
+        self._status = SupervisorStatus.STOPPED
+        return self._status
+
+    async def restart(self) -> SupervisorStatus:
+        if self._status == SupervisorStatus.RUNNING:
+            await self.stop()
+        return await self.start()
+
+    def _write_descriptor(self) -> None:
+        import os
+
+        self._descriptor_path.parent.mkdir(parents=True, exist_ok=True)
+        descriptor = _DaemonDescriptor(
+            socket_path=str(self._socket_path),
+            pid=os.getpid(),
+        )
+        self._descriptor_path.write_text(descriptor.to_json(), encoding="utf-8")
+
+    def _remove_descriptor(self) -> None:
+        if self._descriptor_path.exists():
+            self._descriptor_path.unlink()

--- a/tests/test_daemon_registry.py
+++ b/tests/test_daemon_registry.py
@@ -1,0 +1,70 @@
+"""Phase 2a: adapter registry uniqueness + lookup semantics."""
+
+from __future__ import annotations
+
+import pytest
+
+from daemon.registry import AdapterRegistry, AdapterRegistryError
+from protocol.contracts import (
+    DeliveryResult,
+    IngestRequest,
+    IngestResult,
+    LinkCommitRequest,
+    LinkCommitResult,
+    NotificationEvent,
+)
+
+
+class _FakeIngest:
+    def __init__(self, name: str) -> None:
+        self.name = name
+
+    async def ingest(self, _req: IngestRequest) -> IngestResult:
+        return IngestResult(status="accepted")
+
+    async def link_commit(self, _req: LinkCommitRequest) -> LinkCommitResult:
+        return LinkCommitResult(status="linked")
+
+
+class _FakeEgress:
+    def __init__(self, name: str) -> None:
+        self.name = name
+
+    async def deliver(self, _event: NotificationEvent) -> DeliveryResult:
+        return DeliveryResult(status="delivered")
+
+
+def test_register_ingest_then_lookup_returns_same_instance() -> None:
+    """Registry returns the registered instance on lookup."""
+    registry = AdapterRegistry()
+    adapter = _FakeIngest("mcp")
+    registry.register_ingest(adapter)
+    assert registry.lookup_ingest("mcp") is adapter
+
+
+def test_duplicate_ingest_name_raises_on_second_register() -> None:
+    """Two adapters with same name = error, not silent shadow."""
+    registry = AdapterRegistry()
+    registry.register_ingest(_FakeIngest("mcp"))
+    with pytest.raises(AdapterRegistryError, match="already registered"):
+        registry.register_ingest(_FakeIngest("mcp"))
+
+
+def test_unknown_egress_lookup_raises() -> None:
+    """Unknown name is an error — callers cannot silently fall through."""
+    registry = AdapterRegistry()
+    with pytest.raises(AdapterRegistryError, match="unknown egress adapter"):
+        registry.lookup_egress("slack")
+
+
+def test_ingest_and_egress_namespaces_are_independent() -> None:
+    """Same name in both namespaces does not collide."""
+    registry = AdapterRegistry()
+    ing = _FakeIngest("notion")
+    egr = _FakeEgress("notion")
+    registry.register_ingest(ing)
+    registry.register_egress(egr)
+    assert registry.lookup_ingest("notion") is ing
+    assert registry.lookup_egress("notion") is egr
+    assert registry.ingest_names() == ["notion"]
+    assert registry.egress_names() == ["notion"]

--- a/tests/test_daemon_runtime_dispatch.py
+++ b/tests/test_daemon_runtime_dispatch.py
@@ -1,0 +1,133 @@
+"""Phase 2a: Runtime correctly dispatches protocol calls to registered adapters."""
+
+from __future__ import annotations
+
+import shutil
+import tempfile
+from pathlib import Path
+
+import pytest
+
+from daemon.registry import AdapterRegistry, AdapterRegistryError
+from daemon.runtime import Runtime
+from protocol.client import ProtocolClient
+from protocol.contracts import (
+    DeliveryResult,
+    IngestRequest,
+    IngestResult,
+    LinkCommitRequest,
+    LinkCommitResult,
+    NotificationEvent,
+)
+
+
+@pytest.fixture
+def short_socket_dir():
+    base = Path(tempfile.mkdtemp(prefix="bm-", dir="/tmp"))
+    try:
+        yield base
+    finally:
+        shutil.rmtree(base, ignore_errors=True)
+
+
+class _RecordingIngest:
+    def __init__(self, name: str) -> None:
+        self.name = name
+        self.calls: list[IngestRequest] = []
+
+    async def ingest(self, req: IngestRequest) -> IngestResult:
+        self.calls.append(req)
+        return IngestResult(status="accepted", decision_ids=["d1"])
+
+    async def link_commit(self, _req: LinkCommitRequest) -> LinkCommitResult:
+        return LinkCommitResult(status="linked", regions_updated=3)
+
+
+class _RecordingEgress:
+    def __init__(self, name: str) -> None:
+        self.name = name
+        self.calls: list[NotificationEvent] = []
+
+    async def deliver(self, event: NotificationEvent) -> DeliveryResult:
+        self.calls.append(event)
+        return DeliveryResult(status="delivered")
+
+
+async def test_runtime_routes_ingest_to_registered_adapter(short_socket_dir: Path) -> None:
+    """Client.ingest with adapter_name='mcp' reaches the mcp adapter and returns its result."""
+    registry = AdapterRegistry()
+    adapter = _RecordingIngest("mcp")
+    registry.register_ingest(adapter)
+    runtime = Runtime(short_socket_dir / "d.sock", registry)
+    await runtime.start()
+    client = ProtocolClient(socket_path=short_socket_dir / "d.sock")
+    try:
+        await client.connect()
+        result = await client.ingest(
+            IngestRequest(
+                adapter_name="mcp",
+                payload="we decided X",
+                source_id="src-1",
+                source_ref="ref-1",
+            )
+        )
+    finally:
+        await client.close()
+        await runtime.stop()
+    assert result.status == "accepted"
+    assert result.decision_ids == ["d1"]
+    assert len(adapter.calls) == 1
+    assert adapter.calls[0].payload == "we decided X"
+
+
+async def test_runtime_routes_egress_to_channel_named_in_params(
+    short_socket_dir: Path,
+) -> None:
+    """egress.deliver carries a 'channel' param naming the registered egress adapter."""
+    registry = AdapterRegistry()
+    slack = _RecordingEgress("slack")
+    stderr = _RecordingEgress("stderr")
+    registry.register_egress(slack)
+    registry.register_egress(stderr)
+    runtime = Runtime(short_socket_dir / "d.sock", registry)
+    await runtime.start()
+    client = ProtocolClient(socket_path=short_socket_dir / "d.sock")
+    try:
+        await client.connect()
+        # Build the wire payload directly so we can pass 'channel'.
+        params = NotificationEvent(
+            event_type="drift_detected",
+            summary="velocity threshold drifted",
+            severity="warn",
+        ).model_dump()
+        params["channel"] = "slack"
+        result = await client._call("egress.deliver", params)
+    finally:
+        await client.close()
+        await runtime.stop()
+    assert result["status"] == "delivered"
+    assert len(slack.calls) == 1
+    assert len(stderr.calls) == 0
+
+
+async def test_runtime_rejects_unknown_adapter_name(short_socket_dir: Path) -> None:
+    """An ingest call with an unregistered adapter_name surfaces as an RPC error."""
+    registry = AdapterRegistry()
+    # No adapters registered.
+    runtime = Runtime(short_socket_dir / "d.sock", registry)
+    await runtime.start()
+    client = ProtocolClient(socket_path=short_socket_dir / "d.sock")
+    try:
+        await client.connect()
+        with pytest.raises(Exception, match="unknown ingest adapter"):
+            await client.ingest(
+                IngestRequest(
+                    adapter_name="linear",
+                    payload="x",
+                    source_id="s",
+                    source_ref="r",
+                )
+            )
+    finally:
+        await client.close()
+        await runtime.stop()

--- a/tests/test_daemon_supervisor.py
+++ b/tests/test_daemon_supervisor.py
@@ -1,0 +1,115 @@
+"""Phase 2a: supervisor start/stop idempotency + descriptor file contract.
+
+Phase 2c will add real OS-level process spawning + LaunchAgent integration.
+These tests cover the in-process lifecycle controller that's enough to
+host the protocol surface and serve MCP today.
+"""
+
+from __future__ import annotations
+
+import json
+import shutil
+import tempfile
+from pathlib import Path
+
+import pytest
+
+from daemon.registry import AdapterRegistry
+from daemon.supervisor import Supervisor, SupervisorStatus
+from protocol.client import ProtocolClient
+
+
+@pytest.fixture
+def short_state_dir():
+    """macOS AF_UNIX limit; pytest tmp_path is too deep for the socket."""
+    base = Path(tempfile.mkdtemp(prefix="bm-", dir="/tmp"))
+    try:
+        yield base
+    finally:
+        shutil.rmtree(base, ignore_errors=True)
+
+
+def _make_supervisor(state_dir: Path) -> Supervisor:
+    return Supervisor(
+        registry=AdapterRegistry(),
+        socket_path=state_dir / "d.sock",
+        descriptor_path=state_dir / "daemon.json",
+    )
+
+
+async def test_start_writes_descriptor_with_socket_and_pid(
+    short_state_dir: Path,
+) -> None:
+    """After start(), daemon.json carries the socket path + PID."""
+    import os
+
+    sup = _make_supervisor(short_state_dir)
+    try:
+        await sup.start()
+        descriptor = json.loads(
+            (short_state_dir / "daemon.json").read_text(encoding="utf-8")
+        )
+        assert descriptor["socket_path"] == str(short_state_dir / "d.sock")
+        assert descriptor["pid"] == os.getpid()
+        assert sup.status == SupervisorStatus.RUNNING
+    finally:
+        await sup.stop()
+
+
+async def test_double_start_is_idempotent_no_second_runtime(
+    short_state_dir: Path,
+) -> None:
+    """Two start() calls produce one Runtime instance, not two."""
+    sup = _make_supervisor(short_state_dir)
+    try:
+        await sup.start()
+        runtime_after_first = sup.runtime
+        await sup.start()
+        assert sup.runtime is runtime_after_first
+        assert sup.status == SupervisorStatus.RUNNING
+    finally:
+        await sup.stop()
+
+
+async def test_stop_removes_descriptor_and_transitions_to_stopped(
+    short_state_dir: Path,
+) -> None:
+    """Clean shutdown deletes daemon.json + flips status."""
+    sup = _make_supervisor(short_state_dir)
+    await sup.start()
+    assert (short_state_dir / "daemon.json").exists()
+    await sup.stop()
+    assert not (short_state_dir / "daemon.json").exists()
+    assert sup.status == SupervisorStatus.STOPPED
+
+
+async def test_protocol_client_connects_via_descriptor_socket_path(
+    short_state_dir: Path,
+) -> None:
+    """End-to-end: client reads daemon.json, connects, handshake passes."""
+    sup = _make_supervisor(short_state_dir)
+    try:
+        await sup.start()
+        descriptor = json.loads(
+            (short_state_dir / "daemon.json").read_text(encoding="utf-8")
+        )
+        client = ProtocolClient(socket_path=Path(descriptor["socket_path"]))
+        try:
+            await client.connect()  # verifies system.version handshake
+        finally:
+            await client.close()
+    finally:
+        await sup.stop()
+
+
+async def test_restart_starts_new_runtime_instance(short_state_dir: Path) -> None:
+    """After restart(), the runtime is a fresh instance."""
+    sup = _make_supervisor(short_state_dir)
+    try:
+        await sup.start()
+        runtime_before = sup.runtime
+        await sup.restart()
+        assert sup.runtime is not runtime_before
+        assert sup.status == SupervisorStatus.RUNNING
+    finally:
+        await sup.stop()


### PR DESCRIPTION
## Summary

Phase 2a of the daemon-extraction refactor — introduces the `daemon/` module: in-process lifecycle controller (`Supervisor`), the adapter registry (`AdapterRegistry`), and the runtime that wires `ProtocolServer` to registered adapters. No code is moved yet; this lands the scaffolding that Phases 2b and 2c populate.

**What's in this PR**:

- `daemon/registry.py` — `AdapterRegistry` with separate ingest/egress namespaces; duplicate names raise rather than silently shadow.
- `daemon/runtime.py` — `Runtime` registers `ingest.ingest`, `ingest.link_commit`, `egress.deliver` against the registry and serves them over `ProtocolServer`.
- `daemon/supervisor.py` — `Supervisor` owns the Runtime; idempotent `start()`, clean `stop()`, `restart()`, status. Writes `~/.bicameral/daemon.json` with socket path + PID so `ProtocolClient` can discover the daemon without out-of-band coordination.
- 12 tests across `tests/test_daemon_{registry,supervisor,runtime_dispatch}.py`; Phase 1's 6 tests regress green.

**Surface choices**:
- Supervisor manages lifecycle *in-process* for Phase 2a. Real OS-level process supervision (LaunchAgent on macOS, surreal child) lands in Phase 2c — when the ledger physically moves into `daemon/`. Today's in-process daemon is exactly what MCP needs when no system daemon is installed.
- `link_commit` dispatch picks the first registered ingest adapter (single-MCP-adapter assumption). Phase 2c generalizes to per-repo routing once multiple adapters can register.
- `egress.deliver`'s wire payload carries a `channel: str` parameter naming the egress adapter; the rest of the payload deserializes into `NotificationEvent`.

## Plan / Audit / Seal

- **Plan**: `docs/Planning/plan-daemon-extract-universal-surface.md` (gitignored per qor convention)
  sha256:`c8678f36de684b1a57d60e87ba78d61a9fb3973bb792dda5f65b0df262a2ab1e`
  Phase 2 Affected Files section covers `daemon/registry.py`, `daemon/runtime.py`, `daemon/supervisor.py`.
- **Audit**: covered by the umbrella audit on the daemon-extract plan (verdict PASS).
  report sha256:`3d4e03d3bca5a7a6b3c2397b37720994e845836be58e9c29bd118df4fb79adc1`
- **Seal**: pending merge to `dev`

## Test plan

- [x] `pytest tests/test_daemon_registry.py -v` (4/4)
- [x] `pytest tests/test_daemon_supervisor.py -v` (5/5)
- [x] `pytest tests/test_daemon_runtime_dispatch.py -v` (3/3)
- [x] Phase 1 regression: `pytest tests/test_protocol_*.py -v` (6/6)
- [x] `mypy daemon/ protocol/` — no issues

## What's NOT in this PR (and is coming)

- Phase 2b — handler routing through `ProtocolClient` (every handler in `handlers/` stops importing `ledger.*` / `dashboard.*` etc. directly, talks to the daemon via the protocol).
- Phase 2c — physical code moves into `daemon/` (ledger, dashboard, governance, audit, grounding); LaunchAgent install; surreal child supervision; closes BicameralAI/bicameral-mcp#301 + most of BicameralAI/bicameral-daemon#1 ACs.

## Linked issues

Refs BicameralAI/bicameral-daemon#1 — Phase 2c implements full ACs
Refs BicameralAI/bicameral-daemon#2 — Phase 2c rebinds onto the ledger locator
Refs BicameralAI/bicameral-daemon#3 — adapters register against `AdapterRegistry`
Refs BicameralAI/bicameral-daemon#4 — `EgressAdapter` dispatch lives here

Stacks on top of BicameralAI/bicameral-mcp#485 (Phase 1, merged).

🤖 Generated with [Claude Code](https://claude.com/claude-code)