### PR TITLE
feat(daemon): MCP adapter shells + tenant-aware bootstrap (Phase 2b)

### DIFF
--- a/daemon/runtime.py
+++ b/daemon/runtime.py
@@ -4,8 +4,10 @@ The runtime is the *thing inside* the daemon process. It registers all
 default RPC methods (`ingest.*`, `egress.*`, `grounding.*`, `system.*`)
 against the registry, then runs the server until ``stop()`` is called.
 
-In Phase 2c the runtime also spawns + supervises the surreal child
-process; today it only hosts the protocol surface.
+Phase 2b: adapters now receive a ConnectionContext alongside their request
+so they can scope per tenant. Phase 2c will spawn + supervise the surreal
+child process and wire concrete handlers; today the runtime hosts the
+protocol surface and dispatches to registered adapter shells.
 """
 
 from __future__ import annotations
@@ -14,6 +16,7 @@ from pathlib import Path
 from typing import Any
 
 from protocol.contracts import (
+    ConnectionContext,
     IngestRequest,
     LinkCommitRequest,
     NotificationEvent,
@@ -42,16 +45,20 @@ class Runtime:
         self._server.register("ingest.link_commit", self._handle_link_commit)
         self._server.register("egress.deliver", self._handle_deliver)
         # grounding.* methods land in Phase 2c when the code-locator + drift
-        # analyzer move into daemon/grounding/. system.version is already
-        # registered by ProtocolServer itself.
+        # analyzer move into daemon/grounding/. system.version + system.attach
+        # are registered by ProtocolServer itself.
 
-    async def _handle_ingest(self, params: dict[str, Any]) -> dict[str, Any]:
+    async def _handle_ingest(
+        self, params: dict[str, Any], ctx: ConnectionContext
+    ) -> dict[str, Any]:
         req = IngestRequest.model_validate(params)
         adapter = self._registry.lookup_ingest(req.adapter_name)
-        result = await adapter.ingest(req)
+        result = await adapter.ingest(req, ctx)
         return result.model_dump()
 
-    async def _handle_link_commit(self, params: dict[str, Any]) -> dict[str, Any]:
+    async def _handle_link_commit(
+        self, params: dict[str, Any], ctx: ConnectionContext
+    ) -> dict[str, Any]:
         req = LinkCommitRequest.model_validate(params)
         # link_commit dispatches to ANY ingest adapter that opted into commit
         # binding — for v0.1 we route by repo_id convention; the active MCP
@@ -60,17 +67,19 @@ class Runtime:
         if not ingest_names:
             raise RuntimeError("no ingest adapters registered for link_commit")
         adapter = self._registry.lookup_ingest(ingest_names[0])
-        result = await adapter.link_commit(req)
+        result = await adapter.link_commit(req, ctx)
         return result.model_dump()
 
-    async def _handle_deliver(self, params: dict[str, Any]) -> dict[str, Any]:
+    async def _handle_deliver(
+        self, params: dict[str, Any], ctx: ConnectionContext
+    ) -> dict[str, Any]:
         # The egress channel is selected by the embedded channel name.
         channel = params.pop("channel", None)
         if not isinstance(channel, str):
             raise ValueError("egress.deliver requires a 'channel' string")
         event = NotificationEvent.model_validate(params)
         adapter = self._registry.lookup_egress(channel)
-        result = await adapter.deliver(event)
+        result = await adapter.deliver(event, ctx)
         return result.model_dump()
 
     async def start(self) -> None:

--- a/daemon/supervisor.py
+++ b/daemon/supervisor.py
@@ -67,6 +67,8 @@ class Supervisor:
         self._descriptor_path = descriptor_path or default_descriptor_path()
         self._runtime: Runtime | None = None
         self._status: SupervisorStatus = SupervisorStatus.STOPPED
+        # Phase 2b: captured by bootstrap; Phase 2c uses for storage path layout.
+        self.default_tenant_id: str | None = None
 
     @property
     def registry(self) -> AdapterRegistry:

--- a/integrations/__init__.py
+++ b/integrations/__init__.py
@@ -1,0 +1,7 @@
+"""Integrations — adapter packages that implement the universal
+ingest/egress/grounding surface from ``bicameral-protocol``.
+
+Today only ``mcp_adapter`` ships here. Future plans add Linear, Notion,
+Slack, dbt etc. as separate packages — each speaks the same Protocols
+so the daemon never has to know about a specific source.
+"""

--- a/integrations/mcp_adapter/__init__.py
+++ b/integrations/mcp_adapter/__init__.py
@@ -1,0 +1,24 @@
+"""MCP-side adapter — the bridge between the bicameral MCP stdio server
+and the daemon.
+
+Phase 2b (this commit): adapter shells that satisfy the IngestAdapter /
+EgressAdapter Protocols and register cleanly with the daemon's
+AdapterRegistry. Real ledger + notification wiring lands in Phase 2c —
+once the protocol surface is expanded to cover ratify/supersede/query
+and the ledger module physically moves into ``daemon/``.
+
+The bootstrap entry point — ``bootstrap_mcp_daemon`` — is callable
+today; server.py wires it in during Phase 2c.
+"""
+
+from __future__ import annotations
+
+from .bootstrap import bootstrap_mcp_daemon
+from .egress import MCPEgressAdapter
+from .ingest import MCPIngestAdapter
+
+__all__ = [
+    "MCPEgressAdapter",
+    "MCPIngestAdapter",
+    "bootstrap_mcp_daemon",
+]

--- a/integrations/mcp_adapter/bootstrap.py
+++ b/integrations/mcp_adapter/bootstrap.py
@@ -1,0 +1,38 @@
+"""Bootstrap entry — boots a Supervisor with the MCP adapter registered.
+
+Phase 2b ships this as a callable that tests + dev-time daemon checks
+can invoke; Phase 2c wires it into ``server.py`` startup so every MCP
+process either spawns or attaches to the user-scoped daemon.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from daemon.registry import AdapterRegistry
+from daemon.supervisor import Supervisor
+
+from .egress import MCPEgressAdapter
+from .ingest import MCPIngestAdapter
+
+
+async def bootstrap_mcp_daemon(
+    socket_path: Path | None = None,
+    descriptor_path: Path | None = None,
+) -> Supervisor:
+    """Build + start a Supervisor with the MCP IngestAdapter and
+    EgressAdapter pre-registered.
+
+    Returns the running Supervisor; caller is responsible for
+    ``await supervisor.stop()`` on teardown.
+    """
+    registry = AdapterRegistry()
+    registry.register_ingest(MCPIngestAdapter())
+    registry.register_egress(MCPEgressAdapter())
+    supervisor = Supervisor(
+        registry=registry,
+        socket_path=socket_path,
+        descriptor_path=descriptor_path,
+    )
+    await supervisor.start()
+    return supervisor

