### PR TITLE
feat(diagnose): #252 Layer 5 — opt-in remediation recipe (rebased from #274)

### DIFF
--- a/cli/_diagnose_gather.py
+++ b/cli/_diagnose_gather.py
@@ -187,36 +187,49 @@ def _tail_recent_events(audit_path: Path | None, limit: int) -> list[dict]:
     return safe
 
 
+def _remediation_recipe() -> str:
+    """One-line export → reset → import recipe + policy-doc pointer.
+
+    Used by three suggestion branches in `_compute_suggestions` (drift,
+    unavailable, large-ledger) so the wording lives at one source of truth.
+    """
+    return (
+        "back up ledger and re-roundtrip via "
+        "`bicameral-mcp ledger-export > backup.jsonl && bicameral-mcp reset && "
+        "bicameral-mcp ledger-import --from-file backup.jsonl` "
+        "(see docs/policies/ledger-export.md)"
+    )
+
+
 def _compute_suggestions(d_partial: dict[str, Any]) -> list[str]:
-    """Run 5 hardcoded heuristics against the assembled partial Diagnosis dict."""
+    """Run 6 hardcoded heuristics against the assembled partial Diagnosis dict."""
     suggestions: list[str] = []
     drift = d_partial.get("drift_status")
+    bv = d_partial.get("bicameral_version", "")
+    recipe = _remediation_recipe()
     if drift == "drift":
         rec = d_partial.get("surrealdb_last_write")
         run = d_partial.get("surrealdb_running")
         suggestions.append(
             f"Schema-revision drift: recorded {rec} != running {run}; "
-            f"`pip install --upgrade surrealdb=={rec}` to match writer, "
-            "OR back up ledger and `bicameral-mcp reset`."
+            f"`pip install --upgrade surrealdb=={rec}` to match writer, OR {recipe}."
+        )
+    if drift == "unavailable" and bv and bv != "unknown":
+        suggestions.append(
+            f"Ledger predates Layer 2 wire-format sentinel (bicameral_meta missing); to acquire the sentinel, {recipe}."
         )
     rec_v = _fetch_recommended()
-    cur_v = d_partial.get("bicameral_version", "")
-    if rec_v and cur_v and rec_v != cur_v:
+    if rec_v and bv and rec_v != bv:
         suggestions.append(
-            f"Recommended version {rec_v} available; "
-            "`bicameral.update {action: 'apply'}` to upgrade."
+            f"Recommended version {rec_v} available; `bicameral.update {{action: 'apply'}}` to upgrade."
         )
     if d_partial.get("audit_log_channel") == "stderr":
         suggestions.append(
-            "Audit log not file-persisted. "
-            "Set `BICAMERAL_AUDIT_LOG=<path>` to capture incident events for SOC 2 evidence."
+            "Audit log not file-persisted. Set `BICAMERAL_AUDIT_LOG=<path>` to capture incident events for SOC 2 evidence."
         )
     size = d_partial.get("ledger_size_bytes")
     if isinstance(size, int) and size > _LARGE_LEDGER_BYTES:
-        suggestions.append(
-            f"Ledger file > 100 MiB (current: {size} bytes); "
-            "consider future `bicameral-mcp ledger-export` (Layer 4) for backup."
-        )
+        suggestions.append(f"Ledger file > 100 MiB (current: {size} bytes); {recipe}.")
     rec_schema = d_partial.get("schema_version_recorded")
     exp_schema = d_partial.get("schema_version_expected")
     if isinstance(rec_schema, int) and isinstance(exp_schema, int) and rec_schema < exp_schema:

--- a/docs/policies/diagnose-output.md
+++ b/docs/policies/diagnose-output.md
@@ -28,17 +28,43 @@ The `bicameral-mcp diagnose` CLI emits a markdown-styled report containing **str
 
 ## Suggestion heuristic catalog
 
-7 hardcoded heuristics fire based on the assembled Diagnosis fields:
+8 hardcoded heuristics fire based on the assembled Diagnosis fields:
 
