### PR TITLE
feat(handlers): mutation writes routed through DaemonProxy (Phase 2c-6c)

### DIFF
--- a/daemon/proxy.py
+++ b/daemon/proxy.py
@@ -457,3 +457,111 @@ class DaemonProxy:
                 "ref": ref,
             },
         )
+
+    # ── Mutation writes (Phase 2c-6c) ────────────────────────────────────
+
+    async def ratify(
+        self,
+        *,
+        repo_id: str,
+        decision_id: str,
+        signer: str,
+        note: str = "",
+        action: str = "ratify",
+        preflight_id: str | None = None,
+    ) -> dict[str, Any]:
+        """Invoke ``write.ratify`` on the daemon and return the raw payload.
+
+        Routes signoff writes through the daemon's single-writer queue so
+        concurrent ratify calls serialize correctly. The MCP-side
+        ``handle_ratify`` facade wraps this dict into a ``RatifyResponse``.
+        """
+        return await self._call_with_retry(
+            "write.ratify",
+            {
+                "repo_id": repo_id,
+                "decision_id": decision_id,
+                "signer": signer,
+                "note": note,
+                "action": action,
+                "preflight_id": preflight_id,
+            },
+        )
+
+    async def resolve_compliance(
+        self,
+        *,
+        repo_id: str,
+        phase: str,
+        verdicts: list[dict[str, Any]],
+        commit_hash: str | None = None,
+        flow_id: str | None = None,
+    ) -> dict[str, Any]:
+        """Invoke ``write.resolve_compliance`` on the daemon and return the raw payload.
+
+        Compliance verdict writes go through the daemon's single-writer queue.
+        The MCP-side ``handle_resolve_compliance`` facade wraps this dict into
+        a ``ResolveComplianceResponse``.
+        """
+        return await self._call_with_retry(
+            "write.resolve_compliance",
+            {
+                "repo_id": repo_id,
+                "phase": phase,
+                "verdicts": verdicts,
+                "commit_hash": commit_hash,
+                "flow_id": flow_id,
+            },
+        )
+
+    async def resolve_collision(
+        self,
+        *,
+        repo_id: str,
+        new_id: str | None = None,
+        old_id: str | None = None,
+        action: str | None = None,
+        span_id: str | None = None,
+        decision_id: str | None = None,
+        confirmed: bool | None = None,
+    ) -> dict[str, Any]:
+        """Invoke ``write.resolve_collision`` on the daemon and return the raw payload.
+
+        Collision resolution writes go through the daemon's single-writer queue.
+        The MCP-side ``handle_resolve_collision`` facade wraps this dict into
+        a ``ResolveCollisionResponse``.
+        """
+        return await self._call_with_retry(
+            "write.resolve_collision",
+            {
+                "repo_id": repo_id,
+                "new_id": new_id,
+                "old_id": old_id,
+                "action": action,
+                "span_id": span_id,
+                "decision_id": decision_id,
+                "confirmed": confirmed,
+            },
+        )
+
+    async def judge_gaps(
+        self,
+        *,
+        repo_id: str,
+        topic: str,
+        max_decisions: int = 10,
+    ) -> dict[str, Any]:
+        """Invoke ``write.judge_gaps`` on the daemon and return the raw payload.
+
+        The MCP-side ``handle_judge_gaps`` facade wraps this dict through
+        ``JudgeGapsResult.model_validate`` and deserializes the nested
+        ``GapJudgmentPayload`` (or returns ``None`` on the empty path).
+        """
+        return await self._call_with_retry(
+            "write.judge_gaps",
+            {
+                "repo_id": repo_id,
+                "topic": topic,
+                "max_decisions": max_decisions,
+            },
+        )

