### PR TITLE
fix(ledger): refuse to boot on surrealdb SDK version drift (hotfix v0.16.3)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,56 @@
 All notable changes to bicameral-mcp are tracked here. Format loosely follows
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
+## v0.16.3 — Hotfix: refuse to boot on surrealdb SDK version drift
+
+P1 hotfix. When bicameral-mcp's `surrealdb==X.Y.Z` pin changes between releases (or when a user has two installs on the same machine with different pins — pipx + uv tool, or two venvs), the previously-written ledger rows become unreadable by the newly-installed SDK. The deserialization fails mid-RPC with:
+
+```
+SurrealDB row deserialization failed: Invalid revision `N` for type `Value`
+SQL: UPDATE decision:... SET status = $s, updated_at = time::now()
+```
+
+The infrastructure to detect this was already in place — `bicameral_meta` tracks `surrealdb_client_version_at_last_write`, and `_write_wire_format_sentinel` emits a `LEDGER_VERSION_DRIFT` audit event when running and recorded versions disagree — but the event was observability-only. Boot continued, and the next write crashed.
+
+This release converts the silent crash into a loud, actionable startup error.
+
+### Fixed
+
+- **SDK-version startup guard** (`ledger/adapter.py`). `adapter.connect()` now runs a pre-check that reads `bicameral_meta` *without updating it*, and raises `SurrealClientVersionMismatchError` when the recorded SDK version doesn't match `importlib.metadata.version("surrealdb")`. The MCP tool boundary surfaces this as a structured error with `action`: `bicameral-mcp reset --confirm --wipe-mode=ledger --replay-from-events`, so the operator gets a clear path instead of a runtime traceback.
+- **Pin tightened in `requirements.txt`**: `surrealdb>=1.0.0` → `surrealdb==2.0.0`, matching `pyproject.toml`. Closes the `pip install -r requirements.txt` resolution gap that let developers end up with arbitrary SDK wheels.
+
+### Bypass
+
+For emergencies (operator knows the on-disk format is actually compatible, e.g. cosmetic SDK metadata version bump with no format change):
+
+```
+BICAMERAL_SKIP_SDK_GUARD=1 bicameral-mcp
+```
+
+The bypass logs a WARN every connect — running in best-effort mode is opt-in and visible in logs. Bypass is NOT recommended; data loss is possible if the underlying surrealkv format genuinely changed.
+
+### Scope
+
+The guard catches **`surrealdb` Python package version drift** — the dominant cause. It does NOT catch surrealkv-internal format changes within a single `surrealdb` version (the bundled rust binary versions independently). That deeper case is tracked separately and belongs alongside the daemon work (#372), which isolates the SDK behind a stable `ws://` wire protocol.
+
+### Affected users
+
+- Anyone in-place upgrading bicameral-mcp across a release that bumped the `surrealdb` pin.
+- Anyone with multiple bicameral-mcp installations on the same machine (different package managers, different venvs).
+- Fresh installs and users on a pin-stable release path: not affected.
+
+### Upgrade
+
+```
+uv tool upgrade bicameral-mcp
+# or
+pipx upgrade bicameral-mcp
+```
+
+If upgrade is from a release that pinned a different `surrealdb` version, the first MCP startup will refuse to connect and print the recovery command verbatim. Run that command and re-start.
+
+---
+
 ## v0.16.2 — Hotfix: tighten `requires-python` to `>=3.11`
 
 P1 hotfix. v0.16.0 and v0.16.1 declared `requires-python = ">=3.10"` but the code uses `datetime.UTC` (added in Python 3.11) at `preflight_telemetry.py:47`. Every install on Python 3.10 passed pip's metadata check and then crashed at server import:

--- a/ledger/adapter.py
+++ b/ledger/adapter.py
@@ -205,6 +205,43 @@ class EventReplaySchemaViolation(RuntimeError):
 _STATUS_PRIORITY = {"drifted": 3, "reflected": 2, "pending": 1, "ungrounded": 0}
 
 
+_SDK_GUARD_BYPASS_ENV = "BICAMERAL_SKIP_SDK_GUARD"
+_TRUTHY = frozenset({"1", "true", "yes", "on"})
+
+
+class SurrealClientVersionMismatchError(RuntimeError):
+    """The running ``surrealdb`` SDK doesn't match the version that last
+    wrote the ledger. Raised at ``adapter.connect()`` BEFORE any RPC can
+    fire, so the failure mode is a loud actionable startup error instead
+    of an opaque mid-RPC ``Invalid revision N for type Value`` crash on
+    the first UPDATE.
+
+    The bypass env var (``BICAMERAL_SKIP_SDK_GUARD=1``) is documented as
+    last-resort — bypassing does not fix the underlying on-disk
+    incompatibility; it only lets the server attempt to run and accept
+    the deserialization failures as they happen.
+    """
+
+    def __init__(self, *, recorded: str | None, running: str | None, url: str) -> None:
+        self.recorded = recorded
+        self.running = running
+        self.url = url
+        super().__init__(
+            f"surrealdb SDK version mismatch on ledger {url}: "
+            f"last write recorded by surrealdb {recorded!r}, currently running surrealdb {running!r}. "
+            f"On-disk row format is likely incompatible — proceeding will crash mid-RPC with "
+            f"'Invalid revision N for type Value' on the first UPDATE. "
+            f"Recover with: `bicameral-mcp reset --confirm --wipe-mode=ledger --replay-from-events`, "
+            f"or downgrade bicameral-mcp to a version that pins surrealdb {recorded!r}. "
+            f"To bypass this guard (NOT RECOMMENDED — risks silent data loss), "
+            f"set {_SDK_GUARD_BYPASS_ENV}=1."
+        )
+
+
+def _sdk_guard_bypassed() -> bool:
+    return os.getenv(_SDK_GUARD_BYPASS_ENV, "").strip().lower() in _TRUTHY
+
+
 def _aggregate_decision_status(region_statuses: list[str]) -> str:
     """Collapse per-region statuses to a single decision status.
 
@@ -268,16 +305,76 @@ class SurrealDBLedgerAdapter:
             # and provide isolation for the two-layer try/except.
             await self._emit_wire_format_sentinel()
 
+    async def _sdk_version_pre_check(self) -> tuple[str | None, str, str]:
+        """Read the recorded vs. running surrealdb SDK version WITHOUT
+        updating ``bicameral_meta``. The matching writer
+        (``_write_wire_format_sentinel``) updates ``last_write`` on every
+        connect — including drift — which means a single mismatched boot
+        silently disarms detection on the next one. Pre-checking against
+        the un-updated row preserves the signal across boots until the
+        operator explicitly recovers or bypasses.
+
+        Returns ``(recorded, running, status)`` where ``status`` is
+        ``"match"``, ``"drift"``, or ``"first-write"`` (no recorded
+        version yet). Treats any read failure as ``"first-write"`` — the
+        ``bicameral_meta`` row is freshly initialized by ``init_schema``
+        on every connect, so a missing row is the legitimate first-boot
+        case rather than an indicator of corruption.
+        """
+        import importlib.metadata
+
+        try:
+            running = importlib.metadata.version("surrealdb")
+        except importlib.metadata.PackageNotFoundError:
+            return None, "unknown", "first-write"
+
+        try:
+            rows = await self._client.query("SELECT * FROM bicameral_meta LIMIT 1")
+        except Exception:  # noqa: BLE001 — pre-check MUST NOT raise on read failure
+            return None, running, "first-write"
+
+        if not rows:
+            return None, running, "first-write"
+
+        recorded = rows[0].get("surrealdb_client_version_at_last_write")
+        if recorded is None:
+            return None, running, "first-write"
+        if recorded == running:
+            return recorded, running, "match"
+        return recorded, running, "drift"
+
     async def _emit_wire_format_sentinel(self) -> None:
         """#252 Layer 2: write the bicameral_meta sentinel row + emit audit-log.
+
+        SDK version guard runs BEFORE the writer: if the recorded SDK
+        version doesn't match the running one, raise
+        ``SurrealClientVersionMismatchError`` so startup fails loudly
+        instead of crashing mid-RPC on the first UPDATE. Bypass with
+        ``BICAMERAL_SKIP_SDK_GUARD=1``.
 
         Two-layer try/except: the outer wrap catches any
         ``_write_wire_format_sentinel`` raise (so a sentinel-helper failure
         doesn't break connect); the inner wrap catches any ``audit_log.emit``
         raise (so a stubbed-out emit raise — common in tests — doesn't
         propagate either). Both layers are required by the existing audit_log
-        discipline ("audit log MUST NOT break callers").
+        discipline ("audit log MUST NOT break callers"). The SDK guard
+        SITS OUTSIDE both wraps — it's a deliberate startup-blocker.
         """
+        pre_recorded, pre_running, pre_status = await self._sdk_version_pre_check()
+        if pre_status == "drift":
+            if _sdk_guard_bypassed():
+                logger.warning(
+                    "[ledger] surrealdb SDK version drift: recorded=%r running=%r — "
+                    "guard bypassed via %s; on-disk format may be incompatible",
+                    pre_recorded,
+                    pre_running,
+                    _SDK_GUARD_BYPASS_ENV,
+                )
+            else:
+                raise SurrealClientVersionMismatchError(
+                    recorded=pre_recorded, running=pre_running, url=self._url
+                )
+
         try:
             recorded, running, status = await _write_wire_format_sentinel(self._client)
         except Exception:  # noqa: BLE001 — observability MUST NOT break connect

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "bicameral-mcp"
-version = "0.16.2"
+version = "0.16.3"
 description = "Decision ledger MCP server — ingests meeting transcripts, maps decisions to code, tracks drift"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/requirements.txt
+++ b/requirements.txt
@@ -13,7 +13,7 @@ bm25s>=0.3.8
 pydantic>=2.0.0
 pyyaml>=6.0
 python-dotenv
-surrealdb>=1.0.0
+surrealdb==2.0.0  # MUST match pyproject.toml — on-disk row format ties to the SDK; mismatch causes "Invalid revision N for type Value" crashes mid-RPC
 cocoindex>=0.3.36,<1.0.0  # v1.0 alpha breaks flow API (op, flow_def, sources)
 sqlite-vec>=0.1.9
 sentence-transformers>=2.6.0

--- a/server.py
+++ b/server.py
@@ -50,6 +50,7 @@ from handlers.reset import handle_reset
 from handlers.resolve_collision import handle_resolve_collision
 from handlers.resolve_compliance import handle_resolve_compliance
 from handlers.update import get_update_notice, handle_update
+from ledger.adapter import SurrealClientVersionMismatchError
 from ledger.schema import DestructiveMigrationRequired, SchemaVersionTooNew
 
 SERVER_NAME = "bicameral-mcp"
@@ -1321,12 +1322,20 @@ async def _call_tool_impl(name: str, arguments: dict) -> list[TextContent]:
                 ),
             )
         ]
-    except (DestructiveMigrationRequired, SchemaVersionTooNew) as exc:
-        action = (
-            "run bicameral_reset(confirm=True) to apply the breaking migration and clear legacy data"
-            if isinstance(exc, DestructiveMigrationRequired)
-            else "upgrade your binary: pipx upgrade bicameral-mcp"
-        )
+    except (
+        DestructiveMigrationRequired,
+        SchemaVersionTooNew,
+        SurrealClientVersionMismatchError,
+    ) as exc:
+        if isinstance(exc, DestructiveMigrationRequired):
+            action = "run bicameral_reset(confirm=True) to apply the breaking migration and clear legacy data"
+        elif isinstance(exc, SchemaVersionTooNew):
+            action = "upgrade your binary: pipx upgrade bicameral-mcp"
+        else:
+            action = (
+                "run `bicameral-mcp reset --confirm --wipe-mode=ledger --replay-from-events` "
+                "to rebuild the ledger under the running surrealdb SDK"
+            )
         return [
             TextContent(
                 type="text",

--- a/tests/test_sdk_version_guard.py
+++ b/tests/test_sdk_version_guard.py
@@ -1,0 +1,147 @@
+"""Startup guard: refuse to boot when the recorded surrealdb SDK version
+doesn't match the running one.
+
+Catches the in-place-upgrade failure mode where bicameral-mcp bumps its
+``surrealdb==X.Y.Z`` pin and existing users' ledgers, written by the old
+SDK, become unreadable by the new SDK ("Invalid revision N for type
+Value" crashes mid-RPC on the first UPDATE). Converts the silent
+mid-RPC failure into a loud actionable startup error.
+"""
+
+from __future__ import annotations
+
+import os
+
+import pytest
+
+from ledger.adapter import (
+    SurrealClientVersionMismatchError,
+    SurrealDBLedgerAdapter,
+)
+
+
+async def _seed_recorded_version(adapter: SurrealDBLedgerAdapter, version: str) -> None:
+    """Overwrite ``bicameral_meta`` so the recorded SDK version is ``version``.
+
+    Used to simulate the post-upgrade state where the ledger was last
+    written by a different SDK pin than the one running now.
+    """
+    await adapter._client.query(
+        "UPDATE bicameral_meta SET "
+        "surrealdb_client_version_at_first_write = $v, "
+        "surrealdb_client_version_at_last_write = $v",
+        {"v": version},
+    )
+
+
+@pytest.mark.asyncio
+async def test_pre_check_detects_drift():
+    """Recorded != running ⇒ pre-check reports ``"drift"``.
+
+    Solitary on the env var (we control os.environ), sociable on the
+    ledger (real ``memory://`` adapter — the pre-check reads the actual
+    ``bicameral_meta`` row written by ``_write_wire_format_sentinel``).
+    """
+    adapter = SurrealDBLedgerAdapter(url="memory://")
+    await adapter.connect()
+    await _seed_recorded_version(adapter, "0.99.0-fictional-old-pin")
+
+    recorded, running, status = await adapter._sdk_version_pre_check()
+
+    assert status == "drift"
+    assert recorded == "0.99.0-fictional-old-pin"
+    assert running != "0.99.0-fictional-old-pin"
+
+
+@pytest.mark.asyncio
+async def test_pre_check_reports_match_on_fresh_ledger():
+    adapter = SurrealDBLedgerAdapter(url="memory://")
+    await adapter.connect()
+
+    _recorded, _running, status = await adapter._sdk_version_pre_check()
+
+    assert status == "match"
+
+
+@pytest.mark.asyncio
+async def test_sentinel_raises_on_drift(monkeypatch):
+    """Direct exercise of the guarded sentinel call: drift ⇒ raise.
+
+    We invoke ``_emit_wire_format_sentinel`` against an already-connected
+    adapter (so the seeded ``bicameral_meta`` row survives) — re-driving
+    ``adapter.connect()`` won't work for ``memory://`` because every
+    ``LedgerClient.connect()`` instantiates a fresh in-memory database
+    and erases the seeded state. The pre-check + raise behavior is what
+    matters at the production startup path; ``connect()`` calls this
+    method exactly once, on first boot, where the same survival
+    invariant holds (the ``surrealkv://`` file persists across runs).
+    """
+    monkeypatch.delenv("BICAMERAL_SKIP_SDK_GUARD", raising=False)
+
+    adapter = SurrealDBLedgerAdapter(url="memory://")
+    await adapter.connect()
+    await _seed_recorded_version(adapter, "0.99.0-fictional-old-pin")
+
+    with pytest.raises(SurrealClientVersionMismatchError) as exc_info:
+        await adapter._emit_wire_format_sentinel()
+
+    msg = str(exc_info.value)
+    assert "0.99.0-fictional-old-pin" in msg
+    assert "BICAMERAL_SKIP_SDK_GUARD" in msg
+    assert "bicameral-mcp reset" in msg
+    assert exc_info.value.recorded == "0.99.0-fictional-old-pin"
+
+
+@pytest.mark.asyncio
+async def test_env_var_bypasses_guard(monkeypatch, caplog):
+    """``BICAMERAL_SKIP_SDK_GUARD=1`` lets the sentinel call proceed; logs WARN."""
+    monkeypatch.setenv("BICAMERAL_SKIP_SDK_GUARD", "1")
+
+    adapter = SurrealDBLedgerAdapter(url="memory://")
+    await adapter.connect()
+    await _seed_recorded_version(adapter, "0.99.0-fictional-old-pin")
+
+    import logging
+
+    caplog.set_level(logging.WARNING)
+    await adapter._emit_wire_format_sentinel()
+
+    assert any("BICAMERAL_SKIP_SDK_GUARD" in r.message for r in caplog.records), (
+        "guard bypass must log a WARN line so operators see they're running "
+        "in best-effort mode — found records: "
+        f"{[r.message for r in caplog.records]}"
+    )
+
+
+@pytest.mark.asyncio
+async def test_fresh_ledger_first_write_does_not_raise(monkeypatch):
+    """No prior recorded version ⇒ first-write path, no raise.
+
+    Protects fresh installs from accidental fail-loud-on-empty bugs.
+    """
+    monkeypatch.delenv("BICAMERAL_SKIP_SDK_GUARD", raising=False)
+
+    adapter = SurrealDBLedgerAdapter(url="memory://")
+    await adapter.connect()
+
+
+@pytest.mark.asyncio
+async def test_guard_disarmed_state_persists_across_pre_checks():
+    """Pre-check is read-only — it does NOT update ``last_write``.
+
+    Critical contract: if the pre-check accidentally updated the row,
+    the second boot under the same drifted SDK would silently see
+    "match" and the guard would disarm itself. Verifies that re-running
+    the pre-check returns ``drift`` again.
+    """
+    adapter = SurrealDBLedgerAdapter(url="memory://")
+    await adapter.connect()
+    await _seed_recorded_version(adapter, "0.99.0-fictional-old-pin")
+
+    _, _, first = await adapter._sdk_version_pre_check()
+    _, _, second = await adapter._sdk_version_pre_check()
+    _, _, third = await adapter._sdk_version_pre_check()
+
+    assert first == "drift"
+    assert second == "drift"
+    assert third == "drift"

--- a/tests/test_v21_compliance_check_backfill.py
+++ b/tests/test_v21_compliance_check_backfill.py
@@ -55,9 +55,7 @@ async def _seed_reflected_decision_with_binding(
     )
     drow = drows[0]
     rid = drow.get("id")
-    decision_id = (
-        f"decision:{rid.get('id', rid)}" if isinstance(rid, dict) else str(rid)
-    )
+    decision_id = f"decision:{rid.get('id', rid)}" if isinstance(rid, dict) else str(rid)
 
     rrows = await c.query(
         "CREATE code_region SET file_path = $f, start_line = 1, end_line = 5, "
@@ -66,13 +64,10 @@ async def _seed_reflected_decision_with_binding(
     )
     rrow = rrows[0]
     rrid = rrow.get("id")
-    region_id = (
-        f"code_region:{rrid.get('id', rrid)}" if isinstance(rrid, dict) else str(rrid)
-    )
+    region_id = f"code_region:{rrid.get('id', rrid)}" if isinstance(rrid, dict) else str(rrid)
 
     await c.query(
-        f"RELATE {decision_id}->binds_to->{region_id} "
-        "SET content_hash = $h, confidence = 1.0",
+        f"RELATE {decision_id}->binds_to->{region_id} SET content_hash = $h, confidence = 1.0",
         {"h": "abc123hashvalue"},
     )
     return decision_id, region_id


### PR DESCRIPTION
## Summary

When `bicameral-mcp` ships a release that bumps its `surrealdb==X.Y.Z` pin, existing users' ledgers — written by the old SDK — become unreadable by the new SDK. The failure mode today is a silent mid-RPC `Invalid revision N for type Value` crash on the first UPDATE. This converts that into a loud, actionable **startup** error so the user sees a clear recovery command instead of a runtime traceback.

The detection infrastructure (`bicameral_meta.surrealdb_client_version_at_last_write`, the `_write_wire_format_sentinel` helper, the `LEDGER_VERSION_DRIFT` audit event) was **already in place** — but observability-only. Boot continued, then crashed mid-RPC. This PR makes the drift status a startup-blocker.

## Why P1

We've already hit this category twice in dogfood:
- Today's session: canonical DB at `~/.bicameral/projects/<id>/ledger.db` crashes every `link_commit`, `preflight`, `diagnose` write path.
- Memory note #8895 ("SurrealDB SDK version mismatch prevents ledger-mode reset recovery") — same class.

Future releases that touch the surrealdb pin (security, perf, deps cleanup) will reproduce this for every existing user. Silent data corruption potential.

## What

1. **`SurrealClientVersionMismatchError`** (new, `ledger/adapter.py`) — raised at `adapter.connect()` BEFORE any RPC fires. Message names the recorded version, the running version, the recovery command, and the bypass env var.

2. **`SurrealDBLedgerAdapter._sdk_version_pre_check()`** (new) — reads `bicameral_meta` *without* updating it. Critical: the existing sentinel writer updates `last_write` on every connect, which means a single boot under a mismatched SDK silently disarms detection. The pre-check preserves the signal across boots until the operator explicitly recovers or bypasses.

3. **`_emit_wire_format_sentinel`** now raises the new error BEFORE invoking the writer when drift is detected. Bypass with `BICAMERAL_SKIP_SDK_GUARD=1` (logs a WARN on every connect).

4. **`server.py` boundary handler** surfaces the error with `action`: `bicameral-mcp reset --confirm --wipe-mode=ledger --replay-from-events`, matching the existing pattern for `DestructiveMigrationRequired`.

5. **`requirements.txt`**: `surrealdb>=1.0.0` → `surrealdb==2.0.0`, matching `pyproject.toml`. Closes the `pip install -r requirements.txt` resolution gap that let developers end up with arbitrary SDK wheels.

## Out of scope

- Surrealkv-internal format changes within a single `surrealdb` version (the bundled rust binary versions independently). That deeper case belongs alongside the daemon work (#372), which isolates the SDK behind a stable `ws://` wire protocol. Tracked separately.
- Data-preserving migration across SDK bumps (dump-and-reload). Hotfix scope is "fail loudly with a clear recovery path"; the actual data preservation belongs in `migrate-state` after the daemon lands.
- Removing the now-redundant `LEDGER_VERSION_DRIFT` audit event. It's still emitted on bypass (operator visibility); could be cleaned up later but not in a hotfix.

## Acceptance

- [x] Pre-check returns `"drift"` when recorded != running.
- [x] Pre-check is read-only — three consecutive calls all return `"drift"` (no self-disarm).
- [x] `_emit_wire_format_sentinel` raises `SurrealClientVersionMismatchError` on drift, message contains the recorded version + recovery command + bypass env var.
- [x] `BICAMERAL_SKIP_SDK_GUARD=1` bypasses the raise AND emits a WARN to logs.
- [x] Fresh `memory://` ledger (no prior recorded version) does not raise — first-write path is untouched.
- [x] Existing audit-log behavior preserved (still emits `LEDGER_VERSION_DRIFT` when bypassed).
- [x] `requirements.txt` matches `pyproject.toml` pin.

## Test plan

- [x] `tests/test_sdk_version_guard.py` — 6 new sociable tests against real `memory://` adapter. All green.
- [x] `tests/test_ledger_mock_regression.py` — unchanged regression suite, still green.
- [x] `tests/test_schema_recoverable_errors.py` — full-pass.
- [x] Ruff clean across the diff.
- [ ] CI green on the hotfix flow.

## Upgrade path for affected users

```
uv tool upgrade bicameral-mcp   # or pipx upgrade bicameral-mcp
```

If the user's ledger was last written by a different surrealdb pin, the first MCP startup after upgrade now prints:

```
surrealdb SDK version mismatch on ledger surrealkv://~/.bicameral/projects/<id>/ledger.db:
last write recorded by surrealdb '1.0.8', currently running surrealdb '2.0.0'.
On-disk row format is likely incompatible — proceeding will crash mid-RPC with
'Invalid revision N for type Value' on the first UPDATE.
Recover with: `bicameral-mcp reset --confirm --wipe-mode=ledger --replay-from-events`,
or downgrade bicameral-mcp to a version that pins surrealdb '1.0.8'.
```

Then they run the recovery command and get a clean ledger rebuilt from event journals.

## Related

- BicameralAI/bicameral-daemon#1 (bicameral-daemon) — the structural fix that makes SDK version drift impossible by separating clients from the SDK over `ws://`.
- BicameralAI/bicameral-mcp#494 (filed earlier today) — the parallel `.mcp.json` migration bug (different cause, same class of "we shipped a state-layout change without rewriting existing user config").

🤖 Generated with [Claude Code](https://claude.com/claude-code)