--- a/integrations/mcp_adapter/bootstrap.py
+++ b/integrations/mcp_adapter/bootstrap.py
@@ -1,8 +1,13 @@
 """Bootstrap entry — boots a Supervisor with the MCP adapter registered.
 
-Phase 2b ships this as a callable that tests + dev-time daemon checks
-can invoke; Phase 2c wires it into ``server.py`` startup so every MCP
-process either spawns or attaches to the user-scoped daemon.
+Phase 2b: ``tenant_id`` defaults to ``"local"`` per the connection-scoped
+tenant model. Hosted mode passes the gateway-resolved tenant identity
+when the daemon process itself is multi-tenant; for now, ``tenant_id``
+is wired through to the storage layout (Phase 2c uses it to compute
+``~/.bicameral/tenants/<tenant_id>/projects/<repo_id>/``).
+
+Phase 2c wires this into ``server.py`` startup so every MCP process
+either spawns or attaches to the user-scoped daemon.
 """
 
 from __future__ import annotations
@@ -11,6 +16,7 @@ from pathlib import Path
 
 from daemon.registry import AdapterRegistry
 from daemon.supervisor import Supervisor
+from protocol.contracts import LOCAL_TENANT_ID
 
 from .egress import MCPEgressAdapter
 from .ingest import MCPIngestAdapter
@@ -19,9 +25,15 @@ from .ingest import MCPIngestAdapter
 async def bootstrap_mcp_daemon(
     socket_path: Path | None = None,
     descriptor_path: Path | None = None,
+    tenant_id: str = LOCAL_TENANT_ID,
 ) -> Supervisor:
     """Build + start a Supervisor with the MCP IngestAdapter and
     EgressAdapter pre-registered.
+
+    ``tenant_id`` defaults to ``"local"``. Local-mode daemons always run
+    as a single-tenant process and don't need to vary this; hosted-mode
+    setup will pass the per-tenant identity here when the multi-tenant
+    daemon is brought up in Phase 5.
 
     Returns the running Supervisor; caller is responsible for
     ``await supervisor.stop()`` on teardown.
@@ -34,5 +46,6 @@ async def bootstrap_mcp_daemon(
         socket_path=socket_path,
         descriptor_path=descriptor_path,
     )
+    supervisor.default_tenant_id = tenant_id  # captured for future Phase 2c use
     await supervisor.start()
     return supervisor

--- a/integrations/mcp_adapter/egress.py
+++ b/integrations/mcp_adapter/egress.py
@@ -1,30 +1,28 @@
 """MCP-side EgressAdapter shell.
 
-Phase 2b stub. Phase 2c rewires this to the existing
-``notifications/stderr.py`` channel (and any other channels MCP exposes
-today) so the daemon's egress router replaces the in-handler emit
-shortcut without losing observable behavior.
+Phase 2b stub: writes a stderr marker including tenant_id from the
+ConnectionContext so dispatch is verifiable in tests. Phase 2c rewires
+this to the existing ``notifications/stderr.py`` channel (and any other
+channels MCP exposes today) so the daemon's egress router replaces the
+in-handler emit shortcut without losing observable behavior.
 """
 
 from __future__ import annotations
 
 import sys
 
-from protocol.contracts import DeliveryResult, NotificationEvent
+from protocol.contracts import ConnectionContext, DeliveryResult, NotificationEvent
 
 
 class MCPEgressAdapter:
-    """Registers as EgressAdapter named ``mcp``.
-
-    Phase 2b writes a one-line marker to stderr so the dispatch path
-    leaves a verifiable trace; Phase 2c routes this through the
-    structured notification machinery in ``notifications/``.
-    """
+    """Registers as EgressAdapter named ``mcp``."""
 
     name = "mcp"
 
-    async def deliver(self, event: NotificationEvent) -> DeliveryResult:
-        marker = f"[bicameral.egress] {event.event_type}: {event.summary}\n"
+    async def deliver(
+        self, event: NotificationEvent, ctx: ConnectionContext
+    ) -> DeliveryResult:
+        marker = f"[bicameral.egress tenant={ctx.tenant_id}] {event.event_type}: {event.summary}\n"
         sys.stderr.write(marker)
         sys.stderr.flush()
         return DeliveryResult(status="delivered")

--- a/integrations/mcp_adapter/egress.py
+++ b/integrations/mcp_adapter/egress.py
@@ -1,0 +1,30 @@
+"""MCP-side EgressAdapter shell.
+
+Phase 2b stub. Phase 2c rewires this to the existing
+``notifications/stderr.py`` channel (and any other channels MCP exposes
+today) so the daemon's egress router replaces the in-handler emit
+shortcut without losing observable behavior.
+"""
+
+from __future__ import annotations
+
+import sys
+
+from protocol.contracts import DeliveryResult, NotificationEvent
+
+
+class MCPEgressAdapter:
+    """Registers as EgressAdapter named ``mcp``.
+
+    Phase 2b writes a one-line marker to stderr so the dispatch path
+    leaves a verifiable trace; Phase 2c routes this through the
+    structured notification machinery in ``notifications/``.
+    """
+
+    name = "mcp"
+
+    async def deliver(self, event: NotificationEvent) -> DeliveryResult:
+        marker = f"[bicameral.egress] {event.event_type}: {event.summary}\n"
+        sys.stderr.write(marker)
+        sys.stderr.flush()
+        return DeliveryResult(status="delivered")

--- a/integrations/mcp_adapter/ingest.py
+++ b/integrations/mcp_adapter/ingest.py
@@ -1,0 +1,36 @@
+"""MCP-side IngestAdapter shell.
+
+Phase 2b: stub responses that exercise the registry → runtime → adapter
+dispatch path without yet writing to the ledger. Phase 2c replaces the
+bodies with calls into the moved ``daemon/ledger/`` writer (and the
+expanded protocol surface adds the read/write methods that today's MCP
+handlers use directly).
+"""
+
+from __future__ import annotations
+
+from protocol.contracts import (
+    IngestRequest,
+    IngestResult,
+    LinkCommitRequest,
+    LinkCommitResult,
+)
+
+
+class MCPIngestAdapter:
+    """Registers as IngestAdapter named ``mcp``."""
+
+    name = "mcp"
+
+    async def ingest(self, req: IngestRequest) -> IngestResult:
+        # Phase 2c wires the real ledger write. For now, accept + echo
+        # a deterministic stub id so the round-trip path is exercisable
+        # end-to-end in tests and during dev-time daemon smoke checks.
+        return IngestResult(
+            status="accepted",
+            decision_ids=[f"stub-{req.source_id}"],
+            reason=None,
+        )
+
+    async def link_commit(self, _req: LinkCommitRequest) -> LinkCommitResult:
+        return LinkCommitResult(status="no_change", regions_updated=0)

--- a/integrations/mcp_adapter/ingest.py
+++ b/integrations/mcp_adapter/ingest.py
@@ -1,15 +1,18 @@
 """MCP-side IngestAdapter shell.
 
 Phase 2b: stub responses that exercise the registry → runtime → adapter
