### PR TITLE
feat(protocol): rename ingest.* + grounding.* to match categorized namespace (Phase 2c-2c)

### DIFF
--- a/daemon/runtime.py
+++ b/daemon/runtime.py
@@ -41,12 +41,18 @@ class Runtime:
         return self._registry
 
     def _register_default_methods(self) -> None:
-        self._server.register("ingest.ingest", self._handle_ingest)
-        self._server.register("ingest.link_commit", self._handle_link_commit)
+        # Phase 2c-2c — registrations align with the categorized protocol
+        # namespace (write.* / grounding.lookup.* / grounding.analyze.* /
+        # system.* established in Phase 2c-1). ``egress.deliver`` stays under
+        # ``egress.*`` pending an explicit decision on whether to add
+        # ``EGRESS_PREFIX`` to the categorization surface.
+        self._server.register("write.ingest", self._handle_ingest)
+        self._server.register("write.link_commit", self._handle_link_commit)
         self._server.register("egress.deliver", self._handle_deliver)
-        # grounding.* methods land in Phase 2c when the code-locator + drift
-        # analyzer move into daemon/grounding/. system.version + system.attach
-        # are registered by ProtocolServer itself.
+        # grounding.lookup.* / grounding.analyze.* methods land in later
+        # phases when the code-locator + drift analyzer move into
+        # daemon/grounding/. system.version + system.attach are registered
+        # by ProtocolServer itself.
 
     async def _handle_ingest(
         self, params: dict[str, Any], ctx: ConnectionContext

--- a/protocol/client.py
+++ b/protocol/client.py
@@ -164,33 +164,40 @@ class ProtocolClient:
     # ── Typed adapter facade ─────────────────────────────────────────
 
     async def ingest(self, req: IngestRequest) -> IngestResult:
-        result = await self._call("ingest.ingest", req.model_dump())
+        result = await self._call("write.ingest", req.model_dump())
         return IngestResult.model_validate(result)
 
     async def link_commit(self, req: LinkCommitRequest) -> LinkCommitResult:
-        result = await self._call("ingest.link_commit", req.model_dump())
+        result = await self._call("write.link_commit", req.model_dump())
         return LinkCommitResult.model_validate(result)
 
     async def deliver(self, event: NotificationEvent) -> DeliveryResult:
+        # ``egress.deliver`` stays under the ``egress.*`` namespace pending an
+        # explicit decision on adding ``EGRESS_PREFIX`` to the categorization
+        # surface. The current categorization (read/write/grounding/system)
+        # has no slot for outbound notifications; treating egress as a write
+        # would conflate ledger mutation with delivery semantics. Tracked in
+        # the 2c-2c PR description; revisit before Phase 2c-3 ships the
+        # daemon supervisor.
         result = await self._call("egress.deliver", event.model_dump())
         return DeliveryResult.model_validate(result)
 
     async def validate_symbols(self, req: ValidateSymbolsRequest) -> list[Symbol]:
-        result = await self._call("grounding.validate_symbols", req.model_dump())
+        result = await self._call("grounding.lookup.validate_symbols", req.model_dump())
         return [Symbol.model_validate(item) for item in result]
 
     async def extract_symbols(self, req: ExtractSymbolsRequest) -> list[Symbol]:
-        result = await self._call("grounding.extract_symbols", req.model_dump())
+        result = await self._call("grounding.lookup.extract_symbols", req.model_dump())
         return [Symbol.model_validate(item) for item in result]
 
     async def get_neighbors(self, req: GetNeighborsRequest) -> list[Neighbor]:
-        result = await self._call("grounding.get_neighbors", req.model_dump())
+        result = await self._call("grounding.lookup.get_neighbors", req.model_dump())
         return [Neighbor.model_validate(item) for item in result]
 
     async def analyze_region(self, req: AnalyzeRegionRequest) -> DriftResult:
-        result = await self._call("grounding.analyze_region", req.model_dump())
+        result = await self._call("grounding.analyze.region", req.model_dump())
         return DriftResult.model_validate(result)
 
     async def batch_analyze_regions(self, req: BatchAnalyzeRequest) -> list[DriftResult]:
-        result = await self._call("grounding.batch_analyze_regions", req.model_dump())
+        result = await self._call("grounding.analyze.batch", req.model_dump())
         return [DriftResult.model_validate(item) for item in result]

--- a/tests/test_protocol_namespace_invariant.py
+++ b/tests/test_protocol_namespace_invariant.py
@@ -1,0 +1,138 @@
+"""Phase 2c-2c invariant: every wire method name on ``ProtocolClient`` and
+``daemon.runtime.Runtime`` lives under a categorized prefix.
+
+The categorized prefixes — ``read.``, ``write.``, ``grounding.lookup.``,
+``grounding.analyze.``, ``system.`` — were locked in Phase 2c-1
+(``protocol/categorization.py``). This test prevents the regression where
+new methods get added with un-categorized names like ``ingest.foo`` or
+``grounding.bar``.
+
+``egress.deliver`` is on the explicit allowlist because the categorization
+surface has no ``egress.*`` slot yet; expanding it is its own design
+decision (see PR #503's follow-up discussion). Adding entries to the
+allowlist should require explaining why the new prefix shouldn't be a
+category — keep the list short.
+"""
+
+from __future__ import annotations
+
+import ast
+import inspect
+from pathlib import Path
+
+from protocol import client as client_module
+from protocol.categorization import (
+    GROUNDING_ANALYZE_PREFIX,
+    GROUNDING_LOOKUP_PREFIX,
+    READ_PREFIX,
+    SYSTEM_PREFIX,
+    WRITE_PREFIX,
+)
+
+# Method names that intentionally live outside the five categorized prefixes.
+# Each entry needs a one-line rationale; keep this list small.
+WIRE_METHOD_ALLOWLIST: frozenset[str] = frozenset(
+    {
+        # Outbound delivery to humans-where-they-live. The categorization
+        # currently has no `egress.*` prefix; adding one is its own design
+        # decision (write conflates ledger mutation with delivery semantics).
+        "egress.deliver",
+    }
+)
+
+
+_CATEGORIZED_PREFIXES = (
+    READ_PREFIX,
+    WRITE_PREFIX,
+    GROUNDING_LOOKUP_PREFIX,
+    GROUNDING_ANALYZE_PREFIX,
+    SYSTEM_PREFIX,
+)
+
+
+def _extract_method_name_strings(source_path: Path) -> set[str]:
+    """Return every string literal passed as the first positional argument to
+    a ``self._call(...)`` or ``self._server.register(...)`` call in ``source_path``.
+
+    AST-based so we don't accidentally match docstrings, comments, or string
+    literals used for other purposes (event_type strings, log messages, etc.).
+    """
+    tree = ast.parse(source_path.read_text(encoding="utf-8"))
+    found: set[str] = set()
+
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.Call):
+            continue
+        # Match `<receiver>._call(name, ...)` and `<receiver>.register(name, ...)`.
+        if not isinstance(node.func, ast.Attribute):
+            continue
+        if node.func.attr not in {"_call", "register"}:
+            continue
+        if not node.args:
+            continue
+        first = node.args[0]
+        if isinstance(first, ast.Constant) and isinstance(first.value, str):
+            found.add(first.value)
+    return found
+
+
+def _is_categorized_or_allowlisted(method: str) -> bool:
+    if method in WIRE_METHOD_ALLOWLIST:
+        return True
+    return any(method.startswith(p) for p in _CATEGORIZED_PREFIXES)
+
+
+def test_protocol_client_facade_uses_categorized_names() -> None:
+    """Every method-name string in ``protocol/client.py`` matches the
+    categorized prefixes (or is on the explicit allowlist)."""
+    client_path = Path(inspect.getfile(client_module))
+    methods = _extract_method_name_strings(client_path)
+
+    # Smoke: the facade has at least the read + write surfaces wired.
+    assert "write.ingest" in methods, "write.ingest facade missing"
+    assert any(m.startswith(GROUNDING_LOOKUP_PREFIX) for m in methods), (
+        "no grounding.lookup.* methods on facade"
+    )
+
+    uncategorized = sorted(m for m in methods if not _is_categorized_or_allowlisted(m))
+    assert not uncategorized, (
+        "ProtocolClient method-name strings not matching a categorized prefix "
+        "(or the explicit allowlist):\n  " + "\n  ".join(uncategorized)
+    )
+
+
+def test_daemon_runtime_registrations_use_categorized_names() -> None:
+    """Every server-side ``register(...)`` call in ``daemon/runtime.py``
+    matches the categorized prefixes (or allowlist)."""
+    import daemon.runtime as runtime_module
+
+    runtime_path = Path(inspect.getfile(runtime_module))
+    methods = _extract_method_name_strings(runtime_path)
+
+    assert "write.ingest" in methods or "write.link_commit" in methods, (
+        "daemon runtime no longer registers write.* — check the renames"
+    )
+
+    uncategorized = sorted(m for m in methods if not _is_categorized_or_allowlisted(m))
+    assert not uncategorized, (
+        "daemon.runtime registers method names not matching a categorized prefix "
+        "(or the explicit allowlist):\n  " + "\n  ".join(uncategorized)
+    )
+
+
+def test_allowlist_entries_are_actually_used() -> None:
+    """Catch dead allowlist entries — every name on the allowlist must
+    actually appear somewhere in the codebase. A removed/renamed method
+    that left a stale allowlist entry is exactly the rot we want to prevent.
+    """
+    import daemon.runtime as runtime_module
+
+    client_methods = _extract_method_name_strings(Path(inspect.getfile(client_module)))
+    runtime_methods = _extract_method_name_strings(Path(inspect.getfile(runtime_module)))
+    all_used = client_methods | runtime_methods
+
+    stale = sorted(name for name in WIRE_METHOD_ALLOWLIST if name not in all_used)
+    assert not stale, (
+        "Stale WIRE_METHOD_ALLOWLIST entries (no longer referenced anywhere "
+        "in protocol/client.py or daemon/runtime.py):\n  " + "\n  ".join(stale)
+    )

