### PR TITLE
fix(packaging): tighten requires-python to >=3.11 (hotfix v0.16.2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,48 @@
 All notable changes to bicameral-mcp are tracked here. Format loosely follows
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
+## v0.16.2 — Hotfix: tighten `requires-python` to `>=3.11`
+
+P1 hotfix. v0.16.0 and v0.16.1 declared `requires-python = ">=3.10"` but the code uses `datetime.UTC` (added in Python 3.11) at `preflight_telemetry.py:47`. Every install on Python 3.10 passed pip's metadata check and then crashed at server import:
+
+```
+ImportError: cannot import name 'UTC' from 'datetime'
+```
+
+uv tool installations were the most common path to this state — uv reuses whatever Python is already on PATH (or in an existing tool venv), so users with a 3.10 default got a broken bicameral-mcp 0.16.x install. The bug was masked by the install-success line; only first MCP startup surfaced it.
+
+### Fixed
+
+- **`requires-python` corrected** to match actual runtime requirements (#490 follow-up). 3.10 installs now fail with a clear PEP 517 error at install time instead of a runtime `ImportError`. Users affected get an actionable message ("requires Python >= 3.11") instead of the cryptic traceback.
+
+### Affected users
+
+Anyone whose `bicameral-mcp` was installed against Python 3.10. With uv:
+
+```
+uv tool list  # check the active Python; if 3.10 → reinstall
+```
+
+### Upgrade
+
+```
+uv tool uninstall bicameral-mcp
+uv tool install --python python3.13 bicameral-mcp
+```
+
+(or any Python 3.11+; recommended 3.13.)
+
+### Prevention (deferred to a follow-up PR)
+
+This bug-class (metadata claims a Python floor lower than what the code actually needs) is structurally preventable via:
+
+- **CI matrix on minimum-claimed Python** — when `requires-python = ">=3.11"`, CI runs a 3.11 job that does a real `pip install` + import smoke test
+- **`ruff --target-version=py311`** — catches `datetime.UTC` and similar 3.11-only APIs at lint time
+
+Filed for a follow-up dev-branch PR; not bundled in this hotfix to keep the diff focused.
+
+---
+
 ## v0.16.1 — Hotfix: v20→v21 migration uses valid enum values
 
 P0 hotfix for v0.16.0 (and earlier). The v20→v21 migration backfills synthetic `compliance_check` rows for pre-verdict-era reflected decisions; the original implementation used sentinel values (`confidence='migrated'`, `phase='migration'`) that are rejected by their schema ASSERTs at runtime. The migration raises a SurrealDB schema-violation error on the first `CREATE compliance_check` statement, blocking **any** `bicameral.ingest` call against an affected ledger.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,10 +4,10 @@ build-backend = "hatchling.build"
 
 [project]
 name = "bicameral-mcp"
-version = "0.16.1"
+version = "0.16.2"
 description = "Decision ledger MCP server — ingests meeting transcripts, maps decisions to code, tracks drift"
 readme = "README.md"
-requires-python = ">=3.10"
+requires-python = ">=3.11"
 license = {text = "MIT"}
 authors = [{name = "Bicameral AI"}]
 keywords = ["mcp", "decision-ledger", "code-locator", "drift-detection", "llm"]


### PR DESCRIPTION
## Hotfix v0.16.2 — flow:hotfix → main

**Severity**: P1. Affects v0.16.0 and v0.16.1 on PyPI. Every install against Python 3.10 succeeds the metadata gate then crashes at server import.

## What broke

`pyproject.toml` declared `requires-python = ">=3.10"` but the code imports `from datetime import UTC` at `preflight_telemetry.py:47`. `datetime.UTC` was added in Python 3.11. On 3.10:

```
ImportError: cannot import name 'UTC' from 'datetime'
```

uv tool installations were the dominant path to this state — uv reuses whatever Python is on PATH or already in a tool venv, so users defaulting to 3.10 got a broken `bicameral-mcp` install. The bug was masked by uv's install-success line; only the first MCP startup surfaced it.

## Fix

Single-line metadata change: `requires-python = ">=3.10"` → `">=3.11"`. No code change.

3.10 installs now fail at install time with a clear PEP 517 message ("requires Python >= 3.11") instead of a runtime `ImportError`. Honest contract, actionable error.

## Plan / Audit / Seal

- **Plan**: trivial; risk:L1 (metadata + CHANGELOG)
- **Audit**: bug class is symmetric to #488 (declared contract drifted from actual code requirements); same prevention pattern proposed for follow-up
- **Seal**: on tag-push + GitHub Release

## Test plan

- [x] Repro confirmed — installing v0.16.1 in a uv-managed Python 3.10 venv produces the documented `ImportError` on `bicameral-mcp --version`
- [x] Resolution confirmed — `uv tool install --python python3.13 bicameral-mcp==0.16.1` (or v0.16.2) starts cleanly; `bicameral-mcp --version` prints the version
- [x] No code change; existing test suite unaffected

## Sync-back to dev (per DEV_CYCLE §10)

`dev` carries the same `pyproject.toml` floor. Sync-back PR follows after this lands.

## Prevention work (deliberately deferred)

This bug-class — declared contract diverging from code reality, only caught at runtime — is structurally preventable via:

1. **CI matrix on minimum-claimed Python** — when `requires-python = ">=3.11"`, CI must include a 3.11 job that does a real `pip install` + import smoke test
2. **`ruff --target-version=py311`** — catches `datetime.UTC` and similar 3.11-only APIs at lint time

Same pattern as the #488 v20→v21 migration bug (schema ASSERT vs migration write drift). Both surface only at runtime against real data/environments. Filed for a follow-up dev-branch PR alongside the schema-aware lint and migration-test mandate from the #488 retro.

## Discovery context

Found during v0.16.1 rollout: after `uv tool install --force bicameral-mcp==0.16.1`, the upgraded binary still crashed at startup with the same `ImportError`. Investigation showed the install used Python 3.10 (uv's tool venv default for this user), and the v0.16.x code requires 3.11+. The v0.16.1 hotfix landed correctly on disk; the install just couldn't run it.

## Linked

- #488 — v0.16.1 hotfix (the original migration enum-mismatch); same hotfix doctrine
- #490 — v0.16.1 release PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)