-dispatch path without yet writing to the ledger. Phase 2c replaces the
-bodies with calls into the moved ``daemon/ledger/`` writer (and the
+dispatch path including the ConnectionContext (tenant_id from the
+connection's ``system.attach`` lands on every call). Phase 2c replaces
+the bodies with calls into the moved ``daemon/ledger/`` writer (and the
 expanded protocol surface adds the read/write methods that today's MCP
-handlers use directly).
+handlers use directly). The stub IDs surface ``ctx.tenant_id`` so that
+tenant-scoping is verifiable in tests today.
 """
 
 from __future__ import annotations
 
 from protocol.contracts import (
+    ConnectionContext,
     IngestRequest,
     IngestResult,
     LinkCommitRequest,
@@ -22,15 +25,17 @@ class MCPIngestAdapter:
 
     name = "mcp"
 
-    async def ingest(self, req: IngestRequest) -> IngestResult:
+    async def ingest(self, req: IngestRequest, ctx: ConnectionContext) -> IngestResult:
         # Phase 2c wires the real ledger write. For now, accept + echo
-        # a deterministic stub id so the round-trip path is exercisable
-        # end-to-end in tests and during dev-time daemon smoke checks.
+        # a deterministic stub id that includes the tenant so tests can
+        # verify the tenant_id is threading correctly through dispatch.
         return IngestResult(
             status="accepted",
-            decision_ids=[f"stub-{req.source_id}"],
+            decision_ids=[f"stub-{ctx.tenant_id}-{req.source_id}"],
             reason=None,
         )
 
-    async def link_commit(self, _req: LinkCommitRequest) -> LinkCommitResult:
+    async def link_commit(
+        self, _req: LinkCommitRequest, _ctx: ConnectionContext
+    ) -> LinkCommitResult:
         return LinkCommitResult(status="no_change", regions_updated=0)

--- a/protocol/__init__.py
+++ b/protocol/__init__.py
@@ -13,8 +13,11 @@ from __future__ import annotations
 
 from .client import ProtocolClient
 from .contracts import (
+    LOCAL_TENANT_ID,
     PROTOCOL_VERSION,
     AnalyzeRegionRequest,
+    AttachRequest,
+    AttachResult,
     BatchAnalyzeRequest,
     CodeRegion,
     DeliveryResult,
@@ -29,19 +32,24 @@ from .contracts import (
     LinkCommitRequest,
     LinkCommitResult,
     Neighbor,
+    NotAttachedError,
     NotificationEvent,
     ProtocolError,
     ProtocolVersionError,
     Symbol,
     ValidateSymbolsRequest,
 )
-from .server import ProtocolServer
+from .server import ConnectionContext, ProtocolServer
 
 __all__ = [
+    "LOCAL_TENANT_ID",
     "PROTOCOL_VERSION",
     "AnalyzeRegionRequest",
+    "AttachRequest",
+    "AttachResult",
     "BatchAnalyzeRequest",
     "CodeRegion",
+    "ConnectionContext",
     "DeliveryResult",
     "DriftResult",
     "EgressAdapter",
@@ -54,6 +62,7 @@ __all__ = [
     "LinkCommitRequest",
     "LinkCommitResult",
     "Neighbor",
+    "NotAttachedError",
     "NotificationEvent",
     "ProtocolClient",
     "ProtocolError",

--- a/protocol/client.py
+++ b/protocol/client.py
@@ -18,8 +18,10 @@ from pathlib import Path
 from typing import Any
 
 from .contracts import (
+    LOCAL_TENANT_ID,
     PROTOCOL_VERSION,
     AnalyzeRegionRequest,
+    AttachRequest,
     BatchAnalyzeRequest,
     DriftResult,
     ExtractSymbolsRequest,
@@ -58,14 +60,25 @@ class ProtocolClient:
         await client.close()
     """
 
-    def __init__(self, socket_path: Path | None = None) -> None:
+    def __init__(
+        self,
+        socket_path: Path | None = None,
+        tenant_id: str = LOCAL_TENANT_ID,
+        user_id: str | None = None,
+    ) -> None:
         self._socket_path = socket_path or self._read_daemon_socket()
+        self._tenant_id = tenant_id
+        self._user_id = user_id
         self._reader: asyncio.StreamReader | None = None
         self._writer: asyncio.StreamWriter | None = None
         self._id_iter = itertools.count(1)
         self._pending: dict[int, asyncio.Future[Any]] = {}
         self._reader_task: asyncio.Task[None] | None = None
         self._closed = False
+
+    @property
+    def tenant_id(self) -> str:
+        return self._tenant_id
 
     @staticmethod
     def _read_daemon_socket() -> Path:
@@ -81,6 +94,7 @@ class ProtocolClient:
         )
         self._reader_task = asyncio.create_task(self._read_loop())
         await self._verify_version()
