### PR TITLE
feat(handlers): handle_history routed through DaemonProxy (Phase 2c-4)

### DIFF
--- a/context.py
+++ b/context.py
@@ -529,6 +529,13 @@ class BicameralContext:
     # same session). Read via `seen_ingest_warning` property; set via
     # `set_seen_ingest_warning(bool)`.
     _sync_state: dict = field(default_factory=dict)
+    # Phase 2c-4: mode-aware proxy to the bicameral daemon. Lazy-connect —
+    # constructing this is cheap (no I/O); the underlying ProtocolClient
+    # opens its UDS connection on first RPC call. Tests that don't go
+    # through the daemon path never trigger the connection. Handlers that
+    # migrate to daemon-routed dispatch (handle_history first, in 2c-4)
+    # invoke ``await ctx.daemon.history(...)`` etc.
+    daemon: object | None = None
 
     @property
     def seen_ingest_warning(self) -> bool:
@@ -568,6 +575,16 @@ class BicameralContext:
         # to _SESSION_ID UUID on git/salt failure.
         session_id = _resolve_agent_identity(repo_path)
 
+        # Phase 2c-4: lazy daemon proxy. Constructing it does no I/O —
+        # the underlying ProtocolClient connection opens on first RPC call.
+        # Tests that mock-construct BicameralContext directly (without
+        # going through from_env) leave ``daemon=None``; handlers that
+        # require it raise an honest AttributeError when invoked, which
+        # the test suite catches early.
+        from daemon.proxy import DaemonProxy
+
+        daemon_proxy = DaemonProxy(tenant_id=session_id or "local")
+
         instance = cls(
             repo_path=repo_path,
             head_sha=state.head_commit,
@@ -587,6 +604,7 @@ class BicameralContext:
             ingest_rate_limit_refill_per_sec=ingest_rate_limit_refill_per_sec,
             query_timeout_read_seconds=query_timeout_read_seconds,
             query_timeout_drift_seconds=query_timeout_drift_seconds,
+            daemon=daemon_proxy,
         )
         _emit_config_load_once(instance)
         return instance