--- a/handlers/gap_judge.py
+++ b/handlers/gap_judge.py
@@ -1,5 +1,11 @@
 """Handler for /bicameral_judge_gaps MCP tool (v0.4.19 — business-only rubric).
 
+Phase 2c-6c: split into facade (handle_judge_gaps) + pure impl
+(_handle_judge_gaps_impl). The daemon's ``write.judge_gaps`` dispatcher calls
+``_handle_judge_gaps_impl`` directly; the MCP-side facade routes through
+``ctx.daemon.judge_gaps`` when available.
+
+
 Caller-session LLM gap judge. The server builds a structured context
 pack — decisions with source excerpts, cross-symbol related decision
 ids, phrasing-based gaps, and a 5-category rubric scoped to **business
@@ -29,6 +35,7 @@ from __future__ import annotations
 
 import logging
 from datetime import UTC, datetime
+from typing import Any
 
 from contracts import (
     DecisionMatch,
@@ -262,21 +269,34 @@ def _build_context_decisions(
 # ── Public handler ───────────────────────────────────────────────────
 
 
-@write_tool("write.judge_gaps")
-async def handle_judge_gaps(
+async def _handle_judge_gaps_impl(
+    ctx,
+    topic: str,
+    max_decisions: int = 10,
+) -> dict[str, Any]:
+    """Core judge_gaps logic — builds the gap judgment context pack.
+
+    Invoked by the daemon's ``write.judge_gaps`` protocol handler and by the
+    MCP-side facade when the daemon is not reachable.
+
+    Returns a dict with key ``payload`` (the serialized GapJudgmentPayload,
+    or None on the honest empty path).
+    """
+    result = await _handle_judge_gaps_core(ctx=ctx, topic=topic, max_decisions=max_decisions)
+    if result is None:
+        return {"payload": None}
+    return {"payload": result.model_dump()}
+
+
+async def _handle_judge_gaps_core(
     ctx,
     topic: str,
     max_decisions: int = 10,
 ) -> GapJudgmentPayload | None:
-    """Build the caller-session gap judgment pack for a topic.
+    """Internal core — returns a GapJudgmentPayload or None.
 
-    Returns ``None`` on the honest empty path — when no decisions
-    match the topic, there is nothing to judge. The caller should
-    skip rendering entirely rather than render an empty pack.
-
-    Never calls an LLM. The returned payload contains the rubric
-    and the judgment prompt; the caller's Claude session does the
-    reasoning in its own LLM context.
+    Both ``_handle_judge_gaps_impl`` and ``handle_judge_gaps`` delegate here
+    to share the full body without duplication.
     """
     search_result: SearchDecisionsResponse = await handle_search_decisions(
         ctx,
@@ -299,3 +319,47 @@ async def handle_judge_gaps(
         rubric=_build_rubric(),
         judgment_prompt=_JUDGMENT_PROMPT,
     )
+
+
+@write_tool("write.judge_gaps")
+async def handle_judge_gaps(
+    ctx,
+    topic: str,
+    max_decisions: int = 10,
+) -> GapJudgmentPayload | None:
+    """Build the caller-session gap judgment pack for a topic.
+
+    Returns ``None`` on the honest empty path — when no decisions
+    match the topic, there is nothing to judge. The caller should
+    skip rendering entirely rather than render an empty pack.
+
+    Never calls an LLM. The returned payload contains the rubric
+    and the judgment prompt; the caller's Claude session does the
+    reasoning in its own LLM context.
+
+    Phase 2c-6c: if ``ctx.daemon`` is reachable, routes through the daemon.
+    Falls through to ``_handle_judge_gaps_core`` otherwise.
+    """
+    daemon = getattr(ctx, "daemon", None)
+
+    if daemon is not None:
+        try:
+            from protocol.contracts import JudgeGapsResult
+
+            repo_id = getattr(ctx, "repo_id", None) or "local"
+            raw = await daemon.judge_gaps(
+                repo_id=repo_id,
+                topic=topic,
+                max_decisions=max_decisions,
+            )
+            result = JudgeGapsResult.model_validate(raw)
+            if result.payload is None:
+                return None
+            return GapJudgmentPayload.model_validate(result.payload)
+        except Exception:
+            logger.debug(
+                "[handle_judge_gaps] daemon call failed, falling through to in-process impl",
+                exc_info=True,
+            )
+
+    return await _handle_judge_gaps_core(ctx=ctx, topic=topic, max_decisions=max_decisions)

--- a/handlers/ratify.py
+++ b/handlers/ratify.py
@@ -9,12 +9,17 @@ that returns the existing signoff with was_new=False.
 
 No unratify. Rescinding ratification or rejection requires writing a new
 decision that supersedes the previous one — clean audit trail, no rollback.
+
+Phase 2c-6c: split into facade (handle_ratify) + pure impl (_handle_ratify_impl).
+The daemon's ``write.ratify`` dispatcher calls ``_handle_ratify_impl`` directly;
+the MCP-side facade routes through ``ctx.daemon.ratify`` when available.
 """
 
 from __future__ import annotations
 
 import logging
 from datetime import UTC, datetime
+from typing import Any
 
 from contracts import RatifyResponse
 from ledger.queries import decision_exists, project_decision_status
@@ -24,8 +29,7 @@ from protocol.categorization import write_tool
 logger = logging.getLogger(__name__)
 
 
-@write_tool("write.ratify")
-async def handle_ratify(
+async def _handle_ratify_impl(
     ctx,
     decision_id: str,
     signer: str,
@@ -33,16 +37,11 @@ async def handle_ratify(
     action: str = "ratify",
     *,
     preflight_id: str | None = None,
-) -> RatifyResponse:
-    """Set signoff on a decision.
+) -> dict[str, Any]:
+    """Core ratify logic — ledger mutation, telemetry emit.
 
-    action='ratify' (default): proposed → ratified. Drift tracking activates.
-    action='reject': records explicit rejection. The decision stays in the
-    ledger as a negative signal — agents consult it to avoid implementing
-    decisions the product team has explicitly rejected.
-
-    Idempotent: calling with the same action on an already-finalized decision
-    returns was_new=False and leaves the existing signoff untouched.
+    Invoked by the daemon's ``write.ratify`` protocol handler and by the
+    MCP-side facade when the daemon is not reachable.
     """
     if action not in ("ratify", "reject"):
         raise ValueError(f"Unknown action '{action}'; must be 'ratify' or 'reject'")
@@ -84,7 +83,7 @@ async def handle_ratify(
             signoff=existing_signoff,
             projected_status=projected,
             preflight_id=preflight_id,
-        )
+        ).model_dump()
 
     head_ref = getattr(ctx, "authoritative_sha", "") or ""
     session_id = getattr(ctx, "session_id", None) or ""
@@ -136,4 +135,67 @@ async def handle_ratify(
         signoff=signoff,
         projected_status=projected,
         preflight_id=preflight_id,
+    ).model_dump()
+
+
+@write_tool("write.ratify")
+async def handle_ratify(
+    ctx,
+    decision_id: str,
+    signer: str,
+    note: str = "",
+    action: str = "ratify",
+    *,
+    preflight_id: str | None = None,
+) -> RatifyResponse:
+    """Set signoff on a decision.
+
+    action='ratify' (default): proposed → ratified. Drift tracking activates.
+    action='reject': records explicit rejection. The decision stays in the
+    ledger as a negative signal — agents consult it to avoid implementing
+    decisions the product team has explicitly rejected.
+
+    Idempotent: calling with the same action on an already-finalized decision
+    returns was_new=False and leaves the existing signoff untouched.
+
+    Phase 2c-6c: if ``ctx.daemon`` is reachable, routes through the daemon's
+    single-writer queue. Falls through to ``_handle_ratify_impl`` otherwise.
+    """
+    daemon = getattr(ctx, "daemon", None)
+
+    if daemon is not None:
+        try:
+            from protocol.contracts import RatifyResult
+
+            repo_id = getattr(ctx, "repo_id", None) or "local"
+            raw = await daemon.ratify(
+                repo_id=repo_id,
+                decision_id=decision_id,
+                signer=signer,
+                note=note,
+                action=action,
+                preflight_id=preflight_id,
+            )
+            result = RatifyResult.model_validate(raw)
+            return RatifyResponse(
+                decision_id=result.decision_id,
+                was_new=result.was_new,
+                signoff=result.signoff,
+                projected_status=result.projected_status,  # type: ignore[arg-type]
+                preflight_id=None,
+            )
+        except Exception:
+            logger.debug(
+                "[handle_ratify] daemon call failed, falling through to in-process impl",
+                exc_info=True,
+            )
+
+    raw = await _handle_ratify_impl(
+        ctx=ctx,
+        decision_id=decision_id,
+        signer=signer,
+        note=note,
+        action=action,
+        preflight_id=preflight_id,
     )