+        await self._attach()
 
     async def _verify_version(self) -> None:
         server_version = await self._call("system.version", {})
@@ -90,6 +104,10 @@ class ProtocolClient:
             raise ProtocolVersionError(
                 f"client {PROTOCOL_VERSION} incompatible with server {server_version}"
             )
+
+    async def _attach(self) -> None:
+        req = AttachRequest(tenant_id=self._tenant_id, user_id=self._user_id)
+        await self._call("system.attach", req.model_dump())
 
     async def _read_loop(self) -> None:
         assert self._reader is not None

--- a/protocol/contracts.py
+++ b/protocol/contracts.py
@@ -9,13 +9,17 @@ daemon + adapter release. Every grounding-related request carries
 
 from __future__ import annotations
 
-from typing import Literal, Protocol, runtime_checkable
+from dataclasses import dataclass, field
+from typing import Any, Literal, Protocol, runtime_checkable
 
 from pydantic import BaseModel, ConfigDict, Field
 
 PROTOCOL_VERSION = "0.1.0"
 
 BATCH_REGION_LIMIT = 1000
+
+# Default tenant identifier when no explicit one is supplied (local deploy).
+LOCAL_TENANT_ID = "local"
 
 
 class ProtocolError(Exception):
@@ -24,6 +28,44 @@ class ProtocolError(Exception):
 
 class ProtocolVersionError(ProtocolError):
     """Raised when client and server disagree on major version."""
