### PR TITLE
feat(ci): no format-only commits in PR history (#357 sub-task 3 AC3)

### DIFF
--- a/.github/workflows/lint-and-typecheck.yml
+++ b/.github/workflows/lint-and-typecheck.yml
@@ -48,6 +48,68 @@ jobs:
           echo "git add -u && git commit --amend --no-edit  # or new commit" >> $GITHUB_STEP_SUMMARY
           echo '```' >> $GITHUB_STEP_SUMMARY
           exit 1
+      - name: No format-only commits in PR history (#357 sub-task 3 AC3)
+        # Fails the PR if its commit history contains a follow-up
+        # ruff-format / lint-fix-only commit (style:, chore(format),
+        # chore(lint), ci(lint) prefixes). The presence of such a commit
+        # is proof that the contributor pushed without running the
+        # pre-commit hook locally — the failure mode #357 sub-task 3
+        # exists to prevent.
+        #
+        # Three style: format commits landed AFTER the pre-commit infra
+        # itself shipped (553c15f, 2026-05-15):
+        #   - 3624482 style: ruff format the #368 diff
+        #   - 2a9ae8a style: ruff format the v25 migration backfill test
+        #   - 8c4bd47 style: ruff format the schema fix files
+        # i.e., shipping pre-commit-config.yaml alone wasn't sufficient.
+        # This gate closes the loop: clean history is enforced at PR
+        # time, contributors discover pre-commit through the failure.
+        #
+        # Escape hatch: rebase and squash format commits into their
+        # source commits before re-pushing. The error message names the
+        # offending SHAs + the recovery command.
+        #
+        # --no-merges so a PR that merges from base (and inadvertently
+        # includes someone ELSE's prior style: commit) doesn't get
+        # blamed. Only commits unique to the PR side count.
+        run: |
+          git fetch origin "${{ github.base_ref }}" --depth=200
+          OFFENDERS=$(git log --no-merges --format='%h %s' \
+            "origin/${{ github.base_ref }}...HEAD" |
+            grep -iE '^[a-f0-9]+ (style:|chore\(format\)|chore\(lint\)|ci\(lint\)).*(ruff|format|lint)' || true)
+          if [ -n "$OFFENDERS" ]; then
+            echo "::error::Format-only commits detected in PR history:"
+            echo "$OFFENDERS" | while IFS= read -r line; do
+              echo "::error::  $line"
+            done
+            echo "::error::"
+            echo "::error::These should have been caught by the pre-commit hook before push."
+            echo "::error::Install once per clone:"
+            echo "::error::  pip install pre-commit && pre-commit install"
+            echo "::error::Then squash the format commits into their source commits before re-pushing."
+            {
+              echo "## Format-only commits detected — pre-commit hook would have prevented this"
+              echo ""
+              echo "Offending commits:"
+              echo '```'
+              echo "$OFFENDERS"
+              echo '```'
+              echo ""
+              echo "Install pre-commit locally so this never happens again:"
+              echo '```bash'
+              echo "pip install pre-commit && pre-commit install"
+              echo '```'
+              echo ""
+              echo "Then rebase + squash the format commits into their source commits:"
+              echo '```bash'
+              echo "git rebase -i origin/${{ github.base_ref }}"
+              echo "# mark each style: / chore(format): commit as 'fixup' or 'squash'"
+              echo "git push --force-with-lease"
+              echo '```'
+            } >> "$GITHUB_STEP_SUMMARY"
+            exit 1
+          fi
+
       - name: Plan-grounding lint (#114 Check A)
         # Only lints plan-*.md files modified in this PR — historical
         # plans that referenced now-deleted files would otherwise block

--- a/.github/workflows/lint-and-typecheck.yml
+++ b/.github/workflows/lint-and-typecheck.yml
@@ -10,6 +10,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+        with:
+          # Full history needed for the "No format-only commits in PR
+          # history" step below (#357 sub-task 3 AC3). With the default
+          # depth=1, the PR side has no common ancestor with origin/dev,
+          # so the `origin/dev..HEAD` range falls back to listing every
+          # commit on dev — false positives across the whole repo history.
+          fetch-depth: 0
       - uses: actions/setup-python@v5
         with:
           python-version: '3.11'
@@ -72,10 +79,16 @@ jobs:
         # --no-merges so a PR that merges from base (and inadvertently
         # includes someone ELSE's prior style: commit) doesn't get
         # blamed. Only commits unique to the PR side count.
+        #
+        # Two-dot range (`A..HEAD`) — commits reachable from HEAD but
+        # NOT from origin/<base>. The three-dot symmetric-difference
+        # form was wrong: with a shallow PR checkout it has no common
+        # ancestor and lists every commit on dev as an "offender."
+        # Requires `fetch-depth: 0` on actions/checkout above.
         run: |
           git fetch origin "${{ github.base_ref }}" --depth=200
           OFFENDERS=$(git log --no-merges --format='%h %s' \
-            "origin/${{ github.base_ref }}...HEAD" |
+            "origin/${{ github.base_ref }}..HEAD" |
             grep -iE '^[a-f0-9]+ (style:|chore\(format\)|chore\(lint\)|ci\(lint\)).*(ruff|format|lint)' || true)
           if [ -n "$OFFENDERS" ]; then
             echo "::error::Format-only commits detected in PR history:"

--- a/docs/DEV_CYCLE.md
+++ b/docs/DEV_CYCLE.md
@@ -584,10 +584,22 @@ pre-commit run --all-files
 ```
 
 **CI fallback.** If you push without `pre-commit install` and the CI
-lint step fails, the workflow now emits an explicit install hint to
+lint step fails, the workflow emits an explicit install hint to
 `$GITHUB_STEP_SUMMARY` and to the job log via `::error::`. That hint
 exists exclusively to break the "push → red CI → push `style:` fixup"
 loop — see PR #357 commit message for the failure history.
+
+**CI hard gate — no format-only commits in PR history.** Shipping the
+config alone wasn't enough: three `style: ruff format` commits landed
+*after* `553c15f` (the pre-commit infra commit), proving the hook was
+still being skipped in practice. The `lint-and-typecheck.yml`
+"No format-only commits in PR history" step now fails the PR if its
+commit graph contains a `style:` / `chore(format)` / `chore(lint)` /
+`ci(lint)` commit naming `ruff` / `format` / `lint`. Merge commits are
+excluded (a PR that merges from base doesn't get blamed for someone
+else's prior style: commit). To recover: rebase + squash the offending
+commits into their source commits before re-pushing — the failure
+output includes the exact `git rebase -i` recipe.
 
 ### 4.6 Review feedback discipline
 


### PR DESCRIPTION
## Summary

Closes the last open AC on **#357 sub-task 3**. The `.pre-commit-config.yaml` landed 2026-05-15 (553c15f) but **three more `style: ruff format` commits landed AFTER it**, proving contributors still push without running `pre-commit install`. Config alone wasn't sufficient.

This PR adds a hard CI gate that fails when a PR's commit history contains a format-only commit — the failure mode #357 sub-task 3 exists to prevent.

## What this adds

A new step in `.github/workflows/lint-and-typecheck.yml`: **"No format-only commits in PR history"**. Greps PR commits (excluding merges from base) for four prefixes that historically signal "I forgot pre-commit":

- `style:` ... ruff / format / lint
- `chore(format)` ... ruff / format / lint
- `chore(lint)` ... ruff / format / lint
- `ci(lint)` ... ruff / format / lint

When any match, fails with a `::error::` annotation listing the offending SHAs and a `$GITHUB_STEP_SUMMARY` block with the rebase+squash recovery recipe.

## Regex smoke-tested locally

- **Matches** all 3 historical offenders since 553c15f: `3624482`, `2a9ae8a`, `8c4bd47`
- **Matches** the `chore(lint):` / `ci(lint):` family from earlier history: `5f599b6`, `e2bdc06`, `fa23b48`
- **Does not** false-match the pre-commit infra commit (`553c15f infra(pre-commit):`)
- **Does not** false-match any feature/fix commit (verified against the last 5+ on `dev`)

## `--no-merges` filter

A PR that merges from base and inadvertently carries someone else's prior `style:` commit doesn't get blamed. Only commits unique to the PR side count.

## Escape hatch

The error annotation ships the exact recipe:

```bash
pip install pre-commit && pre-commit install
git rebase -i origin/<base>
# mark each style: / chore(format): commit as fixup or squash
git push --force-with-lease
```

## Sub-task 3 state after this

| AC | Status |
|---|---|
| Add `.pre-commit-config.yaml` | ✅ done (553c15f) |
| `pre-commit install` documented in DEV_CYCLE.md | ✅ done (§4.5.5) |
| CI hint on lint failure | ✅ done (lint-and-typecheck.yml "Pre-commit install hint" step) |
| **CI fail on format-only commits in history** | **✅ this PR** |
| Follow-up sweep of pre-existing style commits | out of scope per issue |

## Test plan

- [x] YAML validates (`python -c \"import yaml; yaml.safe_load(...)\"`)
- [x] Regex smoke-tested against 3 known offenders + 5 legitimate commits + 4 edge cases
- [ ] CI green on the new step

Closes #357 sub-task 3. Refs #357.

🤖 Generated with [Claude Code](https://claude.com/claude-code)