-1. **drift detected** — `drift_status == "drift"` → recommend `pip install --upgrade surrealdb==<recorded>` or `bicameral-mcp reset` after backup.
+1. **drift detected** — `drift_status == "drift"` → recommend `pip install --upgrade surrealdb==<recorded>` to match the writer, OR the export → reset → import recipe (see Remediation recipe below).
 2. **recommended-version mismatch** — `bicameral_version` differs from the fetched `RECOMMENDED_VERSION` → recommend `bicameral.update {action: "apply"}`.
 3. **audit log disabled** — `audit_log_channel == "stderr"` (default) → recommend setting `BICAMERAL_AUDIT_LOG=<path>` for SOC 2 evidence capture.
-4. **ledger > 100 MiB** — `ledger_size_bytes > 100 * 1024 * 1024` → recommend future `bicameral-mcp ledger-export` (Layer 4) for backup.
+4. **ledger > 100 MiB** — `ledger_size_bytes > 100 * 1024 * 1024` → recommend the export → reset → import recipe (see Remediation recipe below) for backup.
 5. **schema version old** — `schema_version_recorded < schema_version_expected` → recommend running `bicameral-mcp` once to apply pending migrations.
-6. **row-level deserialization errors** — `row_probe_warnings` non-empty → recommend backing up the ledger and `bicameral-mcp reset` (typically a SurrealDB SDK version mismatch).
-7. **peer event replay blocked by local schema** (#405) — `recent_events` contains `event_type == "event_replay_schema_violation"` → recommend `pipx upgrade bicameral-mcp` (or `bicameral.update {action: "apply"}`) and re-running sync. The watermark is held by the replay path so queued events drain automatically once the binary understands the offending value. Inspect the audit log for the offending field + value (which are stripped from `recent_events` by the Layer 3 allowlist).
+6. **ledger predates Layer 2 sentinel** — `drift_status == "unavailable"` (the `bicameral_meta` table is absent on a binary that should have it) AND `bicameral_version` is not `"unknown"` → recommend the export → reset → import recipe (see Remediation recipe below) to acquire the sentinel.
+7. **row-level deserialization errors** — `row_probe_warnings` non-empty → recommend backing up the ledger and `bicameral-mcp reset` (typically a SurrealDB SDK version mismatch).
+8. **peer event replay blocked by local schema** (#405) — `recent_events` contains `event_type == "event_replay_schema_violation"` → recommend `pipx upgrade bicameral-mcp` (or `bicameral.update {action: "apply"}`) and re-running sync. The watermark is held by the replay path so queued events drain automatically once the binary understands the offending value. Inspect the audit log for the offending field + value (which are stripped from `recent_events` by the Layer 3 allowlist).
 
 Operators with custom diagnostic needs run `python -m cli.diagnose` directly and inspect the `Diagnosis` dataclass; the suggestion engine is a UX layer over the structural data, not a gate.
+
+## Remediation recipe (#252 Layer 5)
+
+Three of the eight heuristics above (drift, ledger > 100 MiB, predates Layer 2) emit a single shared recommended remediation: back up the ledger and re-roundtrip it through Layer 4's portable JSON-Lines vehicle. The recipe is operator-facing display text; bicameral-mcp itself never executes it. The wording lives at one source of truth in `cli/_diagnose_gather.py::_remediation_recipe()`; the operator copy-pastes from the diagnose output into their own shell.
+
+The recipe one-liner:
+
+```bash
+bicameral-mcp ledger-export > backup.jsonl && bicameral-mcp reset && bicameral-mcp ledger-import --from-file backup.jsonl
+```
+
+What it does, step by step:
+
+1. **`bicameral-mcp ledger-export > backup.jsonl`** — emits every row in every canonical table as JSON-Lines to stdout, captured to a portable file (see [`docs/policies/ledger-export.md`](ledger-export.md) for the canonical record shape and the privacy posture).
+2. **`bicameral-mcp reset`** — wipes the local SurrealDB ledger. After this step the ledger is empty; the source data lives only in `backup.jsonl`.
+3. **`bicameral-mcp ledger-import --from-file backup.jsonl`** — replays the JSON-Lines back into a fresh, sentinel-equipped ledger; the Layer 2 wire-format sentinel and any newer schema fields are populated by the connect/migrate path during import.
+
+Operator-facing properties:
+
+- **Opt-in only**: diagnose never executes the recipe; the operator runs it manually after reading the diagnose output. Per the gating-is-observability discipline.
+- **Idempotent against drift**: running the recipe against a sentinel-already-equipped ledger is harmless; the `bicameral_meta` row gets re-populated with the operator's current binary's wire-format identity.
+- **Right-to-erasure capable**: between steps 1 and 3, the operator can edit `backup.jsonl` to drop personally-identifying records (per [`docs/policies/ledger-export.md`](ledger-export.md) GDPR Art. 17 workflow).
+- **GDPR Art. 15 capable**: the exported `backup.jsonl` IS the data subject's portable export; operators can hand it to a data subject directly.
+
+The recipe is the same whether the trigger was schema-revision drift, a large ledger that needs a backup vehicle, or a ledger that pre-dates the Layer 2 sentinel. Single source of truth keeps the wording locked.
 
 ## Operator paste discipline
 

--- a/tests/test_compliance_policy_docs.py
+++ b/tests/test_compliance_policy_docs.py
@@ -156,6 +156,23 @@ def test_diagnose_output_policy_doc_documents_suggestion_heuristics() -> None:
         assert heuristic in content, f"heuristic {heuristic!r} missing from policy doc"
 
 
+def test_diagnose_output_doc_documents_layer5_remediation_recipe() -> None:
+    """#252 Layer 5: the policy doc must document the export → reset →
+    import remediation recipe AND cross-link to docs/policies/ledger-export.md.
+    Locks the wording the code emits (`_remediation_recipe()` helper)
+    against the operator-facing doc; prose drift between the two policy
+    docs trips at test time rather than at operator-confusion time."""
+    content = DIAGNOSE_OUTPUT_POLICY.read_text(encoding="utf-8")
+    for marker in (
+        "ledger-export",
+        "reset",
+        "ledger-import --from-file",
+        "docs/policies/ledger-export.md",
+        "predates Layer 2",
+    ):
+        assert marker in content, f"Layer 5 marker {marker!r} missing from policy doc"
+
+
 def test_ledger_export_policy_doc_lists_canonical_record_fields() -> None:
     """#252 Layer 4: every canonical record-shape field must appear in the policy doc.
     Locks doc/code drift between the export-record format and the operator-facing

--- a/tests/test_diagnose_remediation.py
+++ b/tests/test_diagnose_remediation.py
@@ -1,0 +1,151 @@
+"""Functional tests for #252 Layer 5 — diagnose remediation recipe.
+
+Pins the `_remediation_recipe` helper's wording AND the
+`_compute_suggestions` heuristic firings for every drift_status branch
+(drift, unavailable, match, first-write) plus the large-ledger branch's
+de-stale-ed wording. Closes the gating-is-observability discipline at
+the test layer: clean states emit no remediation, drifty states emit
+the recipe, and the recipe wording lives at one source of truth.
+"""
+
+from __future__ import annotations
+
+from cli._diagnose_gather import _compute_suggestions, _remediation_recipe
+
+
+def test_remediation_recipe_returns_export_reset_import_one_liner():
+    """Pin the helper's return value: must contain the four load-bearing
+    substrings (export command, reset command, import command, policy
+    pointer). Locks single source of truth for the recipe wording."""
+    recipe = _remediation_recipe()
+    assert "ledger-export" in recipe
+    assert "reset" in recipe
+    assert "ledger-import --from-file" in recipe
+    assert "docs/policies/ledger-export.md" in recipe
+
+
+def test_drift_status_drift_emits_export_import_recipe(monkeypatch):
+    """drift_status='drift' branch fires AND emits both remediation paths:
+    pin-down-the-writer (`pip install --upgrade surrealdb==<rec>`) AND
+    the export → reset → import recipe. Verifies the live recipe
+    replaced the vague pre-Layer-4 'back up ledger and reset' tail."""
+    # Pin recommended-version fetch so the recommended-version branch doesn't fire.
+    monkeypatch.setattr("cli._diagnose_gather._fetch_recommended", lambda: None)
+    suggestions = _compute_suggestions(
+        {
+            "drift_status": "drift",
+            "surrealdb_last_write": "1.0.0",
+            "surrealdb_running": "2.0.0",
+            "bicameral_version": "0.13.8",
+        }
+    )
+    drift_lines = [s for s in suggestions if "Schema-revision drift" in s]
+    assert len(drift_lines) == 1
+    line = drift_lines[0]
+    assert "pip install --upgrade surrealdb==1.0.0" in line
+    assert "ledger-export" in line
+    assert "reset" in line
+    assert "ledger-import --from-file" in line
+
+
+def test_drift_status_unavailable_emits_acquire_sentinel_recipe(monkeypatch):
+    """drift_status='unavailable' branch fires when bicameral_version
+    resolves. Emits the recipe + 'predates Layer 2' diagnostic context.
+    Verifies the new branch fires."""
+    monkeypatch.setattr("cli._diagnose_gather._fetch_recommended", lambda: None)
+    suggestions = _compute_suggestions(
+        {"drift_status": "unavailable", "bicameral_version": "0.13.8"}
+    )
+    matches = [s for s in suggestions if "predates Layer 2" in s]
+    assert len(matches) == 1
+    line = matches[0]
+    assert "ledger-export" in line
+    assert "reset" in line
+    assert "ledger-import --from-file" in line
+
+
+def test_drift_status_unavailable_skips_when_version_unknown(monkeypatch):
+    """drift_status='unavailable' branch skips when bicameral_version is
+    'unknown'. Avoids noise on installs without resolvable version
+    metadata. Locks the heuristic-skip guard."""
+    monkeypatch.setattr("cli._diagnose_gather._fetch_recommended", lambda: None)
+    suggestions = _compute_suggestions(
+        {"drift_status": "unavailable", "bicameral_version": "unknown"}
+    )
+    assert not any("predates Layer 2" in s for s in suggestions)
+
+
+def test_drift_status_match_emits_no_remediation(monkeypatch):
+    """drift_status='match' (clean state) emits no remediation recipe.
+    Locks the gating-is-observability discipline: clean state is silent."""
+    monkeypatch.setattr("cli._diagnose_gather._fetch_recommended", lambda: None)
+    suggestions = _compute_suggestions(
+        {
+            "drift_status": "match",
+            "audit_log_channel": "/var/log/bicameral.log",
+            "ledger_size_bytes": 1024,
+            "schema_version_recorded": 16,
+            "schema_version_expected": 16,
+            "bicameral_version": "0.13.8",
+        }
+    )
+    assert not any("ledger-export" in s for s in suggestions)
+    assert not any("ledger-import" in s for s in suggestions)
+
+
+def test_drift_status_first_write_emits_no_remediation(monkeypatch):
+    """drift_status='first-write' (Layer 2 just connected, no second write
+    yet) emits no remediation recipe. 'first-write' is normal post-Layer-2
+    boot, not drift."""
+    monkeypatch.setattr("cli._diagnose_gather._fetch_recommended", lambda: None)
+    suggestions = _compute_suggestions(
+        {
+            "drift_status": "first-write",
+            "audit_log_channel": "/var/log/bicameral.log",
+            "ledger_size_bytes": 1024,
+            "schema_version_recorded": 16,
+            "schema_version_expected": 16,
+            "bicameral_version": "0.13.8",
+        }
+    )
+    assert not any("ledger-export" in s for s in suggestions)
+    assert not any("ledger-import" in s for s in suggestions)
+
+
+def test_large_ledger_suggestion_emits_recipe_no_layer4_parenthetical(monkeypatch):
+    """large-ledger branch emits the live recipe AND drops the stale
+    pre-Layer-4 reference ('consider future ... (Layer 4)'). Locks the
+    de-stale-ing of the wording."""
+    from cli._diagnose_gather import _LARGE_LEDGER_BYTES
+
+    monkeypatch.setattr("cli._diagnose_gather._fetch_recommended", lambda: None)
+    suggestions = _compute_suggestions(
+        {
+            "drift_status": "match",
+            "audit_log_channel": "/var/log/bicameral.log",
+            "ledger_size_bytes": _LARGE_LEDGER_BYTES + 1,
+            "bicameral_version": "0.13.8",
+        }
+    )
+    matches = [s for s in suggestions if "> 100 MiB" in s]
+    assert len(matches) == 1
+    line = matches[0]
+    assert "ledger-export" in line
+    assert "(Layer 4)" not in line
+    assert "future" not in line
+
+
+def test_unavailable_branch_does_not_double_fire_with_drift_branch(monkeypatch):
+    """A diagnosis with drift_status='drift' should NOT also trigger the
+    'unavailable' branch (the two are mutually exclusive enum values).
+    Locks the branch discrimination."""
+    monkeypatch.setattr("cli._diagnose_gather._fetch_recommended", lambda: None)
+    suggestions = _compute_suggestions(
+        {
+            "drift_status": "drift",
+            "surrealdb_last_write": "1.0.0",
+            "surrealdb_running": "2.0.0",
+            "bicameral_version": "0.13.8",
+        }
+    )
+    assert not any("predates Layer 2" in s for s in suggestions)


### PR DESCRIPTION
## Summary

Rebases @Knapp-Kevin's #252 Layer 5 work (originally PR #274) onto current `dev`. The original branch had 14 days of drift (540 files / 71k deletions diff vs dev) so a full rebase wasn't tractable — instead I cherry-picked the two Layer 5 commits onto fresh `dev` and resolved two small conflicts.

Closes Kevin's strategy for #252: when `bicameral-mcp diagnose` detects a non-clean ledger state (`drift_status` ∈ {`drift`, `unavailable`}) or a >100 MiB ledger, the suggestion catalog now points operators at Layer 4's portable JSON-Lines roundtrip recipe as the recommended remediation. Recipe is operator-facing display text only — diagnose never executes it.

## What ships

- **`cli/_diagnose_gather.py::_remediation_recipe()`** — single source of truth for the export → reset → import wording, used by three suggestion branches (drift, unavailable, large-ledger).
- **`cli/_diagnose_gather.py::_compute_suggestions` modifications**:
  - drift branch: replaces vague tail with the explicit recipe.
  - large-ledger branch: replaces stale "consider future `bicameral-mcp ledger-export` (Layer 4)" parenthetical with the live recipe.
  - new `unavailable` branch: emits the recipe + "predates Layer 2" diagnostic when `drift_status == "unavailable"` AND `bicameral_version != "unknown"`.
- **`docs/policies/diagnose-output.md` extension** — heuristic catalog renumbered to 8 (Kevin's branch added "predates Layer 2 sentinel" as #6; dev had already added `row_probe_warnings` and the #405 peer-replay heuristic). New "Remediation recipe (#252 Layer 5)" section documenting the one-liner, step-by-step semantics, and operator-facing properties.
- **`tests/test_diagnose_remediation.py`** (new) — 8 functional tests, all passing locally.
- **`tests/test_compliance_policy_docs.py`** — 1 new content-contract test locking diagnose-output.md against the recipe wording the code emits.

## Conflicts resolved during rebase

1. **`cli/_diagnose_gather.py`** — dev added two new heuristics since Kevin's branch (`row_probe_warnings` + #405 peer-replay). Kept dev's superset; Layer 5's `_remediation_recipe` helper and drift/unavailable/large-ledger refactors apply cleanly above the conflict.
2. **`docs/policies/diagnose-output.md`** — heuristic catalog count merged from "6" vs "7" → "8". "Three of the six" updated to "Three of the eight". Renumbered list to slot Kevin's "predates Layer 2 sentinel" as #6 while keeping dev's row_probe + peer-replay as #7 and #8.
3. **`docs/META_LEDGER.md` (seal commit)** — Kevin's seal would have written entry #49, but that number was renumbered on dev for the team-server tier v1 research brief. Seal commit skipped; META_LEDGER entry can be added in a follow-up at the next available index.

## Verification (local)

- 8/8 Layer 5 functional tests pass: `tests/test_diagnose_remediation.py`
- `ruff check` clean
- `ruff format` clean (one re-format applied during rebase)
- Pre-existing dev-baseline failures NOT introduced by this PR:
  - `test_readme_compliance_section_links_all_three_policies` (README #270 restructure)
  - `test_diagnose_format.py::*` (8 tests; `Diagnosis.__init__()` requires `row_probe_warnings`; fails on plain dev too — separate bug)

## Replaces

Replaces #274 (14 days stale, CI red, was draft-blocked behind #258 which has since merged).

Co-Authored-By: WulfForge (Kevin Knapp) <krknapp@gmail.com>