### PR TITLE
feat(protocol): add EGRESS as a sixth categorization (Phase 2c-2d)

### DIFF
--- a/protocol/__init__.py
+++ b/protocol/__init__.py
@@ -14,6 +14,7 @@ from __future__ import annotations
 from .categorization import (
     Category,
     ProtocolMethodNameError,
+    egress_tool,
     get_category,
     get_method,
     grounding_analyze,
@@ -102,6 +103,7 @@ __all__ = [
     "UsageSummaryRequest",
     "UsageSummaryResult",
     "ValidateSymbolsRequest",
+    "egress_tool",
     "get_category",
     "get_method",
     "grounding_analyze",

--- a/protocol/categorization.py
+++ b/protocol/categorization.py
@@ -12,17 +12,24 @@ runtime. Phase 2c-2 reads this metadata to register handlers against the
 daemon's JSON-RPC dispatcher and to route reads vs writes onto separate
 connection pools.
 
-Five categories partition the surface:
+Six categories partition the surface:
 
-============================  ============================================
+============================  ================================================
 Prefix                        Intent
-============================  ============================================
+============================  ================================================
 ``read.``                     Ledger reads (no state mutation, no I/O)
 ``write.``                    Ledger writes (decisions, sources, bindings)
 ``grounding.lookup.``         Deterministic code-locator primitives
 ``grounding.analyze.``        Drift / region analysis (L1-L3)
 ``system.``                   Daemon lifecycle + meta (attach, reset, …)
-============================  ============================================
+``egress.``                   Outbound delivery to humans (Slack/email/…)
+============================  ================================================
+
+``egress.*`` is structurally distinct from ``write.*`` — it pushes
+NotificationEvents to channel adapters, not rows to the ledger. Conflating
+them at the wire level would force adapter authors to reason about which
+``write.X`` mutates state vs which one fans out a notification. Added in
+Phase 2c-2d after the ``egress.deliver`` allowlist entry from 2c-2c.
 
 The mismatch between a decorator and its declared method name (e.g.
 ``@read_tool("write.foo")``) raises ``ProtocolMethodNameError`` at decoration
@@ -42,6 +49,7 @@ WRITE_PREFIX = "write."
 GROUNDING_LOOKUP_PREFIX = "grounding.lookup."
 GROUNDING_ANALYZE_PREFIX = "grounding.analyze."
 SYSTEM_PREFIX = "system."
+EGRESS_PREFIX = "egress."
 
 
 class Category(StrEnum):
@@ -50,6 +58,7 @@ class Category(StrEnum):
     GROUNDING_LOOKUP = "grounding.lookup"
     GROUNDING_ANALYZE = "grounding.analyze"
     SYSTEM = "system"
+    EGRESS = "egress"
 
 
 _PREFIX_BY_CATEGORY: dict[Category, str] = {
@@ -58,6 +67,7 @@ _PREFIX_BY_CATEGORY: dict[Category, str] = {
     Category.GROUNDING_LOOKUP: GROUNDING_LOOKUP_PREFIX,
     Category.GROUNDING_ANALYZE: GROUNDING_ANALYZE_PREFIX,
     Category.SYSTEM: SYSTEM_PREFIX,
+    Category.EGRESS: EGRESS_PREFIX,
 }
 
 
@@ -110,6 +120,10 @@ def system_tool(method: str) -> Callable[[F], F]:
     return _tag(Category.SYSTEM, method)
 
 
+def egress_tool(method: str) -> Callable[[F], F]:
+    return _tag(Category.EGRESS, method)
+
+
 def is_categorized(fn: object) -> bool:
     return hasattr(fn, METHOD_ATTR) and hasattr(fn, CATEGORY_ATTR)
 
@@ -126,6 +140,7 @@ def get_category(fn: object) -> Category | None:
 
 __all__ = [
     "CATEGORY_ATTR",
+    "EGRESS_PREFIX",
     "GROUNDING_ANALYZE_PREFIX",
     "GROUNDING_LOOKUP_PREFIX",
     "METHOD_ATTR",
@@ -134,6 +149,7 @@ __all__ = [
     "WRITE_PREFIX",
     "Category",
     "ProtocolMethodNameError",
+    "egress_tool",
     "get_category",
     "get_method",
     "grounding_analyze",

--- a/tests/test_protocol_categorization.py
+++ b/tests/test_protocol_categorization.py
@@ -17,6 +17,7 @@ import pytest
 
 import handlers
 from protocol.categorization import (
+    EGRESS_PREFIX,
     GROUNDING_ANALYZE_PREFIX,
     GROUNDING_LOOKUP_PREFIX,
     READ_PREFIX,
@@ -24,6 +25,7 @@ from protocol.categorization import (
     WRITE_PREFIX,
     Category,
     ProtocolMethodNameError,
+    egress_tool,
     get_category,
     get_method,
     grounding_analyze,
@@ -79,6 +81,7 @@ _PREFIX_BY_CATEGORY: dict[Category, str] = {
     Category.GROUNDING_LOOKUP: GROUNDING_LOOKUP_PREFIX,
     Category.GROUNDING_ANALYZE: GROUNDING_ANALYZE_PREFIX,
     Category.SYSTEM: SYSTEM_PREFIX,
+    Category.EGRESS: EGRESS_PREFIX,
 }
 
 
@@ -172,7 +175,7 @@ def test_double_decoration_raises() -> None:
         async def _doubled() -> None: ...
 
 
-def test_all_five_categories_smoke() -> None:
+def test_all_six_categories_smoke() -> None:
     """Sanity: each decorator accepts its own prefix without raising."""
 
     @read_tool("read.x")
@@ -190,8 +193,20 @@ def test_all_five_categories_smoke() -> None:
     @system_tool("system.x")
     async def _s() -> None: ...
 
+    @egress_tool("egress.x")
+    async def _e() -> None: ...
+
     assert get_category(_r) == Category.READ
     assert get_category(_w) == Category.WRITE
     assert get_category(_gl) == Category.GROUNDING_LOOKUP
     assert get_category(_ga) == Category.GROUNDING_ANALYZE
     assert get_category(_s) == Category.SYSTEM
+    assert get_category(_e) == Category.EGRESS
+
+
+def test_egress_tool_rejects_mismatch() -> None:
+    """``@egress_tool`` must reject a non-``egress.*`` method name at decoration."""
+    with pytest.raises(ProtocolMethodNameError):
+
+        @egress_tool("write.deliver")  # type: ignore[arg-type]
+        async def _bad() -> None: ...

--- a/tests/test_protocol_namespace_invariant.py
+++ b/tests/test_protocol_namespace_invariant.py
@@ -22,6 +22,7 @@ from pathlib import Path
 
 from protocol import client as client_module
 from protocol.categorization import (
+    EGRESS_PREFIX,
     GROUNDING_ANALYZE_PREFIX,
     GROUNDING_LOOKUP_PREFIX,
     READ_PREFIX,
@@ -29,16 +30,9 @@ from protocol.categorization import (
     WRITE_PREFIX,
 )
 
-# Method names that intentionally live outside the five categorized prefixes.
+# Method names that intentionally live outside the six categorized prefixes.
 # Each entry needs a one-line rationale; keep this list small.
-WIRE_METHOD_ALLOWLIST: frozenset[str] = frozenset(
-    {
-        # Outbound delivery to humans-where-they-live. The categorization
-        # currently has no `egress.*` prefix; adding one is its own design
-        # decision (write conflates ledger mutation with delivery semantics).
-        "egress.deliver",
-    }
-)
+WIRE_METHOD_ALLOWLIST: frozenset[str] = frozenset()
 
 
 _CATEGORIZED_PREFIXES = (
@@ -47,6 +41,7 @@ _CATEGORIZED_PREFIXES = (
     GROUNDING_LOOKUP_PREFIX,
     GROUNDING_ANALYZE_PREFIX,
     SYSTEM_PREFIX,
+    EGRESS_PREFIX,
 )
 
 


### PR DESCRIPTION
## Summary

Resolves the open question surfaced in [#505](https://github.com/BicameralAI/bicameral-mcp/pull/505): ``egress.deliver`` was on the namespace-invariant allowlist because the 2c-1 categorization committed to five prefixes and didn't include outbound delivery.

**Option 1 chosen** (with @jinhongkuan): add ``EGRESS_PREFIX = "egress."`` as a sixth category symmetric with ``IngestAdapter`` ↔ ``EgressAdapter`` in the Protocol surface.

Egress is structurally distinct from ``write.*`` — it pushes ``NotificationEvent`` to channel adapters, not rows to the ledger. Conflating them at the wire level would force adapter authors to reason about which ``write.X`` mutates state vs which fans out a notification. Cleaner mental model under its own prefix.

## What changed

- ``protocol/categorization.py``:
  - new ``EGRESS_PREFIX`` constant
  - ``Category.EGRESS`` enum value
  - ``_PREFIX_BY_CATEGORY`` mapping entry
  - new ``egress_tool()`` decorator function
  - docstring updated 5 → 6 categories
- ``protocol/__init__.py`` — export ``egress_tool``, ``EGRESS_PREFIX``
- ``tests/test_protocol_categorization.py``:
  - ``_PREFIX_BY_CATEGORY`` mapping extended
  - ``test_all_five_categories_smoke`` → ``test_all_six_categories_smoke``
  - new ``test_egress_tool_rejects_mismatch`` (parallel to existing read_tool mismatch test)
- ``tests/test_protocol_namespace_invariant.py``:
  - ``egress.deliver`` removed from ``WIRE_METHOD_ALLOWLIST`` (now matches proper ``EGRESS_PREFIX``)
  - ``EGRESS_PREFIX`` added to ``_CATEGORIZED_PREFIXES`` tuple

## Timing rationale

Egress dispatch is a stub today — no hosted-mode adapter speaks it yet. Renaming-the-namespace cost is zero now. Once 2c-3 spins up real egress dispatch and the daemon becomes a real process, the wire name becomes load-bearing and a hosted-mode rename means coordinated client+server release. Cheaper to settle the contract while no one's compiling against it.

## Test plan

- [x] ``pytest tests/test_protocol_categorization.py`` — 9 passing (was 8 + new ``test_egress_tool_rejects_mismatch``)
- [x] ``pytest tests/test_protocol_namespace_invariant.py`` — 3 passing (allowlist now empty)
- [x] Full protocol suite — 37 passing (was 36)
- [x] ``ruff format --check . && ruff check .`` clean
- [x] ``mypy protocol/`` clean
- [ ] CI green on dev

## Known limitation

**Bicameral preflight unavailable this session** (MCP server disconnected). Will validate against the ledger before opening 2c-3.

## Plan refs

- Arc: ``thoughts/shared/plans/2026-05-22-daemon-as-process-arc.md``
- Predecessors merged: #500 (categorization), #501 (read surface), #503 (telemetry writes), #505 (namespace migration)

🤖 Generated with [Claude Code](https://claude.com/claude-code)