### PR TITLE
feat(protocol): read.* surface — typed RPC for history + usage_summary (Phase 2c-2)

### DIFF
--- a/protocol/__init__.py
+++ b/protocol/__init__.py
@@ -38,6 +38,7 @@ from .contracts import (
     ExtractSymbolsRequest,
     GetNeighborsRequest,
     GroundingPort,
+    HistoryRequest,
     IngestAdapter,
     IngestRequest,
     IngestResult,
@@ -49,6 +50,8 @@ from .contracts import (
     ProtocolError,
     ProtocolVersionError,
     Symbol,
+    UsageSummaryRequest,
+    UsageSummaryResult,
     ValidateSymbolsRequest,
 )
 from .server import ConnectionContext, ProtocolServer
@@ -69,6 +72,7 @@ __all__ = [
     "ExtractSymbolsRequest",
     "GetNeighborsRequest",
     "GroundingPort",
+    "HistoryRequest",
     "IngestAdapter",
     "IngestRequest",
     "IngestResult",
@@ -83,6 +87,8 @@ __all__ = [
     "ProtocolServer",
     "ProtocolVersionError",
     "Symbol",
+    "UsageSummaryRequest",
+    "UsageSummaryResult",
     "ValidateSymbolsRequest",
     "get_category",
     "get_method",

--- a/protocol/contracts.py
+++ b/protocol/contracts.py
@@ -192,6 +192,57 @@ class BatchAnalyzeRequest(BaseModel):
     regions: list[CodeRegion] = Field(max_length=BATCH_REGION_LIMIT)
 
 
+# ── Reads ───────────────────────────────────────────────────────────────
+
+
+class HistoryRequest(BaseModel):
+    """Wire payload for ``read.history``.
+
+    The daemon owns the enriched SurrealQL traversal + PII archive
+    resolution + feature-area grouping. MCP only sends the filters.
+    """
+
+    model_config = ConfigDict(extra="forbid")
+    repo_id: str
+    ref: str = "HEAD"
+    feature_filter: str | None = None
+    include_superseded: bool = True
+    include_pruned: bool = False
+    as_of: str | None = None
+
+
+class UsageSummaryRequest(BaseModel):
+    """Wire payload for ``read.usage_summary``."""
+
+    model_config = ConfigDict(extra="forbid")
+    repo_id: str
+    days: int = Field(default=7, ge=0, le=365)
+
+
+class UsageSummaryResult(BaseModel):
+    """Aggregate usage stats. Flat by design — no nested envelope."""
+
+    model_config = ConfigDict(extra="ignore")
+    period_days: int
+    ingest_calls: int
+    bind_calls_total: int
+    decisions_ingested: int
+    decisions_ungrounded: int
+    decisions_pending: int
+    decisions_reflected: int
+    decisions_drifted: int
+    reflected_pct: float
+    drift_pct: float
+    cosmetic_drift_pct: float
+    error_rate: float
+
+
+# ``HistoryResponse`` (the wire shape for ``read.history`` results) is owned by
+# ``contracts.HistoryResponse`` — MCP and the daemon share the exact same model,
+# so we don't redefine it here. The protocol method returns it verbatim per
+# the "flat envelopes" constraint.
+
+
 # ── Adapter Protocols ──────────────────────────────────────────────────
 
 

--- a/protocol/handlers/__init__.py
+++ b/protocol/handlers/__init__.py
@@ -1,0 +1,18 @@
+"""Server-side handlers for the universal protocol.
+
+In Phase 2c-2 these run **in the same Python process as MCP** — there is no
+daemon subprocess yet. They exist to make the protocol's read/write surface
+real (every method dispatches to working code), so the call-site migration
+in Phase 2c-4 onward has a concrete target.
+
+In Phase 2c-3, when the daemon supervisor lands and spawns a real process,
+these handlers run inside the daemon and MCP becomes their only client. The
+handler bodies don't change — they already delegate to the existing in-tree
+ledger code. Only the deployment topology shifts.
+"""
+
+from __future__ import annotations
+
+from .reads import register_read_handlers
+
+__all__ = ["register_read_handlers"]

--- a/protocol/handlers/reads.py
+++ b/protocol/handlers/reads.py
@@ -1,0 +1,86 @@
+"""Server-side handlers for ``read.*`` protocol methods.
+
+Phase 2c-2 — these are thin adapters between the JSON-RPC dispatcher and
+today's in-tree MCP handlers. The daemon validates the request payload via
+Pydantic, builds a ``BicameralContext`` (single-repo for now — multi-repo
+resolution lands in 2c-3), delegates to the existing handler, and serializes
+the response.
+
+No MCP handler bodies are modified by this module. The call-site migration —
+where MCP handlers stop importing ``handlers.history`` directly and instead
+go through ``ProtocolClient`` — happens in Phase 2c-4 onward.
+
+Constraint (bicameral preflight, decision:wndwxgam2m8yjor0igya):
+``read.*`` handlers must remain deterministic. No LLM imports, no LLM calls.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any
+
+from protocol.contracts import (
+    ConnectionContext,
+    HistoryRequest,
+    UsageSummaryRequest,
+    UsageSummaryResult,
+)
+
+if TYPE_CHECKING:
+    from context import BicameralContext
+    from protocol.server import ProtocolServer
+
+
+def _resolve_context(_ctx: ConnectionContext, _repo_id: str) -> BicameralContext:
+    """Resolve the legacy ``BicameralContext`` for a protocol request.
+
+    Phase 2c-2 shim: ignores ``ConnectionContext.tenant_id`` and
+    ``request.repo_id`` and returns ``BicameralContext.from_env()`` — the
+    same context MCP builds today. Multi-repo resolution (looking up the
+    repo by ID and constructing a context against the right ledger
+    instance) lands in 2c-3 when the daemon is genuinely separate from
+    MCP and can host multiple repos in one process.
+
+    The argument names already reflect the eventual shape; only the body
+    needs to change.
+    """
+    from context import BicameralContext
+
+    return BicameralContext.from_env()
+
+
+async def handle_read_history(params: dict[str, Any], ctx: ConnectionContext) -> dict[str, Any]:
+    req = HistoryRequest.model_validate(params)
+    bctx = _resolve_context(ctx, req.repo_id)
+    from handlers.history import handle_history
+
+    result = await handle_history(
+        bctx,
+        feature_filter=req.feature_filter,
+        include_superseded=req.include_superseded,
+        include_pruned=req.include_pruned,
+        as_of=req.as_of,
+    )
+    return result.model_dump()
+
+
+async def handle_read_usage_summary(
+    params: dict[str, Any], ctx: ConnectionContext
+) -> dict[str, Any]:
+    req = UsageSummaryRequest.model_validate(params)
+    bctx = _resolve_context(ctx, req.repo_id)
+    from handlers.usage_summary import handle_usage_summary
+
+    raw = await handle_usage_summary(bctx, days=req.days)
+    # ``handle_usage_summary`` returns a plain dict; round-trip it through the
+    # typed result so the wire shape is enforced.
+    return UsageSummaryResult.model_validate(raw).model_dump()
+
+
+def register_read_handlers(server: ProtocolServer) -> None:
+    """Register every ``read.*`` method on ``server``.
+
+    Idempotent: re-registering overwrites the existing handler. Test
+    fixtures may call this against a fresh server in each test.
+    """
+    server.register("read.history", handle_read_history)
+    server.register("read.usage_summary", handle_read_usage_summary)

--- a/tests/test_protocol_read_conformance.py
+++ b/tests/test_protocol_read_conformance.py
@@ -1,0 +1,206 @@
+"""Phase 2c-2 conformance tests for the ``read.*`` protocol surface.
+
+Every registered method must dispatch on a well-formed request and return a
+response that round-trips through its declared result model. Two extra
+constraint tests encode the bicameral-preflight findings:
+
+- Deterministic read path (no LLM hop in read handlers).
+- Lazy ledger connect preserved (``ProtocolServer.__init__`` does not open
+  a SurrealDB connection).
+
+These tests run the server **in-process** — same Python interpreter, UDS
+loopback. Phase 2c-4 adds the per-test daemon-subprocess fixture that
+verifies wire-level + connection-lifecycle behavior across a real process
+boundary; the in-process tests stay focused on contract shape.
+"""
+
+from __future__ import annotations
+
+import inspect
+import os
+import shutil
+import tempfile
+from pathlib import Path
+
+import pytest
+
+from protocol.client import ProtocolClient
+from protocol.handlers.reads import register_read_handlers
+from protocol.server import ProtocolServer
+
+
+@pytest.fixture
+def short_socket_dir():
+    """macOS AF_UNIX paths cap around 104 chars; pytest's tmp_path is too deep."""
+    base = Path(tempfile.mkdtemp(prefix="bm-", dir="/tmp"))
+    try:
+        yield base
+    finally:
+        shutil.rmtree(base, ignore_errors=True)
+
+
+@pytest.fixture
+def memory_ledger_env(monkeypatch, tmp_path):
+    """Point ``BicameralContext.from_env()`` at a fresh in-memory ledger.
+
+    Required because the protocol read handlers delegate to the real MCP
+    handlers (``handlers.history``, ``handlers.usage_summary``), which build
+    a ``BicameralContext`` that opens a SurrealDB connection. ``memory://``
+    keeps each test isolated without a SurrealKV file on disk.
+    """
+    monkeypatch.setenv("SURREAL_URL", "memory://")
+    monkeypatch.setenv("REPO_PATH", str(tmp_path))
+    # Initialize a minimal git repo so resolve_head doesn't choke.
+    import subprocess
+
+    subprocess.run(["git", "init", "-q"], cwd=tmp_path, check=True)
+    subprocess.run(
+        ["git", "commit", "--allow-empty", "-q", "-m", "init"],
+        cwd=tmp_path,
+        check=True,
+        env={
+            **os.environ,
+            "GIT_AUTHOR_NAME": "t",
+            "GIT_AUTHOR_EMAIL": "t@t",
+            "GIT_COMMITTER_NAME": "t",
+            "GIT_COMMITTER_EMAIL": "t@t",
+        },
+    )
+    yield tmp_path
+
+
+async def test_read_history_dispatches(short_socket_dir, memory_ledger_env):
+    """``read.history`` returns a HistoryResponse-shaped payload for an empty ledger."""
+    server = ProtocolServer(short_socket_dir / "d.sock")
+    register_read_handlers(server)
+    await server.start()
+
+    client = ProtocolClient(socket_path=short_socket_dir / "d.sock")
+    try:
+        await client.connect()
+        result = await client._call("read.history", {"repo_id": "test", "ref": "HEAD"})
+        assert isinstance(result, dict)
+        # Wire shape: HistoryResponse — features, truncated, total_features, as_of.
+        assert "features" in result
+        assert "truncated" in result
+        assert "total_features" in result
+        assert result["total_features"] == 0  # empty ledger
+        assert result["features"] == []
+    finally:
+        await client.close()
+        await server.stop()
+
+
+async def test_read_usage_summary_dispatches(short_socket_dir, memory_ledger_env):
+    """``read.usage_summary`` returns the flat UsageSummaryResult envelope."""
+    server = ProtocolServer(short_socket_dir / "d.sock")
+    register_read_handlers(server)
+    await server.start()
+
+    client = ProtocolClient(socket_path=short_socket_dir / "d.sock")
+    try:
+        await client.connect()
+        result = await client._call("read.usage_summary", {"repo_id": "test", "days": 7})
+        assert isinstance(result, dict)
+        # Flat envelope per the "no nested wrappers" preflight constraint.
+        for key in (
+            "period_days",
+            "ingest_calls",
+            "bind_calls_total",
+            "decisions_ingested",
+            "decisions_ungrounded",
+            "decisions_pending",
+            "decisions_reflected",
+            "decisions_drifted",
+            "reflected_pct",
+            "drift_pct",
+            "cosmetic_drift_pct",
+            "error_rate",
+        ):
+            assert key in result, f"missing field {key}"
+        assert result["period_days"] == 7
+    finally:
+        await client.close()
+        await server.stop()
+
+
+async def test_read_usage_summary_rejects_out_of_range_days(short_socket_dir, memory_ledger_env):
+    """Pydantic validation: ``days`` is bounded [0, 365]; out-of-range raises."""
+    from protocol.contracts import ProtocolError
+
+    server = ProtocolServer(short_socket_dir / "d.sock")
+    register_read_handlers(server)
+    await server.start()
+
+    client = ProtocolClient(socket_path=short_socket_dir / "d.sock")
+    try:
+        await client.connect()
+        with pytest.raises(ProtocolError):
+            await client._call("read.usage_summary", {"repo_id": "test", "days": 999})
+    finally:
+        await client.close()
+        await server.stop()
+
+
+# ── Constraint tests (bicameral preflight, 2026-05-22) ──────────────────
+
+
+def test_read_handlers_have_no_llm_imports():
+    """Constraint: ``read.*`` methods stay deterministic — no LLM hop.
+
+    Bound decision: ``decision:wndwxgam2m8yjor0igya`` — "MCP server:
+    deterministic tools, no nested LLM". A future contributor adding an LLM
+    fallback to a read handler must come back and explain why.
+    """
+    import protocol.handlers.reads as reads_module
+
+    source = inspect.getsource(reads_module)
+    forbidden = [
+        "import litellm",
+        "from litellm",
+        "import openai",
+        "from openai",
+        "import anthropic",
+        "from anthropic",
+        "ChatCompletion",
+        "AsyncAnthropic",
+    ]
+    for keyword in forbidden:
+        assert keyword not in source, (
+            f"read handler imports '{keyword}' — read.* must remain deterministic "
+            f"(bicameral decision:wndwxgam2m8yjor0igya)"
+        )
+
+
+def test_protocol_server_init_does_not_open_db_connection(tmp_path):
+    """Constraint: lazy ledger connect preserved.
+
+    Bound decision: ``decision:k44cko8xtkcswk55kytz`` — "Lazy connection
+    in SurrealDB ledger adapter". ``ProtocolServer(socket_path)`` must not
+    open a SurrealDB connection or read the ledger; that happens on first
+    method dispatch.
+    """
+    sock = tmp_path / "d.sock"
+    # Construct + register without starting — must not touch the DB.
+    server = ProtocolServer(sock)
+    register_read_handlers(server)
+
+    # Smoke: no DB-related attributes spuriously populated on the server itself.
+    assert not hasattr(server, "_db")
+    assert not hasattr(server, "_ledger")
+    assert not hasattr(server, "_client")
+
+
+def test_register_read_handlers_is_idempotent(tmp_path):
+    """Re-registering the same method overwrites the prior handler.
+
+    Per-test daemon fixtures will call ``register_read_handlers(server)`` on
+    a fresh server each time; this assertion locks the no-conflict contract.
+    """
+    sock = tmp_path / "d.sock"
+    server = ProtocolServer(sock)
+    register_read_handlers(server)
+    # Second call must not raise.
+    register_read_handlers(server)
+    assert "read.history" in server._methods
+    assert "read.usage_summary" in server._methods

--- a/thoughts/shared/plans/2026-05-22-2c-2-read-surface.md
+++ b/thoughts/shared/plans/2026-05-22-2c-2-read-surface.md
@@ -1,0 +1,255 @@
+# Phase 2c-2 — Read Surface (first PR)
+
+**Date**: 2026-05-22
+**Branch**: `feat/daemon-02c-protocol-surface`
+**Parent**: `2026-05-22-daemon-as-process-arc.md` (full arc 2c-2 through 2c-8)
+**Predecessors**: Phase 2c-1 (categorization decorators), merged in #500
+
+## Scope of THIS PR
+
+Define the externally-callable **read.\*** subset of the protocol surface:
+
+- `read.history` — full ledger dump grouped by feature area
+- `read.usage_summary` — aggregate usage stats over a window
+
+The PR adds Pydantic request/result models, registers server-side handlers that delegate to today's in-tree ledger code, and ships a conformance test asserting every registered method dispatches.
+
+**Deferred to 2c-5**: `read.search_decisions` (internal BM25 search used by `judge_gaps` + `preflight`). No external caller today; migrates with its callers.
+
+**Out of scope** (later sub-phases):
+- `write.*` surface (sibling PR 2c-2b)
+- Grounding RPCs (`grounding.lookup.*`, `grounding.analyze.*` — they already exist as `validate_symbols`/`get_neighbors`/`analyze_region`; the only addition is `grounding.analyze.preflight`)
+- Daemon supervisor + process lifecycle (2c-3)
+- Any handler body rewrites (2c-4 onward)
+
+## Bicameral preflight findings (2026-05-22)
+
+Preflight surfaced 3 constraints worth encoding explicitly:
+
+1. **Deterministic read path** — no LLM hop inside any `read.*` method. *(Bound decision: `decision:wndwxgam2m8yjor0igya` — "MCP server: deterministic tools, no nested LLM".)* Encoded as a conformance assertion: protocol read handlers must not import `litellm`, `anthropic`, `openai`, or call any function whose name contains `llm`.
+2. **Flat response shapes** — protocol result models mirror handler return shapes one-to-one, no additional wrapper envelopes. *(Bound decision: `decision:cqrnefjlmih8r2102rj3` — "Keep MCP response contracts lean and flat".)* Practical: `HistoryResponse` (the type today's handler returns) IS the protocol result type. No `HistoryRPCResult { data: HistoryResponse }` wrapping.
+3. **Lazy ledger connect preserved** — `ProtocolServer.__init__` must NOT open a SurrealDB connection. Lazy on first method call, matching today's `SurrealDBLedgerAdapter` semantics. *(Bound decision: `decision:k44cko8xtkcswk55kytz` — "Lazy connection in SurrealDB ledger adapter".)*
+
+No drift candidates, no open divergences, no prior daemon-protocol decisions to honor or override.
+
+## Inventory — what `read.*` handlers actually do today
+
+### `handle_history` (`handlers/history.py:310`)
+
+External collaborators:
+
+| Call | Path | Purpose |
+|------|------|---------|
+| `resolve_head(ctx.repo_path)` | `ledger.status` | Resolve git HEAD when `as_of=None` |
+| `ledger.connect()` | adapter | Idempotent connect (lazy-OK) |
+| `inner._client.query(SurrealQL)` | `ledger.client` | Custom enriched graph-traversal query — bypasses adapter |
+| `ledger.get_all_decisions(filter="all")` | adapter | Fallback when enriched query fails |
+| `_resolve_span_text(archive, span)` | `ledger.queries` | PII archive lookup for source-span text |
+| `inner._client.query(...)` | `ledger.client` | Compliance-check status lookup for ephemeral filtering |
+| `ensure_ledger_synced(ctx)` | `handlers.sync_middleware` | Auto-sync to HEAD before read |
+
+**Protocol shape**: ONE method `read.history(repo_id, ref, filters) -> HistoryResponse`. The daemon owns the enriched SurrealQL + PII resolution + grouping + filtering. MCP doesn't see the SurrealQL.
+
+### `handle_usage_summary` (`handlers/usage_summary.py:22`)
+
+External collaborators:
+
+| Call | Path | Purpose |
+|------|------|---------|
+| `read_counters()` | `local_counters` | Read `~/.bicameral/counters/*.jsonl` for tool-call counts |
+| `client.query("SELECT status, count() ...")` | `ledger.client` | Decision status counts by status, windowed |
+| `client.query("SELECT verdict, count() ...")` | `ledger.client` | Compliance verdict counts (cosmetic vs drifted) |
+
+**Protocol shape**: ONE method `read.usage_summary(repo_id, days) -> UsageSummaryResponse`. The daemon owns the counter file read + ledger queries.
+
+### Internal: `handle_search_decisions` (`handlers/search_decisions.py:22`)
+
+Called by `handle_judge_gaps` and `handle_preflight`. External collaborator:
+
+| Call | Path | Purpose |
+|------|------|---------|
+| `ctx.ledger.search_by_query(...)` | adapter | BM25 search over decisions |
+
+**Protocol shape**: ONE method `read.search_decisions(repo_id, query, limit, search_hint) -> list[DecisionMatch]`. Daemon owns the BM25 index.
+
+This isn't externally callable from MCP today (it's internal to gap_judge / preflight), but the daemon needs to expose it because those callers will eventually go through the protocol too.
+
+## Pydantic models to add to `protocol/contracts.py`
+
+```python
+# ── Read: history ──
+class HistoryRequest(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+    repo_id: str
+    ref: str = "HEAD"
+    feature_filter: str | None = None
+    include_superseded: bool = True
+    include_pruned: bool = False
+    as_of: str | None = None
+
+# HistoryResponse already exists in contracts.py (the MCP-facing one).
+# Re-export from protocol.contracts for the daemon wire.
+
+# ── Read: usage summary ──
+class UsageSummaryRequest(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+    repo_id: str
+    days: int = Field(default=7, ge=0, le=365)
+
+class UsageSummaryResult(BaseModel):
+    model_config = ConfigDict(extra="ignore")
+    period_days: int
+    ingest_calls: int
+    bind_calls_total: int
+    decisions_ingested: int
+    decisions_ungrounded: int
+    decisions_pending: int
+    decisions_reflected: int
+    decisions_drifted: int
+    reflected_pct: float
+    drift_pct: float
+    cosmetic_drift_pct: float
+    error_rate: float
+
+# ── Read: search decisions ──
+class SearchDecisionsRequest(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+    repo_id: str
+    query: str
+    limit: int = Field(default=10, ge=1, le=100)
+    search_hint: str | None = None
+
+class DecisionMatchSummary(BaseModel):
+    """Wire shape for one BM25 hit. Flat — no nested score envelope."""
+    model_config = ConfigDict(extra="ignore")
+    decision_id: str
+    description: str
+    rationale: str
+    feature_hint: str | None = None
+    score: float
+    status: str
+    source_ref: str | None = None
+```
+
+**Note on `HistoryResponse`**: today's `contracts.HistoryResponse` IS the right wire shape (per the "flat envelopes" constraint). The protocol's `read.history` returns it as-is. No re-modeling.
+
+## Server-side handler registration
+
+Add a new module `protocol/handlers/reads.py` that wires the three read methods. Each handler is a thin async adapter:
+
+```python
+# protocol/handlers/reads.py
+from protocol.contracts import (
+    HistoryRequest, HistoryResponse,
+    UsageSummaryRequest, UsageSummaryResult,
+    SearchDecisionsRequest, DecisionMatchSummary,
+    ConnectionContext,
+)
+
+
+async def handle_read_history(
+    params: dict, ctx: ConnectionContext
+) -> dict:
+    req = HistoryRequest.model_validate(params)
+    # Daemon-side: import the EXISTING handler. In 2c-4 this will be inverted
+    # (MCP handler calls into the daemon), but in 2c-2 the daemon shell delegates
+    # to the same in-tree code.
+    from handlers.history import handle_history
+    bctx = _resolve_context(ctx, req.repo_id)  # built from ConnectionContext
+    result = await handle_history(
+        bctx,
+        feature_filter=req.feature_filter,
+        include_superseded=req.include_superseded,
+        include_pruned=req.include_pruned,
+        as_of=req.as_of,
+    )
+    return result.model_dump()
+
+
+async def handle_read_usage_summary(
+    params: dict, ctx: ConnectionContext
+) -> dict:
+    req = UsageSummaryRequest.model_validate(params)
+    from handlers.usage_summary import handle_usage_summary
+    bctx = _resolve_context(ctx, req.repo_id)
+    return await handle_usage_summary(bctx, days=req.days)
+
+
+async def handle_read_search_decisions(
+    params: dict, ctx: ConnectionContext
+) -> list[dict]:
+    req = SearchDecisionsRequest.model_validate(params)
+    from handlers.search_decisions import handle_search_decisions
+    bctx = _resolve_context(ctx, req.repo_id)
+    matches = await handle_search_decisions(
+        bctx, query=req.query, limit=req.limit, search_hint=req.search_hint
+    )
+    return [DecisionMatchSummary.model_validate(m).model_dump() for m in matches]
+
+
+def register(server) -> None:
+    server.register("read.history", handle_read_history)
+    server.register("read.usage_summary", handle_read_usage_summary)
+    server.register("read.search_decisions", handle_read_search_decisions)
+```
+
+**Critically**: this code runs *inside the same Python process as MCP today*. No daemon process exists yet. The dispatch path is `ProtocolClient → ProtocolServer (in-process) → existing handler`. That's fine for 2c-2 — we're validating contract shape, not boundary semantics. Phase 2c-3 spawns a real daemon process; phase 2c-4 starts the call-site migration.
+
+**`_resolve_context` helper**: builds a `BicameralContext` from the `ConnectionContext.tenant_id` + the request's `repo_id`. For local-tenant single-repo mode (today's only configuration), this is straight-through. Multi-repo / multi-tenant resolution waits for 2c-3.
+
+## Conformance test
+
+`tests/test_protocol_read_conformance.py`:
+
+```python
+"""Conformance: every registered read.* method dispatches on a well-formed request."""
+
+@pytest.mark.asyncio
+async def test_read_history_dispatches(short_socket_dir, real_ledger):
+    server = ProtocolServer(short_socket_dir / "daemon.sock")
+    register_read_handlers(server)
+    await server.start()
+
+    client = ProtocolClient(short_socket_dir / "daemon.sock")
+    await client.connect()
+    result = await client._call("read.history", {"repo_id": "test", "ref": "HEAD"})
+    assert "features" in result
+    assert "total_features" in result
+    await client.close()
+    await server.stop()
+
+
+async def test_read_usage_summary_dispatches(...): ...
+async def test_read_search_decisions_dispatches(...): ...
+
+
+def test_no_llm_imports_in_read_handlers():
+    """Constraint from bicameral preflight: read.* handlers must not invoke LLMs."""
+    import protocol.handlers.reads as reads_module
+    source = inspect.getsource(reads_module)
+    forbidden = ["litellm", "anthropic.AsyncAnthropic", "openai.AsyncOpenAI", "ChatCompletion"]
+    for keyword in forbidden:
+        assert keyword not in source, f"read handler imports {keyword}"
+
+
+def test_protocol_server_does_not_open_db_on_init(tmp_path):
+    """Constraint from bicameral preflight: lazy connect preserved."""
+    server = ProtocolServer(tmp_path / "daemon.sock")
+    register_read_handlers(server)
+    # No connection until .start() is called and a method dispatches.
+    assert not hasattr(server, "_db_connected") or server._db_connected is False
+```
+
+## Acceptance
+
+- [ ] `protocol/contracts.py` exports `HistoryRequest`, `UsageSummaryRequest/Result`, `SearchDecisionsRequest`, `DecisionMatchSummary`.
+- [ ] `protocol/handlers/reads.py` exists with three registered methods.
+- [ ] `tests/test_protocol_read_conformance.py` — all dispatch + constraint tests pass.
+- [ ] Existing `pytest tests/test_protocol_categorization.py` still passes.
+- [ ] Full suite: no regressions vs baseline (the 88 pre-existing failures we already characterized).
+- [ ] `ruff check` and `ruff format --check` both clean.
+- [ ] No handler in `handlers/` has been modified. (Verifying: this PR is contract-shaped, not call-site-shaped.)
+
+## Reversibility
+
+Pure-additive PR. New files, no existing-file edits except protocol/__init__.py re-exports. `git revert <sha>` cleanly removes the protocol read surface; no downstream depends on it yet.

--- a/thoughts/shared/plans/2026-05-22-daemon-as-process-arc.md
+++ b/thoughts/shared/plans/2026-05-22-daemon-as-process-arc.md
@@ -1,0 +1,177 @@
+# Daemon-as-Process — Multi-PR Arc
+
+**Date**: 2026-05-22
+**Owner**: Jin
+**Parent plan**: `~/github/bicameral/thoughts/shared/plans/2026-05-21-daemon-extraction-and-universal-ingest-egress.md`
+**Predecessor**: Phase 2c-1 (read/write tool categorization, merged in #500)
+
+## Architectural commitment
+
+**The daemon is a real process. Always.** `bicameral-daemon` is not a library MCP imports; it's a binary MCP launches and talks to over a Unix domain socket (HTTPS later for hosted mode). This locks the testing strategy, the failure modes, and the deployment story — no in-process shortcut.
+
+Consequences:
+
+- MCP handlers stop calling `from ledger.queries import X` directly. Every ledger/governance/dashboard operation becomes an async RPC through `ProtocolClient`.
+- `bicameral-mcp` installs `bicameral-daemon` as a peer with its own CLI entrypoint, not as an importable Python package.
+- Tests that verify the daemon boundary spin up a real daemon subprocess. No fake in-memory ProtocolServer dressed up as integration.
+- Single-writer property (#301-class races) becomes real — the daemon owns the SurrealDB connection, no concurrent MCP processes can collide.
+
+## Test strategy (per Fowler advisory, 2026-05-22)
+
+**Three-tier pyramid, explicitly labeled:**
+
+1. **Handler logic — sociable in-process tests** (today's pattern, unchanged). Real `SurrealDBLedgerAdapter` over `memory://`, real Pydantic models, real query results. Tests handler decision-making, not the IPC boundary. ~95% of the suite stays this shape.
+
+2. **Boundary tests — per-test logical daemon** (new). Each test owns its socket path and ledger DB file. A pytest fixture hides the process lifecycle: starts with subprocess-per-test, swappable to a pooled-warmed-daemon later when cold-start cost actually bites. Tests:
+   - Wire serialization (Pydantic round-trips through JSON)
+   - Connection lifecycle (daemon-killed-mid-call, reconnect, refused-connection)
+   - Concurrency (single-writer serialization under contended writes)
+   - **Volume target**: tens of tests, not hundreds.
+
+3. **Contract tests — in-process ProtocolServer** (separate file, separate label). Verifies *shape* of the contract: every registered method, every request/result model. Cheap, fast, no subprocess. Lives in the protocol package's own conformance suite. Does NOT crowd out tier 2.
+
+**Anti-patterns explicitly rejected:**
+
+- Session-scoped shared daemon → state bleeds, debugging hell, isolation traded for unmeasured perf.
+- In-memory ProtocolServer pretending to be a boundary test → false confidence.
+- Pre-optimization (pooling, async warm-up, etc.) before measuring subprocess startup cost.
+
+## Sub-phase breakdown
+
+Each sub-phase is one PR. Each PR is independently shippable — MCP keeps working whether or not a given operation has been migrated yet (until the cleanup phase). Branches off `dev`.
+
+### 2c-2 — Protocol surface expansion (this branch)
+**Branch**: `feat/daemon-02c-protocol-surface`
+**Size**: ~1 week. Reads first; writes follow in a sibling PR (2c-2b) if scope demands.
+
+Define every read/write/grounding/system operation today's 19 handlers depend on. Each gets:
+- Pydantic request + result model in `protocol/contracts.py`
+- Method-name slot in the categorized namespace (`read.X`, `write.Y`, etc.)
+- Server-side handler in `protocol/server.py` (or a new `protocol/handlers/` submodule) that validates the request, calls today's in-tree ledger code, and serializes the response
+- Conformance test entry — every registered method passes a smoke dispatch
+
+**Critically, no call sites change in 2c-2.** MCP handlers still do `from ledger.queries import X` directly. The protocol surface becomes real; nobody uses it yet. This isolates "is the contract complete?" from "does the rewire work?"
+
+Scope split: start with **reads** (`read.history`, `read.usage_summary`, and the internal queries reads decompose into — `decision_exists`, `project_decision_status`, `get_canonical_id`, etc.). Reads are idempotent, no ledger mutation, lowest risk. Writes follow in 2c-2b once the pattern is validated.
+
+**Acceptance**:
+- Inventory doc lists every operation handlers call.
+- Read surface has 100% coverage in the conformance suite.
+- `protocol/contracts.py` exports all read models.
+- Full test suite still passes (no regressions; no call sites changed).
+- ~300-600 LOC + tests, single PR.
+
+### 2c-2b — Write surface expansion (sibling PR)
+**Branch**: `feat/daemon-02c-protocol-surface-writes`
+
+Same pattern, write operations. Decisions inserted, sources removed, regions updated, bindings created, governance verdicts written, audit log emitted. Conformance covers all of them.
+
+**Acceptance**: write surface 100% in conformance suite. Still no call sites changed.
+
+### 2c-3 — Daemon supervisor + process lifecycle
+**Branch**: `feat/daemon-03-supervisor`
+**Size**: ~3-4 days.
+
+`bicameral-mcp daemon {start,stop,restart,status,uninstall}` actually launches a supervised daemon process running `ProtocolServer` with the registered handlers. The daemon:
+- Spawns `surreal start` (or the embedded SurrealDB instance)
+- Listens on a UDS socket
+- Publishes socket path to `~/.bicameral/daemon.json`
+- Health-check endpoint
+- Restart-on-crash supervision
+- macOS LaunchAgent install via `setup_wizard.py`
+
+**MCP does not use the daemon yet.** Daemon runs in parallel, idle. This isolates lifecycle bugs from call-site bugs.
+
+**Acceptance**: `bicameral-mcp daemon start` succeeds. Client can connect to the socket and call `system.version`. Daemon survives SIGHUP / config reload. Crash → automatic restart within 5s. No effect on today's MCP behavior.
+
+### 2c-4 — First call-site migration: `read.history` (load-bearing prototype)
+**Branch**: `feat/daemon-04-history-via-daemon`
+**Size**: ~2 days.
+
+Pick **one** read handler. Rewrite its body to use `ProtocolClient` instead of direct imports. Build the **per-test daemon fixture**: `tmp_path` for the ledger DB, ephemeral socket path, subprocess started in the fixture, torn down after the test. Validate end-to-end:
+- Latency in single-call mode (cold + warm)
+- Reconnect-on-daemon-crash semantics
+- Test ergonomics (do tests feel painful? what would make them better?)
+- Error semantics (daemon returns malformed response → what does the handler see?)
+
+**This is the load-bearing PR.** Everything that comes after assumes the test fixture works. If the prototype reveals the fixture needs to be different (pool, alternate transport, anything), redesign here before bulk migration.
+
+**Acceptance**: `handle_history` does not import `ledger.status` directly. Existing `test_history_*` tests pass via the new fixture. New boundary tests cover wire+lifecycle+reconnect for at least one read operation.
+
+### 2c-5 — Migrate remaining reads
+**Branch**: `feat/daemon-05-reads-via-daemon`
+**Size**: ~3 days.
+
+`read.usage_summary`, `read.preflight` (via `grounding.analyze.preflight` — which internally is a composite of reads + grounding analyze calls), and the internal read helpers. Each rewritten one at a time, tests updated to use the fixture.
+
+### 2c-6 — Migrate writes in safety order
+**Branch**: `feat/daemon-06-writes-via-daemon`
+**Size**: ~1 week.
+
+Order matters. Safest first:
+1. **Telemetry-only writes** (no ledger mutation): `write.feedback`, `write.skill_begin`, `write.skill_end`. Sends events, no rows.
+2. **Append-only ledger writes**: `write.ingest`, `write.link_commit`. Adds rows, never deletes.
+3. **Mutation writes**: `write.ratify`, `write.resolve_compliance`, `write.resolve_collision`, `write.judge_gaps`. Updates existing rows. Concurrency matters here — boundary test must cover contended writes through the daemon's single-writer queue.
+4. **Destructive writes**: `write.remove_decision`, `write.remove_source`. Deletes. Boundary test for "two callers race to remove the same decision."
+
+Probably split into 2-3 PRs along these layers.
+
+### 2c-7 — Grounding + dashboard via daemon
+**Branch**: `feat/daemon-07-grounding-and-dashboard`
+**Size**: ~3-5 days.
+
+- `grounding.lookup.bind`, `grounding.analyze.preflight`, the batch analyzers.
+- Dashboard server moves out of MCP into the daemon: the daemon hosts HTTP+SSE; MCP no longer starts a dashboard server. `system.dashboard` becomes "return the daemon's dashboard URL" rather than "spawn a server."
+
+### 2c-8 — Cleanup + invariant assertions
+**Branch**: `feat/daemon-08-cleanup`
+**Size**: ~2 days.
+
+- Delete unused ledger imports from `handlers/`.
+- Delete the in-tree dashboard server (now daemon-owned).
+- Add CI assertion: `git grep "from ledger\." handlers/ | wc -l` returns 0.
+- Add CI assertion: `git grep "from dashboard\." handlers/ | wc -l` returns 0.
+- Add CI assertion: `git grep "from audit_log import" handlers/ | wc -l` returns 0.
+- Update CLAUDE.md to reflect the new boundary.
+
+After 2c-8 lands, **Phase 3** (the actual cross-repo split) becomes mechanical: every file under `daemon/` and `protocol/server-side handlers/` moves to the private `BicameralAI/bicameral-daemon` repo via `git filter-repo` preserving history. `bicameral-protocol` extracts as its own public package. Issues transfer per the parent plan's mapping table.
+
+## Cross-cutting design decisions
+
+**Connection lifecycle.** Each MCP server process opens one `ProtocolClient` connection at startup, attaches the tenant, holds it for the process lifetime. Reconnect-on-failure with exponential backoff (200ms → 2s, max 5 retries). Failed reconnect surfaces as a typed `DaemonUnreachableError` that handlers translate to a user-facing "daemon offline — run `bicameral-mcp daemon start`" message.
+
+**Request shape.** Every RPC carries `(repo_id, ref)` because the daemon is multi-repo-aware. `tenant_id` lives on the connection (from `system.attach`), not in every payload. This matches the Phase 2b decision baked into `ConnectionContext`.
+
+**Backpressure.** Single-writer means writes serialize. A long-running ingest can block other writes. The daemon's writer pool needs at least a "writes queue depth" diagnostic surface for the dashboard. Out of scope for 2c-2 through 2c-6; tracked separately.
+
+**Error semantics.** Three error tiers:
+1. **Transport** — connection dropped, malformed frame. `ProtocolError` raised by client.
+2. **Protocol** — unknown method, type-validation failure. Server returns JSON-RPC error response; client raises `ProtocolError` with the structured `code` + `message`.
+3. **Domain** — ledger constraint violation, governance veto, validation rejection. Server returns a success result with a domain-error envelope (e.g. `IngestResult(status="refused", reason="size_limit_exceeded")`). Handlers translate to today's MCP-level error responses unchanged.
+
+**Migration safety.** Between 2c-4 and 2c-8, MCP has *some* handlers going through the daemon and *some* going direct. That's fine because:
+- The daemon and the MCP process both connect to the same SurrealDB (just via different paths).
+- Reads through either route see the same data.
+- Writes through either route end up in the same DB. The single-writer guarantee only takes effect once every writer is going through the daemon — until then, we accept that two MCP processes can still race on direct writes. We don't lose ground.
+
+The cleanup phase (2c-8) is where the single-writer property becomes real.
+
+## Reversibility
+
+Through 2c-7: every PR is independently revertable. Reverting a call-site migration restores the direct import. Reverting the supervisor PR removes the `daemon start` command. The protocol surface (2c-2 / 2c-2b) is additive — nothing depends on it until 2c-4.
+
+After 2c-8: still revertable, but multi-PR revert. The CI assertions in 2c-8 are the point of no return for the in-tree direct-import path.
+
+After Phase 3 (repo split): not revertable without remerging the private repo. By then we should have hosted-mode in production and the question is moot.
+
+## Acceptance for the whole arc
+
+Once 2c-8 lands:
+- `git grep "from ledger\." handlers/` returns empty
+- `git grep "from dashboard\." handlers/` returns empty
+- `git grep "from audit_log import" handlers/` returns empty
+- All MCP handler tests pass
+- All boundary tests pass against a real daemon subprocess
+- `bicameral-mcp daemon start` is the only path to a running ledger
+- The dashboard is daemon-owned
+- Phase 3 (repo split) is a `git filter-repo` operation, not an architectural rewrite


### PR DESCRIPTION
## Summary

First in the **daemon-as-process** arc — full plan in [`thoughts/shared/plans/2026-05-22-daemon-as-process-arc.md`](thoughts/shared/plans/2026-05-22-daemon-as-process-arc.md). The arc commits to: daemon is a real process (not a wheel MCP imports); IPC is the only path; tests that verify the boundary spin up a real daemon subprocess.

This PR adds the **externally-callable read** half of the protocol surface so Phase 2c-4 (the load-bearing first-call-site-migration PR) has concrete RPC targets when it starts rewiring MCP handler bodies through ``ProtocolClient``.

## What changed

- `protocol/contracts.py` — new Pydantic models: ``HistoryRequest``, ``UsageSummaryRequest``, ``UsageSummaryResult``. ``HistoryResponse`` stays in ``contracts.py`` (shared wire shape between MCP and daemon per the "flat envelopes" preflight constraint).
- `protocol/handlers/reads.py` — server-side dispatchers. Validate payloads, build a ``BicameralContext`` via a single-repo shim (multi-repo lands in 2c-3), delegate to today's ``handlers.history`` / ``handlers.usage_summary`` code. **No MCP handler bodies are modified by this PR.**
- `tests/test_protocol_read_conformance.py` — 6 tests. Dispatch shape + Pydantic input validation + idempotent registration + two **constraint tests** encoding bicameral-preflight findings:
  - `test_read_handlers_have_no_llm_imports` — pins the "deterministic read path" constraint (`decision:wndwxgam2m8yjor0igya`).
  - `test_protocol_server_init_does_not_open_db_connection` — pins the "lazy ledger connect" constraint (`decision:k44cko8xtkcswk55kytz`).

## Test strategy (per Fowler advisory, 2026-05-22)

In-process loopback only in this PR. The per-test daemon-subprocess fixture lands in **2c-4** alongside the first real call-site migration — build the fixture when there's a call site to test through it, not before.

## Compatibility

Pure-additive. MCP server unchanged. End-user MCP tool names (`bicameral.history`, `bicameral.usage_summary`) keep working through the today's direct-import path. Nothing in this PR routes through `ProtocolClient` yet.

## Acceptance

- [ ] `pytest tests/test_protocol_read_conformance.py` — 6 passing
- [ ] `pytest tests/test_protocol_categorization.py` + other protocol tests — still green (no regressions)
- [ ] `ruff check` + `ruff format --check` — both clean
- [ ] `mypy protocol/` — clean
- [ ] CI green on dev

## Plan refs

- Arc plan: `thoughts/shared/plans/2026-05-22-daemon-as-process-arc.md`
- This PR's plan: `thoughts/shared/plans/2026-05-22-2c-2-read-surface.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)