### PR TITLE
feat(codegenome): #136 content-addressed cache wedge — classify_drift + categorize_diff

### DIFF
--- a/codegenome/_content_cache.py
+++ b/codegenome/_content_cache.py
@@ -1,0 +1,326 @@
+"""Content-addressed memoization for deterministic transforms (#136 wedge).
+
+Wraps a synchronous pure function so repeat calls with the same inputs hit
+a SQLite-backed content cache instead of re-invoking. Designed for the
+"tool froze" UX problem (#136 + #431): the same cosmetic diff is
+classified once, every subsequent sweep reads from disk in single-digit ms.
+
+NOT a general-purpose memoize. Constraints by design:
+
+- **Synchronous only.** Async transforms entangle with ledger writes; the
+  wedge scope (plan-136) leaves those for daemon Phase 2c-6+.
+- **Allowlist-typed args.** Validated at every call, fail-loud on misuse.
+  Anything outside ``(str | int | float | bool | None | tuple |
+  frozenset | dict[str, primitive])`` is a programming error.
+- **Pickle for outputs.** Acceptable because the cache lives per-machine,
+  per-user. Not a trust boundary. Unpickle errors are treated as misses.
+- **``behavior_version`` is mandatory** on the decorator. Bump on any
+  logic change inside the wrapped function — the snapshot test in
+  ``tests/test_content_cache_fingerprint.py`` catches accidental drift.
+
+Cache file location resolution:
+
+1. Explicit ``cache=`` arg to the decorator (used in tests)
+2. ``BICAMERAL_CONTENT_CACHE_PATH`` env var
+3. Fallback: ``~/.bicameral/content_cache.db``
+
+The default-cache location will be revisited when daemon Phase 2c-6 lands
+and ``codegenome/`` moves into ``daemon/``. The cache primitive itself
+travels with no daemon-specific imports; only the path constant changes.
+"""
+
+from __future__ import annotations
+
+import functools
+import hashlib
+import inspect
+import json
+import logging
+import os
+import pickle
+import sqlite3
+import threading
+import time
+from collections.abc import Callable
+from pathlib import Path
+from typing import Any, TypeVar
+
+logger = logging.getLogger(__name__)
+
+T = TypeVar("T")
+
+_ALLOWED_PRIMITIVES = (str, int, float, bool, type(None))
+_ALLOWED_CONTAINERS = (tuple, frozenset)
+
+
+def _is_allowed_arg(value: Any) -> bool:
+    """Recursively check that a value is in the canonical-serializable set."""
+    if isinstance(value, _ALLOWED_PRIMITIVES):
+        return True
+    if isinstance(value, _ALLOWED_CONTAINERS):
+        return all(_is_allowed_arg(v) for v in value)
+    if isinstance(value, dict):
+        return all(isinstance(k, str) and _is_allowed_arg(v) for k, v in value.items())
+    return False
+
+
+def _canonical(value: Any) -> Any:
+    """Convert a value into a JSON-serializable canonical form.
+
+    Tuples become ``["__tuple__", ...]`` so a tuple and a list of the same
+    items hash differently. Frozensets become sorted lists tagged
+    ``__frozenset__`` for the same reason.
+    """
+    if isinstance(value, _ALLOWED_PRIMITIVES):
+        return value
+    if isinstance(value, tuple):
+        return ["__tuple__", *(_canonical(v) for v in value)]
+    if isinstance(value, frozenset):
+        return ["__frozenset__", *sorted((_canonical(v) for v in value), key=repr)]
+    if isinstance(value, dict):
+        return {k: _canonical(v) for k, v in sorted(value.items())}
+    raise TypeError(f"unsupported arg type for content_cached: {type(value).__name__}")
+
+
+def _cache_key(
+    func_name: str,
+    behavior_version: int,
+    args: tuple[Any, ...],
+    kwargs: dict[str, Any],
+) -> str:
+    """Stable 32-hex-char (128-bit) sha256 key derived from canonical args."""
+    payload = {
+        "fn": func_name,
+        "v": behavior_version,
+        "args": [_canonical(a) for a in args],
+        "kwargs": {k: _canonical(v) for k, v in sorted(kwargs.items())},
+    }
+    raw = json.dumps(payload, sort_keys=True, separators=(",", ":")).encode()
+    return hashlib.sha256(raw).hexdigest()[:32]
+
+
+class ContentCache:
+    """SQLite-backed content cache for deterministic transforms.
+
+    Thread-safe within a process via ``threading.Lock``; multi-process
+    safety comes from SQLite's WAL mode. Each call opens its own
+    connection — premature pooling isn't worth the complexity at the
+    expected per-request rate (single-digit ops per sweep).
+
+    Eviction: when an insert pushes total bytes above ``max_bytes``,
+    rows are deleted in least-hit / oldest-first order until under cap.
+    """
+
+    _SCHEMA = """
+        CREATE TABLE IF NOT EXISTS content_cache (
+            key TEXT PRIMARY KEY,
+            value BLOB NOT NULL,
+            behavior_version INTEGER NOT NULL,
+            created_at REAL NOT NULL,
+            hits INTEGER NOT NULL DEFAULT 0,
+            bytes INTEGER NOT NULL
+        );
+        CREATE INDEX IF NOT EXISTS ix_content_cache_lru
+            ON content_cache (hits, created_at);
+    """
+
+    def __init__(self, path: Path | str, max_bytes: int = 100 * 1024 * 1024):
+        self._path = Path(path)
+        self._max_bytes = max_bytes
+        self._lock = threading.Lock()
+        self._schema_initialized = False
+
+    @property
+    def path(self) -> Path:
+        return self._path
+
+    def _connect(self) -> sqlite3.Connection:
+        self._path.parent.mkdir(parents=True, exist_ok=True)
+        conn = sqlite3.connect(str(self._path), isolation_level=None, timeout=5.0)
+        conn.execute("PRAGMA journal_mode=WAL")
+        conn.execute("PRAGMA synchronous=NORMAL")
+        return conn
+
+    def _ensure_schema(self, conn: sqlite3.Connection) -> None:
+        if self._schema_initialized:
+            return
+        conn.executescript(self._SCHEMA)
+        self._schema_initialized = True
+
+    def get(self, key: str, behavior_version: int) -> tuple[bool, Any]:
+        """Return ``(hit, value)``.
+
+        ``hit=False`` means: key not present, version mismatch, SQLite
+        error, or unpickling failure. The wrapper treats all four
+        identically — compute and overwrite.
+
+        ``hit=True, value=None`` is a legitimate cached ``None`` return.
+        """
+        try:
+            with self._lock:
+                conn = self._connect()
+                try:
+                    self._ensure_schema(conn)
+                    row = conn.execute(
+                        "SELECT value, behavior_version FROM content_cache WHERE key=?",
+                        (key,),
+                    ).fetchone()
+                    if row is None:
+                        return False, None
+                    value_blob, stored_version = row
+                    if stored_version != behavior_version:
+                        return False, None
+                    conn.execute(
+                        "UPDATE content_cache SET hits=hits+1 WHERE key=?",
+                        (key,),
+                    )
+                    return True, pickle.loads(value_blob)
+                finally:
+                    conn.close()
+        except (sqlite3.Error, pickle.UnpicklingError, EOFError) as exc:
+            logger.debug("[content_cache] get treated as miss on error: %s", exc)
+            return False, None
+
+    def set(self, key: str, value: Any, behavior_version: int) -> None:
+        """Store ``value`` under ``key``. Refuses entries larger than the cap."""
+        blob = pickle.dumps(value)
+        size = len(blob)
+        if size > self._max_bytes:
+            logger.warning(
+                "[content_cache] entry size %d > cap %d for key=%s; skipping",
+                size,
+                self._max_bytes,
+                key,
+            )
+            return
+        with self._lock:
+            conn = self._connect()
+            try:
+                self._ensure_schema(conn)
+                conn.execute(
+                    "INSERT OR REPLACE INTO content_cache "
+                    "(key, value, behavior_version, created_at, hits, bytes) "
+                    "VALUES (?, ?, ?, ?, 0, ?)",
+                    (key, blob, behavior_version, time.time(), size),
+                )
+                self._evict_if_over_cap(conn)
+            finally:
+                conn.close()
+
+    def _evict_if_over_cap(self, conn: sqlite3.Connection) -> None:
+        """Drop least-hit / oldest entries until total bytes <= cap."""
+        total = conn.execute("SELECT COALESCE(SUM(bytes), 0) FROM content_cache").fetchone()[0]
+        if total <= self._max_bytes:
+            return
+        rows = conn.execute(
+            "SELECT key, bytes FROM content_cache ORDER BY hits ASC, created_at ASC"
+        ).fetchall()
+        evicted = 0
+        for key, byts in rows:
+            if total - evicted <= self._max_bytes:
+                break
+            conn.execute("DELETE FROM content_cache WHERE key=?", (key,))
+            evicted += byts
+
+    def stats(self) -> dict[str, int]:
+        """Diagnostic snapshot: ``entries``, ``bytes``, ``hits``."""
+        with self._lock:
+            conn = self._connect()
+            try:
+                self._ensure_schema(conn)
+                row = conn.execute(
+                    "SELECT COUNT(*), COALESCE(SUM(bytes), 0), COALESCE(SUM(hits), 0) "
+                    "FROM content_cache"
+                ).fetchone()
+                return {"entries": int(row[0]), "bytes": int(row[1]), "hits": int(row[2])}
+            finally:
+                conn.close()
+
+
+_DEFAULT_CACHE: ContentCache | None = None
+_DEFAULT_LOCK = threading.Lock()
+
+
+def default_cache() -> ContentCache:
+    """Lazily resolve the process-default content cache.
+
+    Order: ``$BICAMERAL_CONTENT_CACHE_PATH`` → ``~/.bicameral/content_cache.db``.
+    """
+    global _DEFAULT_CACHE
+    if _DEFAULT_CACHE is not None:
+        return _DEFAULT_CACHE
+    with _DEFAULT_LOCK:
+        if _DEFAULT_CACHE is None:
+            path_str = os.environ.get(
+                "BICAMERAL_CONTENT_CACHE_PATH",
+                str(Path.home() / ".bicameral" / "content_cache.db"),
+            )
+            _DEFAULT_CACHE = ContentCache(path_str)
+    return _DEFAULT_CACHE
+
+
+def _reset_default_cache_for_tests() -> None:
+    """Test hook: clear the module-level default so the next call rebuilds.
+
+    Test code that mutates ``BICAMERAL_CONTENT_CACHE_PATH`` after the
+    default has already been resolved would otherwise get a stale cache.
+    Not part of the public API; named with leading underscore.
+    """
+    global _DEFAULT_CACHE
+    with _DEFAULT_LOCK:
+        _DEFAULT_CACHE = None
+
+
+def content_cached(
+    *,
+    behavior_version: int,
+    cache: ContentCache | None = None,
+) -> Callable[[Callable[..., T]], Callable[..., T]]:
+    """Memoize a pure synchronous function with a content-addressed cache.
+
+    Mandatory ``behavior_version``: bump on any logic change inside the
+    wrapped function. Snapshot test in
+    ``tests/test_content_cache_fingerprint.py`` pins the key fingerprint
+    of a representative input so accidental drift fails CI.
+
+    Rejects async functions at decorator-bind time (fail-loud). Rejects
+    non-allowlist arg types at first call (fail-loud).
+    """
+
+    def decorator(fn: Callable[..., T]) -> Callable[..., T]:
+        if inspect.iscoroutinefunction(fn):
+            raise TypeError(
+                f"content_cached cannot wrap async function {fn.__qualname__}; "
+                "scope intentionally synchronous (plan-136)"
+            )
+        fn_name = f"{fn.__module__}.{fn.__qualname__}"
+
+        @functools.wraps(fn)
+        def wrapper(*args: Any, **kwargs: Any) -> T:
+            cache_inst = cache if cache is not None else default_cache()
+            for a in args:
+                if not _is_allowed_arg(a):
+                    raise TypeError(
+                        f"content_cached({fn_name}): positional arg of type "
+                        f"{type(a).__name__} is not in the allowlist"
+                    )
+            for k, v in kwargs.items():
+                if not _is_allowed_arg(v):
+                    raise TypeError(
+                        f"content_cached({fn_name}): kwarg {k!r} of type "
+                        f"{type(v).__name__} is not in the allowlist"
+                    )
+            key = _cache_key(fn_name, behavior_version, args, kwargs)
+            hit, value = cache_inst.get(key, behavior_version)
+            if hit:
+                return value  # type: ignore[no-any-return]
+            result = fn(*args, **kwargs)
+            cache_inst.set(key, result, behavior_version)
+            return result
+
+        wrapper.__wrapped__ = fn  # type: ignore[attr-defined]
+        wrapper._content_cached_version = behavior_version  # type: ignore[attr-defined]
+        wrapper._content_cached_fn_name = fn_name  # type: ignore[attr-defined]
+        return wrapper
+
+    return decorator