+    return RatifyResponse.model_validate(raw)

--- a/handlers/resolve_collision.py
+++ b/handlers/resolve_collision.py
@@ -16,12 +16,18 @@ Dual-mode HITL resolution tool:
 
 Decision.status is NEVER changed directly by this tool. It is recomputed via
 project_decision_status (the double-entry authority) after each action.
+
+Phase 2c-6c: split into facade (handle_resolve_collision) + pure impl
+(_handle_resolve_collision_impl). The daemon's ``write.resolve_collision``
+dispatcher calls ``_handle_resolve_collision_impl`` directly; the MCP-side
+facade routes through ``ctx.daemon.resolve_collision`` when available.
 """
 
 from __future__ import annotations
 
 import logging
 from datetime import UTC, datetime
+from typing import Any
 
 from contracts import ResolveCollisionResponse
 from ledger.queries import (
@@ -35,8 +41,7 @@ from protocol.categorization import write_tool
 logger = logging.getLogger(__name__)
 
 
-@write_tool("write.resolve_collision")
-async def handle_resolve_collision(
+async def _handle_resolve_collision_impl(
     ctx,
     # Collision mode params
     new_id: str | None = None,
@@ -46,8 +51,38 @@ async def handle_resolve_collision(
     span_id: str | None = None,
     decision_id: str | None = None,
     confirmed: bool | None = None,
+) -> dict[str, Any]:
+    """Core resolve_collision logic — ledger mutation.
+
+    Invoked by the daemon's ``write.resolve_collision`` protocol handler and by
+    the MCP-side facade when the daemon is not reachable.
+    """
+    result = await _handle_resolve_collision_core(
+        ctx=ctx,
+        new_id=new_id,
+        old_id=old_id,
+        action=action,
+        span_id=span_id,
+        decision_id=decision_id,
+        confirmed=confirmed,
+    )
+    return result.model_dump()
+
+
+async def _handle_resolve_collision_core(
+    ctx,
+    new_id: str | None = None,
+    old_id: str | None = None,
+    action: str | None = None,
+    span_id: str | None = None,
+    decision_id: str | None = None,
+    confirmed: bool | None = None,
 ) -> ResolveCollisionResponse:
-    """Resolve a collision or context_for candidate surfaced during ingest."""
+    """Internal core — returns a ResolveCollisionResponse object.
+
+    Both ``_handle_resolve_collision_impl`` and ``handle_resolve_collision``
+    delegate here to share the full body without duplication.
+    """
     ledger = ctx.ledger
     if hasattr(ledger, "connect"):
         await ledger.connect()
@@ -177,4 +212,67 @@ async def handle_resolve_collision(
     raise ValueError(
         "resolve_collision requires either action= (collision mode) "
         "or confirmed= (context_for mode)"
+    )
+
+
+@write_tool("write.resolve_collision")
+async def handle_resolve_collision(
+    ctx,
+    # Collision mode params
+    new_id: str | None = None,
+    old_id: str | None = None,
+    action: str | None = None,  # 'supersede' | 'keep_both'
+    # Context-for mode params
+    span_id: str | None = None,
+    decision_id: str | None = None,
+    confirmed: bool | None = None,
+) -> ResolveCollisionResponse:
+    """Resolve a collision or context_for candidate surfaced during ingest.
+
+    Phase 2c-6c: if ``ctx.daemon`` is reachable, routes through the daemon's
+    single-writer queue. Falls through to ``_handle_resolve_collision_impl``
+    (via ``_handle_resolve_collision_core``) otherwise.
+    """
+    daemon = getattr(ctx, "daemon", None)
+
+    if daemon is not None:
+        try:
+            from protocol.contracts import ResolveCollisionResult
+
+            repo_id = getattr(ctx, "repo_id", None) or "local"
+            raw = await daemon.resolve_collision(
+                repo_id=repo_id,
+                new_id=new_id,
+                old_id=old_id,
+                action=action,
+                span_id=span_id,
+                decision_id=decision_id,
+                confirmed=confirmed,
+            )
+            result = ResolveCollisionResult.model_validate(raw)
+            return ResolveCollisionResponse(
+                mode=result.mode,  # type: ignore[arg-type]
+                action_taken=result.action_taken,
+                new_decision_id=result.new_decision_id,
+                old_decision_id=result.old_decision_id,
+                span_id=result.span_id,
+                decision_id=result.decision_id,
+                edge_written=result.edge_written,
+                new_status=result.new_status,
+                old_status=result.old_status,
+            )
+        except Exception:
+            logger.debug(
+                "[handle_resolve_collision] daemon call failed, falling through to in-process impl",
+                exc_info=True,
+            )
+
+    return await _handle_resolve_collision_core(
+        ctx=ctx,
+        new_id=new_id,
+        old_id=old_id,
+        action=action,
+        span_id=span_id,
+        decision_id=decision_id,
+        confirmed=confirmed,
     )

--- a/handlers/resolve_compliance.py
+++ b/handlers/resolve_compliance.py
@@ -1,5 +1,11 @@
 """Handler for /bicameral.resolve_compliance MCP tool — v0.5.0.
 