+
+
+class NotAttachedError(ProtocolError):
+    """Raised when a tenant-scoped RPC is issued before ``system.attach``."""
+
+
+# ── Session attach ─────────────────────────────────────────────────────
+
+
+class AttachRequest(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+    tenant_id: str
+    user_id: str | None = None  # within-tenant actor identity (e.g., signer email)
+
+
+class AttachResult(BaseModel):
+    model_config = ConfigDict(extra="ignore")
+    tenant_id: str
+    protocol_version: str = PROTOCOL_VERSION
+
+
+@dataclass
+class ConnectionContext:
+    """Per-connection state set by ``system.attach`` and threaded into
+    every adapter call. Adapters use ``tenant_id`` for scoping; ``user_id``
+    captures the within-tenant actor for ratification provenance.
+
+    Defined here (not in server.py) so adapter Protocols can reference it
+    without importing the server module.
+    """
+
+    tenant_id: str | None = None
+    user_id: str | None = None
+    state: dict[str, Any] = field(default_factory=dict)
+
+    @property
+    def attached(self) -> bool:
+        return self.tenant_id is not None
 
 
 # ── Ingest ──────────────────────────────────────────────────────────────
@@ -155,13 +197,19 @@ class BatchAnalyzeRequest(BaseModel):
 
 @runtime_checkable
 class IngestAdapter(Protocol):
-    """Pulls intent + artifact events into the ledger."""
+    """Pulls intent + artifact events into the ledger.
+
+    Adapters receive a ``ConnectionContext`` so they can scope writes by
+    tenant + attribute the actor for ratification provenance.
+    """
 
     name: str
 
-    async def ingest(self, req: IngestRequest) -> IngestResult: ...
+    async def ingest(self, req: IngestRequest, ctx: ConnectionContext) -> IngestResult: ...
 
-    async def link_commit(self, req: LinkCommitRequest) -> LinkCommitResult: ...
+    async def link_commit(
+        self, req: LinkCommitRequest, ctx: ConnectionContext
+    ) -> LinkCommitResult: ...
 
 
 @runtime_checkable
@@ -170,29 +218,34 @@ class EgressAdapter(Protocol):
 
     name: str
 
-    async def deliver(self, event: NotificationEvent) -> DeliveryResult: ...
+    async def deliver(
+        self, event: NotificationEvent, ctx: ConnectionContext
+    ) -> DeliveryResult: ...
 
 
 @runtime_checkable
 class GroundingPort(Protocol):
-    """Resolves symbols + analyzes drift against a `(repo_id, ref)` pair."""
+    """Resolves symbols + analyzes drift against a ``(tenant_id, repo_id, ref)``
+    tuple. ``tenant_id`` comes from the ConnectionContext; the request itself
+    carries ``repo_id`` and ``ref``.
+    """
 
     async def validate_symbols(
-        self, req: ValidateSymbolsRequest
+        self, req: ValidateSymbolsRequest, ctx: ConnectionContext
     ) -> list[Symbol]: ...
 
     async def extract_symbols(
-        self, req: ExtractSymbolsRequest
+        self, req: ExtractSymbolsRequest, ctx: ConnectionContext
     ) -> list[Symbol]: ...
 
     async def get_neighbors(
-        self, req: GetNeighborsRequest
+        self, req: GetNeighborsRequest, ctx: ConnectionContext
     ) -> list[Neighbor]: ...
 
     async def analyze_region(
-        self, req: AnalyzeRegionRequest
+        self, req: AnalyzeRegionRequest, ctx: ConnectionContext
     ) -> DriftResult: ...
 
     async def batch_analyze_regions(
-        self, req: BatchAnalyzeRequest
+        self, req: BatchAnalyzeRequest, ctx: ConnectionContext
     ) -> list[DriftResult]: ...

--- a/protocol/server.py
+++ b/protocol/server.py
@@ -1,9 +1,14 @@
 """UDS + JSON-RPC server stub for the universal protocol.
 
-Phase 1 ships the dispatch surface; Phase 2 wires concrete handlers
-(ingest/egress routers, grounding port) when the daemon process is
-extracted. The server today is only used by the conformance test suite and
-by the in-tree round-trip tests for the protocol package itself.
+Phase 1 shipped the dispatch surface; Phase 2b adds connection-scoped
+tenant binding via the ``system.attach`` RPC. Handlers that need a
+tenant_id receive it from the ``ConnectionContext`` rather than from the
+request payload.
+
+Phase 2c will wire concrete handlers (ingest/egress routers, grounding
+port) when the daemon process is extracted. The server today is used by
+the conformance test suite and by the in-tree round-trip tests for the
+protocol package itself.
 """
 
 from __future__ import annotations
@@ -13,18 +18,32 @@ import inspect
 from pathlib import Path
 from typing import Any, Awaitable, Callable
 
-from .contracts import PROTOCOL_VERSION, ProtocolError
+from .contracts import (
+    PROTOCOL_VERSION,
+    AttachRequest,
+    AttachResult,
+    ConnectionContext,
+    NotAttachedError,
+    ProtocolError,
+)
 from .transport import make_error, make_response, read_message, write_message
 
-Handler = Callable[[dict[str, Any]], Awaitable[Any]]
+Handler = Callable[..., Awaitable[Any] | Any]
+
+
+# Methods that are allowed before ``system.attach`` lands a tenant on the
+# connection. Everything else requires attach first.
+_PRE_ATTACH_ALLOWED = frozenset({"system.version", "system.attach"})
 
 
 class ProtocolServer:
     """Asyncio UDS server with a JSON-RPC method-dispatch table.
 
-    Registered handlers receive the raw `params` dict and return any value
-    JSON-serializable. The built-in ``system.version`` method always
-    responds with the server's ``PROTOCOL_VERSION``.
+    Registered handlers may take either ``(params)`` or ``(params, ctx)`` —
+    the dispatcher introspects the signature and passes ``ConnectionContext``
+    when the handler expects it. Handlers may return any JSON-serializable
+    value. The built-in ``system.version`` / ``system.attach`` methods are
+    always registered.
     """
 
     def __init__(self, socket_path: Path) -> None:
@@ -32,16 +51,25 @@ class ProtocolServer:
         self._methods: dict[str, Handler] = {}
         self._server: asyncio.AbstractServer | None = None
         self.register("system.version", self._handle_version)
+        self.register("system.attach", self._handle_attach)
 
     @staticmethod
     async def _handle_version(_: dict[str, Any]) -> str:
         return PROTOCOL_VERSION
 
+    @staticmethod
+    async def _handle_attach(
+        params: dict[str, Any], ctx: ConnectionContext
+    ) -> dict[str, Any]:
+        req = AttachRequest.model_validate(params)
+        ctx.tenant_id = req.tenant_id
+        ctx.user_id = req.user_id
+        return AttachResult(tenant_id=req.tenant_id).model_dump()
+
     def register(self, method: str, handler: Handler) -> None:
         self._methods[method] = handler
 
     async def start(self) -> None:
-        # Defensive: remove a stale socket file from a previous run.
         if self._socket_path.exists():
             self._socket_path.unlink()
         self._socket_path.parent.mkdir(parents=True, exist_ok=True)
@@ -59,13 +87,14 @@ class ProtocolServer:
     async def _handle_client(
         self, reader: asyncio.StreamReader, writer: asyncio.StreamWriter
     ) -> None:
+        ctx = ConnectionContext()
         try:
             while True:
                 try:
                     msg = await read_message(reader)
                 except ProtocolError:
                     return
-                await self._handle_message(msg, writer)
+                await self._handle_message(msg, writer, ctx)
         finally:
             writer.close()
             try:
@@ -74,7 +103,10 @@ class ProtocolServer:
                 pass
 
     async def _handle_message(
-        self, msg: dict[str, Any], writer: asyncio.StreamWriter
+        self,
+        msg: dict[str, Any],
+        writer: asyncio.StreamWriter,
+        ctx: ConnectionContext,
     ) -> None:
         req_id = msg.get("id")
         method = msg.get("method")
@@ -82,15 +114,31 @@ class ProtocolServer:
         if not isinstance(method, str):
             await write_message(writer, make_error(req_id, -32600, "missing method"))
             return
+        if method not in _PRE_ATTACH_ALLOWED and not ctx.attached:
+            await write_message(
+                writer,
+                make_error(req_id, -32002, "session not attached; call system.attach first"),
+            )
+            return
         handler = self._methods.get(method)
         if handler is None:
             await write_message(writer, make_error(req_id, -32601, f"unknown method {method}"))
             return
         try:
-            result = handler(params)
+            result = self._invoke(handler, params, ctx)
             if inspect.isawaitable(result):
                 result = await result
+        except NotAttachedError as exc:
+            await write_message(writer, make_error(req_id, -32002, str(exc)))
+            return
         except Exception as exc:  # noqa: BLE001 — boundary serializes any handler error
             await write_message(writer, make_error(req_id, -32000, str(exc)))
             return
         await write_message(writer, make_response(req_id, result))
+
+    @staticmethod
+    def _invoke(handler: Handler, params: dict[str, Any], ctx: ConnectionContext) -> Any:
+        sig = inspect.signature(handler)
+        if len(sig.parameters) >= 2:
+            return handler(params, ctx)
+        return handler(params)

--- a/tests/test_daemon_registry.py
+++ b/tests/test_daemon_registry.py
@@ -6,6 +6,7 @@ import pytest
 
 from daemon.registry import AdapterRegistry, AdapterRegistryError
 from protocol.contracts import (
+    ConnectionContext,
     DeliveryResult,
     IngestRequest,
     IngestResult,
@@ -19,10 +20,14 @@ class _FakeIngest:
     def __init__(self, name: str) -> None:
         self.name = name
 
-    async def ingest(self, _req: IngestRequest) -> IngestResult:
+    async def ingest(
+        self, _req: IngestRequest, _ctx: ConnectionContext
+    ) -> IngestResult:
         return IngestResult(status="accepted")
 
-    async def link_commit(self, _req: LinkCommitRequest) -> LinkCommitResult:
+    async def link_commit(
+        self, _req: LinkCommitRequest, _ctx: ConnectionContext
+    ) -> LinkCommitResult:
         return LinkCommitResult(status="linked")
 
 
@@ -30,7 +35,9 @@ class _FakeEgress:
     def __init__(self, name: str) -> None:
         self.name = name
 
-    async def deliver(self, _event: NotificationEvent) -> DeliveryResult:
+    async def deliver(
+        self, _event: NotificationEvent, _ctx: ConnectionContext
+    ) -> DeliveryResult:
         return DeliveryResult(status="delivered")
 
 

--- a/tests/test_daemon_runtime_dispatch.py
+++ b/tests/test_daemon_runtime_dispatch.py
@@ -12,6 +12,7 @@ from daemon.registry import AdapterRegistry, AdapterRegistryError
 from daemon.runtime import Runtime
 from protocol.client import ProtocolClient
 from protocol.contracts import (
+    ConnectionContext,
     DeliveryResult,
     IngestRequest,
     IngestResult,
@@ -33,23 +34,27 @@ def short_socket_dir():
 class _RecordingIngest:
     def __init__(self, name: str) -> None:
         self.name = name
-        self.calls: list[IngestRequest] = []
+        self.calls: list[tuple[IngestRequest, ConnectionContext]] = []
 
-    async def ingest(self, req: IngestRequest) -> IngestResult:
-        self.calls.append(req)
+    async def ingest(self, req: IngestRequest, ctx: ConnectionContext) -> IngestResult:
+        self.calls.append((req, ctx))
         return IngestResult(status="accepted", decision_ids=["d1"])
 
-    async def link_commit(self, _req: LinkCommitRequest) -> LinkCommitResult:
+    async def link_commit(
+        self, _req: LinkCommitRequest, _ctx: ConnectionContext
+    ) -> LinkCommitResult:
         return LinkCommitResult(status="linked", regions_updated=3)
 
 
 class _RecordingEgress:
     def __init__(self, name: str) -> None:
         self.name = name
-        self.calls: list[NotificationEvent] = []
+        self.calls: list[tuple[NotificationEvent, ConnectionContext]] = []
 
-    async def deliver(self, event: NotificationEvent) -> DeliveryResult:
-        self.calls.append(event)
+    async def deliver(
+        self, event: NotificationEvent, ctx: ConnectionContext
+    ) -> DeliveryResult:
+        self.calls.append((event, ctx))
         return DeliveryResult(status="delivered")
 
 
@@ -77,7 +82,9 @@ async def test_runtime_routes_ingest_to_registered_adapter(short_socket_dir: Pat
     assert result.status == "accepted"
     assert result.decision_ids == ["d1"]
     assert len(adapter.calls) == 1
-    assert adapter.calls[0].payload == "we decided X"
+    captured_req, captured_ctx = adapter.calls[0]
+    assert captured_req.payload == "we decided X"
+    assert captured_ctx.tenant_id == "local"  # default from ProtocolClient
 
 
 async def test_runtime_routes_egress_to_channel_named_in_params(

--- a/tests/test_mcp_adapter_bootstrap.py
+++ b/tests/test_mcp_adapter_bootstrap.py
@@ -1,0 +1,113 @@
+"""Phase 2b: MCP adapter shells register cleanly and complete the round-trip
+through the daemon's protocol surface.
+
+These tests verify that the *bootstrap path* works end-to-end — supervisor
+boot, adapter registration, ProtocolClient connect, ingest/egress dispatch.
+The shell adapters' bodies are stubs (Phase 2c wires real ledger + notif),
+so the assertions target the dispatch path, not the business logic.
+"""
+
+from __future__ import annotations
+
+import shutil
+import tempfile
+from pathlib import Path
+
+import pytest
+
+from integrations.mcp_adapter import (
+    MCPEgressAdapter,
+    MCPIngestAdapter,
+    bootstrap_mcp_daemon,
+)
+from protocol.client import ProtocolClient
+from protocol.contracts import IngestRequest, LinkCommitRequest, NotificationEvent
+
+
+@pytest.fixture
+def short_state_dir():
+    base = Path(tempfile.mkdtemp(prefix="bm-", dir="/tmp"))
+    try:
+        yield base
+    finally:
+        shutil.rmtree(base, ignore_errors=True)
+
+
+async def test_bootstrap_registers_mcp_adapter_under_name_mcp(
+    short_state_dir: Path,
+) -> None:
+    """After bootstrap, the registry exposes ingest+egress named 'mcp'."""
+    supervisor = await bootstrap_mcp_daemon(
+        socket_path=short_state_dir / "d.sock",
+        descriptor_path=short_state_dir / "daemon.json",
+    )
+    try:
+        assert "mcp" in supervisor.registry.ingest_names()
+        assert "mcp" in supervisor.registry.egress_names()
+        assert isinstance(
+            supervisor.registry.lookup_ingest("mcp"), MCPIngestAdapter
+        )
+        assert isinstance(
+            supervisor.registry.lookup_egress("mcp"), MCPEgressAdapter
+        )
+    finally:
+        await supervisor.stop()
+
+
+async def test_client_ingest_through_mcp_adapter_returns_stub_decision_id(
+    short_state_dir: Path,
+) -> None:
+    """End-to-end: client → daemon → MCP adapter → stub response."""
+    supervisor = await bootstrap_mcp_daemon(
+        socket_path=short_state_dir / "d.sock",
+        descriptor_path=short_state_dir / "daemon.json",
+    )
+    client = ProtocolClient(socket_path=short_state_dir / "d.sock")
+    try:
+        await client.connect()
+        result = await client.ingest(
+            IngestRequest(
+                adapter_name="mcp",
+                payload="meeting note",
+                source_id="fathom-123",
+                source_ref="2026-05-21 standup",
+            )
+        )
+        assert result.status == "accepted"
+        assert result.decision_ids == ["stub-fathom-123"]
+
+        link_result = await client.link_commit(
+            LinkCommitRequest(
+                repo_id="bicameral-mcp", commit_sha="abc1234", ref="HEAD"
+            )
+        )
+        assert link_result.status == "no_change"
+    finally:
+        await client.close()
+        await supervisor.stop()
+
+
+async def test_client_egress_through_mcp_adapter_returns_delivered(
+    short_state_dir: Path, capsys: pytest.CaptureFixture
+) -> None:
+    """Egress dispatch reaches MCP adapter; stderr marker is emitted."""
+    supervisor = await bootstrap_mcp_daemon(
+        socket_path=short_state_dir / "d.sock",
+        descriptor_path=short_state_dir / "daemon.json",
+    )
+    client = ProtocolClient(socket_path=short_state_dir / "d.sock")
+    try:
+        await client.connect()
+        params = NotificationEvent(
+            event_type="drift_detected",
+            summary="velocity threshold drifted",
+            severity="warn",
+        ).model_dump()
+        params["channel"] = "mcp"
+        result = await client._call("egress.deliver", params)
+        assert result["status"] == "delivered"
+    finally:
+        await client.close()
+        await supervisor.stop()
+    captured = capsys.readouterr()
+    assert "[bicameral.egress] drift_detected" in captured.err

--- a/tests/test_mcp_adapter_bootstrap.py
+++ b/tests/test_mcp_adapter_bootstrap.py
@@ -74,7 +74,8 @@ async def test_client_ingest_through_mcp_adapter_returns_stub_decision_id(
             )
         )
         assert result.status == "accepted"
-        assert result.decision_ids == ["stub-fathom-123"]
+        # Stub now includes tenant_id from the connection — default 'local'.
+        assert result.decision_ids == ["stub-local-fathom-123"]
 
         link_result = await client.link_commit(
             LinkCommitRequest(
@@ -110,4 +111,4 @@ async def test_client_egress_through_mcp_adapter_returns_delivered(
         await client.close()
         await supervisor.stop()
     captured = capsys.readouterr()
-    assert "[bicameral.egress] drift_detected" in captured.err
+    assert "[bicameral.egress tenant=local] drift_detected" in captured.err

--- a/tests/test_protocol_attach.py
+++ b/tests/test_protocol_attach.py
@@ -1,0 +1,123 @@
+"""Phase 2b: system.attach RPC binds tenant_id to the connection.
+
+After attach, every subsequent RPC sees the tenant via ConnectionContext.
+Before attach, only system.version and system.attach are allowed.
+"""
+
+from __future__ import annotations
+
+import shutil
+import tempfile
+from pathlib import Path
+
+import pytest
+
+from protocol.client import ProtocolClient
+from protocol.contracts import ConnectionContext, IngestRequest
+from protocol.server import ProtocolServer
+
+
+@pytest.fixture
+def short_socket_dir():
+    base = Path(tempfile.mkdtemp(prefix="bm-", dir="/tmp"))
+    try:
+        yield base
+    finally:
+        shutil.rmtree(base, ignore_errors=True)
+
+
+async def test_pre_attach_rpc_other_than_version_is_refused(
+    short_socket_dir: Path,
+) -> None:
+    """A custom RPC before system.attach gets a protocol error response."""
+    server = ProtocolServer(short_socket_dir / "d.sock")
+
+    async def handle_anything(params: dict, ctx: ConnectionContext) -> dict:
+        return {"ok": True, "tenant": ctx.tenant_id}
+
+    server.register("custom.method", handle_anything)
+    await server.start()
+
+    # Build a raw client that does NOT auto-attach so we can issue a
+    # pre-attach call and verify rejection.
+    import asyncio
+    import json
+
+    reader, writer = await asyncio.open_unix_connection(
+        str(short_socket_dir / "d.sock")
+    )
+    try:
+        # custom.method with no prior system.attach: expect error response.
+        req = {"jsonrpc": "2.0", "id": 1, "method": "custom.method", "params": {}}
+        writer.write((json.dumps(req) + "\n").encode())
+        await writer.drain()
+        resp_line = await reader.readline()
+        resp = json.loads(resp_line)
+        assert "error" in resp
+        assert "system.attach" in resp["error"]["message"]
+    finally:
+        writer.close()
+        await writer.wait_closed()
+        await server.stop()
+
+
+async def test_attach_then_call_sees_tenant_in_context(
+    short_socket_dir: Path,
+) -> None:
+    """After system.attach, ConnectionContext.tenant_id flows to the handler."""
+    server = ProtocolServer(short_socket_dir / "d.sock")
+
+    received: list[ConnectionContext] = []
+
+    async def handle_probe(_params: dict, ctx: ConnectionContext) -> dict:
+        received.append(ctx)
+        return {"tenant": ctx.tenant_id, "user": ctx.user_id}
+
+    server.register("probe.context", handle_probe)
+    await server.start()
+
+    client = ProtocolClient(
+        socket_path=short_socket_dir / "d.sock",
+        tenant_id="acme-team",
+        user_id="alice@acme.example",
+    )
+    try:
+        await client.connect()  # connect now also runs system.attach
+        result = await client._call("probe.context", {})
+        assert result == {"tenant": "acme-team", "user": "alice@acme.example"}
+        assert received[0].tenant_id == "acme-team"
+        assert received[0].user_id == "alice@acme.example"
+    finally:
+        await client.close()
+        await server.stop()
+
+
+async def test_each_connection_has_independent_tenant_binding(
+    short_socket_dir: Path,
+) -> None:
+    """Two concurrent clients with different tenant_ids do not share context."""
+    server = ProtocolServer(short_socket_dir / "d.sock")
+
+    async def handle_whoami(_params: dict, ctx: ConnectionContext) -> dict:
+        return {"tenant": ctx.tenant_id}
+
+    server.register("probe.whoami", handle_whoami)
+    await server.start()
+
+    client_a = ProtocolClient(
+        socket_path=short_socket_dir / "d.sock", tenant_id="tenant-a"
+    )
+    client_b = ProtocolClient(
+        socket_path=short_socket_dir / "d.sock", tenant_id="tenant-b"
+    )
+    try:
+        await client_a.connect()
+        await client_b.connect()
+        r_a = await client_a._call("probe.whoami", {})
+        r_b = await client_b._call("probe.whoami", {})
+        assert r_a == {"tenant": "tenant-a"}
+        assert r_b == {"tenant": "tenant-b"}
+    finally:
+        await client_a.close()
+        await client_b.close()
+        await server.stop()


### PR DESCRIPTION
## Summary

Phase 2b of the daemon-extraction refactor, **revised after `/plan-eng-review` D1-D5** to bake the dual-deployment architecture into the foundation.

The same daemon binary serves both local-deploy and hosted-deploy. What differs:
- **tenant_id** supplied at session attach (defaults `"local"`; hosted gateway injects per-tenant identity)
- **event-storage backend** injected at boot (Drive in local; hosted DB in hosted — Phase 2c/5)

### What's in this PR

**Commit 1 (`5dea2f1`)** — initial MCP adapter shells + bootstrap helper:
- `integrations/mcp_adapter/{ingest,egress,bootstrap}.py` — adapter shells, registry-wired bootstrap

**Commit 2 (`996f7d6`)** — tenant awareness after D1-D5:
- `system.attach` RPC (client must attach after version handshake; pre-attach RPCs other than `system.version` are refused)
- `ConnectionContext` dataclass: per-connection `tenant_id` + `user_id`; threaded into every adapter call
- `IngestAdapter` / `EgressAdapter` / `GroundingPort` Protocols now take `(req, ctx)` so adapters can scope by tenant and attribute the actor
- `ProtocolClient(tenant_id="local", user_id=None)` — auto-attaches on `connect()`
- `bootstrap_mcp_daemon(tenant_id="local")` — forward-compat parameter; captured on `Supervisor.default_tenant_id`
- Tests verify tenant_id flows end-to-end (stub IDs include tenant, stderr markers include tenant)

### Dual-deployment commitments encoded

Per `/plan-eng-review` 2026-05-21 (`docs/Planning/plan-daemon-extract-universal-surface.md` `Dual-deployment commitments` section):

| ID | Decision | Effect on this PR |
|---|---|---|
| **D1** | Daemon owns grounding compute; MCP ships metadata + per-request snippets | `GroundingPort` Protocol signatures take `ctx` (Phase 2c wires actual snippet handling) |
| **D2** | Hosted writes online-only via gateway → daemon | No CRDT/offline-buffer code in Phase 2b |
| **D3** | `system.attach(tenant_id, user_id?)` RPC; team = tenant | **Implemented this PR** |
| **D4** | Hosted drops Drive; uses Bicameral DB via pluggable event backend | `events/backends/` Protocol stays as the seam (Phase 2c) |
| **D5** | Rewrite 2b on same branch then merge | **This PR** |

## Plan / Audit / Seal

- **Plan**: `docs/Planning/plan-daemon-extract-universal-surface.md` (revised this commit — `Dual-deployment commitments` + 6 Open Questions). Gitignored per qor convention.
- **Audit**: prior qor-audit PASS holds; D1-D5 extend boundaries, don't change verdict. Eng-review (`/plan-eng-review`) PASS captured in 5 AskUserQuestion decisions in the session log.
- **Seal**: pending merge to `dev`

## Test plan

- [x] `pytest tests/test_protocol_attach.py -v` (3/3 — new tests)
  - `pre_attach_rpc_other_than_version_is_refused`
  - `attach_then_call_sees_tenant_in_context`
  - `each_connection_has_independent_tenant_binding`
- [x] `pytest tests/test_protocol_serialization.py tests/test_protocol_transport_uds.py tests/test_protocol_versioning.py` (6/6 regression)
- [x] `pytest tests/test_daemon_registry.py tests/test_daemon_supervisor.py tests/test_daemon_runtime_dispatch.py` (12/12, updated to take ctx)
- [x] `pytest tests/test_mcp_adapter_bootstrap.py` (3/3 — verifies tenant_id end-to-end)
- [x] `mypy daemon/ protocol/ integrations/` — no issues
- [x] `python scripts/lint_plan_grounding.py docs/Planning/plan-daemon-extract-universal-surface.md` — clean

**Total**: 24 tests green, 0 mypy errors.

## What's NOT in this PR (and is coming)

- Phase 2c — physical code moves (ledger, dashboard, governance, audit, sync into `daemon/`); daemon-side drift analyzer (grounding compute); event-backend Protocol with `local_folder` + Drive + `hosted_db` stubs; handler rewrites through `ProtocolClient`.
- Phase 5 (later) — hosted gateway implementation, multi-tenant daemon hardening, PLG metering wiring.

## Linked issues

Refs BicameralAI/bicameral-daemon#1 — sibling daemon issue (Phase 2c implements full ACs)
Refs BicameralAI/bicameral-daemon#3 — adapters register against `AdapterRegistry`, tenant scoping ready
Refs BicameralAI/bicameral-daemon#4 — `EgressAdapter` dispatch with `ConnectionContext` (per-tenant routing in Phase 4)
Refs BicameralAI/bicameral-daemon#5 — Dashboard v2 frontend will consume `ConnectionContext` shape in Phase 3 TS bindings

Stacks on BicameralAI/bicameral-mcp#486 (Phase 2a, merged at `c3f337e`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)