### PR TITLE
release: v0.16.1 — hotfix for v20→v21 migration enum-value mismatch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,36 @@
 All notable changes to bicameral-mcp are tracked here. Format loosely follows
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
+## v0.16.1 — Hotfix: v20→v21 migration uses valid enum values
+
+P0 hotfix for v0.16.0 (and earlier). The v20→v21 migration backfills synthetic `compliance_check` rows for pre-verdict-era reflected decisions; the original implementation used sentinel values (`confidence='migrated'`, `phase='migration'`) that are rejected by their schema ASSERTs at runtime. The migration raises a SurrealDB schema-violation error on the first `CREATE compliance_check` statement, blocking **any** `bicameral.ingest` call against an affected ledger.
+
+### Fixed
+
+- **v20→v21 migration enum-value mismatch** (#488) — Map sentinel values to existing enum members: `confidence='migrated'` → `'low'` (synthetic backfill, lowest confidence is honest), `phase='migration'` → `'regrounding'` (closest semantic match — the migration re-establishes the verdict for an already-grounded decision). Provenance preserved in the `explanation` field, which still reads `"backfilled by v20→v21 migration: pre-verdict-era reflected decision"`. No schema change.
+
+### Affected users
+
+Any user whose local ledger crosses the v20→v21 schema boundary with at least one decision in `status='reflected'` that has a `binds_to` relation to a `code_region` row. That includes most active users with non-trivial decision-ratification history. The bug manifests as a `SurrealDB rejected statement: Found 'migrated' for field 'confidence'` error on the first ingest attempt after upgrade.
+
+### Upgrade
+
+```
+pip install --upgrade bicameral-mcp
+```
+
+No state migration required beyond what's already shipped. The migration now applies cleanly on the next ledger open after upgrade.
+
+### Tests
+
+`tests/test_v21_compliance_check_backfill.py` adds 5 sociable regression tests against real SurrealDB over `memory://` — bug repro, enum-mapping verification, idempotency, skip-on-existing-row, empty-state noop.
+
+### Sync-back
+
+PR #489 synced the fix from main back to dev per DEV_CYCLE §10.
+
+---
+
 ## v0.16.0 — Ledger Locator (out-of-tree state) + `partial` verdict + recovery-path hardening
 
 Triage release draining the dev → main backlog. Lands the **#368 Ledger Locator** (relocates project-scoped state out of the working tree and gives worktrees / submodules a clean contract), introduces the **`partial` verdict** for in-progress work (#405), wires the missing **`bicameral_reset` CLI + `bicameral_diagnose` recovery path** (#410), and flips the **`M_skill_preflight` CI gates from warn → hard** (#398).

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "bicameral-mcp"
-version = "0.16.0"
+version = "0.16.1"
 description = "Decision ledger MCP server — ingests meeting transcripts, maps decisions to code, tracks drift"
 readme = "README.md"
 requires-python = ">=3.10"


### PR DESCRIPTION
## v0.16.1 — Hotfix release

P0 hotfix release. Closes the release loop for #488 (the v20→v21 migration enum-value fix already merged to `main` at `66fba0e`). This PR bumps version + adds CHANGELOG entry so the GitHub Release can be cut and PyPI publish triggered.

## What's in this release

Just the version bump + CHANGELOG. The actual code fix shipped in #488; this is the release-PR per DEV_CYCLE §6 (`flow:release` targets `main` and carries no new code, only the integrated `main` HEAD at release time).

- `pyproject.toml` — `version = "0.16.0"` → `"0.16.1"`
- `CHANGELOG.md` — v0.16.1 entry under the top heading with the hotfix description, affected users, upgrade instructions, and sync-back reference

## Plan / Audit / Seal

- **Plan**: trivial; risk:L1 (version + CHANGELOG only)
- **Audit**: covered by #488's regression tests (5/5 passing)
- **Seal**: on tag-push + GitHub Release creation; `publish.yml` triggers on `release.types=[published]` → PyPI publish via OIDC

## After merge

1. Tag `v0.16.1` on the merge commit
2. Create GitHub Release from the tag with the CHANGELOG v0.16.1 section as the body
3. `publish.yml` auto-fires on Release publish → PyPI

## Linked

- #488 — the hotfix landing on `main`
- #489 — sync-back to `dev`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed v20→v21 migration issue preventing data ingestion due to schema validation failures.

* **Documentation**
  * Added v0.16.1 release notes documenting the hotfix and migration upgrade instructions.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/BicameralAI/bicameral-mcp/pull/490?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->