### PR TITLE
feat(daemon): cross-platform supervisor + bicameral-mcp daemon CLI (Phase 2c-3)

### DIFF
--- a/cli/daemon_cli.py
+++ b/cli/daemon_cli.py
@@ -1,0 +1,120 @@
+"""``bicameral-mcp daemon`` CLI — start / stop / restart / status.
+
+Thin shell around ``daemon.process``: argparse plumbing + JSON output for
+``status``. Lives under ``cli/`` to match the convention every other
+subcommand uses (``sync_and_brief_cli``, ``brief_cli``, etc.).
+
+Phase 2c-3 — daemon-as-process arc. Auto-start install (LaunchAgent /
+Windows Service / systemd-user) ships as separate per-platform PRs.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+
+from daemon.process import (
+    DaemonAlreadyRunningError,
+    DaemonNotRunningError,
+    spawn,
+    status,
+    stop,
+)
+
+
+def _build_argparser(parser: argparse.ArgumentParser) -> None:
+    """Add the daemon sub-subcommands (start/stop/restart/status) to ``parser``.
+
+    Called from ``server.py::_register_subparsers`` against the ``daemon``
+    subparser slot. Matches the pattern every other CLI module uses.
+    """
+    sub = parser.add_subparsers(dest="daemon_action", required=False)
+
+    for action_name, help_text in (
+        ("start", "spawn the daemon as a detached subprocess (idempotent)"),
+        ("stop", "send SIGTERM to the running daemon; SIGKILL after timeout"),
+        ("restart", "stop (if running) + start; preserves socket path"),
+        ("status", "print daemon liveness as JSON: running | stopped | stale"),
+    ):
+        sp = sub.add_parser(action_name, help=help_text)
+        sp.add_argument(
+            "--socket",
+            type=Path,
+            default=None,
+            help="override the UDS socket path (default: ~/.bicameral/daemon.sock)",
+        )
+        sp.add_argument(
+            "--descriptor",
+            type=Path,
+            default=None,
+            help="override the descriptor path (default: ~/.bicameral/daemon.json)",
+        )
+
+
+def main(args: argparse.Namespace) -> int:
+    action = getattr(args, "daemon_action", None)
+    if action is None:
+        # ``bicameral-mcp daemon`` with no subcommand prints status. Useful
+        # as a quick-check at the shell.
+        print(json.dumps(status(descriptor_path=args.descriptor), indent=2))
+        return 0
+    if action == "start":
+        return _cmd_start(args)
+    if action == "stop":
+        return _cmd_stop(args)
+    if action == "restart":
+        return _cmd_restart(args)
+    if action == "status":
+        print(json.dumps(status(descriptor_path=args.descriptor), indent=2))
+        return 0
+    print(f"unknown daemon action: {action}", file=sys.stderr)
+    return 2
+
+
+def _cmd_start(args: argparse.Namespace) -> int:
+    try:
+        descriptor = spawn(
+            socket_path=args.socket,
+            descriptor_path=args.descriptor,
+        )
+    except DaemonAlreadyRunningError as exc:
+        # Idempotent at the CLI level: report and exit 0. Treating "already
+        # running" as an error would force every caller to swallow it.
+        print(f"daemon already running: {exc}", file=sys.stderr)
+        return 0
+    except (TimeoutError, RuntimeError) as exc:
+        print(f"daemon start failed: {exc}", file=sys.stderr)
+        return 1
+    print(
+        json.dumps(
+            {
+                "status": "started",
+                "pid": descriptor.pid,
+                "socket_path": str(descriptor.socket_path),
+            },
+            indent=2,
+        )
+    )
+    return 0
+
+
+def _cmd_stop(args: argparse.Namespace) -> int:
+    try:
+        stop(descriptor_path=args.descriptor)
+    except DaemonNotRunningError as exc:
+        # Idempotent: stopping a stopped daemon is a no-op success.
+        print(f"daemon already stopped: {exc}", file=sys.stderr)
+        return 0
+    print(json.dumps({"status": "stopped"}, indent=2))
+    return 0
+
+
+def _cmd_restart(args: argparse.Namespace) -> int:
+    # Stop is idempotent — failure to find a running daemon is fine.
+    try:
+        stop(descriptor_path=args.descriptor)
+    except DaemonNotRunningError:
+        pass
+    return _cmd_start(args)

--- a/daemon/__main__.py
+++ b/daemon/__main__.py
@@ -1,0 +1,82 @@
+"""Entry point for the daemon subprocess (``python -m daemon serve``).
+
+Spawned by ``bicameral-mcp daemon start`` via ``subprocess.Popen``. Runs the
+asyncio event loop until SIGTERM / SIGINT, at which point it gracefully
+stops the ``Supervisor`` (closes the UDS socket, removes the descriptor,
+unregisters adapters).
+
+Stays minimal on purpose — process lifecycle plumbing only. The actual RPC
+surface lives in ``protocol/`` + ``daemon/runtime.py``; the adapter wiring
+lives in ``integrations/mcp_adapter/bootstrap.py``.
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import signal
+import sys
+from pathlib import Path
+
+from integrations.mcp_adapter.bootstrap import bootstrap_mcp_daemon
+
+
+def _parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(prog="python -m daemon")
+    sub = parser.add_subparsers(dest="action", required=True)
+    serve = sub.add_parser("serve", help="run the daemon process until SIGTERM")
+    serve.add_argument(
+        "--socket",
+        type=Path,
+        default=None,
+        help="override the default UDS socket path (~/.bicameral/daemon.sock)",
+    )
+    serve.add_argument(
+        "--descriptor",
+        type=Path,
+        default=None,
+        help="override the descriptor path (~/.bicameral/daemon.json)",
+    )
+    return parser.parse_args(argv)
+
+
+async def _serve(socket_path: Path | None, descriptor_path: Path | None) -> int:
+    supervisor = await bootstrap_mcp_daemon(
+        socket_path=socket_path,
+        descriptor_path=descriptor_path,
+    )
+    stop_event = asyncio.Event()
+
+    def _trigger_stop(_signum: int | None = None, _frame: object = None) -> None:
+        stop_event.set()
+
+    loop = asyncio.get_running_loop()
+    for sig_name in ("SIGTERM", "SIGINT"):
+        sig = getattr(signal, sig_name, None)
+        if sig is None:
+            continue
+        try:
+            loop.add_signal_handler(sig, _trigger_stop)
+        except NotImplementedError:
+            # Windows asyncio doesn't support add_signal_handler. Fall
+            # back to the synchronous signal module; the handler sets the
+            # event from any thread and asyncio picks it up on the next
+            # event-loop tick.
+            signal.signal(sig, _trigger_stop)
+
+    try:
+        await stop_event.wait()
+    finally:
+        await supervisor.stop()
+    return 0
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = _parse_args(argv)
+    if args.action == "serve":
+        return asyncio.run(_serve(args.socket, args.descriptor))
+    return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/daemon/process.py
+++ b/daemon/process.py
@@ -1,0 +1,279 @@
+"""Cross-platform process lifecycle helpers for the bicameral daemon.
+
+The spawn model is the same on every platform — ``subprocess.Popen`` with
+detach flags appropriate to the OS, child writes ``~/.bicameral/daemon.json``
+via the supervisor, parent exits. Stop sends SIGTERM (POSIX) or invokes
+``terminate()`` which maps to ``TerminateProcess`` (Windows). No double-fork,
+no LaunchAgent in this layer — auto-start is its own follow-up PR.
+
+This module deliberately does NOT supervise the spawned child. A daemon that
+crashes stays crashed until the user runs ``bicameral-mcp daemon start``
+again. Restart-on-crash is the OS supervisor's job (launchd / systemd /
+Windows Service Control Manager), introduced as a separate concern.
+
+Phase 2c-3 — daemon-as-process arc, plan in
+``thoughts/shared/plans/2026-05-22-daemon-as-process-arc.md``.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import signal
+import subprocess
+import sys
+import time
+from dataclasses import dataclass
+from pathlib import Path
+
+from daemon.supervisor import default_descriptor_path, default_socket_path
+
+
+class DaemonNotRunningError(RuntimeError):
+    """Raised when an operation needs a running daemon but none is."""
+
+
+class DaemonAlreadyRunningError(RuntimeError):
+    """Raised when ``start`` is called and the descriptor points to a live process."""
+
+
+@dataclass
+class DaemonDescriptor:
+    """Read-side mirror of ``daemon.supervisor._DaemonDescriptor``."""
+
+    socket_path: Path
+    pid: int
+
+    @classmethod
+    def load(cls, path: Path) -> DaemonDescriptor | None:
+        if not path.exists():
+            return None
+        try:
+            data = json.loads(path.read_text(encoding="utf-8"))
+            return cls(socket_path=Path(data["socket_path"]), pid=int(data["pid"]))
+        except (json.JSONDecodeError, KeyError, ValueError):
+            return None
+
+
+def is_alive(pid: int) -> bool:
+    """Return True iff ``pid`` names a running process this user can signal."""
+    if pid <= 0:
+        return False
+    if sys.platform == "win32":
+        # ``OpenProcess`` is the canonical Windows check, but we can rely on
+        # the simpler ``kill(0)`` semantics via the ``signal`` module on 3.11+.
+        # Falling back to a process listing avoids loading ctypes for one line.
+        try:
+            os.kill(pid, 0)
+            return True
+        except (OSError, PermissionError):
+            return False
+    try:
+        os.kill(pid, 0)
+        return True
+    except ProcessLookupError:
+        return False
+    except PermissionError:
+        # Process exists but is owned by another user; we treat as alive for
+        # the "is the daemon up?" question. The caller can still try to stop
+        # it and will get a clean permission error.
+        return True
+
+
+def spawn(
+    *,
+    socket_path: Path | None = None,
+    descriptor_path: Path | None = None,
+    log_path: Path | None = None,
+    wait_timeout_s: float = 5.0,
+) -> DaemonDescriptor:
+    """Spawn a detached daemon subprocess and wait for the descriptor.
+
+    Returns the descriptor the child wrote. Raises
+    ``DaemonAlreadyRunningError`` if an existing descriptor points to a live
+    PID. Raises ``TimeoutError`` if the child hasn't published its
+    descriptor within ``wait_timeout_s``.
+
+    The child runs ``python -m daemon serve`` with detach flags appropriate
+    to the host OS. Parent process exits as soon as the descriptor file
+    appears + the process is verifiably alive.
+    """
+    socket_path = socket_path or default_socket_path()
+    descriptor_path = descriptor_path or default_descriptor_path()
+    descriptor_path.parent.mkdir(parents=True, exist_ok=True)
+
+    existing = DaemonDescriptor.load(descriptor_path)
+    if existing is not None and is_alive(existing.pid):
+        raise DaemonAlreadyRunningError(
+            f"daemon already running (pid={existing.pid}, socket={existing.socket_path})"
+        )
+    # Stale descriptor (process gone) — remove so the child can rewrite cleanly.
+    if existing is not None and not is_alive(existing.pid):
+        descriptor_path.unlink(missing_ok=True)
+
+    log_path = log_path or descriptor_path.parent / "daemon.log"
+    log_fh = open(log_path, "a", encoding="utf-8")
+
+    argv = [
+        sys.executable,
+        "-m",
+        "daemon",
+        "serve",
+        "--socket",
+        str(socket_path),
+        "--descriptor",
+        str(descriptor_path),
+    ]
+    if sys.platform == "win32":
+        # DETACHED_PROCESS hides the console window; CREATE_NEW_PROCESS_GROUP
+        # lets us send signals (Ctrl+Break) to the child group later. Both
+        # are required for a clean Windows detach.
+        creationflags = (
+            subprocess.DETACHED_PROCESS  # type: ignore[attr-defined]
+            | subprocess.CREATE_NEW_PROCESS_GROUP  # type: ignore[attr-defined]
+        )
+        proc = subprocess.Popen(
+            argv,
+            stdin=subprocess.DEVNULL,
+            stdout=log_fh,
+            stderr=subprocess.STDOUT,
+            close_fds=True,
+            creationflags=creationflags,
+        )
+    else:
+        # ``start_new_session`` runs ``setsid`` in the child so it survives
+        # the parent shell exiting.
+        proc = subprocess.Popen(
+            argv,
+            stdin=subprocess.DEVNULL,
+            stdout=log_fh,
+            stderr=subprocess.STDOUT,
+            close_fds=True,
+            start_new_session=True,
+        )
+
+    # Wait for the child to publish its descriptor — this is the liveness
+    # signal that the asyncio loop is up and the UDS socket is bound.
+    deadline = time.monotonic() + wait_timeout_s
+    while time.monotonic() < deadline:
+        # Child died before publishing → propagate as a hard error.
+        if proc.poll() is not None:
+            log_fh.close()
+            raise RuntimeError(
+                f"daemon process exited before publishing descriptor "
+                f"(exit code {proc.returncode}); see {log_path}"
+            )
+        descriptor = DaemonDescriptor.load(descriptor_path)
+        if descriptor is not None and descriptor.pid == proc.pid:
+            log_fh.close()
+            return descriptor
+        time.sleep(0.05)
+
+    # Timeout — kill the orphan and bail.
+    proc.terminate()
+    log_fh.close()
+    raise TimeoutError(
+        f"daemon did not publish descriptor within {wait_timeout_s:.1f}s; see {log_path}"
+    )
+
+
+def stop(
+    *,
+    descriptor_path: Path | None = None,
+    timeout_s: float = 10.0,
+) -> None:
+    """Send SIGTERM to the running daemon and wait for clean exit.
+
+    Reads the PID from the descriptor. After ``timeout_s`` with the process
+    still alive, escalates to SIGKILL / ``TerminateProcess`` and returns.
+    Removes the descriptor file last so a partial stop leaves observable
+    state.
+
+    Raises ``DaemonNotRunningError`` if no descriptor exists or its PID is
+    already dead.
+    """
+    descriptor_path = descriptor_path or default_descriptor_path()
+    descriptor = DaemonDescriptor.load(descriptor_path)
+    if descriptor is None or not is_alive(descriptor.pid):
+        # Idempotent: a stop on an already-stopped daemon cleans up the
+        # stale descriptor and returns. Callers shouldn't have to special-
+        # case "stop after a crash."
+        descriptor_path.unlink(missing_ok=True)
+        if descriptor is None:
+            raise DaemonNotRunningError("no daemon descriptor found")
+        return
+
+    # Phase 1: polite SIGTERM. The supervisor's signal handler closes the
+    # asyncio loop, the supervisor stops, descriptor is removed by the
+    # child itself.
+    try:
+        if sys.platform == "win32":
+            # ``CTRL_BREAK_EVENT`` is what corresponds to SIGINT for processes
+            # launched with ``CREATE_NEW_PROCESS_GROUP``.
+            os.kill(descriptor.pid, signal.CTRL_BREAK_EVENT)  # type: ignore[attr-defined]
+        else:
+            os.kill(descriptor.pid, signal.SIGTERM)
+    except ProcessLookupError:
+        descriptor_path.unlink(missing_ok=True)
+        return
+
+    deadline = time.monotonic() + timeout_s
+    while time.monotonic() < deadline:
+        if not is_alive(descriptor.pid):
+            descriptor_path.unlink(missing_ok=True)
+            return
+        time.sleep(0.1)
+
+    # Phase 2: SIGKILL escalation. The supervisor didn't shut down cleanly;
+    # force it. Descriptor is removed regardless so the next ``start`` doesn't
+    # see a phantom-alive entry.
+    try:
+        if sys.platform == "win32":
+            # Last-resort kill on Windows.
+            subprocess.run(
+                ["taskkill", "/PID", str(descriptor.pid), "/F"],
+                check=False,
+                capture_output=True,
+            )
+        else:
+            os.kill(descriptor.pid, signal.SIGKILL)
+    except ProcessLookupError:
+        pass
+    descriptor_path.unlink(missing_ok=True)
+
+
+def status(*, descriptor_path: Path | None = None) -> dict[str, object]:
+    """Return a JSON-serializable status snapshot for ``daemon status`` output.
+
+    Shape:
+        {"status": "stopped" | "running" | "stale",
+         "pid": int | None,
+         "socket_path": str | None,
+         "descriptor_path": str}
+
+    ``"stale"`` means a descriptor exists but the PID isn't alive — usually
+    a crash without cleanup. Operators should run ``daemon stop`` (idempotent
+    cleanup) before ``daemon start``.
+    """
+    descriptor_path = descriptor_path or default_descriptor_path()
+    descriptor = DaemonDescriptor.load(descriptor_path)
+    if descriptor is None:
+        return {
+            "status": "stopped",
+            "pid": None,
+            "socket_path": None,
+            "descriptor_path": str(descriptor_path),
+        }
+    if not is_alive(descriptor.pid):
+        return {
+            "status": "stale",
+            "pid": descriptor.pid,
+            "socket_path": str(descriptor.socket_path),
+            "descriptor_path": str(descriptor_path),
+        }
+    return {
+        "status": "running",
+        "pid": descriptor.pid,
+        "socket_path": str(descriptor.socket_path),
+        "descriptor_path": str(descriptor_path),
+    }

--- a/server.py
+++ b/server.py
@@ -1438,6 +1438,13 @@ def _register_subparsers(parser: ArgumentParser, subparsers: Any) -> None:
         "diagnose",
         help="emit a privacy-preserving operator bug-report (#252 Layer 3)",
     )
+    daemon = subparsers.add_parser(
+        "daemon",
+        help="manage the bicameral daemon process — start | stop | restart | status (Phase 2c-3)",
+    )
+    from cli.daemon_cli import _build_argparser as _daemon_build
+
+    _daemon_build(daemon)
     sync_and_brief = subparsers.add_parser(
         "sync-and-brief",
         help="pull from configured sources, ingest new transcripts, scan drift, print brief (#279)",
@@ -1568,6 +1575,10 @@ def _dispatch(args: Any) -> int:
         from cli.diagnose import main as diagnose_main
 
         return diagnose_main()
+    if args.command == "daemon":
+        from cli.daemon_cli import main as daemon_main
+
+        return daemon_main(args)
     if args.command == "sync-and-brief":
         from cli.sync_and_brief_cli import main as sync_and_brief_main
 

--- a/tests/test_daemon_lifecycle.py
+++ b/tests/test_daemon_lifecycle.py
@@ -1,0 +1,205 @@
+"""Phase 2c-3: sociable lifecycle tests for the daemon subprocess.
+
+Each test spins up a real ``python -m daemon serve`` subprocess against a
+``tmp_path`` socket + descriptor pair. Verifies behavior across the process
+boundary — that's the whole point of the daemon-as-process commitment. No
+mocks; the only "seam" is the per-test temp dir.
+
+When this batch of tests starts costing measurable CI time, swap the
+fixture body for a pooled-warmed-daemon implementation (per Fowler's
+ObjectPool guidance) — the tests don't change.
+"""
+
+from __future__ import annotations
+
+import shutil
+import tempfile
+from pathlib import Path
+
+import pytest
+
+from daemon.process import (
+    DaemonAlreadyRunningError,
+    DaemonDescriptor,
+    DaemonNotRunningError,
+    is_alive,
+    spawn,
+    status,
+    stop,
+)
+from protocol.client import ProtocolClient
+
+
+@pytest.fixture
+def short_state_dir():
+    """macOS AF_UNIX paths cap around 104 chars; pytest tmp_path is too deep.
+
+    The daemon writes its descriptor + socket under this dir; tests pass
+    explicit paths so no developer ``~/.bicameral/`` state is touched.
+    """
+    base = Path(tempfile.mkdtemp(prefix="bm-daemon-", dir="/tmp"))
+    try:
+        yield base
+    finally:
+        # Best-effort: kill any leftover daemon from a failed assertion.
+        descriptor_path = base / "daemon.json"
+        descriptor = DaemonDescriptor.load(descriptor_path)
+        if descriptor is not None and is_alive(descriptor.pid):
+            try:
+                stop(descriptor_path=descriptor_path, timeout_s=2.0)
+            except Exception:
+                pass
+        shutil.rmtree(base, ignore_errors=True)
+
+
+def _paths(state_dir: Path) -> tuple[Path, Path]:
+    return state_dir / "daemon.sock", state_dir / "daemon.json"
+
+
+def test_spawn_publishes_descriptor_and_socket(short_state_dir):
+    """The spawned subprocess writes a descriptor + binds the UDS socket."""
+    socket_path, descriptor_path = _paths(short_state_dir)
+    descriptor = spawn(socket_path=socket_path, descriptor_path=descriptor_path)
+    try:
+        assert descriptor.pid > 0
+        assert descriptor.socket_path == socket_path
+        assert descriptor_path.exists()
+        assert socket_path.exists()
+        assert is_alive(descriptor.pid)
+    finally:
+        stop(descriptor_path=descriptor_path)
+
+
+def test_status_reports_running_then_stopped(short_state_dir):
+    """``status`` reflects the actual descriptor + liveness state."""
+    socket_path, descriptor_path = _paths(short_state_dir)
+
+    pre = status(descriptor_path=descriptor_path)
+    assert pre["status"] == "stopped"
+    assert pre["pid"] is None
+
+    descriptor = spawn(socket_path=socket_path, descriptor_path=descriptor_path)
+    try:
+        running = status(descriptor_path=descriptor_path)
+        assert running["status"] == "running"
+        assert running["pid"] == descriptor.pid
+        assert running["socket_path"] == str(socket_path)
+    finally:
+        stop(descriptor_path=descriptor_path)
+
+    post = status(descriptor_path=descriptor_path)
+    assert post["status"] == "stopped"
+    assert post["pid"] is None
+
+
+async def test_protocol_client_can_attach_to_spawned_daemon(short_state_dir):
+    """Real ProtocolClient → real socket → real daemon → real system.version.
+
+    This is the load-bearing wire test: the JSON-RPC layer round-trips
+    across a true subprocess boundary, not a same-process loopback.
+    """
+    socket_path, descriptor_path = _paths(short_state_dir)
+    spawn(socket_path=socket_path, descriptor_path=descriptor_path)
+    try:
+        client = ProtocolClient(socket_path=socket_path)
+        await client.connect()  # version handshake + attach happens inside
+        try:
+            version = await client._call("system.version", {})
+            assert isinstance(version, str)
+            assert version  # non-empty
+        finally:
+            await client.close()
+    finally:
+        stop(descriptor_path=descriptor_path)
+
+
+def test_spawn_refuses_when_already_running(short_state_dir):
+    """Second ``spawn`` against the same descriptor raises ``DaemonAlreadyRunningError``."""
+    socket_path, descriptor_path = _paths(short_state_dir)
+    descriptor = spawn(socket_path=socket_path, descriptor_path=descriptor_path)
+    try:
+        with pytest.raises(DaemonAlreadyRunningError):
+            spawn(socket_path=socket_path, descriptor_path=descriptor_path)
+        assert is_alive(descriptor.pid)
+    finally:
+        stop(descriptor_path=descriptor_path)
+
+
+def test_stop_raises_when_no_daemon_running(short_state_dir):
+    """Stop on a fresh state dir → ``DaemonNotRunningError`` (CLI swallows it)."""
+    _, descriptor_path = _paths(short_state_dir)
+    with pytest.raises(DaemonNotRunningError):
+        stop(descriptor_path=descriptor_path)
+
+
+def test_stop_cleans_up_stale_descriptor(short_state_dir):
+    """A descriptor pointing at a dead PID is silently cleaned up by ``stop``.
+
+    Simulates "daemon crashed without removing its file" — the next start
+    must not see a phantom-alive entry. Contract: ``stop`` returns
+    successfully (no raise) and removes the stale descriptor.
+    """
+    _, descriptor_path = _paths(short_state_dir)
+    descriptor_path.parent.mkdir(parents=True, exist_ok=True)
+    # PID 999_999_999 is well beyond any plausible live PID — exercises the
+    # "descriptor exists but PID is dead" branch in ``stop``.
+    descriptor_path.write_text(
+        '{"socket_path": "/tmp/bm-stale-not-real.sock", "pid": 999999999}',
+        encoding="utf-8",
+    )
+    # No raise — silent cleanup is the contract for stale descriptors.
+    stop(descriptor_path=descriptor_path)
+    assert not descriptor_path.exists()
+
+
+def test_status_reports_stale_descriptor(short_state_dir):
+    """When PID is dead but descriptor lives, ``status`` returns ``"stale"``."""
+    _, descriptor_path = _paths(short_state_dir)
+    descriptor_path.parent.mkdir(parents=True, exist_ok=True)
+    descriptor_path.write_text(
+        '{"socket_path": "/tmp/bm-stale-not-real.sock", "pid": 999999999}',
+        encoding="utf-8",
+    )
+    snapshot = status(descriptor_path=descriptor_path)
+    assert snapshot["status"] == "stale"
+    assert snapshot["pid"] == 999999999
+
+
+def test_spawn_after_stop_with_same_paths(short_state_dir):
+    """Restart loop: spawn → stop → spawn against identical paths works.
+
+    Observable contract: after stop, a fresh spawn against the same paths
+    succeeds and produces a working daemon. We deliberately do NOT assert
+    ``is_alive(first.pid)`` is False because POSIX PIDs are reusable —
+    after the kernel reaps the daemon, that PID can be assigned to an
+    unrelated process within microseconds. What we care about is "can we
+    start a new one", which the second ``spawn`` answers.
+    """
+    socket_path, descriptor_path = _paths(short_state_dir)
+    first = spawn(socket_path=socket_path, descriptor_path=descriptor_path)
+    stop(descriptor_path=descriptor_path)
+    assert not descriptor_path.exists()
+
+    second = spawn(socket_path=socket_path, descriptor_path=descriptor_path)
+    try:
+        assert second.socket_path == socket_path
+        assert is_alive(second.pid)
+        # Different process: at minimum the descriptor was rewritten by a
+        # genuinely-new asyncio loop. Strict ``second.pid != first.pid``
+        # is the usual case but not guaranteed by POSIX, so don't assert it.
+        _ = first  # silence unused — kept for readability of the restart story
+    finally:
+        stop(descriptor_path=descriptor_path)
+
+
+def test_stop_after_stop_is_idempotent_at_cli_layer(short_state_dir):
+    """``DaemonNotRunningError`` is the contract; CLI's ``_cmd_stop`` swallows.
+
+    This test pins the contract at the ``daemon.process.stop`` layer; the
+    CLI's idempotency is exercised separately if we ever wire a CLI test.
+    """
+    socket_path, descriptor_path = _paths(short_state_dir)
+    spawn(socket_path=socket_path, descriptor_path=descriptor_path)
+    stop(descriptor_path=descriptor_path)
+    with pytest.raises(DaemonNotRunningError):
+        stop(descriptor_path=descriptor_path)


### PR DESCRIPTION
## Summary

Fifth in the **daemon-as-process** arc ([plan](thoughts/shared/plans/2026-05-22-daemon-as-process-arc.md)) — and the first PR where the daemon **actually runs as a separate OS-level process**. Through 2c-2d the protocol surface was real but the ``Supervisor`` only managed the ``Runtime`` in-process. This PR adds the subprocess spawn, signal handling, descriptor lifecycle, and the CLI plumbing so MCP can launch a real detached daemon.

End-to-end works locally (verified manually):

```
$ python server.py daemon start --socket /tmp/bm.sock --descriptor /tmp/bm.json
{"status": "started", "pid": 16051, "socket_path": "/tmp/bm.sock"}

$ python server.py daemon status --descriptor /tmp/bm.json
{"status": "running", "pid": 16051, "socket_path": "/tmp/bm.sock", ...}

$ python server.py daemon stop --descriptor /tmp/bm.json
{"status": "stopped"}
```

## What ships

| File | Purpose |
|---|---|
| ``daemon/__main__.py`` | ``python -m daemon serve`` entry — bootstraps asyncio + MCP adapters, installs SIGTERM/SIGINT handlers, graceful shutdown |
| ``daemon/process.py`` | ``spawn()`` / ``stop()`` / ``status()`` / ``is_alive()`` — cross-platform via ``Popen`` with platform-conditional detach flags |
| ``cli/daemon_cli.py`` | ``bicameral-mcp daemon`` argparse: ``start`` / ``stop`` / ``restart`` / ``status``. Idempotent at the CLI layer |
| ``server.py`` | Wires the ``daemon`` subparser + dispatch into the existing CLI |
| ``tests/test_daemon_lifecycle.py`` | 9 sociable tests. Each spawns a real ``python -m daemon serve`` subprocess against a ``tmp_path`` socket + descriptor |

## Cross-platform model

Same observable behavior on macOS / Linux / Windows; only the OS-detach flags differ:

```python
if sys.platform == "win32":
    creationflags = DETACHED_PROCESS | CREATE_NEW_PROCESS_GROUP
    proc = subprocess.Popen(argv, creationflags=creationflags, ...)
else:
    proc = subprocess.Popen(argv, start_new_session=True, ...)
```

``stop`` uses SIGTERM on POSIX, ``CTRL_BREAK_EVENT`` on Windows (matches the new process group). 10s grace, then SIGKILL escalation.

## Test strategy

Per Fowler's [2026-05-22 advisory](thoughts/shared/plans/2026-05-22-daemon-as-process-arc.md#test-strategy-per-fowler-advisory-2026-05-22):

- **Each boundary test gets its own logical daemon** — own socket, own descriptor, own ``tmp_path``.
- **Subprocess-per-test for now** — ~8s per test, 9 tests, 72s total. Measured, not speculated.
- **Per-test fixture hides lifecycle** — when this batch starts costing measurable CI time, swap the fixture body for an ``ObjectPool`` of pre-warmed daemons. Tests don't change.

## Out of scope (separate PRs)

- **macOS LaunchAgent auto-start install** → 2c-3b
- **Linux systemd-user auto-start** → 2c-3c (when demand arrives)
- **Windows Service install** → 2c-3d (when demand arrives)

Until the platform-specific auto-start PRs land: ``daemon start`` survives until reboot or explicit ``daemon stop``. For hosted-mode customers (the funnel-stage-1 focus) the hosting platform IS the supervisor and auto-start is irrelevant.

## Test plan

- [x] ``pytest tests/test_daemon_lifecycle.py`` — 9 passing (72s)
- [x] Full protocol + daemon suite — 46 passing (no regressions vs dev)
- [x] ``ruff format --check . && ruff check .`` clean
- [x] ``mypy daemon/ cli/daemon_cli.py`` clean
- [x] Manual end-to-end verified: spawn → status → stop loop
- [ ] CI green on dev

## Known limitation

**Bicameral preflight unavailable this session** (MCP server disconnected mid-session). Will validate against the ledger before 2c-4.

## Plan refs

- Arc: ``thoughts/shared/plans/2026-05-22-daemon-as-process-arc.md``
- Predecessors merged: #500, #501, #503, #505, #507

🤖 Generated with [Claude Code](https://claude.com/claude-code)