### PR TITLE
fix(hooks): keep dogfood hooks source-relative; drop duplicate post-commit reminder

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -39,6 +39,16 @@
           }
         ]
       }
+    ],
+    "SessionStart": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "[ -d .bicameral ] && bicameral-mcp sync-and-brief 2>>\"${HOME}/.bicameral/hook-errors.log\" || true; exit 0"
+          }
+        ]
+      }
     ]
   }
 }


### PR DESCRIPTION
## Summary

Addresses two findings from a Codex review of the prior `.claude/settings.json` edit:

1. **[P1]** Reverts `bicameral-mcp-collision-capture-reminder` and `bicameral-mcp-preflight-reminder` to their source-relative `python3 scripts/hooks/...` forms. The packaged console-script form adds a PATH/install-time dependency that the project-level dogfood config did not previously have — a fresh source checkout without `pip install` would silently lose both reminders.

2. **[P3]** Removes the duplicate `bicameral-mcp-post-commit-sync-reminder` entry on `PostToolUse/Bash`. Packaged + source-relative entries were both firing on the same event, duplicating reminder context on every commit/merge/pull/rebase-continue.

The new `SessionStart` `bicameral-mcp sync-and-brief` block stays — it's a CLI invocation, not a hook script, so no source-relative equivalent exists. Its three safety nets (\`[ -d .bicameral ]\`, \`|| true\`, \`; exit 0\`) make a missing CLI binary a no-op rather than a session-startup failure.

## Test plan

- [x] \`python3 -c "import json; json.load(open('.claude/settings.json'))"\` validates the JSON
- [ ] Open a session in a fresh source checkout: PostToolUse / UserPromptSubmit reminders fire without \`pip install\`
- [ ] Commit a change in a session: only one \`bicameral: new commit detected\` reminder appears (not two)

🤖 Generated with [Claude Code](https://claude.com/claude-code)