### PR TITLE
fix(ledger): v20→v21 migration uses valid enum values (hotfix)

### DIFF
--- a/ledger/schema.py
+++ b/ledger/schema.py
@@ -1290,9 +1290,24 @@ async def _migrate_v20_to_v21(client: LedgerClient) -> None:
     This migration creates a synthetic compliance_check(verdict='compliant')
     for each (decision, region) pair where the decision is 'reflected' but
     no compliance_check exists.  The synthetic row uses the region's current
-    content_hash and is marked phase='migration' for traceability.
+    content_hash.  The ``explanation`` field carries the provenance string
+    so the row is recognizable as a migration backfill.
 
     Idempotent: skips decisions that already have compliance_check rows.
+
+    NOTE on enum values: ``confidence`` is constrained by the schema to
+    ['high', 'medium', 'low'] and ``phase`` to ['ingest', 'drift',
+    'regrounding', 'supersession', 'divergence']. The migration uses
+    ``confidence='low'`` (synthetic backfill, lowest confidence is honest)
+    and ``phase='regrounding'`` (closest semantic match — the migration
+    re-establishes the verdict for an already-grounded decision).
+    Provenance lives in the ``explanation`` field.
+
+    Hotfix history: the original migration used sentinel values
+    ``confidence='migrated'`` and ``phase='migration'`` which were rejected
+    by their respective ASSERTs at runtime, blocking ingest for any user
+    whose ledger crossed the v20→v21 boundary with non-empty reflected
+    decisions. Fixed by mapping to existing enum values.
     """
     reflected_rows = await client.query(
         "SELECT type::string(id) AS did FROM decision WHERE status = 'reflected'"
@@ -1324,9 +1339,9 @@ async def _migrate_v20_to_v21(client: LedgerClient) -> None:
             await client.execute(
                 "CREATE compliance_check SET "
                 "decision_id = $d, region_id = $r, content_hash = $h, "
-                "verdict = 'compliant', confidence = 'migrated', "
+                "verdict = 'compliant', confidence = 'low', "
                 "explanation = 'backfilled by v20→v21 migration: pre-verdict-era reflected decision', "
-                "phase = 'migration', pruned = false, ephemeral = false",
+                "phase = 'regrounding', pruned = false, ephemeral = false",
                 {"d": did, "r": rid, "h": ch},
             )
             backfilled += 1

--- a/tests/test_v21_compliance_check_backfill.py
+++ b/tests/test_v21_compliance_check_backfill.py
@@ -1,0 +1,176 @@
+"""v20 → v21 migration: backfill compliance_check rows for pre-verdict reflected decisions.
+
+Regression test for the hotfix: the original migration used sentinel values
+``confidence='migrated'`` and ``phase='migration'`` which were rejected by
+their respective ASSERTs at runtime, blocking ingest for any user whose
+ledger crossed the v20→v21 boundary with non-empty reflected decisions.
+
+This test seeds a reflected decision with a binding (the trigger state)
+and runs ``_migrate_v20_to_v21`` directly, asserting that the synthetic
+compliance_check row lands successfully (no SchemaError) with the fix's
+remapped enum values (``confidence='low'``, ``phase='regrounding'``).
+
+Sociable test — real SurrealDB adapter over ``memory://``; real schema
+init + migrate; no mocks on the ledger surface.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from ledger.client import LedgerClient
+from ledger.schema import _migrate_v20_to_v21, init_schema, migrate
+
+_NS_COUNTER = 0
+
+
+async def _fresh_client() -> LedgerClient:
+    global _NS_COUNTER
+    _NS_COUNTER += 1
+    c = LedgerClient(
+        url="memory://",
+        ns=f"v21_test_{_NS_COUNTER}",
+        db="ledger_v21_test",
+    )
+    await c.connect()
+    await init_schema(c)
+    await migrate(c, allow_destructive=True)
+    return c
+
+
+async def _seed_reflected_decision_with_binding(
+    c: LedgerClient, *, description: str
+) -> tuple[str, str]:
+    """Create a 'reflected' decision bound to a code region. Returns (decision_id, region_id).
+
+    Mirrors the pre-verdict-era state the migration is designed to repair —
+    decision is `reflected` via legacy hash-comparison, but no compliance_check
+    row exists. After the migration, exactly one synthetic compliance_check
+    should land.
+    """
+    drows = await c.query(
+        "CREATE decision SET description = $d, source_type = 'manual', "
+        "canonical_id = $cid, status = 'reflected'",
+        {"d": description, "cid": f"cid-{description}"},
+    )
+    drow = drows[0]
+    rid = drow.get("id")
+    decision_id = (
+        f"decision:{rid.get('id', rid)}" if isinstance(rid, dict) else str(rid)
+    )
+
+    rrows = await c.query(
+        "CREATE code_region SET file_path = $f, start_line = 1, end_line = 5, "
+        "symbol_name = $s, content_hash = $h",
+        {"f": "src/x.py", "s": "fn_x", "h": "abc123hashvalue"},
+    )
+    rrow = rrows[0]
+    rrid = rrow.get("id")
+    region_id = (
+        f"code_region:{rrid.get('id', rrid)}" if isinstance(rrid, dict) else str(rrid)
+    )
+
+    await c.query(
+        f"RELATE {decision_id}->binds_to->{region_id} "
+        "SET content_hash = $h, confidence = 1.0",
+        {"h": "abc123hashvalue"},
+    )
+    return decision_id, region_id
+
+
+async def test_v20_to_v21_migration_does_not_raise_on_reflected_with_binding() -> None:
+    """Original bug: migration set confidence='migrated' and phase='migration',
+    both rejected by their ASSERTs, raising SurrealDB ERROR. Fix maps to
+    ``confidence='low'`` and ``phase='regrounding'`` (valid enum values).
+    Test passes iff the migration completes without raising.
+    """
+    c = await _fresh_client()
+    await _seed_reflected_decision_with_binding(c, description="kyc tier1 ssn-last4")
+
+    # Should complete cleanly; without the hotfix this raises a SurrealDB
+    # schema-violation error on the CREATE compliance_check statement.
+    await _migrate_v20_to_v21(c)
+
+
+async def test_v20_to_v21_migration_writes_one_compliance_check_per_binding() -> None:
+    """Verify the migration's actual output: a synthetic compliance_check
+    row exists for the reflected decision after the migration runs, with
+    verdict='compliant' and the matching content_hash.
+    """
+    c = await _fresh_client()
+    decision_id, region_id = await _seed_reflected_decision_with_binding(
+        c, description="velocity check 3-per-5"
+    )
+
+    await _migrate_v20_to_v21(c)
+
+    rows = await c.query(
+        "SELECT verdict, confidence, phase, content_hash, explanation "
+        "FROM compliance_check WHERE decision_id = $d",
+        {"d": decision_id},
+    )
+    assert len(rows) == 1, f"expected 1 compliance_check row, got {len(rows)}"
+    row = rows[0]
+    assert row["verdict"] == "compliant"
+    assert row["confidence"] == "low"  # hotfix mapping
+    assert row["phase"] == "regrounding"  # hotfix mapping
+    assert row["content_hash"] == "abc123hashvalue"
+    assert "backfilled by v20→v21" in row["explanation"]
+
+
+async def test_v20_to_v21_migration_is_idempotent() -> None:
+    """Idempotency: running the migration twice does not create duplicate
+    compliance_check rows for the same decision.
+    """
+    c = await _fresh_client()
+    decision_id, _ = await _seed_reflected_decision_with_binding(
+        c, description="velocity check 3-per-5"
+    )
+
+    await _migrate_v20_to_v21(c)
+    await _migrate_v20_to_v21(c)
+
+    rows = await c.query(
+        "SELECT id FROM compliance_check WHERE decision_id = $d",
+        {"d": decision_id},
+    )
+    assert len(rows) == 1
+
+
+async def test_v20_to_v21_migration_skips_decision_with_existing_check() -> None:
+    """A reflected decision that ALREADY has a compliance_check row is not
+    re-backfilled by the migration.
+    """
+    c = await _fresh_client()
+    decision_id, region_id = await _seed_reflected_decision_with_binding(
+        c, description="cross border wire fee"
+    )
+
+    # Pre-existing compliance_check (e.g., written by the modern verdict gate)
+    await c.execute(
+        "CREATE compliance_check SET decision_id = $d, region_id = $r, "
+        "content_hash = $h, verdict = 'compliant', confidence = 'high', "
+        "explanation = 'real verdict, not migration backfill', "
+        "phase = 'ingest', pruned = false, ephemeral = false",
+        {"d": decision_id, "r": region_id, "h": "abc123hashvalue"},
+    )
+
+    await _migrate_v20_to_v21(c)
+
+    rows = await c.query(
+        "SELECT confidence, explanation FROM compliance_check WHERE decision_id = $d",
+        {"d": decision_id},
+    )
+    assert len(rows) == 1
+    assert rows[0]["confidence"] == "high"  # original row preserved, not overwritten
+    assert "real verdict" in rows[0]["explanation"]
+
+
+async def test_v20_to_v21_migration_noop_when_no_reflected_decisions() -> None:
+    """Migration short-circuits when there are no reflected decisions to backfill."""
+    c = await _fresh_client()
+    # No decisions seeded.
+    await _migrate_v20_to_v21(c)
+
+    rows = await c.query("SELECT id FROM compliance_check")
+    assert rows == []