--- a/codegenome/diff_categorizer.py
+++ b/codegenome/diff_categorizer.py
@@ -22,6 +22,7 @@ import difflib
 from dataclasses import dataclass
 
 from . import _diff_dispatch
+from ._content_cache import content_cached
 from ._line_categorizers import categorize as _categorize_line
 
 
@@ -100,6 +101,7 @@ def _bucket(
     return counts
 
 
+@content_cached(behavior_version=1)
 def categorize_diff(
     old_body: str,
     new_body: str,
@@ -112,6 +114,15 @@ def categorize_diff(
     (``codegenome.drift_classifier.classify_drift``) short-circuits
     unsupported languages to ``"uncertain"`` before this function is
     reached.
+
+    Content-cached (#136 Step 3) since difflib runs O(N²) on line count
+    — large bodies are real CPU. All three args are ``str``, so the
+    cache decorator wraps directly without an outer normalization layer.
+
+    Bump ``behavior_version`` on any change to: bucket categories,
+    cosmetic_ratio formula, the underlying ``_categorize_line`` /
+    ``_diff_dispatch.compute_slot_flags`` heuristics, or the returned
+    ``DiffStats`` shape.
     """
     removed, added = _changed_lines(old_body, new_body)
     old_flags = _diff_dispatch.compute_slot_flags(old_body, language)

--- a/codegenome/drift_classifier.py
+++ b/codegenome/drift_classifier.py
@@ -22,6 +22,7 @@ from typing import Literal
 
 from code_locator.indexing.call_site_extractor import extract_call_sites
 
+from ._content_cache import content_cached
 from .continuity import _jaccard
 from .diff_categorizer import categorize_diff
 
@@ -186,6 +187,47 @@ def classify_drift(
 
     Unsupported languages return ``verdict='uncertain'`` so the caller
     LLM still sees the pending check (just without a meaningful hint).
+
+    Thin normalization wrapper: converts iterable neighbor inputs to
+    frozenset before delegating to the cached inner implementation. The
+    content cache (#136) requires allowlist-typed args; tuple/frozenset
+    is the canonical form. Order doesn't matter for the Jaccard signal,
+    so any iterable collapses safely to frozenset.
+    """
+    old_nbrs = frozenset(old_neighbors) if old_neighbors is not None else None
+    new_nbrs = frozenset(new_neighbors) if new_neighbors is not None else None
+    return _classify_drift_cached(
+        old_body,
+        new_body,
+        old_signature_hash=old_signature_hash,
+        new_signature_hash=new_signature_hash,
+        old_neighbors=old_nbrs,
+        new_neighbors=new_nbrs,
+        language=language,
+    )
+
+
+@content_cached(behavior_version=1)
+def _classify_drift_cached(
+    old_body: str,
+    new_body: str,
+    *,
+    old_signature_hash: str | None,
+    new_signature_hash: str | None,
+    old_neighbors: frozenset[str] | None,
+    new_neighbors: frozenset[str] | None,
+    language: str,
+) -> DriftClassification:
+    """Cached inner implementation of classify_drift.
+
+    Behavior IS classify_drift's prior body — same signals, same score
+    formula, same thresholds. The split exists only to give the content
+    cache typed (allowlist-compatible) args.
+
+    Bump ``behavior_version`` on any change to the signals dict, the
+    weights, the thresholds, or the verdict logic. Snapshot test in
+    ``tests/test_content_cache_fingerprint.py`` pins canonical input
+    fingerprints so accidental drift in serialization gets caught.
     """
     if language not in _SUPPORTED_LANGUAGES:
         return DriftClassification(

--- a/tests/eval_136_per_check_latency.py
+++ b/tests/eval_136_per_check_latency.py
@@ -1,0 +1,550 @@
+"""M_per_check_latency — wedge measurement for #136 + #431.
+
+Measures cold + warm per-call latency on the three transforms the
+content cache wraps (or will wrap):
+
+- ``codegenome.drift_classifier.classify_drift``
+- ``codegenome.diff_categorizer.categorize_diff``
+- ``governance.engine.evaluate``
+
+For each transform + input category, runs N iterations cold (cache
+empty) and N iterations warm (cache pre-populated). Reports p50/p95/p99
+in milliseconds plus a warm/cold ratio.
+
+The gate threshold derives from Jin's 2026-05-20 comment on #136:
+
+    Median per-check latency on cosmetic diff target: ≤ 10ms
+    (blob-SHA equality, no LLM)
+
+So the gate is: **warm p50 ≤ 10ms** on the cosmetic input category, for
+every transform with the cache wired in. Transforms that haven't been
+wired yet are measured but exempt from the gate (warn-only).
+
+CLI shape mirrors ``tests/eval_shadow_parity.py``:
+
+    python tests/eval_136_per_check_latency.py
+    python tests/eval_136_per_check_latency.py --gate-mode hard
+    python tests/eval_136_per_check_latency.py -o test-results/m136.json
+
+Out of scope for this eval:
+
+- End-to-end ``resolve_compliance`` sweep latency — covered by
+  ``tests/test_sweep_latency_with_cache.py`` (planned Step 5).
+- LLM-judge latency — that's #136's Phase 2 deliverable, not yet scoped.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import statistics
+import sys
+import tempfile
+import time
+from collections.abc import Callable
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any
+
+_REPO_ROOT = Path(__file__).resolve().parent.parent
+if str(_REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(_REPO_ROOT))
+
+from codegenome._content_cache import (  # noqa: E402
+    ContentCache,
+    _reset_default_cache_for_tests,
+)
+
+# ── Corpus ─────────────────────────────────────────────────────────────
+
+
+@dataclass(frozen=True)
+class DriftInput:
+    """One classify_drift input row."""
+
+    category: str
+    old_body: str
+    new_body: str
+    old_signature_hash: str | None
+    new_signature_hash: str | None
+    old_neighbors: frozenset[str] | None
+    new_neighbors: frozenset[str] | None
+    language: str
+
+
+@dataclass(frozen=True)
+class DiffInput:
+    """One categorize_diff input row."""
+
+    category: str
+    old_body: str
+    new_body: str
+    language: str
+
+
+def _cosmetic_drift_input() -> DriftInput:
+    """Whitespace/comment-only change — the case the cache must trivially
+    short-circuit. Cosmetic ratio = 1.0; classifier verdict = cosmetic."""
+    return DriftInput(
+        category="cosmetic",
+        old_body='def f():\n    """Old docstring."""\n    return 1\n',
+        new_body='def f():\n    """New docstring."""\n    return 1\n',
+        old_signature_hash="sig_abc",
+        new_signature_hash="sig_abc",
+        old_neighbors=frozenset({"helper_a", "helper_b"}),
+        new_neighbors=frozenset({"helper_a", "helper_b"}),
+        language="python",
+    )
+
+
+def _structural_drift_input() -> DriftInput:
+    """Logic-bearing change (return value flips, new callee). Classifier
+    will compute all four signals, including the relatively expensive
+    diff_categorizer step. This is the category that proves the cache
+    earns its keep — uncached takes real CPU work."""
+    return DriftInput(
+        category="structural",
+        old_body=("def compute(x):\n    if x > 0:\n        return x * 2\n    return 0\n"),
+        new_body=("def compute(x):\n    if x > 0:\n        return helper(x)\n    return 0\n"),
+        old_signature_hash="sig_compute_v1",
+        new_signature_hash="sig_compute_v1",
+        old_neighbors=frozenset({"caller_a"}),
+        new_neighbors=frozenset({"caller_a", "helper"}),
+        language="python",
+    )
+
+
+def _large_drift_input() -> DriftInput:
+    """100+ line function body — representative of real production code.
+    The categorize_diff helper runs difflib O(N²) on line count, so
+    larger bodies cost real CPU. This is where the cache earns its keep."""
+    base_lines = [
+        "def long_function(",
+        "    param_a: str,",
+        "    param_b: int,",
+        "    param_c: dict[str, int] | None = None,",
+        ") -> tuple[str, int]:",
+        '    """A representatively-sized function for benchmarking."""',
+    ]
+    body_lines = [f"    step_{i} = compute_step({i}, param_a)" for i in range(80)]
+    tail_lines = [
+        "    result_str = str(step_0)",
+        "    result_int = sum(int(s) for s in [step_1, step_2, step_3])",
+        "    return result_str, result_int",
+    ]
+    old_body = "\n".join(base_lines + body_lines + tail_lines) + "\n"
+    # Cosmetic-only edit: add one comment line, change a docstring.
+    new_lines = base_lines.copy()
+    new_lines[5] = '    """A representatively-sized function for benchmarking — updated docs."""'
+    new_body = "\n".join(new_lines + ["    # added comment"] + body_lines + tail_lines) + "\n"
+    return DriftInput(
+        category="large_cosmetic",
+        old_body=old_body,
+        new_body=new_body,
+        old_signature_hash="sig_long_v1",
+        new_signature_hash="sig_long_v1",
+        old_neighbors=frozenset({"compute_step", "caller_x", "caller_y"}),
+        new_neighbors=frozenset({"compute_step", "caller_x", "caller_y"}),
+        language="python",
+    )
+
+
+def _unsupported_drift_input() -> DriftInput:
+    """Language not in _SUPPORTED_LANGUAGES — classifier short-circuits
+    to verdict=uncertain at the top of the function. This category
+    measures the baseline overhead of the cache wrapper itself."""
+    return DriftInput(
+        category="unsupported",
+        old_body="(defn f [] (+ 1 2))",
+        new_body="(defn f [] (+ 1 3))",
+        old_signature_hash=None,
+        new_signature_hash=None,
+        old_neighbors=None,
+        new_neighbors=None,
+        language="clojure",
+    )
+
+
+def _cosmetic_diff_input() -> DiffInput:
+    return DiffInput(
+        category="cosmetic",
+        old_body='def f():\n    """Old docstring."""\n    return 1\n',
+        new_body='def f():\n    """New docstring."""\n    return 1\n',
+        language="python",
+    )
+
+
+def _structural_diff_input() -> DiffInput:
+    return DiffInput(
+        category="structural",
+        old_body=("def compute(x):\n    if x > 0:\n        return x * 2\n    return 0\n"),
+        new_body=("def compute(x):\n    if x > 0:\n        return helper(x)\n    return 0\n"),
+        language="python",
+    )
+
+
+# ── Measurement ────────────────────────────────────────────────────────
+
+
+@dataclass(frozen=True)
+class LatencyStats:
+    """Latency distribution for one (transform, category, phase) cell."""
+
+    n: int
+    p50_ms: float
+    p95_ms: float
+    p99_ms: float
+    mean_ms: float
+
+    @classmethod
+    def from_samples(cls, samples_seconds: list[float]) -> LatencyStats:
+        samples_ms = [s * 1000 for s in samples_seconds]
+        samples_ms.sort()
+        n = len(samples_ms)
+        return cls(
+            n=n,
+            p50_ms=samples_ms[n // 2],
+            p95_ms=samples_ms[min(n - 1, int(n * 0.95))],
+            p99_ms=samples_ms[min(n - 1, int(n * 0.99))],
+            mean_ms=statistics.mean(samples_ms),
+        )
+
+
+@dataclass(frozen=True)
+class TransformResult:
+    """All measurements for one transform."""
+
+    name: str
+    cache_wired: bool
+    cold: dict[str, LatencyStats]
+    warm: dict[str, LatencyStats]
+    breaches: list[str] = field(default_factory=list)
+
+
+_GATE_WARM_P50_MS = 10.0  # Jin 2026-05-20 target
+
+
+def _time_one(fn: Callable[..., Any]) -> float:
+    """Single call latency in seconds. Uses perf_counter for ns precision."""
+    t0 = time.perf_counter()
+    fn()
+    return time.perf_counter() - t0
+
+
+def _fresh_cache_env() -> tuple[Path, Path]:
+    """Create an isolated cache dir + db path; reset the module-level
+    default so the next decorator call picks it up. Returns (dir, db)."""
+    tmpdir = Path(tempfile.mkdtemp(prefix="m136_eval_"))
+    db = tmpdir / "cache.db"
+    os.environ["BICAMERAL_CONTENT_CACHE_PATH"] = str(db)
+    _reset_default_cache_for_tests()
+    return tmpdir, db
+
+
+def _measure_cold(fn: Callable[..., Any], n: int) -> LatencyStats:
+    """N truly cold calls — fresh cache env per sample.
+
+    Each iteration resets the cache before timing, so every sample
+    measures a real cold-path latency (compute + cache insert, no
+    prior entry). Costs more wall time than warm measurement because of
+    the per-iteration tempdir mkdir, but accurate.
+    """
+    samples: list[float] = []
+    for _ in range(n):
+        _fresh_cache_env()
+        samples.append(_time_one(fn))
+    return LatencyStats.from_samples(samples)
+
+
+def _measure_warm(fn: Callable[..., Any], n: int) -> LatencyStats:
+    """N warm calls — one fresh cache env, prime with one call, then
+    measure N subsequent calls. Every sample is a cache hit (or a
+    cache-wrapper passthrough on un-wired transforms)."""
+    _fresh_cache_env()
+    fn()  # prime: populates the cache (or runs compute if not wired)
+    samples = [_time_one(fn) for _ in range(n)]
+    return LatencyStats.from_samples(samples)
+
+
+# ── Per-transform measurement ──────────────────────────────────────────
+
+
+def _measure_classify_drift(n: int) -> TransformResult:
+    """Cold vs warm latency on classify_drift across three categories.
+
+    'Cold' = cache reset + first call per input; the function runs the
+    full structural-classification path.
+    'Warm' = same input called N more times; cache returns the stored
+    DriftClassification.
+    """
+    from codegenome.drift_classifier import classify_drift
+
+    # Cache-wired detection: check the inner cached function's marker
+    # attribute. The public classify_drift is the normalization wrapper;
+    # the @content_cached decoration lives on _classify_drift_cached.
+    try:
+        from codegenome.drift_classifier import _classify_drift_cached
+
+        cache_wired = hasattr(_classify_drift_cached, "_content_cached_version")
+    except ImportError:
+        cache_wired = False
+
+    inputs = [
+        _cosmetic_drift_input(),
+        _structural_drift_input(),
+        _large_drift_input(),
+        _unsupported_drift_input(),
+    ]
+
+    cold: dict[str, LatencyStats] = {}
+    warm: dict[str, LatencyStats] = {}
+
+    for inp in inputs:
+
+        def _call(inp=inp) -> Any:
+            return classify_drift(
+                inp.old_body,
+                inp.new_body,
+                old_signature_hash=inp.old_signature_hash,
+                new_signature_hash=inp.new_signature_hash,
+                old_neighbors=inp.old_neighbors,
+                new_neighbors=inp.new_neighbors,
+                language=inp.language,
+            )
+
+        # Cold sampling is expensive (tempdir per iter) — use n/10 samples
+        cold[inp.category] = _measure_cold(_call, max(5, n // 10))
+        warm[inp.category] = _measure_warm(_call, n)
+
+    breaches: list[str] = []
+    if cache_wired:
+        for category in ("cosmetic", "structural"):
+            if warm[category].p50_ms > _GATE_WARM_P50_MS:
+                breaches.append(
+                    f"classify_drift[{category}]: warm p50 "
+                    f"{warm[category].p50_ms:.2f}ms > gate {_GATE_WARM_P50_MS}ms"
+                )
+
+    return TransformResult(
+        name="classify_drift",
+        cache_wired=cache_wired,
+        cold=cold,
+        warm=warm,
+        breaches=breaches,
+    )
+
+
+def _measure_categorize_diff(n: int) -> TransformResult:
+    from codegenome.diff_categorizer import categorize_diff
+
+    cache_wired = hasattr(categorize_diff, "_content_cached_version") or hasattr(
+        getattr(categorize_diff, "__wrapped__", None), "_content_cached_version"
+    )
+
+    # Re-use the large-body fixture from classify_drift since it's the
+    # same shape (old_body, new_body, language). Avoids fixture drift.
+    large = _large_drift_input()
+    large_diff = DiffInput(
+        category="large_cosmetic",
+        old_body=large.old_body,
+        new_body=large.new_body,
+        language=large.language,
+    )
+    inputs = [_cosmetic_diff_input(), _structural_diff_input(), large_diff]
+    cold: dict[str, LatencyStats] = {}
+    warm: dict[str, LatencyStats] = {}
+
+    for inp in inputs:
+
+        def _call(inp=inp) -> Any:
+            return categorize_diff(inp.old_body, inp.new_body, inp.language)
+
+        cold[inp.category] = _measure_cold(_call, max(5, n // 10))
+        warm[inp.category] = _measure_warm(_call, n)
+
+    breaches: list[str] = []
+    if cache_wired:
+        for category in ("cosmetic", "structural"):
+            if warm[category].p50_ms > _GATE_WARM_P50_MS:
+                breaches.append(
+                    f"categorize_diff[{category}]: warm p50 "
+                    f"{warm[category].p50_ms:.2f}ms > gate {_GATE_WARM_P50_MS}ms"
+                )
+
+    return TransformResult(
+        name="categorize_diff",
+        cache_wired=cache_wired,
+        cold=cold,
+        warm=warm,
+        breaches=breaches,
+    )
+
+
+def _measure_governance_evaluate(n: int) -> TransformResult:
+    """Light input — governance.evaluate is already cheap (~ms uncached)
+    so the cache demonstrates marginal lift, not the headline win."""
+    from governance.config import GovernanceConfig
+    from governance.contracts import (
+        GovernanceFinding,
+        GovernanceMetadata,
+    )
+    from governance.engine import evaluate
+
+    try:
+        from governance.engine import _evaluate_cached
+
+        cache_wired = hasattr(_evaluate_cached, "_content_cached_version")
+    except ImportError:
+        cache_wired = False
+
+    finding = GovernanceFinding(
+        finding_id="00000000-0000-0000-0000-000000000001",
+        decision_id="decision:eval_bench",
+        region_id="region:eval_bench",
+        decision_class="implementation_preference",
+        risk_class="low",
+        escalation_class="warn",
+        source="drift",
+        semantic_status="likely_drift",
+        confidence={"drift_confidence": 0.7, "binding_confidence": 0.9},
+        explanation="bench",
+        evidence_refs=["score:0.700"],
+    )
+    metadata = GovernanceMetadata(
+        decision_class="implementation_preference",
+        risk_class="low",
+        escalation_class="warn",
+    )
+    config = GovernanceConfig()
+
+    cold: dict[str, LatencyStats] = {}
+    warm: dict[str, LatencyStats] = {}
+
+    for category in ("typical",):
+
+        def _call() -> Any:
+            return evaluate(
+                finding=finding,
+                metadata=metadata,
+                config=config,
+                decision_status="ratified",
+                bypass_recency_seconds=None,
+            )
+
+        cold[category] = _measure_cold(_call, max(5, n // 10))
+        warm[category] = _measure_warm(_call, n)
+
+    breaches: list[str] = []
+    if cache_wired:
+        if warm["typical"].p50_ms > _GATE_WARM_P50_MS:
+            breaches.append(
+                f"governance.evaluate[typical]: warm p50 "
+                f"{warm['typical'].p50_ms:.2f}ms > gate {_GATE_WARM_P50_MS}ms"
+            )
+
+    return TransformResult(
+        name="governance.evaluate",
+        cache_wired=cache_wired,
+        cold=cold,
+        warm=warm,
+        breaches=breaches,
+    )
+
+
+# ── Render ─────────────────────────────────────────────────────────────
+
+
+def _render_text(results: list[TransformResult], passed: bool) -> str:
+    lines = ["=" * 72]
+    lines.append("M_per_check_latency (#136 wedge)")
+    lines.append("=" * 72)
+    for r in results:
+        wired_label = "WIRED" if r.cache_wired else "BASELINE (not wired)"
+        lines.append(f"\n{r.name}  [{wired_label}]")
+        for category in sorted(set(list(r.cold.keys()) + list(r.warm.keys()))):
+            cold = r.cold.get(category)
+            warm = r.warm.get(category)
+            if cold is None or warm is None:
+                continue
+            ratio = warm.p50_ms / cold.p50_ms if cold.p50_ms > 0 else float("inf")
+            lines.append(
+                f"  {category:<12} cold p50={cold.p50_ms:7.3f}ms  "
+                f"warm p50={warm.p50_ms:7.3f}ms  "
+                f"ratio={ratio:6.3f}  (n={cold.n} per phase)"
+            )
+    lines.append("")
+    lines.append(
+        f"Gate: warm p50 ≤ {_GATE_WARM_P50_MS}ms on (cosmetic, structural) for wired transforms"
+    )
+    lines.append(f"Result: {'PASS' if passed else 'FAIL'}")
+    return "\n".join(lines)
+
+
+def _serialize(r: TransformResult) -> dict[str, Any]:
+    def cells(d: dict[str, LatencyStats]) -> dict[str, Any]:
+        return {
+            k: {
+                "n": v.n,
+                "p50_ms": round(v.p50_ms, 4),
+                "p95_ms": round(v.p95_ms, 4),
+                "p99_ms": round(v.p99_ms, 4),
+                "mean_ms": round(v.mean_ms, 4),
+            }
+            for k, v in d.items()
+        }
+
+    return {
+        "name": r.name,
+        "cache_wired": r.cache_wired,
+        "cold": cells(r.cold),
+        "warm": cells(r.warm),
+        "breaches": r.breaches,
+    }
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description="M_per_check_latency — wedge measurement (#136)")
+    ap.add_argument("--gate-mode", choices=("warn", "hard"), default="warn")
+    ap.add_argument("--iterations", "-n", type=int, default=100)
+    ap.add_argument("-o", "--output", help="Write JSON results to this path")
+    args = ap.parse_args()
+
+    results = [
+        _measure_classify_drift(args.iterations),
+        _measure_categorize_diff(args.iterations),
+        _measure_governance_evaluate(args.iterations),
+    ]
+
+    all_breaches: list[str] = []
+    for r in results:
+        all_breaches.extend(r.breaches)
+    passed = not all_breaches
+
+    print(_render_text(results, passed))
+
+    if all_breaches:
+        sys.stderr.write("\nBreaches:\n")
+        for b in all_breaches:
+            sys.stderr.write(f"  - {b}\n")
+
+    if args.output:
+        out_payload = {
+            "gate_mode": args.gate_mode,
+            "gate_warm_p50_ms": _GATE_WARM_P50_MS,
+            "passed": passed,
+            "breaches": all_breaches,
+            "iterations": args.iterations,
+            "results": [_serialize(r) for r in results],
+        }
+        Path(args.output).parent.mkdir(parents=True, exist_ok=True)
+        Path(args.output).write_text(json.dumps(out_payload, indent=2))
+        sys.stderr.write(f"\nWrote JSON: {args.output}\n")
+
+    if args.gate_mode == "hard" and not passed:
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/test_classify_drift_cached.py
+++ b/tests/test_classify_drift_cached.py
@@ -1,0 +1,287 @@
+"""Behavior-equivalence tests for classify_drift after content-cache wiring.
+
+The cache wedge (#136 Step 2) split ``classify_drift`` into a thin
+public wrapper (normalizes iterables → frozenset) plus a decorated
+``_classify_drift_cached``. These tests pin three properties:
+
+1. **Behavior equivalence** — the cached path and the underlying
+   uncached function produce byte-identical ``DriftClassification``
+   outputs across a representative corpus.
+
+2. **Cache participation** — calling the public ``classify_drift``
+   twice with the same args (after redirecting the default cache to
+   tmp_path) does NOT re-invoke the inner compute. Verifies the cache
+   is actually wired, not bypassed.
+
+3. **Normalization neutrality** — passing neighbors as a list, set, or
+   tuple all hit the same cache entry. The frozenset normalization
+   inside the wrapper makes ordering irrelevant by construction.
+"""
+
+from __future__ import annotations
+
+import os
+
+import pytest
+
+from codegenome._content_cache import _reset_default_cache_for_tests
+from codegenome.drift_classifier import (
+    _classify_drift_cached,
+    classify_drift,
+)
+
+
+@pytest.fixture(autouse=True)
+def _isolated_cache(tmp_path, monkeypatch):
+    """Each test gets a fresh cache. Without this, equivalence tests
+    would silently rely on stale state from prior tests."""
+    db = tmp_path / "cache.db"
+    monkeypatch.setenv("BICAMERAL_CONTENT_CACHE_PATH", str(db))
+    _reset_default_cache_for_tests()
+    yield
+    _reset_default_cache_for_tests()
+    if "BICAMERAL_CONTENT_CACHE_PATH" in os.environ:
+        del os.environ["BICAMERAL_CONTENT_CACHE_PATH"]
+
+
+# ── Corpus — representative inputs spanning all four signals ───────────
+
+
+_COSMETIC_PAIR = (
+    'def f():\n    """Old."""\n    return 1\n',
+    'def f():\n    """New."""\n    return 1\n',
+)
+
+_STRUCTURAL_PAIR = (
+    "def compute(x):\n    if x > 0:\n        return x * 2\n    return 0\n",
+    "def compute(x):\n    if x > 0:\n        return helper(x)\n    return 0\n",
+)
+
+_RENAMED_PAIR = (
+    "def alpha():\n    return 1\n",
+    "def beta():\n    return 1\n",
+)
+
+_BIG_DIFF_PAIR = (
+    "def f():\n    x = 1\n    y = 2\n    return x + y\n",
+    "def f():\n    x = 100\n    y = 200\n    z = 300\n    return x + y + z\n",
+)
+
+
+def _make_args(old: str, new: str, **overrides):
+    """Default classify_drift kwargs with sensible test values."""
+    base = {
+        "old_signature_hash": "sig_abc",
+        "new_signature_hash": "sig_abc",
+        "old_neighbors": ("helper_a", "helper_b"),
+        "new_neighbors": ("helper_a", "helper_b"),
+        "language": "python",
+    }
+    base.update(overrides)
+    return base
+
+
+@pytest.mark.parametrize(
+    "old,new,case",
+    [
+        (*_COSMETIC_PAIR, "cosmetic"),
+        (*_STRUCTURAL_PAIR, "structural"),
+        (*_RENAMED_PAIR, "renamed"),
+        (*_BIG_DIFF_PAIR, "big_diff"),
+    ],
+)
+def test_cached_matches_uncached_python(old, new, case):
+    """For every corpus pair, the cached public function and the
+    uncached inner produce equal DriftClassification."""
+    args = _make_args(old, new)
+    # The cached wrapper expects neighbors as frozenset (post-normalize);
+    # to call the truly-uncached path we go through the public wrapper
+    # which does the normalization, then peel back to __wrapped__ with
+    # already-normalized args.
+    nbrs = frozenset(args["old_neighbors"])
+    direct_args = dict(args, old_neighbors=nbrs, new_neighbors=nbrs)
+    cached = classify_drift(old, new, **args)
+    uncached = _classify_drift_cached.__wrapped__(old, new, **direct_args)
+    assert cached == uncached, f"case={case}: cached != uncached"
+
+
+@pytest.mark.parametrize(
+    "language",
+    ["javascript", "typescript", "go", "rust", "java", "c_sharp"],
+)
+def test_cached_matches_uncached_other_languages(language):
+    """Spot-check non-Python supported languages. classify_drift's
+    diff_lines + no_new_calls signals dispatch on language, so a
+    behavioral split between cached and uncached would show up here."""
+    old = "function f() { return 1; }"
+    new = "function f() { return 2; }"
+    args = _make_args(old, new, language=language)
+    nbrs = frozenset(args["old_neighbors"])
+    direct_args = dict(args, old_neighbors=nbrs, new_neighbors=nbrs)
+    cached = classify_drift(old, new, **args)
+    uncached = _classify_drift_cached.__wrapped__(old, new, **direct_args)
+    assert cached == uncached, f"language={language}: cached != uncached"
+
+
+def test_unsupported_language_short_circuits_equal_to_uncached():
+    """Unsupported language path returns verdict=uncertain with no
+    signals — cache should mirror that behavior."""
+    args = _make_args("body_a", "body_b", language="clojure")
+    nbrs = frozenset(args["old_neighbors"])
+    direct_args = dict(args, old_neighbors=nbrs, new_neighbors=nbrs)
+    cached = classify_drift("body_a", "body_b", **args)
+    uncached = _classify_drift_cached.__wrapped__("body_a", "body_b", **direct_args)
+    assert cached == uncached
+    assert cached.verdict == "uncertain"
+
+
+def test_none_signature_and_neighbors_equivalent():
+    """None inputs (no signature captured, no neighbors available) must
+    flow through the cache unchanged."""
+    args = _make_args(
+        *_STRUCTURAL_PAIR,
+        old_signature_hash=None,
+        new_signature_hash=None,
+        old_neighbors=None,
+        new_neighbors=None,
+    )
+    direct_args = dict(args, old_neighbors=None, new_neighbors=None)
+    cached = classify_drift(*_STRUCTURAL_PAIR, **args)
+    uncached = _classify_drift_cached.__wrapped__(*_STRUCTURAL_PAIR, **direct_args)
+    assert cached == uncached
+
+
+# ── Cache participation ────────────────────────────────────────────────
+
+
+def test_cache_participation_repeat_call_short_circuits(monkeypatch):
+    """Second call with identical args must NOT re-invoke the inner
+    function. If this fails, the decorator isn't wired (or the args
+    differ in some non-obvious way that drifts the cache key)."""
+    call_counter = {"n": 0}
+    original = _classify_drift_cached.__wrapped__
+
+    def tracking_inner(*args, **kwargs):
+        call_counter["n"] += 1
+        return original(*args, **kwargs)
+
+    monkeypatch.setattr(
+        "codegenome.drift_classifier._classify_drift_cached.__wrapped__",
+        tracking_inner,
+        raising=False,
+    )
+    # Note: monkeypatching __wrapped__ doesn't affect the closure inside
+    # the decorator's wrapper. We need to patch the decorated function
+    # itself. Use a different approach: count the underlying signal
+    # helpers, which run on every cold call.
+    inner_calls = {"n": 0}
+    real_signal = None
+
+    def tracking_signal(old_body, new_body, language):
+        inner_calls["n"] += 1
+        return real_signal(old_body, new_body, language)
+
+    import codegenome.drift_classifier as dc
+
+    real_signal = dc._signal_diff_lines
+    monkeypatch.setattr(dc, "_signal_diff_lines", tracking_signal)
+
+    args = _make_args(*_BIG_DIFF_PAIR)
+    classify_drift(*_BIG_DIFF_PAIR, **args)
+    n_after_first = inner_calls["n"]
+    classify_drift(*_BIG_DIFF_PAIR, **args)
+    n_after_second = inner_calls["n"]
+
+    assert n_after_first == 1, f"first call should invoke once, got {n_after_first}"
+    assert n_after_second == 1, (
+        f"second call should hit cache (no new inner invocation), got {n_after_second} total calls"
+    )
+
+
+def test_cache_partitions_by_argument_change():
+    """Different args → different cache entries → both invocations
+    run. Pins the cache-key-on-args contract."""
+    inner_calls = {"n": 0}
+    import codegenome.drift_classifier as dc
+
+    real_signal = dc._signal_diff_lines
+
+    def tracking_signal(old_body, new_body, language):
+        inner_calls["n"] += 1
+        return real_signal(old_body, new_body, language)
+
+    dc._signal_diff_lines = tracking_signal
+    try:
+        classify_drift(*_BIG_DIFF_PAIR, **_make_args(*_BIG_DIFF_PAIR))
+        classify_drift(*_STRUCTURAL_PAIR, **_make_args(*_STRUCTURAL_PAIR))
+        assert inner_calls["n"] == 2, (
+            f"different args should miss cache, got {inner_calls['n']} calls"
+        )
+    finally:
+        dc._signal_diff_lines = real_signal
+
+
+# ── Normalization neutrality ───────────────────────────────────────────
+
+
+def test_list_set_tuple_neighbors_all_hit_same_cache_entry():
+    """List vs set vs tuple of the same elements → one cache entry.
+    frozenset normalization inside the wrapper collapses input shape."""
+    inner_calls = {"n": 0}
+    import codegenome.drift_classifier as dc
+
+    real_signal = dc._signal_diff_lines
+
+    def tracking_signal(old_body, new_body, language):
+        inner_calls["n"] += 1
+        return real_signal(old_body, new_body, language)
+
+    dc._signal_diff_lines = tracking_signal
+    try:
+        base = _make_args(*_BIG_DIFF_PAIR)
+        # List
+        classify_drift(
+            *_BIG_DIFF_PAIR,
+            **dict(base, old_neighbors=["a", "b", "c"], new_neighbors=["a", "b", "c"]),
+        )
+        # Tuple, different order
+        classify_drift(
+            *_BIG_DIFF_PAIR,
+            **dict(base, old_neighbors=("c", "a", "b"), new_neighbors=("c", "a", "b")),
+        )
+        # Set
+        classify_drift(
+            *_BIG_DIFF_PAIR,
+            **dict(base, old_neighbors={"b", "c", "a"}, new_neighbors={"b", "c", "a"}),
+        )
+        assert inner_calls["n"] == 1, (
+            f"all three iterables should hit one cache entry, got {inner_calls['n']} calls"
+        )
+    finally:
+        dc._signal_diff_lines = real_signal
+
+
+# ── Cache key collision smoke ──────────────────────────────────────────
+
+
+def test_different_languages_partition():
+    """Same bodies in different languages → different cache entries.
+    Language participates in the key per the cached function signature."""
+    inner_calls = {"n": 0}
+    import codegenome.drift_classifier as dc
+
+    real_signal = dc._signal_diff_lines
+
+    def tracking_signal(old_body, new_body, language):
+        inner_calls["n"] += 1
+        return real_signal(old_body, new_body, language)
+
+    dc._signal_diff_lines = tracking_signal
+    try:
+        body_a = "function f() { return 1; }"
+        body_b = "function f() { return 2; }"
+        classify_drift(body_a, body_b, **_make_args(body_a, body_b, language="javascript"))
+        classify_drift(body_a, body_b, **_make_args(body_a, body_b, language="typescript"))
+        assert inner_calls["n"] == 2
+    finally:
+        dc._signal_diff_lines = real_signal

--- a/tests/test_content_cache.py
+++ b/tests/test_content_cache.py
@@ -1,0 +1,458 @@
+"""Sociable tests for ``codegenome._content_cache`` (#136 wedge).
+
+Real SQLite via ``tmp_path``; no MagicMock per CLAUDE.md. The primitive
+exists to ship in production code paths, so the tests exercise its real
+storage, real eviction, real concurrency primitives.
+"""
+
+from __future__ import annotations
+
+import pickle
+import threading
+import time
+from concurrent.futures import ThreadPoolExecutor
+from dataclasses import dataclass
+
+import pytest
+
+from codegenome._content_cache import (
+    ContentCache,
+    _cache_key,
+    _canonical,
+    _is_allowed_arg,
+    content_cached,
+)
+
+
+# Module-level dataclass: pickle requires the class to be importable by
+# its fully-qualified name. A local class defined inside a test function
+# would fail to pickle ("can't pickle local object"). The production
+# return types (DriftClassification, DiffStats, GovernancePolicyResult)
+# are all module-level, so this matches deployed shape.
+@dataclass(frozen=True)
+class _SampleResult:
+    verdict: str
+    score: float
+    signals: tuple[str, ...]
+    evidence: tuple[str, ...] = ()
+
+
+# ── ContentCache primitive ─────────────────────────────────────────────
+
+
+def test_set_then_get_roundtrips(tmp_path):
+    cache = ContentCache(tmp_path / "c.db")
+    cache.set("k1", {"value": 42, "nested": [1, 2]}, behavior_version=1)
+    hit, value = cache.get("k1", behavior_version=1)
+    assert hit is True
+    assert value == {"value": 42, "nested": [1, 2]}
+
+
+def test_get_miss_on_unknown_key(tmp_path):
+    cache = ContentCache(tmp_path / "c.db")
+    hit, value = cache.get("nonexistent", behavior_version=1)
+    assert hit is False
+    assert value is None
+
+
+def test_get_miss_on_version_mismatch(tmp_path):
+    """Bumping ``behavior_version`` invalidates prior entries without
+    requiring an explicit purge. This is the load-bearing safety lever
+    for shipping a logic change to a memoized function."""
+    cache = ContentCache(tmp_path / "c.db")
+    cache.set("k1", "v_at_version_1", behavior_version=1)
+    hit, value = cache.get("k1", behavior_version=2)
+    assert hit is False
+    assert value is None
+
+
+def test_get_returns_legit_none_as_hit(tmp_path):
+    """``None`` is a valid cached value, distinct from a miss. The wrapper
+    relies on ``(hit, value)`` tuple semantics for this — using ``None``
+    as a sentinel would silently re-invoke the function on every call to
+    a function that legitimately returns ``None``."""
+    cache = ContentCache(tmp_path / "c.db")
+    cache.set("k1", None, behavior_version=1)
+    hit, value = cache.get("k1", behavior_version=1)
+    assert hit is True
+    assert value is None
+
+
+def test_set_overwrites_existing_key(tmp_path):
+    cache = ContentCache(tmp_path / "c.db")
+    cache.set("k1", "first", behavior_version=1)
+    cache.set("k1", "second", behavior_version=1)
+    _, value = cache.get("k1", behavior_version=1)
+    assert value == "second"
+
+
+def test_cache_survives_reopen(tmp_path):
+    """Entries written by one ContentCache instance are visible to a
+    second instance pointing at the same file — pins the
+    cross-process-shape guarantee. We use two instances rather than
+    forking because the test exercises SQLite WAL durability, not
+    OS-level process isolation."""
+    db_path = tmp_path / "c.db"
+    cache1 = ContentCache(db_path)
+    cache1.set("k1", "persistent", behavior_version=1)
+    cache2 = ContentCache(db_path)
+    hit, value = cache2.get("k1", behavior_version=1)
+    assert hit is True
+    assert value == "persistent"
+
+
+def test_eviction_triggers_when_over_cap(tmp_path):
+    """LRU-by-(hits, created_at) drops cold entries first. Cap is set
+    small enough that 4 entries of ~1KB each force eviction on the 4th
+    insert."""
+    cache = ContentCache(tmp_path / "c.db", max_bytes=2000)
+    payload = "x" * 800
+    cache.set("k1", payload, behavior_version=1)
+    cache.set("k2", payload, behavior_version=1)
+    # Bump k2 hit count so it's NOT the eviction victim
+    cache.get("k2", behavior_version=1)
+    cache.set("k3", payload, behavior_version=1)
+    cache.set("k4", payload, behavior_version=1)
+    stats = cache.stats()
+    assert stats["bytes"] <= 2000, f"expected eviction but bytes={stats['bytes']}"
+    # k2 had a hit, should survive; k1 had no hits and is oldest
+    hit_k1, _ = cache.get("k1", behavior_version=1)
+    hit_k2, _ = cache.get("k2", behavior_version=1)
+    assert hit_k1 is False, "expected k1 (least-hits, oldest) to be evicted"
+    assert hit_k2 is True, "expected k2 (hit before eviction) to survive"
+
+
+def test_oversized_entry_is_refused_silently(tmp_path):
+    """An entry larger than the entire cap is logged + skipped, not
+    inserted-then-immediately-evicted. Prevents thrash when a transform
+    happens to return an unexpectedly huge value."""
+    cache = ContentCache(tmp_path / "c.db", max_bytes=100)
+    cache.set("k1", "x" * 1000, behavior_version=1)
+    hit, _ = cache.get("k1", behavior_version=1)
+    assert hit is False
+    assert cache.stats()["entries"] == 0
+
+
+def test_get_treats_unpicklable_blob_as_miss(tmp_path):
+    """If the on-disk blob is corrupt (e.g. partial write from an old
+    bug), ``get`` returns a miss instead of raising. The wrapper then
+    computes + overwrites — self-healing."""
+    cache = ContentCache(tmp_path / "c.db")
+    cache.set("k1", "fine", behavior_version=1)
+    # Corrupt the stored blob via the same SQLite file
+    import sqlite3
+
+    conn = sqlite3.connect(str(tmp_path / "c.db"), isolation_level=None)
+    try:
+        conn.execute("UPDATE content_cache SET value=? WHERE key=?", (b"\x00garbage", "k1"))
+    finally:
+        conn.close()
+    hit, _ = cache.get("k1", behavior_version=1)
+    assert hit is False
+
+
+def test_stats_reflects_inserts_and_hits(tmp_path):
+    cache = ContentCache(tmp_path / "c.db")
+    cache.set("k1", "v1", behavior_version=1)
+    cache.set("k2", "v2", behavior_version=1)
+    cache.get("k1", behavior_version=1)
+    cache.get("k1", behavior_version=1)
+    cache.get("k2", behavior_version=1)
+    stats = cache.stats()
+    assert stats["entries"] == 2
+    assert stats["hits"] == 3
+    assert stats["bytes"] > 0
+
+
+def test_concurrent_writes_serialize_safely(tmp_path):
+    """Threading smoke test — eight threads each writing 25 keys against
+    the same cache file. All entries must land; no SQLite contention
+    errors. Catches missing WAL pragma / missing lock / connection-pool
+    bugs."""
+    cache = ContentCache(tmp_path / "c.db")
+
+    def worker(prefix: str):
+        for i in range(25):
+            cache.set(f"{prefix}:{i}", i, behavior_version=1)
+
+    with ThreadPoolExecutor(max_workers=8) as pool:
+        list(pool.map(worker, [f"t{i}" for i in range(8)]))
+
+    assert cache.stats()["entries"] == 200
+
+
+# ── _cache_key + canonicalization ──────────────────────────────────────
+
+
+def test_cache_key_is_stable_across_calls():
+    """Same inputs → same key, every call. Load-bearing for cache hits."""
+    args = ("hello", 42, True)
+    kwargs = {"option": "x"}
+    k1 = _cache_key("module.func", 1, args, kwargs)
+    k2 = _cache_key("module.func", 1, args, kwargs)
+    assert k1 == k2
+
+
+def test_cache_key_differs_on_arg_change():
+    k1 = _cache_key("module.func", 1, ("a",), {})
+    k2 = _cache_key("module.func", 1, ("b",), {})
+    assert k1 != k2
+
+
+def test_cache_key_differs_on_kwarg_change():
+    k1 = _cache_key("module.func", 1, (), {"option": "a"})
+    k2 = _cache_key("module.func", 1, (), {"option": "b"})
+    assert k1 != k2
+
+
+def test_cache_key_differs_on_version_bump():
+    k1 = _cache_key("module.func", 1, ("a",), {})
+    k2 = _cache_key("module.func", 2, ("a",), {})
+    assert k1 != k2
+
+
+def test_cache_key_differs_on_function_rename():
+    """Memoization is scoped to a fully-qualified function name; two
+    different functions with the same args do NOT collide."""
+    k1 = _cache_key("module.func_a", 1, ("x",), {})
+    k2 = _cache_key("module.func_b", 1, ("x",), {})
+    assert k1 != k2
+
+
+def test_canonical_distinguishes_tuple_and_list_shapes():
+    """A frozenset and a tuple of the same items must NOT produce the
+    same canonical form — otherwise their cache keys would collide
+    despite being different Python types with different semantics."""
+    a = _canonical((1, 2, 3))
+    b = _canonical(frozenset([1, 2, 3]))
+    assert a != b
+
+
+def test_canonical_dict_order_is_stable():
+    """Insertion order doesn't matter — dicts canonicalize by sorted keys."""
+    a = _canonical({"a": 1, "b": 2})
+    b = _canonical({"b": 2, "a": 1})
+    assert a == b
+
+
+def test_canonical_rejects_unsupported_type():
+    class CustomObj:
+        pass
+
+    with pytest.raises(TypeError, match="unsupported arg type"):
+        _canonical(CustomObj())
+
+
+def test_is_allowed_arg_accepts_nested_primitives():
+    assert _is_allowed_arg("x") is True
+    assert _is_allowed_arg(42) is True
+    assert _is_allowed_arg(None) is True
+    assert _is_allowed_arg((1, "x", None)) is True
+    assert _is_allowed_arg(frozenset(["a", "b"])) is True
+    assert _is_allowed_arg({"a": 1, "b": (2, 3)}) is True
+
+
+def test_is_allowed_arg_rejects_bytes_and_objects():
+    """Bytes are deliberately excluded — pickle/json asymmetry causes
+    silent bugs. Callers must convert to str (decoded) or list[int]."""
+    assert _is_allowed_arg(b"raw") is False
+    assert _is_allowed_arg([1, 2, 3]) is False  # list, not tuple
+    assert _is_allowed_arg({"a": object()}) is False
+
+
+# ── @content_cached decorator ──────────────────────────────────────────
+
+
+def test_decorator_caches_call(tmp_path):
+    cache = ContentCache(tmp_path / "c.db")
+    counter = {"n": 0}
+
+    @content_cached(behavior_version=1, cache=cache)
+    def expensive(x: int) -> int:
+        counter["n"] += 1
+        return x * 2
+
+    assert expensive(5) == 10
+    assert expensive(5) == 10
+    assert counter["n"] == 1, f"expected 1 call, got {counter['n']}"
+
+
+def test_decorator_misses_on_different_args(tmp_path):
+    cache = ContentCache(tmp_path / "c.db")
+    counter = {"n": 0}
+
+    @content_cached(behavior_version=1, cache=cache)
+    def expensive(x: int) -> int:
+        counter["n"] += 1
+        return x * 2
+
+    expensive(5)
+    expensive(6)
+    expensive(5)
+    expensive(6)
+    assert counter["n"] == 2, f"expected 2 calls (one per unique arg), got {counter['n']}"
+
+
+def test_decorator_kwargs_participate_in_key(tmp_path):
+    cache = ContentCache(tmp_path / "c.db")
+    counter = {"n": 0}
+
+    @content_cached(behavior_version=1, cache=cache)
+    def fn(x: int, *, mode: str = "a") -> str:
+        counter["n"] += 1
+        return f"{x}-{mode}"
+
+    assert fn(1, mode="a") == "1-a"
+    assert fn(1, mode="b") == "1-b"
+    assert fn(1, mode="a") == "1-a"
+    assert counter["n"] == 2
+
+
+def test_decorator_version_bump_recomputes(tmp_path):
+    """Two decorated wrappers around the same underlying function, with
+    different ``behavior_version``s, each have their own cache namespace.
+    Bumping the version on a deployed function therefore forces fresh
+    computation without leaving stale entries readable."""
+    cache = ContentCache(tmp_path / "c.db")
+    counter = {"n": 0}
+
+    def real(x: int) -> int:
+        counter["n"] += 1
+        return x
+
+    v1 = content_cached(behavior_version=1, cache=cache)(real)
+    v2 = content_cached(behavior_version=2, cache=cache)(real)
+    v1(5)
+    v2(5)
+    assert counter["n"] == 2
+
+
+def test_decorator_returns_cached_none(tmp_path):
+    cache = ContentCache(tmp_path / "c.db")
+    counter = {"n": 0}
+
+    @content_cached(behavior_version=1, cache=cache)
+    def maybe_none(x: int) -> int | None:
+        counter["n"] += 1
+        return None if x == 0 else x
+
+    assert maybe_none(0) is None
+    assert maybe_none(0) is None
+    assert counter["n"] == 1, "None must be cached, not re-computed"
+
+
+def test_decorator_rejects_async_at_bind_time():
+    """An ``async def`` wrapped function would produce a coroutine the
+    cache can't pickle. Fail loudly at decorator-application rather than
+    at first call, when the rejection is most surprising."""
+    with pytest.raises(TypeError, match="cannot wrap async function"):
+
+        @content_cached(behavior_version=1)
+        async def coro(x: int) -> int:
+            return x
+
+
+def test_decorator_rejects_disallowed_arg_type_at_call(tmp_path):
+    cache = ContentCache(tmp_path / "c.db")
+
+    @content_cached(behavior_version=1, cache=cache)
+    def fn(x: object) -> str:
+        return str(x)
+
+    class Custom:
+        pass
+
+    with pytest.raises(TypeError, match="not in the allowlist"):
+        fn(Custom())
+
+
+def test_decorator_rejects_disallowed_kwarg_type(tmp_path):
+    cache = ContentCache(tmp_path / "c.db")
+
+    @content_cached(behavior_version=1, cache=cache)
+    def fn(**kwargs: object) -> str:
+        return str(kwargs)
+
+    with pytest.raises(TypeError, match="kwarg 'bad'"):
+        fn(bad=object())
+
+
+def test_decorator_preserves_function_metadata(tmp_path):
+    cache = ContentCache(tmp_path / "c.db")
+
+    @content_cached(behavior_version=3, cache=cache)
+    def my_special_fn(x: int) -> int:
+        """Docstring preserved."""
+        return x
+
+    assert my_special_fn.__name__ == "my_special_fn"
+    assert my_special_fn.__doc__ == "Docstring preserved."
+    assert my_special_fn._content_cached_version == 3  # type: ignore[attr-defined]
+    assert "my_special_fn" in my_special_fn._content_cached_fn_name  # type: ignore[attr-defined]
+    # __wrapped__ exposes the underlying function — enables benchmark tests
+    # that need to call the un-cached version for comparison
+    assert my_special_fn.__wrapped__.__name__ == "my_special_fn"  # type: ignore[attr-defined]
+
+
+def test_decorator_serializes_concurrent_callers_on_first_miss(tmp_path):
+    """Two threads calling the same key concurrently: the underlying
+    function may run twice (TOCTOU between get + set) but both threads
+    receive a correct result. The pure-function precondition makes
+    duplicate computation safe — the writes are identical."""
+    cache = ContentCache(tmp_path / "c.db")
+    call_count = {"n": 0}
+    counter_lock = threading.Lock()
+
+    @content_cached(behavior_version=1, cache=cache)
+    def slow_fn(x: int) -> int:
+        with counter_lock:
+            call_count["n"] += 1
+        time.sleep(0.01)
+        return x * 10
+
+    with ThreadPoolExecutor(max_workers=4) as pool:
+        results = list(pool.map(slow_fn, [7] * 8))
+
+    assert all(r == 70 for r in results)
+    # Under contention, n is in [1, 4] — bounded by pool size, not 8.
+    # Pinning a strict 1 would be a stronger guarantee but requires
+    # cross-thread locking around the get→set window, which costs more
+    # than the rare duplicate compute it would prevent.
+    assert call_count["n"] <= 4
+
+
+# ── End-to-end: confirms primitive's surface against pickle quirks ──────
+
+
+def test_decorator_with_dataclass_return_value(tmp_path):
+    """Dataclass returns roundtrip via pickle. This is the shape of
+    every real wrapped function (``DriftClassification``, ``DiffStats``,
+    ``GovernancePolicyResult``) — a tight test now prevents discovering
+    a pickle quirk while wiring the real transforms."""
+    cache = ContentCache(tmp_path / "c.db")
+    counter = {"n": 0}
+
+    @content_cached(behavior_version=1, cache=cache)
+    def classify(body: str) -> _SampleResult:
+        counter["n"] += 1
+        return _SampleResult(verdict="cosmetic", score=0.95, signals=("a", "b"))
+
+    r1 = classify("hello")
+    r2 = classify("hello")
+    assert r1 == r2
+    assert r1.verdict == "cosmetic"
+    assert counter["n"] == 1
+
+
+def test_pickle_size_estimate_for_typical_payload():
+    """Sanity check: cached payloads are small. A typical
+    DriftClassification-shaped dataclass should fit in a few hundred
+    bytes. If this jumps significantly, revisit the cache cap."""
+    r = _SampleResult(
+        verdict="cosmetic",
+        score=0.95,
+        signals=("signature", "neighbors", "diff_lines", "no_new_calls"),
+        evidence=("score:0.950", "signature:1.00", "neighbors:1.00"),
+    )
+    blob = pickle.dumps(r)
+    assert len(blob) < 1000, f"unexpected payload size {len(blob)} bytes"

--- a/tests/test_content_cache_fingerprint.py
+++ b/tests/test_content_cache_fingerprint.py
@@ -1,0 +1,113 @@
+"""Snapshot test pinning the canonical cache-key fingerprint (#136).
+
+The point of this test: when someone edits ``_cache_key`` or
+``_canonical`` and accidentally changes the serialization shape, *every*
+cached entry in every deployed bicameral install silently invalidates on
+the next decorator call. No error, no log, just stale-feeling slowness
+that nobody traces back to the serialization change.
+
+This test pins a canonical input → key mapping. If the key drifts, this
+test fails loudly and forces the editor to:
+
+1. Verify the drift was intentional.
+2. Bump ``behavior_version`` on every decorated function (so existing
+   cached entries get treated as version-mismatch misses).
+3. Update the expected fingerprint here.
+
+Coverage shape mirrors the actual inputs the decorated functions will
+receive — string bodies, signature hash tuples, neighbor frozensets,
+language enums. Adding a new decorated function shape should add a row
+here too.
+"""
+
+from __future__ import annotations
+
+from codegenome._content_cache import _cache_key
+
+# ── Pinned fingerprints ────────────────────────────────────────────────
+#
+# Format: each entry is (test_name, fn_name, behavior_version, args,
+# kwargs, expected_key). The expected_key was captured by running
+# _cache_key with the listed inputs; do not edit unless the underlying
+# canonicalization actually changed.
+
+
+def test_fingerprint_simple_string_arg():
+    """Baseline: single string positional arg."""
+    key = _cache_key("module.fn", 1, ("hello",), {})
+    assert key == "826a04a44db5236274e72bc3f133fc0d"
+
+
+def test_fingerprint_classify_drift_shape():
+    """Shape matching classify_drift: two bodies + signature hashes +
+    neighbor frozensets + language. Exercise the most complex canonical
+    shape we will actually deploy."""
+    key = _cache_key(
+        "codegenome.drift_classifier.classify_drift",
+        1,
+        ("def old():\n    pass\n", "def new():\n    pass\n"),
+        {
+            "old_signature_hash": "abc123",
+            "new_signature_hash": "abc123",
+            "old_neighbors": frozenset({"helper_a", "helper_b"}),
+            "new_neighbors": frozenset({"helper_a", "helper_b"}),
+            "language": "python",
+        },
+    )
+    assert key == "d19449e2604fbf348a41f94ab9902274"
+
+
+def test_fingerprint_none_signature_hashes():
+    """``None`` is a valid value for signature hashes and neighbors —
+    the classifier handles it as a no-signal sentinel. The fingerprint
+    must distinguish None from missing-arg."""
+    key = _cache_key(
+        "codegenome.drift_classifier.classify_drift",
+        1,
+        ("body_a", "body_b"),
+        {
+            "old_signature_hash": None,
+            "new_signature_hash": None,
+            "old_neighbors": None,
+            "new_neighbors": None,
+            "language": "python",
+        },
+    )
+    assert key == "fbae36612b4ebc9185e24f1256a99f84"
+
+
+def test_fingerprint_diff_categorize_shape():
+    """Shape matching categorize_diff: two bodies + language."""
+    key = _cache_key(
+        "codegenome.diff_categorizer.categorize_diff",
+        1,
+        ("x = 1\n", "x = 2\n", "python"),
+        {},
+    )
+    assert key == "bde77e43c38c07c206acb51bee1a2266"
+
+
+def test_fingerprint_kwarg_order_irrelevant():
+    """Two calls with the same kwargs in different insertion order MUST
+    produce the same key (canonicalization sorts by key)."""
+    key_a = _cache_key("fn", 1, (), {"a": 1, "b": 2, "c": 3})
+    key_b = _cache_key("fn", 1, (), {"c": 3, "a": 1, "b": 2})
+    assert key_a == key_b
+
+
+def test_fingerprint_version_bump_changes_key():
+    """v1 and v2 must produce different keys even when args are
+    identical. This is the primary invalidation lever for shipping
+    logic changes to a decorated function."""
+    key_v1 = _cache_key("fn", 1, ("same",), {})
+    key_v2 = _cache_key("fn", 2, ("same",), {})
+    assert key_v1 != key_v2
+
+
+def test_fingerprint_function_name_changes_key():
+    """Renaming a decorated function (or refactoring it into a different
+    module) invalidates its cache namespace. This is correct behavior —
+    the cache key is scoped to the fully-qualified name."""
+    key_a = _cache_key("module_a.fn", 1, ("x",), {})
+    key_b = _cache_key("module_b.fn", 1, ("x",), {})
+    assert key_a != key_b


### PR DESCRIPTION
## Summary

Wedge implementation of BicameralAI/bicameral-daemon#35 (v1 §6 execution layer) targeting the **engineering lever** of the "tool froze" UX problem Jin called out 2026-05-20. Ships a content-addressed memoization primitive plus two wired transforms.

Closes BicameralAI/bicameral-daemon#35 (partial — see "What's deferred" below). Composes with BicameralAI/bicameral-daemon#20 (product-side subset selection) for the full UX fix.

## Plan-driven shape

| Step | Commit | Deliverable | Measured lift |
|---|---|---|---|
| 1 | `e3719f3` | `codegenome/_content_cache.py` primitive + 40 sociable tests | infrastructure |
| 2 | `fb4ffe6` | Wire `classify_drift` + 11 equivalence tests + `eval_136_per_check_latency.py` | **88% reduction** on large_cosmetic (5.28ms → 0.63ms) |
| 3 | `7df2c4b` | Wire `categorize_diff` | **84% reduction** on large_cosmetic (3.85ms → 0.62ms) |
| 4 | — | **Declined** — measurement showed cache overhead > baseline cost on `governance.evaluate` (150x slowdown). Plan doc updated with rationale. |

## Final M_per_check_latency (warm cache, n=100 per cell)

```
classify_drift  [WIRED]
  cosmetic        cold 3.45ms → warm 0.65ms  (81% reduction)
  large_cosmetic  cold 6.30ms → warm 0.64ms  (90% reduction)
  structural      cold 2.81ms → warm 0.58ms  (79% reduction)

categorize_diff  [WIRED]
  cosmetic        cold 2.65ms → warm 0.70ms  (74% reduction)
  large_cosmetic  cold 4.00ms → warm 0.61ms  (85% reduction)
  structural      cold 1.77ms → warm 0.63ms  (65% reduction)

governance.evaluate  [BASELINE — declined, see Step 4]
  typical         cold 0.006ms → warm 0.004ms
```

**Gate**: `warm p50 ≤ 10ms` (Jin's BicameralAI/bicameral-daemon#35 target) — **PASS on every wired cell.**

## Why NOT CocoIndex (issue body asked for it)

Three findings from research drove the scope shift:

1. **Wrong call shape.** CocoIndex is source-driven (flow → row scope → target table). The drift/identity/policy services are RPC-shaped (handler invokes them synchronously per request). The `@op.function(cache=True)` decorator exists but is documented for in-flow use; lifting it out of a flow context is not a documented pattern. The in-repo precedent (`code_locator/indexing/cocoindex_pipeline.py`) uses CocoIndex strictly as a flow framework.
2. **Cache size blowup.** [cocoindex#1779](https://github.com/cocoindex-io/cocoindex/issues/1779) reports per-function cache tables ballooning to 17 GB (projected 190 GB at 200-repo scale). Our payloads are smaller, but the lesson holds: per-function cache without explicit size + key budgets is a footgun.
3. **Daemon Phase 2c-6 ownership.** Per PR BicameralAI/bicameral-mcp#487's D1 commitment ("daemon owns grounding compute"), pre-committing the daemon to CocoIndex is a decision better made inside that boundary by its designer. A self-contained 200-LOC primitive that ports cleanly is the right wedge shape — when 2c-6 lands and `codegenome/` moves into `daemon/`, the cache travels untouched. Only the path constant changes.

## Honest trade-offs

- **Cache hurts on tiny inputs.** Compute < SQLite roundtrip (~0.6ms): the wrapper makes things slower. 70-90% wins materialize at production-realistic body sizes (50-200+ LOC functions), which are the actual UX-relevant inputs.
- **Doesn't directly avoid LLM round-trips.** The cache reduces server-side compute. Caller-LLM verdict resolution (the bigger ~1-3s per check) is mediated by `drift_service`'s existing auto-resolution path — this PR makes that path's outcome stable + faster on re-sweep.
- **Step 4 declined.** `governance.evaluate` baseline is 0.004ms (pure CPU on pre-built Pydantic models). Cache overhead would be 150x slower than baseline. The eval-after-each-step methodology surfaced this; the plan was revised accordingly.

## Cache primitive design highlights

- **SQLite + WAL** for multi-process safety. Per-call connection (no pool — premature for the expected per-request rate).
- **Allowlist arg types** (`str | int | float | bool | None | tuple | frozenset | dict[str, primitive]`). Validated at every call, fail-loud per project doctrine.
- **`behavior_version` mandatory** on the decorator. Bump on any logic change. Snapshot test in `tests/test_content_cache_fingerprint.py` pins canonical fingerprints — accidental serialization drift fails CI.
- **`get` returns `(hit, value)` tuple** so a cached `None` is a hit, not a miss. Important for the classifier's None-input paths.
- **LRU eviction by (hits, created_at)** when total bytes > 100 MB cap.
- **Default cache path** resolution: `$BICAMERAL_CONTENT_CACHE_PATH` → `~/.bicameral/content_cache.db`. Daemon Phase 2c-6 will repoint to the locator-resolved per-project path.
- **Async refused at decorator-bind time** — wedge scope intentionally synchronous (the async services entangle with ledger writes).

## What's deferred

Per the plan, these stay for inside-daemon work after Phase 2c-6:

- `bind_service.write_codegenome_identity` — async, ledger-write side effects.
- `continuity_service.evaluate_continuity_for_drift` — async, 7-step ledger-write sequence on a match.
- `drift_service.evaluate_drift_classification` — async wrapper; **inner `classify_drift` IS memoized** by this PR.
- LLM-judge memoization (Phase 2 of the deterministic pre-classifier).

## Test surface (sociable per CLAUDE.md)

- `tests/test_content_cache.py` — 33 tests (primitive + decorator + concurrency + corruption-self-heal + dataclass roundtrip)
- `tests/test_content_cache_fingerprint.py` — 7 tests (snapshot pins for canonical serialization)
- `tests/test_classify_drift_cached.py` — 14 tests (behavior equivalence across Python + 6 supported non-Python languages + cache participation + normalization neutrality + cache key partitioning)
- `tests/eval_136_per_check_latency.py` — CLI eval with warn/hard gate modes

All tests use real SQLite via `tmp_path`. No `MagicMock`.

## Plan / refs

- Internal plan: `plan-136-content-cache-wedge.md` (gitignored per qor convention)
- Issue: BicameralAI/bicameral-daemon#35 (CocoIndex execution layer — wedge-scoped subset)
- Composes with: BicameralAI/bicameral-daemon#20 (server-side subset selection)
- Sequencing: Daemon Phase 2c-6 (#372 / BicameralAI/bicameral-daemon#16) will move `codegenome/` into `daemon/`; cache primitive ports untouched

## Test plan

- [x] `pytest tests/test_content_cache.py tests/test_content_cache_fingerprint.py tests/test_classify_drift_cached.py` — 54/54 passing
- [x] `pytest tests/test_codegenome_drift_classifier.py tests/test_codegenome_drift_service.py` — 48/49 (1 pre-existing unrelated elixir-mismatch baseline)
- [x] `python tests/eval_136_per_check_latency.py -n 100` — gate PASS
- [x] `ruff check codegenome/ tests/test_content_cache*.py tests/test_classify_drift_cached.py tests/eval_136_per_check_latency.py` — clean
- [x] `ruff format --check` — clean
- [x] `mypy codegenome/_content_cache.py codegenome/drift_classifier.py codegenome/diff_categorizer.py` — clean
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)