+Phase 2c-6c: split into facade (handle_resolve_compliance) + pure impl
+(_handle_resolve_compliance_impl). The daemon's ``write.resolve_compliance``
+dispatcher calls ``_handle_resolve_compliance_impl`` directly; the MCP-side
+facade routes through ``ctx.daemon.resolve_compliance`` when available.
+
+
 v0.5.0 changes from v0.4.x:
   - verdict field replaces compliant:bool with three-way enum
     ("compliant" | "drifted" | "not_relevant")
@@ -92,34 +98,39 @@ def _coerce_verdicts(raw: Iterable[dict | ComplianceVerdict]) -> list[Compliance
     return out
 
 
-@write_tool("write.resolve_compliance")
-async def handle_resolve_compliance(
+async def _handle_resolve_compliance_impl(
+    ctx,
+    phase: str,
+    verdicts: Iterable[dict | ComplianceVerdict],
+    commit_hash: str | None = None,
+    flow_id: str | None = None,
+) -> dict:
+    """Core resolve_compliance logic — ledger mutation.
+
+    Invoked by the daemon's ``write.resolve_compliance`` protocol handler and by
+    the MCP-side facade when the daemon is not reachable.
+    """
+    result = await _handle_resolve_compliance_core(
+        ctx=ctx,
+        phase=phase,
+        verdicts=verdicts,
+        commit_hash=commit_hash,
+        flow_id=flow_id,
+    )
+    return result.model_dump()
+
+
+async def _handle_resolve_compliance_core(
     ctx,
     phase: str,
     verdicts: Iterable[dict | ComplianceVerdict],
     commit_hash: str | None = None,
     flow_id: str | None = None,
 ) -> ResolveComplianceResponse:
-    """Persist a batch of caller-LLM compliance verdicts.
+    """Internal core — returns a ResolveComplianceResponse object.
 
-    Four-way verdict semantics (#405 added ``partial``):
-      "compliant"    — write compliance_check(verdict='compliant'), keep binds_to
-      "drifted"      — write compliance_check(verdict='drifted'), keep binds_to.
-                       REQUIRES a prior 'compliant' verdict for the same
-                       (decision_id, region_id) pair (reflected-before-drifted
-                       invariant). Otherwise the verdict is rejected with
-                       reason='state_transition_invalid' and the caller-LLM
-                       should downgrade to 'partial' and retry.
-      "partial"      — write compliance_check(verdict='partial'), keep binds_to.
-                       The correct verdict for binding-as-anchor-for-future-work
-                       and for any never-compliant region the caller would
-                       otherwise have called 'drifted'.
-      "not_relevant" — write compliance_check(verdict='not_relevant', pruned=True),
-                       DELETE the binds_to edge (retrieval mistake, not drift)
-
-    After the full batch is written, status for each affected decision is
-    re-projected holistically via project_decision_status (closes the
-    last-verdict-wins caveat from v0.4.x).
+    Both ``_handle_resolve_compliance_impl`` and ``handle_resolve_compliance``
+    delegate here to share the full body without duplication.
     """
     if phase not in _VALID_PHASES:
         raise ValueError(f"Unknown phase {phase!r} — must be one of {sorted(_VALID_PHASES)}")
@@ -329,4 +340,56 @@ async def handle_resolve_compliance(
         phase=phase,
         accepted=accepted,
         rejected=rejected,
+    )
+
+
+@write_tool("write.resolve_compliance")
+async def handle_resolve_compliance(
+    ctx,
+    phase: str,
+    verdicts: Iterable[dict | ComplianceVerdict],
+    commit_hash: str | None = None,
+    flow_id: str | None = None,
+) -> ResolveComplianceResponse:
+    """Persist a batch of caller-LLM compliance verdicts.
+
+    Phase 2c-6c: if ``ctx.daemon`` is reachable, routes through the daemon's
+    single-writer queue. Falls through to ``_handle_resolve_compliance_impl``
+    (via ``_handle_resolve_compliance_core``) otherwise.
+    """
+    daemon = getattr(ctx, "daemon", None)
+
+    if daemon is not None:
+        try:
+            from protocol.contracts import ResolveComplianceResult
+
+            repo_id = getattr(ctx, "repo_id", None) or "local"
+            verdicts_raw = [
+                v.model_dump() if isinstance(v, ComplianceVerdict) else v for v in verdicts
+            ]
+            raw = await daemon.resolve_compliance(
+                repo_id=repo_id,
+                phase=phase,
+                verdicts=verdicts_raw,
+                commit_hash=commit_hash,
+                flow_id=flow_id,
+            )
+            result = ResolveComplianceResult.model_validate(raw)
+            return ResolveComplianceResponse(
+                phase=result.phase,  # type: ignore[arg-type]
+                accepted=[ResolveComplianceAccepted.model_validate(a) for a in result.accepted],
+                rejected=[ResolveComplianceRejection.model_validate(r) for r in result.rejected],
+            )
+        except Exception:
+            logger.debug(
+                "[handle_resolve_compliance] daemon call failed, falling through to in-process impl",
+                exc_info=True,
+            )
+
+    return await _handle_resolve_compliance_core(
+        ctx=ctx,
+        phase=phase,
+        verdicts=verdicts,
+        commit_hash=commit_hash,
+        flow_id=flow_id,
     )

--- a/protocol/contracts.py
+++ b/protocol/contracts.py
@@ -308,6 +308,113 @@ class SkillEndResult(BaseModel):
     diagnostic_warning: str | None = None
 
 
+# ── Writes: mutation (ledger-mutating handlers) ────────────────────────
+
+
+class RatifyRequest(BaseModel):
+    """Wire payload for ``write.ratify``.
+
+    Routes signoff writes (ratify / reject) through the daemon's single-writer
+    queue. ``signer`` is the within-tenant actor; ``action`` defaults to
+    ``'ratify'`` (proposed → ratified) or ``'reject'`` (explicit rejection).
+    """
+
+    model_config = ConfigDict(extra="forbid")
+    repo_id: str
+    decision_id: str
+    signer: str
+    note: str = ""
+    action: str = "ratify"
+    preflight_id: str | None = None
+
+
+class RatifyResult(BaseModel):
+    model_config = ConfigDict(extra="ignore")
+    decision_id: str
+    was_new: bool
+    signoff: dict[str, Any]
+    projected_status: str
+
+
+class ResolveComplianceRequest(BaseModel):
+    """Wire payload for ``write.resolve_compliance``.
+
+    ``verdicts`` is a list of raw dicts — coercion to ``ComplianceVerdict``
+    happens inside the handler impl so the daemon's single-writer queue
+    receives the same raw shape the MCP handler already handles.
+    """
+
+    model_config = ConfigDict(extra="forbid")
+    repo_id: str
+    phase: str
+    verdicts: list[dict[str, Any]]
+    commit_hash: str | None = None
+    flow_id: str | None = None
+
+
+class ResolveComplianceResult(BaseModel):
+    model_config = ConfigDict(extra="ignore")
+    phase: str
+    accepted: list[dict[str, Any]] = Field(default_factory=list)
+    rejected: list[dict[str, Any]] = Field(default_factory=list)
+
+
+class ResolveCollisionRequest(BaseModel):
+    """Wire payload for ``write.resolve_collision``.
+
+    Dual-mode: set ``action`` for collision mode (new_id + old_id + action),
+    or set ``confirmed`` for context-for mode (span_id + decision_id).
+    """
+
+    model_config = ConfigDict(extra="forbid")
+    repo_id: str
+    # Collision mode
+    new_id: str | None = None
+    old_id: str | None = None
+    action: str | None = None
+    # Context-for mode
+    span_id: str | None = None
+    decision_id: str | None = None
+    confirmed: bool | None = None
+
+
+class ResolveCollisionResult(BaseModel):
+    model_config = ConfigDict(extra="ignore")
+    mode: str
+    action_taken: str
+    new_decision_id: str = ""
+    old_decision_id: str = ""
+    span_id: str = ""
+    decision_id: str = ""
+    edge_written: bool = False
+    new_status: str = ""
+    old_status: str = ""
+
+
+class JudgeGapsRequest(BaseModel):
+    """Wire payload for ``write.judge_gaps``.
+
+    Builds the caller-session gap judgment context pack. Pure data-shape
+    builder — no LLM call on the daemon side.
+    """
+
+    model_config = ConfigDict(extra="forbid")
+    repo_id: str
+    topic: str
+    max_decisions: int = Field(default=10, ge=1, le=100)
+
+
+class JudgeGapsResult(BaseModel):
+    """Result for ``write.judge_gaps``.
+
+    ``payload`` is ``None`` on the honest empty path (no decisions matched).
+    Otherwise it is the serialized ``GapJudgmentPayload`` dict.
+    """
+
+    model_config = ConfigDict(extra="ignore")
+    payload: dict[str, Any] | None = None
+
+
 # ── Adapter Protocols ──────────────────────────────────────────────────
 
 

--- a/protocol/handlers/writes.py
+++ b/protocol/handlers/writes.py
@@ -30,6 +30,14 @@ from protocol.contracts import (
     ConnectionContext,
     FeedbackRequest,
     FeedbackResult,
+    JudgeGapsRequest,
+    JudgeGapsResult,
+    RatifyRequest,
+    RatifyResult,
+    ResolveCollisionRequest,
+    ResolveCollisionResult,
+    ResolveComplianceRequest,
+    ResolveComplianceResult,
     SkillBeginRequest,
     SkillBeginResult,
     SkillEndRequest,
@@ -38,6 +46,18 @@ from protocol.contracts import (
 
 if TYPE_CHECKING:
     from protocol.server import ProtocolServer
+
+
+def _resolve_context(conn_ctx: ConnectionContext, repo_id: str):
+    """Build a ``BicameralContext`` for a write protocol handler.
+
+    Phase 2c-6c shim: mirrors the read-side ``_resolve_context`` in
+    ``protocol/handlers/reads.py``. Multi-repo resolution lands in 2c-3;
+    for now we always return ``BicameralContext.from_env()``.
+    """
+    from context import BicameralContext
+
+    return BicameralContext.from_env()
 
 
 async def handle_write_feedback(params: dict[str, Any], _ctx: ConnectionContext) -> dict[str, Any]:
@@ -91,8 +111,78 @@ async def handle_write_skill_end(params: dict[str, Any], _ctx: ConnectionContext
     return SkillEndResult.model_validate(raw).model_dump()
 
 
+async def handle_write_ratify(params: dict[str, Any], ctx: ConnectionContext) -> dict[str, Any]:
+    req = RatifyRequest.model_validate(params)
+    bctx = _resolve_context(ctx, req.repo_id)
+    # Call _handle_ratify_impl directly (not the facade) to avoid an
+    # infinite RPC loop: facade → daemon → this dispatcher → facade → …
+    from handlers.ratify import _handle_ratify_impl
+
+    raw = await _handle_ratify_impl(
+        ctx=bctx,
+        decision_id=req.decision_id,
+        signer=req.signer,
+        note=req.note,
+        action=req.action,
+        preflight_id=req.preflight_id,
+    )
+    return RatifyResult.model_validate(raw).model_dump()
+
+
+async def handle_write_resolve_compliance(
+    params: dict[str, Any], ctx: ConnectionContext
+) -> dict[str, Any]:
+    req = ResolveComplianceRequest.model_validate(params)
+    bctx = _resolve_context(ctx, req.repo_id)
+    # Call _handle_resolve_compliance_impl directly to avoid the RPC loop.
+    from handlers.resolve_compliance import _handle_resolve_compliance_impl
+
+    raw = await _handle_resolve_compliance_impl(
+        ctx=bctx,
+        phase=req.phase,
+        verdicts=req.verdicts,
+        commit_hash=req.commit_hash,
+        flow_id=req.flow_id,
+    )
+    return ResolveComplianceResult.model_validate(raw).model_dump()
+
+
+async def handle_write_resolve_collision(
+    params: dict[str, Any], ctx: ConnectionContext
+) -> dict[str, Any]:
+    req = ResolveCollisionRequest.model_validate(params)
+    bctx = _resolve_context(ctx, req.repo_id)
+    # Call _handle_resolve_collision_impl directly to avoid the RPC loop.
+    from handlers.resolve_collision import _handle_resolve_collision_impl
+
+    raw = await _handle_resolve_collision_impl(
+        ctx=bctx,
+        new_id=req.new_id,
+        old_id=req.old_id,
+        action=req.action,
+        span_id=req.span_id,
+        decision_id=req.decision_id,
+        confirmed=req.confirmed,
+    )
+    return ResolveCollisionResult.model_validate(raw).model_dump()
+
+
+async def handle_write_judge_gaps(params: dict[str, Any], ctx: ConnectionContext) -> dict[str, Any]:
+    req = JudgeGapsRequest.model_validate(params)
+    bctx = _resolve_context(ctx, req.repo_id)
+    # Call _handle_judge_gaps_impl directly to avoid the RPC loop.
+    from handlers.gap_judge import _handle_judge_gaps_impl
+
+    raw = await _handle_judge_gaps_impl(
+        ctx=bctx,
+        topic=req.topic,
+        max_decisions=req.max_decisions,
+    )
+    return JudgeGapsResult.model_validate(raw).model_dump()
+
+
 def register_write_handlers(server: ProtocolServer) -> None:
-    """Register every ``write.*`` telemetry method on ``server``.
+    """Register every ``write.*`` method on ``server``.
 
     Idempotent: re-registering overwrites the existing handler.
 
@@ -105,3 +195,8 @@ def register_write_handlers(server: ProtocolServer) -> None:
     server.register("write.feedback", handle_write_feedback)
     server.register("write.skill_begin", handle_write_skill_begin)
     server.register("write.skill_end", handle_write_skill_end)
+    # Mutation writes (Phase 2c-6c)
+    server.register("write.ratify", handle_write_ratify)
+    server.register("write.resolve_compliance", handle_write_resolve_compliance)
+    server.register("write.resolve_collision", handle_write_resolve_collision)
+    server.register("write.judge_gaps", handle_write_judge_gaps)

--- a/tests/test_mutation_writes_via_daemon.py
+++ b/tests/test_mutation_writes_via_daemon.py
@@ -1,0 +1,384 @@
+"""Phase 2c-6c boundary tests: mutation write handlers through a real daemon subprocess.
+
+Each test exercises the full call chain across the IPC boundary:
+
+    handle_ratify (facade in MCP process)
+        → ctx.daemon.ratify (DaemonProxy)
+            → ProtocolClient over UDS
+                → daemon subprocess
+                    → protocol/handlers/writes.handle_write_ratify
+                        → _handle_ratify_impl (in daemon's ledger)
+
+The boundary tests verify:
+1. Wire serialization — response round-trips through JSON.
+2. Dispatch shape — each dispatcher validates the request and returns the
+   typed result shape.
+3. Daemon=None fallthrough — facades degrade gracefully to in-process impls.
+4. Concurrency serialization — two concurrent ratify calls against the same
+   decision serialize through the daemon's single-writer queue.
+
+Cost: ~8s per daemon-subprocess test. Five tests ≈ 40s.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import os
+import subprocess
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+from daemon.proxy import DaemonProxy, DaemonUnreachableError
+from tests._daemon_fixture import daemon_subprocess, short_state_dir  # noqa: F401
+
+# ── Fixtures ────────────────────────────────────────────────────────────
+
+
+@pytest.fixture
+def fresh_ledger_repo(monkeypatch, tmp_path):
+    """A bare git repo + memory:// ledger. The daemon picks these up via
+    ``REPO_PATH`` / ``SURREAL_URL`` when ``BicameralContext.from_env`` runs."""
+    monkeypatch.setenv("SURREAL_URL", "memory://")
+    monkeypatch.setenv("REPO_PATH", str(tmp_path))
+    subprocess.run(["git", "init", "-q"], cwd=tmp_path, check=True)
+    subprocess.run(
+        ["git", "commit", "--allow-empty", "-q", "-m", "init"],
+        cwd=tmp_path,
+        check=True,
+        env={
+            **os.environ,
+            "GIT_AUTHOR_NAME": "t",
+            "GIT_AUTHOR_EMAIL": "t@t",
+            "GIT_COMMITTER_NAME": "t",
+            "GIT_COMMITTER_EMAIL": "t@t",
+        },
+    )
+    return tmp_path
+
+
+# ── Helpers ──────────────────────────────────────────────────────────────
+
+
+async def _seed_decision_via_daemon(proxy: DaemonProxy, *, repo_id: str = "local") -> str:
+    """Ingest a single decision through the daemon and return its decision_id.
+
+    Uses the protocol client directly (``read.history`` after ingest) to
+    retrieve the assigned id so tests don't need to talk to the local ledger.
+    """
+    # We can't call write.ingest here because it's not yet migrated to 2c-6c.
+    # Instead, seed through the in-process ledger that the daemon shares via
+    # BicameralContext.from_env() (same SURREAL_URL=memory:// env var).
+    import dataclasses
+
+    from adapters.ledger import reset_ledger_singleton
+    from context import BicameralContext
+    from handlers.ingest import handle_ingest
+
+    reset_ledger_singleton()
+    # Build a real BicameralContext (gives us code_graph, all guardrail
+    # fields, etc.) then null the daemon so the in-process facade falls
+    # through and seeds via the local ledger — no daemon recursion.
+    real_ctx = BicameralContext.from_env()
+    ctx = dataclasses.replace(real_ctx, daemon=None)
+    ledger = ctx.ledger
+
+    payload = {
+        "query": "We will use SQLite for the local dev database.",
+        "repo": ctx.repo_path,
+        "mappings": [
+            {
+                "span": {
+                    "source_type": "transcript",
+                    "text": "We will use SQLite for the local dev database.",
+                    "source_ref": "test-ref",
+                },
+                "intent": "We will use SQLite for the local dev database.",
+                "symbols": [],
+                "code_regions": [],
+            }
+        ],
+    }
+    resp = await handle_ingest(ctx, payload, ingest_mode="passive")
+    # IngestResponse exposes decisions through brief.decisions or stats.
+    brief = getattr(resp, "brief", None)
+    decisions = getattr(brief, "decisions", None) if brief else None
+    if decisions:
+        return decisions[0].id if hasattr(decisions[0], "id") else decisions[0].get("id")
+    # Fallback: probe the ledger directly for the most recent decision id
+    all_d = await ledger.get_all_decisions(filter="all")
+    assert all_d, f"ingest produced no decisions: resp={resp}"
+    return str(all_d[-1].get("decision_id") or all_d[-1].get("id"))
+
+
+# ── Proxy missing-descriptor guard ──────────────────────────────────────
+
+
+async def test_proxy_raises_when_no_descriptor_for_ratify(tmp_path):
+    """No daemon.json → DaemonUnreachableError with actionable hint."""
+    proxy = DaemonProxy(
+        descriptor_path=tmp_path / "daemon.json",
+        auth_path=tmp_path / "auth.json",
+    )
+    with pytest.raises(DaemonUnreachableError) as exc_info:
+        await proxy.ratify(
+            repo_id="local",
+            decision_id="decision:abc123",
+            signer="test@example.com",
+        )
+    msg = str(exc_info.value)
+    assert "bicameral-mcp setup" in msg
+    assert "bicameral-mcp daemon start" in msg
+
+
+# ── Ratify boundary test ─────────────────────────────────────────────────
+
+
+@pytest.mark.skip(
+    reason="Requires shared ledger state between test process and daemon subprocess. "
+    "Re-enable after Phase 2c-6b lands write.ingest so we can seed via the daemon."
+)
+async def test_ratify_through_daemon(daemon_subprocess, fresh_ledger_repo, tmp_path):
+    """End-to-end: ingest a decision then ratify it through the daemon.
+
+    Verifies the ratify dispatcher returns the correct typed shape and
+    that was_new=True on first ratification.
+    """
+    proxy = DaemonProxy(
+        descriptor_path=daemon_subprocess.socket_path.parent / "daemon.json",
+        auth_path=tmp_path / "no-auth.json",
+    )
+    try:
+        decision_id = await _seed_decision_via_daemon(proxy, repo_id="local")
+
+        raw = await proxy.ratify(
+            repo_id="local",
+            decision_id=decision_id,
+            signer="agent@bicameral.ai",
+            note="ratified in boundary test",
+            action="ratify",
+        )
+
+        # Typed shape validation
+        from protocol.contracts import RatifyResult
+
+        result = RatifyResult.model_validate(raw)
+        assert result.decision_id == decision_id
+        assert result.was_new is True
+        assert isinstance(result.signoff, dict)
+        assert result.signoff.get("state") == "ratified"
+        assert result.projected_status in (
+            "reflected",
+            "drifted",
+            "partial",
+            "pending",
+            "ungrounded",
+        )
+    finally:
+        await proxy.close()
+
+
+@pytest.mark.skip(
+    reason="Requires shared ledger state. Re-enable after Phase 2c-6b lands write.ingest."
+)
+async def test_ratify_idempotent_through_daemon(daemon_subprocess, fresh_ledger_repo, tmp_path):
+    """Ratify twice — second call returns was_new=False (idempotency)."""
+    proxy = DaemonProxy(
+        descriptor_path=daemon_subprocess.socket_path.parent / "daemon.json",
+        auth_path=tmp_path / "no-auth.json",
+    )
+    try:
+        decision_id = await _seed_decision_via_daemon(proxy, repo_id="local")
+
+        raw1 = await proxy.ratify(
+            repo_id="local",
+            decision_id=decision_id,
+            signer="agent@bicameral.ai",
+            action="ratify",
+        )
+        raw2 = await proxy.ratify(
+            repo_id="local",
+            decision_id=decision_id,
+            signer="agent@bicameral.ai",
+            action="ratify",
+        )
+
+        from protocol.contracts import RatifyResult
+
+        r1 = RatifyResult.model_validate(raw1)
+        r2 = RatifyResult.model_validate(raw2)
+        assert r1.was_new is True
+        assert r2.was_new is False
+        assert r2.signoff.get("state") == "ratified"
+    finally:
+        await proxy.close()
+
+
+# ── Concurrent ratify serialization test ────────────────────────────────
+
+
+@pytest.mark.skip(
+    reason="Requires shared ledger state. Re-enable after Phase 2c-6b lands write.ingest "
+    "so we can seed a decision via the daemon for the concurrency probe."
+)
+async def test_concurrent_ratify_serializes_through_daemon(
+    daemon_subprocess, fresh_ledger_repo, tmp_path
+):
+    """Two concurrent ratify calls for the same decision serialize correctly.
+
+    Expected behavior: both calls complete without error. The first sets
+    was_new=True; the second observes the already-ratified state and returns
+    was_new=False (idempotency). The daemon's single-writer queue ensures
+    both calls produce a valid final state — no lost-update or
+    torn-read anomaly.
+    """
+    proxy = DaemonProxy(
+        descriptor_path=daemon_subprocess.socket_path.parent / "daemon.json",
+        auth_path=tmp_path / "no-auth.json",
+    )
+    try:
+        decision_id = await _seed_decision_via_daemon(proxy, repo_id="local")
+
+        raw1, raw2 = await asyncio.gather(
+            proxy.ratify(
+                repo_id="local",
+                decision_id=decision_id,
+                signer="agent-a@bicameral.ai",
+                action="ratify",
+            ),
+            proxy.ratify(
+                repo_id="local",
+                decision_id=decision_id,
+                signer="agent-b@bicameral.ai",
+                action="ratify",
+            ),
+        )
+
+        from protocol.contracts import RatifyResult
+
+        r1 = RatifyResult.model_validate(raw1)
+        r2 = RatifyResult.model_validate(raw2)
+
+        # Both results must be valid typed shapes
+        assert r1.decision_id == decision_id
+        assert r2.decision_id == decision_id
+
+        # One must have won (was_new=True), the other must see idempotency
+        was_new_values = {r1.was_new, r2.was_new}
+        # Acceptable outcomes: (True, False) or both False (if they raced to the
+        # same tick), but never both True (that would be a double-write anomaly).
+        # Both False can only happen if a third write intervened; for a clean
+        # two-call race, exactly one should be True.
+        assert True in was_new_values, (
+            f"Neither call reported was_new=True — unexpected: {r1}, {r2}"
+        )
+        assert r1.signoff.get("state") == "ratified"
+        assert r2.signoff.get("state") == "ratified"
+    finally:
+        await proxy.close()
+
+
+# ── ResolveCompliance boundary test ─────────────────────────────────────
+
+
+async def test_resolve_compliance_through_daemon(daemon_subprocess, fresh_ledger_repo, tmp_path):
+    """write.resolve_compliance dispatches and returns the typed shape.
+
+    We submit an empty verdicts list (valid — just re-projects existing
+    statuses) to validate the dispatcher without needing to fabricate a
+    real decision + region pair.
+    """
+    proxy = DaemonProxy(
+        descriptor_path=daemon_subprocess.socket_path.parent / "daemon.json",
+        auth_path=tmp_path / "no-auth.json",
+    )
+    try:
+        raw = await proxy.resolve_compliance(
+            repo_id="local",
+            phase="ingest",
+            verdicts=[],  # empty batch — valid, no-op
+        )
+
+        from protocol.contracts import ResolveComplianceResult
+
+        result = ResolveComplianceResult.model_validate(raw)
+        assert result.phase == "ingest"
+        assert result.accepted == []
+        assert result.rejected == []
+    finally:
+        await proxy.close()
+
+
+# ── ResolveCollision boundary test ───────────────────────────────────────
+
+
+async def test_resolve_collision_through_daemon_invalid_raises(
+    daemon_subprocess, fresh_ledger_repo, tmp_path
+):
+    """write.resolve_collision with unknown decision_id returns a protocol error.
+
+    This verifies the dispatcher reaches the impl and domain validation runs.
+    """
+    from protocol.contracts import ProtocolError
+
+    proxy = DaemonProxy(
+        descriptor_path=daemon_subprocess.socket_path.parent / "daemon.json",
+        auth_path=tmp_path / "no-auth.json",
+    )
+    try:
+        with pytest.raises((ProtocolError, Exception)):
+            # Supplying a non-existent new_id with action='keep_both' will
+            # reach the impl and raise ValueError("No decision row for ...").
+            # The dispatcher surfaces this as a ProtocolError on the wire.
+            await proxy.resolve_collision(
+                repo_id="local",
+                new_id="decision:nonexistent123",
+                old_id="decision:nonexistent456",
+                action="keep_both",
+            )
+    finally:
+        await proxy.close()
+
+
+# ── JudgeGaps boundary test ──────────────────────────────────────────────
+
+
+async def test_judge_gaps_through_daemon_empty_ledger(
+    daemon_subprocess, fresh_ledger_repo, tmp_path
+):
+    """write.judge_gaps on an empty ledger returns payload=None (honest empty path)."""
+    proxy = DaemonProxy(
+        descriptor_path=daemon_subprocess.socket_path.parent / "daemon.json",
+        auth_path=tmp_path / "no-auth.json",
+    )
+    try:
+        raw = await proxy.judge_gaps(
+            repo_id="local",
+            topic="database migration strategy",
+        )
+
+        from protocol.contracts import JudgeGapsResult
+
+        result = JudgeGapsResult.model_validate(raw)
+        # Empty ledger → no decisions → honest empty path
+        assert result.payload is None
+    finally:
+        await proxy.close()
+
+
+# ── Dispatcher registration ──────────────────────────────────────────────
+
+
+def test_mutation_write_handlers_registered(tmp_path):
+    """All four mutation dispatchers are registered on the server."""
+    from protocol.handlers.writes import register_write_handlers
+    from protocol.server import ProtocolServer
+
+    server = ProtocolServer(tmp_path / "d.sock")
+    register_write_handlers(server)
+
+    assert "write.ratify" in server._methods
+    assert "write.resolve_compliance" in server._methods
+    assert "write.resolve_collision" in server._methods
+    assert "write.judge_gaps" in server._methods


### PR DESCRIPTION
## Summary

Phase 2c-6c — third write-migration layer. Adds protocol surface + dispatcher + proxy methods for the four mutation handlers (ratify, resolve_compliance, resolve_collision, judge_gaps). Each gets the standard facade/_impl split.

## Plan refs
- Arc: \`thoughts/shared/plans/2026-05-22-daemon-as-process-arc.md\`
- Predecessors: BicameralAI/bicameral-mcp#510, BicameralAI/bicameral-mcp#511, BicameralAI/bicameral-mcp#514
- Parent epic: BicameralAI/bicameral-daemon#16

## Test plan
- [x] \`pytest tests/test_mutation_writes_via_daemon.py\` — 5 passed, 3 skipped (~51s)
- [x] \`ruff format --check . && ruff check .\` clean
- [ ] CI green on dev (merging on lint-only per @jinhongkuan directive)

## Skipped tests
Three end-to-end ratify boundary tests (\`test_ratify_through_daemon\`, \`test_ratify_idempotent_through_daemon\`, \`test_concurrent_ratify_serializes_through_daemon\`) are intentionally skipped — they require seeding a decision in a ledger shared between the test process and the daemon subprocess, which is unblocked once Phase 2c-6b lands \`write.ingest\`. Skip-reasons cite the dependency explicitly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)