--- a/daemon/proxy.py
+++ b/daemon/proxy.py
@@ -1,0 +1,204 @@
+"""Mode-aware proxy from MCP-side handlers to the bicameral daemon.
+
+This module is the bridge between the MCP server process and the daemon
+process. It resolves the configured mode (local UDS vs hosted HTTPS) by
+reading config files in priority order, opens the connection lazily on
+first RPC call, and exposes typed methods that handlers invoke.
+
+Phase 2c-4 — load-bearing first-call-site PR. Only the local-mode UDS
+path is implemented; the hosted-mode branch raises ``NotImplementedError``
+to make the mode seam visible without committing to Phase 5 wiring.
+
+Connection lifecycle: lazy connect on first call, hold for the lifetime
+of the proxy (typically = lifetime of the MCP process), one retry on
+detected disconnect (daemon restarted mid-session). No exponential
+backoff — the second failure raises ``DaemonUnreachableError``.
+
+Error message points users at ``bicameral-mcp setup`` (the wizard, which
+walks them through local/hosted choice + daemon-or-auth bootstrap) and
+``bicameral-mcp daemon start`` (explicit escape hatch for advanced users).
+"""
+
+from __future__ import annotations
+
+import asyncio
+from pathlib import Path
+from typing import Any
+
+from daemon.process import DaemonDescriptor
+from daemon.supervisor import default_descriptor_path, default_state_dir
+from protocol.client import ProtocolClient
+from protocol.contracts import LOCAL_TENANT_ID, ProtocolError
+
+# Hosted-mode marker. Phase 5 fills in the body; for now its presence
+# triggers a ``NotImplementedError`` from the proxy so users who shouldn't
+# be in hosted mode get a clear "wait for Phase 5" signal instead of a
+# silent fall-through to local mode.
+DEFAULT_AUTH_PATH = default_state_dir() / "auth.json"
+
+
+class DaemonUnreachableError(RuntimeError):
+    """Raised when the proxy can't open a connection to any daemon.
+
+    The message includes the actionable next steps (``bicameral-mcp setup``
+    or ``bicameral-mcp daemon start``) so agents and humans get one-glance
+    recovery instructions.
+    """
+
+
+_UNREACHABLE_HINT = (
+    "Run `bicameral-mcp setup` to configure (local or hosted mode), "
+    "or `bicameral-mcp daemon start` if you've already set up local mode."
+)
+
+
+class DaemonProxy:
+    """Lazy-connect typed RPC client bound to a ``BicameralContext``.
+
+    Construct cheaply (no I/O). The first call to a typed method opens the
+    underlying ``ProtocolClient``, runs the version handshake and
+    ``system.attach``, then memoizes the client for subsequent calls.
+
+    Thread-safety: the internal lock guards the connection-establishment
+    race when two concurrent handlers fire on the same proxy. Once the
+    client is set, calls bypass the lock.
+    """
+
+    def __init__(
+        self,
+        *,
+        descriptor_path: Path | None = None,
+        auth_path: Path | None = None,
+        tenant_id: str = LOCAL_TENANT_ID,
+        user_id: str | None = None,
+    ) -> None:
+        self._descriptor_path = descriptor_path or default_descriptor_path()
+        self._auth_path = auth_path or DEFAULT_AUTH_PATH
+        self._tenant_id = tenant_id
+        self._user_id = user_id
+        self._client: ProtocolClient | None = None
+        self._lock = asyncio.Lock()
+
+    async def _ensure_connected(self) -> ProtocolClient:
+        """Open the connection on first call; reuse thereafter.
+
+        Mode resolution order:
+          1. ``auth.json`` present → raise NotImplementedError (Phase 5 stub)
+          2. ``daemon.json`` present + socket connectable → use UDS
+          3. Neither path resolves → raise DaemonUnreachableError
+        """
+        if self._client is not None:
+            return self._client
+        async with self._lock:
+            if self._client is not None:
+                return self._client
+
+            if self._auth_path.exists():
+                # Hosted-mode marker present — Phase 5 fills this in. Raising
+                # rather than silently falling back keeps the mode seam loud.
+                raise NotImplementedError(
+                    f"hosted mode found in {self._auth_path} but not yet wired — "
+                    "see Phase 5 of the daemon-as-process arc plan"
+                )
+
+            descriptor = DaemonDescriptor.load(self._descriptor_path)
+            if descriptor is None:
+                raise DaemonUnreachableError(
+                    f"can't reach the bicameral daemon: no descriptor at "
+                    f"{self._descriptor_path}. {_UNREACHABLE_HINT}"
+                )
+
+            client = ProtocolClient(
+                socket_path=descriptor.socket_path,
+                tenant_id=self._tenant_id,
+                user_id=self._user_id,
+            )
+            try:
+                await client.connect()
+            except (OSError, ProtocolError) as exc:
+                # Descriptor exists but the daemon process is dead, the
+                # socket isn't bound, or the path is otherwise invalid
+                # (e.g. too long for AF_UNIX). All map to the same
+                # actionable error: tell the user the daemon isn't
+                # reachable. ``OSError`` covers ``ConnectionRefusedError``,
+                # ``FileNotFoundError``, ``ENAMETOOLONG``, etc.
+                raise DaemonUnreachableError(
+                    f"daemon descriptor at {self._descriptor_path} but socket "
+                    f"unreachable ({type(exc).__name__}: {exc}). {_UNREACHABLE_HINT}"
+                ) from exc
+            self._client = client
+            return client
+
+    async def _call_with_retry(self, method: str, params: dict[str, Any]) -> Any:
+        """Call ``method`` with one reconnect on detected disconnect.
+
+        If the existing connection has gone half-closed (daemon restarted
+        between calls), the failing write raises ``ProtocolError`` *or*
+        ``ConnectionResetError`` / ``BrokenPipeError`` depending on which
+        asyncio layer notices first. We treat all three as the same
+        "disconnect — retry once" signal, clear the cached client,
+        re-resolve the connection, and retry exactly once. A second
+        failure surfaces as ``DaemonUnreachableError``.
+        """
+        # Errors that mean "the previously-good connection is now dead" —
+        # all three can surface from asyncio depending on whether the
+        # daemon died mid-write, mid-read, or before the next call.
+        _disconnect_errors = (ProtocolError, ConnectionResetError, BrokenPipeError)
+
+        client = await self._ensure_connected()
+        try:
+            return await client._call(method, params)
+        except _disconnect_errors as exc:
+            del exc  # silence unused — kept for clarity of the failure mode
+            # Drop the stale client. The retry path goes through
+            # ``_ensure_connected`` which re-reads the descriptor and
+            # re-opens the socket. If THAT fails it raises
+            # DaemonUnreachableError, which is the right honest answer.
+            self._client = None
+            client = await self._ensure_connected()
+            try:
+                return await client._call(method, params)
+            except _disconnect_errors as exc2:
+                raise DaemonUnreachableError(
+                    f"daemon RPC failed twice ({method}): {exc2}. {_UNREACHABLE_HINT}"
+                ) from exc2
+
+    async def close(self) -> None:
+        """Best-effort cleanup. Safe to call multiple times."""
+        async with self._lock:
+            if self._client is not None:
+                try:
+                    await self._client.close()
+                except Exception:  # noqa: BLE001 — close must never raise
+                    pass
+                self._client = None
+
+    # ── Typed RPC methods (one per migrated handler) ────────────────────
+
+    async def history(
+        self,
+        *,
+        repo_id: str,
+        ref: str = "HEAD",
+        feature_filter: str | None = None,
+        include_superseded: bool = True,
+        include_pruned: bool = False,
+        as_of: str | None = None,
+    ) -> dict[str, Any]:
+        """Invoke ``read.history`` on the daemon and return the raw payload.
+
+        The MCP-side ``handle_history`` facade is responsible for wrapping
+        this dict back into a ``HistoryResponse`` model (and for adding any
+        MCP-specific decoration like ``_guidance`` / ``_update`` notices).
+        """
+        return await self._call_with_retry(
+            "read.history",
+            {
+                "repo_id": repo_id,
+                "ref": ref,
+                "feature_filter": feature_filter,
+                "include_superseded": include_superseded,
+                "include_pruned": include_pruned,
+                "as_of": as_of,
+            },
+        )

--- a/daemon/runtime.py
+++ b/daemon/runtime.py
@@ -43,12 +43,25 @@ class Runtime:
     def _register_default_methods(self) -> None:
         # Phase 2c-2c — registrations align with the categorized protocol
         # namespace (write.* / grounding.lookup.* / grounding.analyze.* /
-        # system.* established in Phase 2c-1). ``egress.deliver`` stays under
-        # ``egress.*`` pending an explicit decision on whether to add
-        # ``EGRESS_PREFIX`` to the categorization surface.
+        # system.* established in Phase 2c-1). 2c-2d added egress.* as
+        # the sixth category, so EgressAdapter is no longer an allowlist
+        # exception.
         self._server.register("write.ingest", self._handle_ingest)
         self._server.register("write.link_commit", self._handle_link_commit)
         self._server.register("egress.deliver", self._handle_deliver)