--- a/tests/test_protocol_transport_uds.py
+++ b/tests/test_protocol_transport_uds.py
@@ -35,7 +35,7 @@ async def running_server(short_socket_dir: Path):
             {"name": name, "file": f"{name}.py", "start_line": 1, "end_line": 5} for name in names
         ]
 
-    server.register("grounding.validate_symbols", handle_validate)
+    server.register("grounding.lookup.validate_symbols", handle_validate)
     await server.start()
     try:
         yield server, short_socket_dir / "d.sock"

--- a/tests/test_protocol_versioning.py
+++ b/tests/test_protocol_versioning.py
@@ -42,7 +42,7 @@ async def test_v0_1_client_ignores_unknown_field_from_v0_2_server(
             "future_telemetry": {"latency_ms": 42},  # v0.2 addition
         }
 
-    server.register("ingest.ingest", handle_ingest_with_extra_field)
+    server.register("write.ingest", handle_ingest_with_extra_field)
     await server.start()
 
     client = ProtocolClient(socket_path=short_socket_dir / "d.sock")


### PR DESCRIPTION
## Summary

Third in the **daemon-as-process** arc ([plan](thoughts/shared/plans/2026-05-22-daemon-as-process-arc.md)). Aligns wire method names on ``ProtocolClient`` and ``daemon.runtime`` with the categorized prefixes that [Phase 2c-1 (#500)](https://github.com/BicameralAI/bicameral-mcp/pull/500) locked in.

Without this, the facade quietly drifts from the namespace it's supposed to enforce — call sites in 2c-4+ would either inherit the drift or ship two renames in one PR. Better to do it now while the surface is small.

## Renames

| Old wire name | New wire name |
|---|---|
| ``ingest.ingest`` | ``write.ingest`` |
| ``ingest.link_commit`` | ``write.link_commit`` |
| ``grounding.validate_symbols`` | ``grounding.lookup.validate_symbols`` |
| ``grounding.extract_symbols`` | ``grounding.lookup.extract_symbols`` |
| ``grounding.get_neighbors`` | ``grounding.lookup.get_neighbors`` |
| ``grounding.analyze_region`` | ``grounding.analyze.region`` |
| ``grounding.batch_analyze_regions`` | ``grounding.analyze.batch`` |

## Files touched

- ``protocol/client.py`` — 7 facade method strings
- ``daemon/runtime.py`` — 2 server-side registrations
- ``tests/test_protocol_versioning.py`` — test stub registration
- ``tests/test_protocol_transport_uds.py`` — test stub registration
- ``tests/test_protocol_namespace_invariant.py`` (new) — 3 invariants:
  1. Every method-name string in ``ProtocolClient`` matches a categorized prefix or the explicit allowlist (AST-walked).
  2. Every ``register(...)`` call in ``daemon.runtime`` matches the same.
  3. ``WIRE_METHOD_ALLOWLIST`` entries are still referenced somewhere (catches dead entries).

## Open question — please weigh in

``egress.deliver`` is **NOT renamed** in this PR. It sits on the explicit allowlist with a comment. The 2c-1 categorization committed to five prefixes (``read.*``, ``write.*``, ``grounding.lookup.*``, ``grounding.analyze.*``, ``system.*``); egress is implicit in the parent plan but not explicit. Three options for follow-up:

1. **Add ``EGRESS_PREFIX = "egress."`` to the categorization** — egress is conceptually distinct (outbound delivery, not ledger mutation). Adds a sixth category + ``@egress_tool`` decorator. Symmetric with ``IngestAdapter``/``EgressAdapter`` Protocols.
2. **Rename ``egress.deliver`` → ``write.deliver``** — conflates ledger mutation with delivery semantics; I'd push back on this, but it keeps the namespace at 5.
3. **Keep the allowlist** — cleanest until ``egress.*`` actually grows beyond ``deliver`` (today it's a single method).

My recommendation: **Option 1**, do it in 2c-3. The daemon supervisor PR is the natural time to expand the categorization since it's also when egress dispatch first runs for real.

## Compatibility

**Breaking** at the wire level if anything outside this repo speaks the protocol — but nothing does yet. The protocol is in-tree pre-extraction; only ``ProtocolClient`` (which this PR updates) and ``daemon.runtime`` (which this PR updates) reference the names.

## Test plan

- [x] ``pytest tests/test_protocol_namespace_invariant.py`` — 3 passing
- [x] ``pytest tests/test_protocol_*.py tests/test_mcp_adapter_bootstrap.py`` — 36 passing (no regressions)
- [x] ``ruff format --check . && ruff check .`` clean
- [x] ``mypy protocol/ daemon/`` clean
- [ ] CI green on dev

## Known limitation

**Bicameral preflight unavailable this session** (MCP server disconnected). Will validate against the ledger before opening 2c-3 (daemon supervisor).

## Plan refs

- Arc: ``thoughts/shared/plans/2026-05-22-daemon-as-process-arc.md``
- Predecessors merged: #500 (categorization), #501 (read surface), #503 (telemetry writes)

🤖 Generated with [Claude Code](https://claude.com/claude-code)