### PR DESCRIPTION
## Hotfix — flow:hotfix → main

**Severity**: P0. Affects v0.16.0 (shipped). Blocks `bicameral.ingest` entirely for any user whose local ledger crosses the v20→v21 boundary with at least one reflected decision that has a binding.

## What broke

The v20→v21 migration backfills synthetic `compliance_check` rows for pre-verdict-era reflected decisions. The original implementation used sentinel values that violate their schema ASSERTs at runtime:

| Field | Sentinel | Schema constraint | Result |
|---|---|---|---|
| `confidence` | `'migrated'` | `ASSERT $value IN ['high', 'medium', 'low']` | ❌ rejected |
| `phase` | `'migration'` | `ASSERT $value IN ['ingest', 'drift', 'regrounding', 'supersession', 'divergence']` | ❌ rejected |

The migration raises a SurrealDB schema-violation error on the first `CREATE compliance_check` statement, propagating up through the daemon/MCP boundary. Every subsequent ingest call against the affected ledger fails the same way.

```
SurrealDB rejected statement: Found 'migrated' for field `confidence`,
with record `compliance_check:o9runtq2l7t5jfj3aw20`,
but field must conform to: $value INSIDE ['high', 'medium', 'low']
```

Introduced in commit `5d2999c` (the #341/#342/#281 fix). Shipped in v0.16.0.

## Fix

Map sentinel values to existing enum members. Provenance preserved in the `explanation` field (already reads "backfilled by v20→v21 migration: pre-verdict-era reflected decision"):

- `confidence='migrated'` → `confidence='low'` (synthetic backfill; lowest confidence is honest)
- `phase='migration'` → `phase='regrounding'` (closest semantic match — the migration re-establishes the verdict for an already-grounded decision)

No schema change. Single-file diff in `ledger/schema.py` plus a regression test.

## Plan / Audit / Seal

- **Plan**: trivial; risk:L1 (two enum-value remaps; no schema change; no API change)
- **Audit**: regression test in `tests/test_v21_compliance_check_backfill.py` covers (a) the migration completes without raising on the trigger state, (b) the row lands with the new enum values, (c) idempotency, (d) skip-on-existing-row path, (e) noop when no reflected decisions exist
- **Seal**: pending merge to `main`

## Test plan

- [x] `pytest tests/test_v21_compliance_check_backfill.py -v` (5/5)
  - `test_v20_to_v21_migration_does_not_raise_on_reflected_with_binding` — the original bug repro; now passes
  - `test_v20_to_v21_migration_writes_one_compliance_check_per_binding` — fix's enum mapping verified
  - `test_v20_to_v21_migration_is_idempotent` — running twice = one row
  - `test_v20_to_v21_migration_skips_decision_with_existing_check` — pre-existing real verdict preserved
  - `test_v20_to_v21_migration_noop_when_no_reflected_decisions` — empty-state short-circuit

## Sync-back to dev (per DEV_CYCLE §10)

The same `ledger/schema.py` file on `dev` carries the identical bug. After this hotfix merges to `main`, sync-back PR to `dev` lands as a separate fast-track PR within the §10 clock.

## Prevention work (deliberately deferred)

This bug-class (migration writes values that violate schema ASSERTs, discovered only at runtime against non-empty data) would have been caught by:

1. A schema-aware lint that parses `DEFINE FIELD ... ASSERT $value IN [...]` clauses and cross-references string literals in `CREATE/UPDATE` statements
2. A project mandate that every migration ships with a corresponding test that seeds the trigger state

Both are filed for a follow-up dev-branch PR (not bundled here to keep the hotfix focused per DEV_CYCLE §6 hotfix scope).

## Discovery context

Found while attempting to ingest the daemon-extraction architecture decisions (D1-D8) into a local ledger via `bicameral.ingest`. The migration crashed before any decision row was written, surfacing the long-latent bug.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected database schema migration to ensure generated compliance records pass validation checks, improving data integrity and system reliability.

* **Tests**
  * Added comprehensive test coverage for compliance record generation during database migrations, including edge cases and idempotency validation.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/BicameralAI/bicameral-mcp/pull/488?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->