### PR TITLE
release: v0.16.4 — migrate-state .mcp.json fix (#494) + Python floor smoke gate (triage)

### DIFF
--- a/.github/workflows/python-floor-smoke.yml
+++ b/.github/workflows/python-floor-smoke.yml
@@ -1,0 +1,51 @@
+name: Python Floor Smoke Test
+
+# Prevention gate for the #491 bug class: `pyproject.toml`'s
+# `requires-python` floor drifting from code that actually uses a
+# newer-version-only API (e.g. `from datetime import UTC`, added in
+# 3.11). The lint gate (`ruff --target-version=py311`) catches most of
+# these statically; this runtime gate installs the package against the
+# declared floor and imports it end-to-end through the same path real
+# users hit (`bicameral-mcp --version`).
+#
+# Cheap by design: one Ubuntu job, single Python version, no test
+# suite. ~30 seconds on a warm runner.
+
+on:
+  pull_request:
+    branches: [main, dev]
+
+jobs:
+  install-and-import:
+    name: Install + import against declared Python floor
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v4
+
+      # The declared floor in pyproject.toml is `requires-python = ">=3.11"`.
+      # If that floor moves, bump this version pin in the same PR — the
+      # contract is "CI runs against the lowest declared-supported Python."
+      - name: Set up Python 3.11 (declared floor)
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+
+      - name: Install package (non-editable, from source tree)
+        # `pip install .` builds the wheel through hatch and installs it
+        # into the runner's site-packages — same code path a user gets
+        # from `pip install bicameral-mcp` against PyPI (modulo network).
+        run: |
+          python -m pip install --upgrade pip
+          pip install .
+
+      - name: Import smoke test (`bicameral-mcp --version`)
+        # The #491 repro: `from datetime import UTC` at
+        # preflight_telemetry.py:47 blows up at import time on 3.10.
+        # `--version` is the smallest invocation that exercises the
+        # full server.py top-level import chain (handlers.* →
+        # preflight_telemetry). Run from outside the source tree so the
+        # installed package is exercised, not the in-tree files.
+        run: |
+          cd /tmp
+          bicameral-mcp --version

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,30 @@
 All notable changes to bicameral-mcp are tracked here. Format loosely follows
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
+## v0.16.3 — Triage: locator-migration `.mcp.json` fix + v0.16.2 prevention gate
+
+Triage release. Two cherry-picks from `dev`:
+
+### Fixed
+
+- **`migrate-state` rewrites legacy `.mcp.json` env block** (#494). After #368 (Ledger Locator) moved per-project state to `~/.bicameral/projects/<id>/`, `migrate-state` moved files on disk but did not touch the `SURREAL_URL` / `CODE_LOCATOR_SQLITE_DB` env overrides in `<repo>/.mcp.json` that older setup_wizard versions wrote. `resolve_ledger_url()` honors `SURREAL_URL` unconditionally, so existing pilots were silently pinned to the pre-locator layout — exactly the cross-worktree determinism the locator was supposed to deliver. `migrate-state` now drops these env entries when they resolve into `<repo>/.bicameral/` and preserves them otherwise (`memory://`, custom paths outside the repo, other env keys, other MCP servers untouched).
+
+### Added (prevention)
+
+- **Python floor smoke test CI gate** (#493 follow-up to #491). One Ubuntu job per PR installs the package against the declared `requires-python` floor (3.11) via `pip install .` and runs `bicameral-mcp --version` end-to-end. Catches the recurrence of the v0.16.2 bug class (`requires-python` floor drifting from code that actually uses a newer-version-only API). Pairs with the `ruff --target-version=py311` lint gate already in `pyproject.toml`.
+
+### Affected users
+
+- **`.mcp.json` rewrite**: any pilot who installed bicameral-mcp before v0.16.0 and ran `migrate-state` since. Symptom: `bicameral.diagnose` reports `ledger_url: surrealkv://<repo>/.bicameral/local/ledger.db` instead of `surrealkv://~/.bicameral/projects/<id>/ledger.db`. Re-run `bicameral-mcp migrate-state --auto` after upgrade; the env block rewrites idempotently and the locator picks up the canonical path on next start.
+- **CI gate**: contributor-facing; no user-visible runtime change.
+
+### Linked
+
+- Closes #494 (the migration gap on existing `.mcp.json` files).
+- Follow-up to #491 (`requires-python >= 3.11` hotfix) — the prevention work that #491's body filed as deliberately deferred.
+
+---
+
 ## v0.16.2 — Hotfix: tighten `requires-python` to `>=3.11`
 
 P1 hotfix. v0.16.0 and v0.16.1 declared `requires-python = ">=3.10"` but the code uses `datetime.UTC` (added in Python 3.11) at `preflight_telemetry.py:47`. Every install on Python 3.10 passed pip's metadata check and then crashed at server import:

--- a/cli/migrate_state.py
+++ b/cli/migrate_state.py
@@ -14,6 +14,7 @@ config.yaml with a warning logged — forward-compat for future versions.
 from __future__ import annotations
 
 import argparse
+import json
 import shutil
 from datetime import UTC, datetime
 from pathlib import Path
@@ -206,6 +207,98 @@ def _partition_config_yaml(
     return did_something, warnings
 
 
+_LEGACY_SURREAL_SCHEME = "surrealkv://"
+
+
+def _is_repo_local_path(path_str: str, repo: Path) -> bool:
+    """Return True when ``path_str`` resolves inside ``<repo>/.bicameral/``.
+
+    Used to identify legacy in-repo overrides written by setup_wizard
+    before #368 shipped. Resolves both sides so symlinked repos and
+    relative paths behave the same way. Unresolvable paths (e.g.,
+    malformed) return False — preserve, don't clobber.
+    """
+    if not path_str:
+        return False
+    try:
+        candidate = Path(path_str).expanduser().resolve(strict=False)
+        legacy_root = (repo / ".bicameral").resolve(strict=False)
+    except (OSError, RuntimeError):
+        return False
+    try:
+        candidate.relative_to(legacy_root)
+    except ValueError:
+        return False
+    return True
+
+
+def _is_legacy_repo_local_surreal_url(url: str, repo: Path) -> bool:
+    """Return True iff ``url`` is a ``surrealkv://`` URL pointing into
+    ``<repo>/.bicameral/``. ``memory://`` and any URL pointing outside
+    the repo are legitimate operator overrides — preserve them.
+    """
+    if not url.startswith(_LEGACY_SURREAL_SCHEME):
+        return False
+    path_part = url[len(_LEGACY_SURREAL_SCHEME) :]
+    return _is_repo_local_path(path_part, repo)
+
+
+def _rewrite_mcp_json(repo: Path, *, dry_run: bool) -> tuple[bool, list[str]]:
+    """Drop legacy in-repo ``SURREAL_URL`` / ``CODE_LOCATOR_SQLITE_DB``
+    overrides from ``<repo>/.mcp.json`` so the locator can resolve the
+    canonical paths at next startup (#494).
+
+    Only the ``mcpServers.bicameral.env`` block is touched, and only
+    when the value resolves into ``<repo>/.bicameral/``. Anything else
+    (other servers, other env keys, ``memory://``, paths outside the
+    repo) is preserved untouched.
+
+    Returns ``(did_rewrite, warnings)``. No-op when the file is absent,
+    unparseable, or already clean.
+    """
+    config_path = repo / ".mcp.json"
+    if not config_path.is_file():
+        return False, []
+
+    raw = config_path.read_text(encoding="utf-8")
+    try:
+        loaded = json.loads(raw)
+    except json.JSONDecodeError as exc:
+        return False, [f".mcp.json unparseable ({exc}) — leaving untouched"]
+    if not isinstance(loaded, dict):
+        return False, [".mcp.json top-level is not an object — leaving untouched"]
+
+    servers = loaded.get("mcpServers")
+    if not isinstance(servers, dict):
+        return False, []
+    bicameral = servers.get("bicameral")
+    if not isinstance(bicameral, dict):
+        return False, []
+    env = bicameral.get("env")
+    if not isinstance(env, dict):
+        return False, []
+
+    removed_keys: list[str] = []
+
+    surreal_url = env.get("SURREAL_URL")
+    if isinstance(surreal_url, str) and _is_legacy_repo_local_surreal_url(surreal_url, repo):
+        del env["SURREAL_URL"]
+        removed_keys.append("SURREAL_URL")
+
+    code_locator_db = env.get("CODE_LOCATOR_SQLITE_DB")
+    if isinstance(code_locator_db, str) and _is_repo_local_path(code_locator_db, repo):
+        del env["CODE_LOCATOR_SQLITE_DB"]
+        removed_keys.append("CODE_LOCATOR_SQLITE_DB")
+
+    if not removed_keys:
+        return False, []
+
+    if not dry_run:
+        config_path.write_text(json.dumps(loaded, indent=2) + "\n", encoding="utf-8")
+
+    return True, [f"dropped legacy env keys from .mcp.json: {', '.join(removed_keys)}"]
+
+
 def _execute_plan(
     plan: list[tuple[Path, Path]],
     archive_dir: Path,
@@ -255,10 +348,19 @@ def _print_summary(
     empty_dirs_removed: list[Path],
     config_did_split: bool,
     config_warnings: list[str],
+    mcp_json_did_rewrite: bool,
+    mcp_json_warnings: list[str],
     *,
     dry_run: bool,
 ) -> None:
-    if not log and not empty_dirs_removed and not config_did_split:
+    if (
+        not log
+        and not empty_dirs_removed
+        and not config_did_split
+        and not mcp_json_did_rewrite
+        and not mcp_json_warnings
+        and not config_warnings
+    ):
         print("  Nothing to migrate.")
         return
     prefix = "[dry-run] " if dry_run else ""
@@ -276,6 +378,10 @@ def _print_summary(
         print(f"  {prefix}split config.yaml → team-identity + operator.yaml")
     for w in config_warnings:
         print(f"  WARN: {w}")
+    for w in mcp_json_warnings:
+        # Both informational ("dropped …") and failure ("unparseable") flow through
+        # the same channel — the message itself carries enough context.
+        print(f"  {prefix}{w}" if w.startswith("dropped") else f"  WARN: {w}")
     # R4 deferred-ephemeral notice (decision:e3xz4c4ji4x7lm3lvq4k).
     print(
         "  Note: ~/.bicameral/projects/ persists per home directory. If you run "
@@ -356,6 +462,7 @@ def main(argv: list[str] | None = None) -> int:
     config_did_split, config_warnings = _partition_config_yaml(
         repo, project_dir, dry_run=args.dry_run
     )
+    mcp_json_did_rewrite, mcp_json_warnings = _rewrite_mcp_json(repo, dry_run=args.dry_run)
     empty_dirs_removed = _cleanup_empty_source_dirs(repo, dry_run=args.dry_run)
 
     _print_summary(
@@ -363,6 +470,8 @@ def main(argv: list[str] | None = None) -> int:
         empty_dirs_removed,
         config_did_split,
         config_warnings,
+        mcp_json_did_rewrite,
+        mcp_json_warnings,
         dry_run=args.dry_run,
     )
     return 0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "bicameral-mcp"
-version = "0.16.2"
+version = "0.16.3"
 description = "Decision ledger MCP server — ingests meeting transcripts, maps decisions to code, tracks drift"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/tests/test_migrate_state.py
+++ b/tests/test_migrate_state.py
@@ -308,3 +308,198 @@ def test_partitions_config_yaml_keys(git_repo: Path) -> None:
     assert op["telemetry"] is False
     assert op["channel"] == "stable"
     assert op["team"] == {"role": "member"}
+
+
+# ── #494: .mcp.json env-block rewrites ─────────────────────────────────
+
+
+def _write_mcp_json(repo: Path, env: dict[str, str], *, extra_servers: dict | None = None) -> Path:
+    """Write a `.mcp.json` with a `bicameral` server entry whose env is
+    ``env``. Optional ``extra_servers`` are written alongside untouched."""
+    import json as _json
+
+    servers: dict = {
+        "bicameral": {
+            "command": "bicameral-mcp",
+            "args": [],
+            "env": env,
+        }
+    }
+    if extra_servers:
+        servers.update(extra_servers)
+    payload = {"mcpServers": servers}
+    path = repo / ".mcp.json"
+    path.write_text(_json.dumps(payload, indent=2) + "\n", encoding="utf-8")
+    return path
+
+
+def _read_bicameral_env(repo: Path) -> dict:
+    import json as _json
+
+    data = _json.loads((repo / ".mcp.json").read_text(encoding="utf-8"))
+    return data["mcpServers"]["bicameral"]["env"]
+
+
+def test_mcp_json_drops_legacy_surreal_url(git_repo: Path) -> None:
+    legacy_db = git_repo / ".bicameral" / "local" / "ledger.db"
+    legacy_db.parent.mkdir(parents=True, exist_ok=True)
+    _write_mcp_json(
+        git_repo,
+        {
+            "REPO_PATH": str(git_repo),
+            "SURREAL_URL": f"surrealkv://{legacy_db}",
+        },
+    )
+
+    rc = migrate_state.main(["--repo", str(git_repo), "--auto"])
+    assert rc == 0
+
+    env = _read_bicameral_env(git_repo)
+    assert "SURREAL_URL" not in env
+    # Unrelated env keys preserved.
+    assert env["REPO_PATH"] == str(git_repo)
+
+
+def test_mcp_json_drops_legacy_code_locator_sqlite_db(git_repo: Path) -> None:
+    legacy_db = git_repo / ".bicameral" / "local" / "code-graph.db"
+    legacy_db.parent.mkdir(parents=True, exist_ok=True)
+    _write_mcp_json(
+        git_repo,
+        {
+            "REPO_PATH": str(git_repo),
+            "CODE_LOCATOR_SQLITE_DB": str(legacy_db),
+        },
+    )
+
+    rc = migrate_state.main(["--repo", str(git_repo), "--auto"])
+    assert rc == 0
+
+    env = _read_bicameral_env(git_repo)
+    assert "CODE_LOCATOR_SQLITE_DB" not in env
+    assert env["REPO_PATH"] == str(git_repo)
+
+
+def test_mcp_json_preserves_memory_surreal_url(git_repo: Path) -> None:
+    """`memory://` is a legitimate operator override (tests, ephemeral
+    contexts) — must not be touched."""
+    _write_mcp_json(
+        git_repo,
+        {"REPO_PATH": str(git_repo), "SURREAL_URL": "memory://"},
+    )
+
+    rc = migrate_state.main(["--repo", str(git_repo), "--auto"])
+    assert rc == 0
+
+    assert _read_bicameral_env(git_repo)["SURREAL_URL"] == "memory://"
+
+
+def test_mcp_json_preserves_non_repo_surreal_url(tmp_path: Path, git_repo: Path) -> None:
+    """A `surrealkv://` URL pointing outside `<repo>/.bicameral/` is a
+    legitimate user customization (private ledger location, alternate
+    home, etc.) — must not be touched."""
+    custom_db = tmp_path / "elsewhere" / "ledger.db"
+    custom_db.parent.mkdir(parents=True, exist_ok=True)
+    custom_url = f"surrealkv://{custom_db}"
+    _write_mcp_json(
+        git_repo,
+        {"REPO_PATH": str(git_repo), "SURREAL_URL": custom_url},
+    )
+
+    rc = migrate_state.main(["--repo", str(git_repo), "--auto"])
+    assert rc == 0
+
+    assert _read_bicameral_env(git_repo)["SURREAL_URL"] == custom_url
+
+
+def test_mcp_json_preserves_non_repo_code_locator_sqlite_db(tmp_path: Path, git_repo: Path) -> None:
+    custom_db = tmp_path / "elsewhere" / "code-graph.db"
+    custom_db.parent.mkdir(parents=True, exist_ok=True)
+    _write_mcp_json(
+        git_repo,
+        {"REPO_PATH": str(git_repo), "CODE_LOCATOR_SQLITE_DB": str(custom_db)},
+    )
+
+    rc = migrate_state.main(["--repo", str(git_repo), "--auto"])
+    assert rc == 0
+
+    assert _read_bicameral_env(git_repo)["CODE_LOCATOR_SQLITE_DB"] == str(custom_db)
+
+
+def test_mcp_json_idempotent_second_run_is_noop(git_repo: Path, capsys) -> None:
+    legacy_db = git_repo / ".bicameral" / "local" / "ledger.db"
+    legacy_db.parent.mkdir(parents=True, exist_ok=True)
+    _write_mcp_json(
+        git_repo,
+        {"REPO_PATH": str(git_repo), "SURREAL_URL": f"surrealkv://{legacy_db}"},
+    )
+
+    assert migrate_state.main(["--repo", str(git_repo), "--auto"]) == 0
+    capsys.readouterr()  # discard first-pass output
+
+    assert migrate_state.main(["--repo", str(git_repo), "--auto"]) == 0
+    out = capsys.readouterr().out
+    assert "Nothing to migrate." in out
+    assert "dropped legacy env keys" not in out
+
+
+def test_mcp_json_absent_is_noop(git_repo: Path) -> None:
+    assert not (git_repo / ".mcp.json").exists()
+    rc = migrate_state.main(["--repo", str(git_repo), "--auto"])
+    assert rc == 0
+    assert not (git_repo / ".mcp.json").exists()
+
+
+def test_mcp_json_unparseable_warns_and_preserves(git_repo: Path, capsys) -> None:
+    (git_repo / ".mcp.json").write_text("{ not json", encoding="utf-8")
+    rc = migrate_state.main(["--repo", str(git_repo), "--auto"])
+    assert rc == 0
+    out = capsys.readouterr().out
+    assert "WARN" in out and "unparseable" in out
+    # File untouched.
+    assert (git_repo / ".mcp.json").read_text(encoding="utf-8") == "{ not json"
+
+
+def test_mcp_json_dry_run_does_not_write(git_repo: Path) -> None:
+    legacy_db = git_repo / ".bicameral" / "local" / "ledger.db"
+    legacy_db.parent.mkdir(parents=True, exist_ok=True)
+    surreal_url = f"surrealkv://{legacy_db}"
+    _write_mcp_json(
+        git_repo,
+        {"REPO_PATH": str(git_repo), "SURREAL_URL": surreal_url},
+    )
+    before = (git_repo / ".mcp.json").read_text(encoding="utf-8")
+
+    rc = migrate_state.main(["--repo", str(git_repo), "--auto", "--dry-run"])
+    assert rc == 0
+    assert (git_repo / ".mcp.json").read_text(encoding="utf-8") == before
+
+
+def test_mcp_json_preserves_other_servers(git_repo: Path) -> None:
+    """A non-bicameral server entry in the same `.mcp.json` (e.g., user's
+    other MCP servers) must remain untouched even when its env happens
+    to contain a key name we recognize."""
+    legacy_db = git_repo / ".bicameral" / "local" / "ledger.db"
+    legacy_db.parent.mkdir(parents=True, exist_ok=True)
+    other_env = {"SURREAL_URL": f"surrealkv://{legacy_db}"}  # decoy
+    _write_mcp_json(
+        git_repo,
+        env={"REPO_PATH": str(git_repo), "SURREAL_URL": f"surrealkv://{legacy_db}"},
+        extra_servers={
+            "other-tool": {
+                "command": "other-mcp",
+                "args": [],
+                "env": other_env,
+            }
+        },
+    )
+
+    rc = migrate_state.main(["--repo", str(git_repo), "--auto"])
+    assert rc == 0
+
+    import json as _json
+
+    data = _json.loads((git_repo / ".mcp.json").read_text(encoding="utf-8"))
+    # bicameral env: rewritten.
+    assert "SURREAL_URL" not in data["mcpServers"]["bicameral"]["env"]
+    # other-tool env: preserved verbatim.
+    assert data["mcpServers"]["other-tool"]["env"] == other_env

--- a/tests/test_v21_compliance_check_backfill.py
+++ b/tests/test_v21_compliance_check_backfill.py
@@ -55,9 +55,7 @@ async def _seed_reflected_decision_with_binding(
     )
     drow = drows[0]
     rid = drow.get("id")
-    decision_id = (
-        f"decision:{rid.get('id', rid)}" if isinstance(rid, dict) else str(rid)
-    )
+    decision_id = f"decision:{rid.get('id', rid)}" if isinstance(rid, dict) else str(rid)
 
     rrows = await c.query(
         "CREATE code_region SET file_path = $f, start_line = 1, end_line = 5, "
@@ -66,13 +64,10 @@ async def _seed_reflected_decision_with_binding(
     )
     rrow = rrows[0]
     rrid = rrow.get("id")
-    region_id = (
-        f"code_region:{rrid.get('id', rrid)}" if isinstance(rrid, dict) else str(rrid)
-    )
+    region_id = f"code_region:{rrid.get('id', rrid)}" if isinstance(rrid, dict) else str(rrid)
 
     await c.query(
-        f"RELATE {decision_id}->binds_to->{region_id} "
-        "SET content_hash = $h, confidence = 1.0",
+        f"RELATE {decision_id}->binds_to->{region_id} SET content_hash = $h, confidence = 1.0",
         {"h": "abc123hashvalue"},
     )
     return decision_id, region_id


### PR DESCRIPTION
## Summary

Triage release. Two cherry-picks from `dev`, each independently shippable:

1. **`fix(ledger): migrate-state rewrites legacy .mcp.json env block` (#494)** — `dev-sha 6f32ce8` → triage-sha `4d3929a`. Fixes the silent locator-determinism break for existing pilots whose `.mcp.json` predates BicameralAI/bicameral-daemon#2.
2. **`ci(infra): Python floor smoke test — prevent BicameralAI/bicameral-mcp#491 bug class` (#493 substance)** — `dev-sha aa0428a` → triage-sha `3d40be6`. The runtime gate from BicameralAI/bicameral-mcp#491's deferred prevention list (the lint half — `ruff --target-version=py311` — already shipped in v0.16.0).

The `ruff format` / `StrEnum` lint fixes from BicameralAI/bicameral-mcp#493 (`dev-sha 985f9f1`, `fa23b48`) are **not** cherry-picked: they target `daemon/` and `protocol/` modules that exist on `dev` but not on `main` (Phase 2a/2b daemon work, not yet released).

## Why triage instead of waiting

- **#494** unblocks the existing-pilot population from a silent state-divergence bug that contradicts a recently-shipped invariant (cross-worktree determinism). Workaround is a per-user manual `.mcp.json` edit; that's not a thing we want pilots discovering.
- **#493** closes the remaining prevention gap for the v0.16.2 hotfix. The longer we go without it, the higher the chance the same class of bug ships again before the daemon work lands.

Neither change touches schema, contracts, or the ledger semantics — both are isolated additions.

## Cherry-pick provenance

| Commit on main | Source on dev | PR | Issue |
|---|---|---|---|
| `3d40be6` | `aa0428a` | BicameralAI/bicameral-mcp#493 | (follows from BicameralAI/bicameral-mcp#491) |
| `4d3929a` | `6f32ce8` | BicameralAI/bicameral-mcp#495 | BicameralAI/bicameral-mcp#494 |
| `c2f32fe` | (release-prep) | — | — |

## Linked issues

Closes BicameralAI/bicameral-mcp#494
Refs BicameralAI/bicameral-mcp#491 (prevention work originally deferred from this hotfix)
Refs BicameralAI/bicameral-mcp#493, BicameralAI/bicameral-mcp#495 (the dev-side PRs being triaged)

## Plan / Audit / Seal

Plan: trivial; risk:L1 (two clean cherry-picks, ~360 LOC, no schema or ledger semantic change).

## Test plan

- [x] Local: full `pytest tests/test_migrate_state.py -q` → 22/22 (run on `release/v0.16.3` head before push).
- [x] `ruff check .` and `ruff format --check .` clean.
- [ ] CI green on this PR (the new Python floor smoke gate runs *on this PR itself* — first end-to-end exercise on `main`-targeting code).
- [ ] After merge: tag `v0.16.3`, GitHub Release, PyPI publish via `publish.yml`.

## Upgrade

```
uv tool install --force --python python3.13 bicameral-mcp==0.16.3
bicameral-mcp migrate-state --auto    # idempotent; rewrites .mcp.json if affected
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a CI smoke-test that installs the package and verifies it runs under the declared Python minimum (pyproject requires-python floor).

* **Bug Fixes**
  * migrate-state now strips legacy repo-local environment overrides that could cause incorrect cross-repo locator resolution.

* **Tests**
  * Added tests covering .mcp.json migration behaviors, idempotence, dry-run, and error cases.

* **Chores**
  * Version bumped to v0.16.4 and changelog updated.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/BicameralAI/bicameral-mcp/pull/496?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->