+
+        # Phase 2c-4: wire the read.* + telemetry write.* handlers that
+        # 2c-2 / 2c-2b registered. They were callable in tests via
+        # ``register_read_handlers(server)`` / ``register_write_handlers``
+        # but the daemon process itself never invoked those functions —
+        # so a spawned daemon would respond ``unknown method read.history``
+        # to any caller. Closing that gap here.
+        from protocol.handlers.reads import register_read_handlers
+        from protocol.handlers.writes import register_write_handlers
+
+        register_read_handlers(self._server)
+        register_write_handlers(self._server)
+
         # grounding.lookup.* / grounding.analyze.* methods land in later
         # phases when the code-locator + drift analyzer move into
         # daemon/grounding/. system.version + system.attach are registered

--- a/handlers/history.py
+++ b/handlers/history.py
@@ -316,7 +316,65 @@ async def handle_history(
     include_pruned: bool = False,
     as_of: str | None = None,
 ) -> HistoryResponse:
-    """Read-only dump of the full decision ledger grouped by feature area.
+    """MCP-side facade for ``read.history``.
+
+    Phase 2c-4 — first call-site migration. The body is now a thin
+    wrapper that delegates to the daemon via ``ctx.daemon.history``;
+    the real read logic lives in ``_handle_history_impl`` (which the
+    daemon's protocol handler invokes on its end).
+
+    Two concerns stay MCP-side because they predate the daemon
+    boundary and 2c-6 hasn't moved them yet:
+
+    1. ``ensure_ledger_synced`` — auto-syncs HEAD via ``link_commit``
+       before reading. Migrates to the daemon when write.* dispatchers
+       land (2c-6).
+    2. ``_guidance`` / ``_update`` envelope decoration — these are
+       MCP-side agent-facing affordances, not daemon concerns. They
+       continue to live in ``server.py::_call_tool_impl``.
+    """
+    from handlers.sync_middleware import ensure_ledger_synced
+
+    await ensure_ledger_synced(ctx)
+
+    daemon = getattr(ctx, "daemon", None)
+    if daemon is None:
+        # Test contexts that mock-construct BicameralContext without going
+        # through ``from_env`` won't have a daemon proxy. Fall through to
+        # the in-process implementation so handler-level tests stay
+        # sociable. Production paths always go through ``from_env`` →
+        # ``DaemonProxy``.
+        return await _handle_history_impl(
+            ctx,
+            feature_filter=feature_filter,
+            include_superseded=include_superseded,
+            include_pruned=include_pruned,
+            as_of=as_of,
+        )
+
+    raw = await daemon.history(
+        repo_id="local",  # multi-repo tenant scoping lands in 2c-5
+        ref=as_of or "HEAD",
+        feature_filter=feature_filter,
+        include_superseded=include_superseded,
+        include_pruned=include_pruned,
+        as_of=as_of,
+    )
+    return HistoryResponse.model_validate(raw)
+
+
+async def _handle_history_impl(
+    ctx,
+    feature_filter: str | None = None,
+    include_superseded: bool = True,
+    include_pruned: bool = False,
+    as_of: str | None = None,
+) -> HistoryResponse:
+    """Core history logic — pure ledger read + transformation.
+
+    Invoked by the daemon's ``read.history`` protocol handler. Does NOT
+    call ``ensure_ledger_synced`` — sync is the MCP-side facade's job
+    until write surface migration (2c-6).
 
     1. Fetch all decisions with enriched source span data.
     2. Group by feature_group → source_ref → "Uncategorized".
@@ -329,10 +387,8 @@ async def handle_history(
     import time as _time
 
     from contracts import SyncMetrics
-    from handlers.sync_middleware import ensure_ledger_synced
 
     _t0 = _time.perf_counter()
-    await ensure_ledger_synced(ctx)
     sync_metrics = SyncMetrics(sync_catchup_ms=round((_time.perf_counter() - _t0) * 1000, 3))
 
     ledger = ctx.ledger

--- a/protocol/handlers/reads.py
+++ b/protocol/handlers/reads.py
@@ -51,9 +51,12 @@ def _resolve_context(_ctx: ConnectionContext, _repo_id: str) -> BicameralContext
 async def handle_read_history(params: dict[str, Any], ctx: ConnectionContext) -> dict[str, Any]:
     req = HistoryRequest.model_validate(params)
     bctx = _resolve_context(ctx, req.repo_id)
-    from handlers.history import handle_history
+    # Phase 2c-4: call the core impl, NOT the facade. The facade routes
+    # through ``ctx.daemon.history(...)``; invoking it from inside the
+    # daemon's own protocol handler would create an infinite RPC loop.
+    from handlers.history import _handle_history_impl
 
-    result = await handle_history(
+    result = await _handle_history_impl(
         bctx,
         feature_filter=req.feature_filter,
         include_superseded=req.include_superseded,

--- a/tests/_daemon_fixture.py
+++ b/tests/_daemon_fixture.py
@@ -1,0 +1,77 @@
+"""Per-test daemon-subprocess fixture for Phase 2c-4+ boundary tests.
+
+Each test gets its own logical daemon — own socket, own descriptor, own
+tmp dir, own subprocess. Per Fowler's [test pyramid advisory of 2026-05-22]
+this fixture exists so handlers can be exercised across a true process
+boundary; the cost (~8s subprocess spawn) is acceptable for boundary tests
+because they're rare. When the per-test cost becomes painful, swap the
+fixture body for an ObjectPool of pre-warmed daemons without touching any
+test.
+
+Usage::
+
+    from tests._daemon_fixture import daemon_subprocess, short_state_dir
+
+    async def test_history_through_daemon(daemon_subprocess):
+        # daemon_subprocess.socket_path is bound to a real running daemon.
+        ...
+
+The fixtures live in a non-``conftest.py`` module so they're explicitly
+opt-in — most tests don't need a daemon and shouldn't pay the spawn cost.
+"""
+
+from __future__ import annotations
+
+import shutil
+import tempfile
+from pathlib import Path
+
+import pytest
+
+from daemon.process import DaemonDescriptor, is_alive, spawn, stop
+
+
+@pytest.fixture
+def short_state_dir():
+    """A short-path tmp dir for the daemon's socket + descriptor.
+
+    macOS AF_UNIX paths cap around 104 chars; pytest's ``tmp_path`` lives
+    under ``/var/folders/...`` which is well over that. ``/tmp`` keeps us
+    under the limit.
+    """
+    base = Path(tempfile.mkdtemp(prefix="bm-daemon-", dir="/tmp"))
+    try:
+        yield base
+    finally:
+        # Best-effort teardown in case the daemon stop() raised mid-test.
+        descriptor_path = base / "daemon.json"
+        descriptor = DaemonDescriptor.load(descriptor_path)
+        if descriptor is not None and is_alive(descriptor.pid):
+            try:
+                stop(descriptor_path=descriptor_path, timeout_s=2.0)
+            except Exception:
+                pass
+        shutil.rmtree(base, ignore_errors=True)
+
+
+@pytest.fixture
+def daemon_subprocess(short_state_dir):
+    """Spawn a real daemon subprocess against the test's tmp paths.
+
+    Yields the ``DaemonDescriptor`` the daemon published. Stops the
+    daemon on teardown. Each test owns its socket + descriptor; no
+    shared state between tests.
+    """
+    socket_path = short_state_dir / "daemon.sock"
+    descriptor_path = short_state_dir / "daemon.json"
+    descriptor = spawn(socket_path=socket_path, descriptor_path=descriptor_path)
+    try:
+        yield descriptor
+    finally:
+        try:
+            stop(descriptor_path=descriptor_path)
+        except Exception:
+            pass
+
+
+__all__ = ["daemon_subprocess", "short_state_dir"]

--- a/tests/test_history_via_daemon.py
+++ b/tests/test_history_via_daemon.py
@@ -1,0 +1,205 @@
+"""Phase 2c-4 boundary tests: handle_history through a real daemon subprocess.
+
+This is the load-bearing prototype per Fowler's 2026-05-22 advisory.
+Each test exercises the full call chain across the IPC boundary:
+
+    handle_history (facade in MCP process)
+        → ctx.daemon.history (DaemonProxy)
+            → ProtocolClient over UDS
+                → daemon subprocess
+                    → protocol/handlers/reads.handle_read_history
+                        → _handle_history_impl (in daemon's ledger)
+
+Three things these tests verify that no in-process test can:
+
+1. **Wire serialization** — HistoryResponse round-trips through JSON.
+2. **Connection lifecycle** — descriptor missing / daemon dead → clear
+   ``DaemonUnreachableError``; reconnect after daemon restart succeeds.
+3. **Same-shape contract** — the facade returns equivalent HistoryResponse
+   to what ``_handle_history_impl`` returns in-process.
+
+Cost: ~8s per test (daemon subprocess spawn). 4 tests = ~32s. Per the
+plan, this is acceptable until measured CI pain triggers an ``ObjectPool``
+of pre-warmed daemons.
+"""
+
+from __future__ import annotations
+
+import os
+import subprocess
+import tempfile
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+from daemon.process import spawn, stop
+from daemon.proxy import DaemonProxy, DaemonUnreachableError
+from tests._daemon_fixture import daemon_subprocess, short_state_dir  # noqa: F401
+
+
+@pytest.fixture
+def fresh_ledger_repo(monkeypatch, tmp_path):
+    """A bare git repo + memory:// ledger env. The daemon picks these up
+    via ``REPO_PATH`` / ``SURREAL_URL`` when ``BicameralContext.from_env``
+    runs inside it.
+    """
+    monkeypatch.setenv("SURREAL_URL", "memory://")
+    monkeypatch.setenv("REPO_PATH", str(tmp_path))
+    subprocess.run(["git", "init", "-q"], cwd=tmp_path, check=True)
+    subprocess.run(
+        ["git", "commit", "--allow-empty", "-q", "-m", "init"],
+        cwd=tmp_path,
+        check=True,
+        env={
+            **os.environ,
+            "GIT_AUTHOR_NAME": "t",
+            "GIT_AUTHOR_EMAIL": "t@t",
+            "GIT_COMMITTER_NAME": "t",
+            "GIT_COMMITTER_EMAIL": "t@t",
+        },
+    )
+    return tmp_path
+
+
+# ── Daemon unreachable ──────────────────────────────────────────────────
+
+
+async def test_proxy_raises_when_no_descriptor(tmp_path):
+    """No ``daemon.json`` and no ``auth.json`` → ``DaemonUnreachableError``
+    with the wizard-pointing message."""
+    proxy = DaemonProxy(
+        descriptor_path=tmp_path / "daemon.json",
+        auth_path=tmp_path / "auth.json",
+    )
+    with pytest.raises(DaemonUnreachableError) as exc_info:
+        await proxy.history(repo_id="local")
+    msg = str(exc_info.value)
+    # Error must name both recovery paths so the agent / human picks the
+    # right one for their mode.
+    assert "bicameral-mcp setup" in msg
+    assert "bicameral-mcp daemon start" in msg
+
+
+async def test_proxy_raises_not_implemented_for_hosted_mode(tmp_path):
+    """``auth.json`` present → NotImplementedError naming Phase 5.
+
+    This is the mode-seam test: the proxy honors hosted mode's marker
+    file even though the wire isn't implemented. Phase 5 fills in the
+    body; nothing in 2c-4 needs to change here.
+    """
+    auth_path = tmp_path / "auth.json"
+    auth_path.write_text('{"endpoint": "https://daemon.bicameral.ai", "token": "stub"}')
+    proxy = DaemonProxy(
+        descriptor_path=tmp_path / "daemon.json",
+        auth_path=auth_path,
+    )
+    with pytest.raises(NotImplementedError) as exc_info:
+        await proxy.history(repo_id="local")
+    assert "hosted mode" in str(exc_info.value)
+    assert "Phase 5" in str(exc_info.value)
+
+
+async def test_proxy_raises_when_descriptor_is_stale(tmp_path):
+    """Descriptor exists but PID is dead → ``DaemonUnreachableError`` with
+    actionable message. Simulates a daemon that crashed without cleaning
+    up its descriptor file."""
+    descriptor_path = tmp_path / "daemon.json"
+    descriptor_path.write_text(f'{{"socket_path": "{tmp_path}/missing.sock", "pid": 999999999}}')
+    proxy = DaemonProxy(descriptor_path=descriptor_path, auth_path=tmp_path / "auth.json")
+    with pytest.raises(DaemonUnreachableError) as exc_info:
+        await proxy.history(repo_id="local")
+    assert "bicameral-mcp daemon start" in str(exc_info.value)
+
+
+# ── Daemon-routed happy path ────────────────────────────────────────────
+
+
+async def test_history_through_daemon_returns_empty_response(
+    daemon_subprocess, fresh_ledger_repo, tmp_path
+):
+    """End-to-end: spawned daemon, ProtocolProxy, real RPC, empty ledger
+    returns empty HistoryResponse."""
+    proxy = DaemonProxy(
+        descriptor_path=daemon_subprocess.socket_path.parent / "daemon.json",
+        auth_path=tmp_path / "no-auth.json",  # absent
+    )
+    try:
+        result = await proxy.history(repo_id="local")
+        assert "features" in result
+        assert "total_features" in result
+        assert result["total_features"] == 0
+        assert result["features"] == []
+    finally:
+        await proxy.close()
+
+
+async def test_history_facade_routes_through_daemon(daemon_subprocess, fresh_ledger_repo, tmp_path):
+    """The MCP-side facade ``handle_history`` calls ``ctx.daemon.history``
+    and returns a HistoryResponse. Asserts the daemon path is exercised
+    (not the in-process fallback for daemon=None contexts)."""
+    from contracts import HistoryResponse
+    from handlers.history import handle_history
+
+    proxy = DaemonProxy(
+        descriptor_path=daemon_subprocess.socket_path.parent / "daemon.json",
+        auth_path=tmp_path / "no-auth.json",
+    )
+    # Minimal ctx — sync_middleware accesses ctx.ledger + ctx.repo_path.
+    # Use a real in-memory ledger for the sync precheck.
+    from adapters.ledger import get_ledger, reset_ledger_singleton
+
+    reset_ledger_singleton()
+    ctx = SimpleNamespace(
+        repo_path=str(fresh_ledger_repo),
+        ledger=get_ledger(),
+        daemon=proxy,
+        head_sha="",
+        authoritative_ref="main",
+        authoritative_sha="",
+    )
+    try:
+        result = await handle_history(ctx)
+        assert isinstance(result, HistoryResponse)
+        # Empty ledger → empty features.
+        assert result.total_features == 0
+    finally:
+        await proxy.close()
+
+
+# ── Reconnect after daemon restart ──────────────────────────────────────
+
+
+async def test_proxy_reconnects_after_daemon_restart(short_state_dir, fresh_ledger_repo):
+    """First call → daemon dies → daemon restarts → second call succeeds.
+
+    Contract: the proxy detects the dropped connection on the failing
+    call, clears its cached client, re-resolves the descriptor, opens
+    a new connection, and retries. ONE retry max — if the second open
+    also fails, raise ``DaemonUnreachableError``.
+    """
+    socket_path = short_state_dir / "daemon.sock"
+    descriptor_path = short_state_dir / "daemon.json"
+
+    # Spawn the first daemon and make a successful call.
+    spawn(socket_path=socket_path, descriptor_path=descriptor_path)
+    proxy = DaemonProxy(
+        descriptor_path=descriptor_path,
+        auth_path=short_state_dir / "no-auth.json",
+    )
+    result1 = await proxy.history(repo_id="local")
+    assert "features" in result1
+
+    # Kill the daemon. The proxy's cached client now points at a dead socket.
+    stop(descriptor_path=descriptor_path)
+
+    # Respawn — same paths, different PID.
+    spawn(socket_path=socket_path, descriptor_path=descriptor_path)
+
+    try:
+        # Next call should detect the broken connection, reconnect, succeed.
+        result2 = await proxy.history(repo_id="local")
+        assert "features" in result2
+    finally:
+        await proxy.close()
+        stop(descriptor_path=descriptor_path)

--- a/tests/test_v0420_history.py
+++ b/tests/test_v0420_history.py
@@ -22,7 +22,14 @@ import pytest
 
 from adapters.ledger import get_ledger, reset_ledger_singleton
 from context import BicameralContext
-from handlers.history import handle_history
+
+# Phase 2c-4: existing history tests exercise the core read logic against
+# a real ``memory://`` ledger — that's sociable handler-level testing and
+# should NOT require a running daemon. Alias the impl so the test bodies
+# stay identical; new boundary tests live in
+# ``tests/test_history_via_daemon.py`` and go through the facade + a
+# per-test daemon fixture.
+from handlers.history import _handle_history_impl as handle_history
 
 # ── Fixtures ─────────────────────────────────────────────────────────────────
 

--- a/thoughts/shared/plans/2026-05-22-2c-4-first-callsite.md
+++ b/thoughts/shared/plans/2026-05-22-2c-4-first-callsite.md
@@ -1,0 +1,254 @@
+# Phase 2c-4 — First call-site migration (Fowler load-bearing PR)
+
+**Date**: 2026-05-22
+**Branch**: `feat/daemon-02c-4-first-callsite-migration`
+**Parent**: `2026-05-22-daemon-as-process-arc.md`
+**Predecessor**: Phase 2c-3 (daemon supervisor, PR #508)
+
+## Why this PR is the load-bearing one
+
+Through 2c-2d the protocol surface was real but no MCP handler used it.
+Through 2c-3 the daemon ran as a real process but MCP didn't talk to it.
+**This PR is the first where MCP actually calls the daemon over IPC for a
+real operation.** Everything that follows (2c-5 through 2c-8) is replication
+of the pattern this PR establishes.
+
+Per the [Fowler advisory of 2026-05-22](2026-05-22-daemon-as-process-arc.md#test-strategy-per-fowler-advisory-2026-05-22):
+
+> Start with subprocess-per-test, write your first ten boundary tests, see
+> what hurts, and pool only if pooling is actually the bottleneck. You'll
+> learn ten times more from the friction of the first ten honest tests
+> than from any amount of upfront design.
+
+If the pattern this PR commits to feels wrong in practice, it has to be
+ripped out before 2c-5 onward. So scope it small, name the decisions
+clearly, and reserve the right to re-design.
+
+## Scope of THIS PR
+
+**One handler migrated**: `handle_history` (per the original arc plan and
+@jinhongkuan's call). More representative of the real complexity — enriched
+SurrealQL traversal, PII archive resolution, fallback paths. If this
+migrates cleanly, the rest will be mechanical.
+
+**Not in this PR**: write migrations (2c-6). Grounding/dashboard (2c-7).
+
+## Architectural choices (all documented for review)
+
+### 1. The `_impl` split
+
+Today `handlers/history.py::handle_history` does everything.
+After migration:
+
+```python
+# Public API — what MCP / server.py call_tool() invokes
+@read_tool("read.history")
+async def handle_history(ctx, days: int = 7) -> dict:
+    return await ctx.daemon.history(days=days)
+
+# Core logic — what the daemon's read.history handler invokes
+async def _handle_history_impl(ctx, days: int = 7) -> dict:
+    # ... today's body, unchanged ...
+```
+
+**Why a same-file split, not a separate module:**
+- Smallest delta — easier to review.
+- Phase 3 (repo split) will move the impl into `bicameral-daemon` and
+  leave the facade in `bicameral-mcp`. Pre-staging that move now would
+  add code churn for a transition we can do mechanically later.
+
+**Loop avoidance**: `protocol/handlers/reads.py::handle_read_history`
+must call `_handle_history_impl` (NOT `handle_history`), or
+MCP-side `handle_history` would recurse: handler → daemon →
+handler → daemon → … Test asserts the impl is what the protocol calls.
+
+### 2. `_DaemonProxy` on `BicameralContext`
+
+```python
+class _DaemonProxy:
+    """Lazy-connect ProtocolClient bound to a single BicameralContext.
+
+    The connection is opened on first RPC call (NOT in ``from_env()``),
+    so existing sync construction paths don't need to become async.
+    Subsequent calls reuse the same connection.
+    """
+    def __init__(
+        self,
+        descriptor_path: Path | None = None,
+        tenant_id: str = LOCAL_TENANT_ID,
+    ) -> None:
+        self._descriptor_path = descriptor_path or default_descriptor_path()
+        self._tenant_id = tenant_id
+        self._client: ProtocolClient | None = None
+        self._lock = asyncio.Lock()
+
+    async def _ensure_connected(self) -> ProtocolClient:
+        async with self._lock:
+            if self._client is None:
+                self._client = ProtocolClient(
+                    socket_path=self._resolve_socket(),
+                    tenant_id=self._tenant_id,
+                )
+                await self._client.connect()
+            return self._client
+
+    async def history(self, *, days: int = 7, repo_id: str = "local") -> dict:
+        client = await self._ensure_connected()
+        result = await client._call(
+            "read.history",
+            {"repo_id": repo_id, "days": days},
+        )
+        return result
+
+    async def close(self) -> None:
+        async with self._lock:
+            if self._client is not None:
+                await self._client.close()
+                self._client = None
+```
+
+`BicameralContext.from_env()` constructs the proxy (cheap, no I/O). First
+RPC call opens the connection. `close()` is best-effort cleanup; the
+MCP process exit handles the socket release.
+
+### 3. Daemon-not-running error semantics — mode-aware
+
+The proxy is **mode-aware** from day one. It checks for config files in
+this order:
+
+1. `~/.bicameral/auth.json` — **hosted-mode** marker (Phase 5). If present,
+   the proxy raises `NotImplementedError("hosted mode found in
+   ~/.bicameral/auth.json but not yet wired — see Phase 5 plan")`. This
+   is the seam future hosted-mode code plugs into without re-architecting.
+2. `~/.bicameral/daemon.json` — **local-mode** descriptor. The proxy
+   opens a UDS connection. This is the only path 2c-4 actually implements.
+3. Neither — `DaemonUnreachableError` with wizard-pointing message:
+   ```
+   DaemonUnreachableError: can't reach the bicameral daemon.
+     Run `bicameral-mcp setup` to configure (local or hosted mode),
+     or `bicameral-mcp daemon start` if you've already set up local mode.
+   ```
+
+`server.py::_call_tool_impl` catches this and translates to a structured
+MCP error response so the agent sees a clear actionable message rather
+than a generic exception traceback.
+
+**Not in this PR**:
+- Auto-spawn the daemon if local-mode descriptor missing. The setup
+  wizard (separate PR, likely 2c-3e) will install LaunchAgent / Windows
+  Service / systemd-user for auto-start, which solves the per-session
+  friction without conflating "MCP can't reach daemon" with "MCP
+  silently bootstraps daemon". Auto-spawn was the expedient answer to
+  the wrong problem.
+- Hosted-mode HTTPS client. The stub `NotImplementedError` is enough to
+  prove the architecture is mode-aware; Phase 5 fills in the body.
+
+### 4. Reconnect-on-daemon-crash
+
+If the daemon dies between calls (e.g. the user runs `bicameral-mcp
+daemon stop`), the next `_ensure_connected()` finds the existing client
+in a half-closed state. The boundary test must specify the contract.
+
+**Decision for this PR**: on detected disconnect, the proxy clears
+`self._client` and reconnects on the same call. ONE retry. If the
+retry also fails, raise `DaemonUnreachableError`. This is the simplest
+honest behavior — covers the "daemon restarted mid-session" case without
+exponential backoff complexity.
+
+Boundary test for this: spawn → call → kill the daemon process →
+respawn → call again → expect success.
+
+### 5. Test pyramid impact
+
+Per Fowler: 80%+ of tests should NOT touch the daemon. Today's
+`tests/test_history*.py` files (if any) move to calling
+`_handle_history_impl` directly with a real `memory://` ledger —
+that's the sociable path, no daemon.
+
+**New tests** (boundary tier, per-test daemon fixture):
+- `handle_history` through a real daemon returns the same shape
+  the impl returns.
+- `DaemonUnreachableError` on no-descriptor.
+- Reconnect-on-daemon-restart succeeds.
+- Latency observation (informational, not assertional).
+
+## Per-test daemon fixture
+
+Reusable across this PR and every future boundary test:
+
+```python
+# tests/conftest.py addition (or tests/_daemon_fixture.py)
+
+@pytest.fixture
+async def daemon_subprocess(short_state_dir):
+    """Per-test daemon: spawn a real subprocess, tear down on teardown.
+
+    Each test owns its socket + descriptor + daemon. No shared state
+    between tests. Per Fowler's per-test-logical-daemon guidance.
+    """
+    socket_path = short_state_dir / "daemon.sock"
+    descriptor_path = short_state_dir / "daemon.json"
+    descriptor = spawn(socket_path=socket_path, descriptor_path=descriptor_path)
+    try:
+        yield descriptor
+    finally:
+        stop(descriptor_path=descriptor_path)
+```
+
+**No pooling in this PR.** ~8s per test is the cost (measured in 2c-3).
+For ~4 boundary tests in 2c-4 that's ~32s — annoying but not blocking.
+The fixture body is the only thing that changes when we eventually pool.
+
+## Files touched
+
+| File | Change |
+|---|---|
+| `handlers/history.py` | Split into facade + `_handle_history_impl` |
+| `protocol/handlers/reads.py` | Update to call `_handle_history_impl` |
+| `context.py` | Add `daemon: _DaemonProxy` attribute on `BicameralContext`; construct in `from_env()` |
+| `daemon/proxy.py` | NEW — the `_DaemonProxy` class + `DaemonUnreachableError` |
+| `tests/conftest.py` | Add `daemon_subprocess` fixture (or new `tests/_daemon_fixture.py` if conftest gets messy) |
+| `tests/test_protocol_history_boundary.py` | NEW — boundary tests through real daemon |
+| `tests/test_history.py` (if it exists) | Migrate to `_handle_history_impl` |
+
+## Acceptance
+
+- [ ] `handle_history` body is `return await ctx.daemon.history(...)` (no other imports from `local_counters`, `ledger.client`, etc. in the facade).
+- [ ] `_handle_history_impl` retains today's exact behavior.
+- [ ] Protocol's `read.history` handler delegates to `_impl`, not the facade.
+- [ ] `DaemonUnreachableError` raised with actionable message when daemon not running.
+- [ ] Boundary tests pass against per-test daemon fixture.
+- [ ] Existing sociable tests still pass against `_impl`.
+- [ ] Full protocol+daemon suite green; no regressions in handlers tests.
+
+## Reversibility
+
+- The facade/impl split is mechanical to revert (rename `_impl` back to `handle_history`, delete the facade).
+- `_DaemonProxy` is additive — `from_env()` constructs it but no one is forced to use it; reverting leaves it as dead code.
+- The fixture is in `conftest.py`; new fixture, removable by deletion.
+
+If the PR shows the per-test daemon cost is unbearable for 2c-5+, we
+revisit pooling here before fanning out.
+
+## Resolved (2026-05-22 with @jinhongkuan)
+
+**Setup-wizard-first model.** The user-facing entry point is
+`bicameral-mcp setup` (existing wizard, to be extended in a separate
+PR). It asks the user which mode they want and walks them through:
+
+- **Local mode**: run `daemon start`, prompt to install LaunchAgent /
+  Windows Service / systemd-user for auto-start across reboots.
+- **Hosted mode** (Phase 5): browser-based OAuth, write `auth.json`
+  with endpoint + token.
+
+Explicit commands (`bicameral-mcp daemon start`, `bicameral-mcp auth
+login`) stay available as escape hatches for advanced users.
+
+This PR (2c-4) doesn't extend the wizard — it just makes sure the
+architecture is mode-aware so the wizard has somewhere to plug in. The
+proxy reads `auth.json` first (hosted, stubbed), then `daemon.json`
+(local, implemented). Error message points at the wizard as the
+recommended next step.
+
+The wizard extension itself is its own PR (likely 2c-3e), to be sized
+once 2c-4 lands and proves the architectural seams hold.


### PR DESCRIPTION
## Summary

**THE load-bearing PR of the daemon-as-process arc.** First MCP handler that actually talks to the daemon over IPC for a real operation. Every subsequent migration (2c-5 onward) replicates this pattern, so the architectural choices here are committed to.

Per @jinhongkuan on 2026-05-22:
- `history` migrates first (over `usage_summary`) — more representative of real complexity.
- Mode-aware proxy with wizard-pointing error messages.
- No auto-spawn; setup wizard (separate PR, 2c-3e) handles bootstrap; LaunchAgent (2c-3b) handles auto-restart.

[Full plan in `thoughts/shared/plans/2026-05-22-2c-4-first-callsite.md`.](thoughts/shared/plans/2026-05-22-2c-4-first-callsite.md)

## Architecture (load-bearing for 2c-5+)

### `daemon/proxy.py` — DaemonProxy
Lazy-connect ProtocolClient wrapper. Resolves mode by checking files in priority:
1. `~/.bicameral/auth.json` (hosted, Phase-5 stub → `NotImplementedError`)
2. `~/.bicameral/daemon.json` (local, implemented)
3. Neither → `DaemonUnreachableError` with wizard-pointing message

Holds connection for ctx lifetime. One reconnect retry on detected disconnect. Error message:
```
DaemonUnreachableError: can't reach the bicameral daemon: no descriptor at /Users/.../daemon.json.
  Run `bicameral-mcp setup` to configure (local or hosted mode), or `bicameral-mcp daemon start`
  if you've already set up local mode.
```

### `context.py` — BicameralContext gains `daemon: DaemonProxy | None`
Constructed cheaply in `from_env()` (no I/O); first RPC call opens the connection. Test contexts that mock-construct ctx directly leave `daemon=None`; facade handlers fall through to the in-process impl in that case.

### `handlers/history.py` — split
- `handle_history` (**facade**, `@read_tool("read.history")`): runs `ensure_ledger_synced` (still MCP-side until 2c-6), then `await ctx.daemon.history(...)`, returns HistoryResponse.
- `_handle_history_impl` (**core**, no decorator): existing body minus `ensure_ledger_synced`. Called by the daemon's `read.history` protocol handler AND by the test alias path.

### `protocol/handlers/reads.py` — call `_handle_history_impl`, not the facade
Calling the facade from inside the daemon's own protocol handler would infinite-loop: handler → daemon → handler → daemon → …

### `daemon/runtime.py` — wire `register_read_handlers` + `register_write_handlers`
**Latent bug from 2c-2 / 2c-2b**: these were callable in tests but the spawned daemon never invoked them, so a real client got `unknown method read.history`. Closing that gap here.

## Two bugs the boundary tests caught (Fowler was right)

1. **`DaemonProxy._ensure_connected`** only caught `ConnectionRefusedError` / `FileNotFoundError` / `ProtocolError`. Stale descriptor with too-deep AF_UNIX path raises `OSError` (ENAMETOOLONG) instead. Widened to `(OSError, ProtocolError)` — strict superset.
2. **`DaemonProxy._call_with_retry`** only caught `ProtocolError`. asyncio raises `ConnectionResetError` / `BrokenPipeError` when daemon dies mid-call. Treats all three as the same disconnect-retry signal.

Both surfaced on the first real subprocess test, exactly per Fowler's "first ten honest tests" advisory.

## Test strategy (per Fowler advisory)

- **Existing tests stay sociable** — `tests/test_v0420_history.py` (11 tests) now imports `_handle_history_impl as handle_history`. Bodies unchanged, no daemon required.
- **New boundary tests** — `tests/test_history_via_daemon.py` (6 tests, ~44s):
  - `DaemonUnreachableError` when no descriptor + no auth.json
  - `NotImplementedError` naming Phase 5 when auth.json present
  - `DaemonUnreachableError` when descriptor stale (dead PID)
  - Empty ledger returns empty `HistoryResponse` through the daemon
  - Facade `handle_history` exercises the daemon path
  - Reconnect-on-daemon-restart succeeds (one retry)
- **Per-test daemon fixture** — `tests/_daemon_fixture.py`. Not in `conftest.py` because most tests don't need a daemon and shouldn't pay the ~8s spawn cost.

## Test plan

- [x] `pytest tests/test_history_via_daemon.py` — 6 passing (~44s)
- [x] `pytest tests/test_v0420_history.py` — 11 passing (no regressions; alias preserved)
- [x] Full protocol + daemon + history suite (13 files) — 68 passing in ~122s
- [x] `ruff format --check . && ruff check .` clean
- [x] `mypy daemon/ handlers/history.py protocol/ context.py` clean
- [ ] CI green on dev

## Known limitations

- **Bicameral preflight unavailable this session** (MCP disconnected mid-session). Will validate before 2c-5.
- **Sync middleware still MCP-side** (ensure_ledger_synced runs before the daemon call). Migrates in 2c-6 when write surface lands.
- **Single-repo `repo_id="local"`** — multi-repo tenant scoping lands in 2c-5.

## Plan refs

- Arc: `thoughts/shared/plans/2026-05-22-daemon-as-process-arc.md`
- This PR: `thoughts/shared/plans/2026-05-22-2c-4-first-callsite.md`
- Predecessors merged: #500, #501, #503, #505, #507, #508

🤖 Generated with [Claude Code](https://claude.com/claude-code)