### PR TITLE
docs(readme): Windows core.symlinks=true required for contributors (#357 sub-task 4)

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,12 @@ bicameral-mcp setup
 powershell -ExecutionPolicy ByPass -c "irm https://astral.sh/uv/install.ps1 | iex"
 ```
 
+> **Windows contributors developing on bicameral-mcp itself (required, not recommended):** before cloning the repo, set
+> ```powershell
+> git config --global core.symlinks true
+> ```
+> The repo tracks `.claude/skills/bicameral-*` as symlinks to canonical `skills/`. Windows defaults to `core.symlinks=false`, which silently materializes those entries as plain text files containing the target path string — slash-command resolution then breaks with no obvious failure. CI enforces this via `tests/test_skills_symlink_integrity.py` (#357 sub-task 4), so a clone without the setting will fail the regression suite. Cloning via WSL works around it. **This requirement does not apply** to users who only `pip install bicameral-mcp` — the published wheel bundles skills as real files, no symlink resolution needed.
+
 The setup wizard detects your repo, registers the MCP server with Claude Code, installs a git hook that auto-syncs the ledger after every commit, and adds a session-end hook that catches mid-session decisions you didn't explicitly ingest. Restart Claude Code and you're done.
 
 Verify:


### PR DESCRIPTION
## Summary

Closes the last AC on **#357 sub-task 4**. CLAUDE.md already says `core.symlinks=true` is **required** (not recommended). README.md only had a generic Windows uv-installer note. This adds the matching symlink-requirement callout immediately after the installer block, so Windows contributors see it at the moment they'd hit the failure.

## Scope-gated wording

The note is explicitly scoped to **contributors developing on bicameral-mcp itself**. Users who only `pip install bicameral-mcp` aren't affected — the published wheel bundles skills as real files (no symlinks at runtime). Documenting that explicitly prevents confused Windows users from thinking pip install needs the setting.

## Audit vs sub-task 4 ACs

| AC | Status |
|---|---|
| Windows CI step asserts `git ls-files -s` returns 22 mode-120000 entries | ✅ done (`test-mcp-regression.yml` "Assert .claude/skills/ symlinks are mode-120000 in git") |
| Install-time check for plain-file materialization | ✅ done in the right layer — `tests/test_skills_symlink_integrity.py::test_skills_symlinks_materialize_on_this_clone`. Its docstring explicitly documents why `setup_wizard` was rejected as the venue (wheel installs don't have symlinks; only repo clones do). |
| Update README / CLAUDE.md Windows note to say `core.symlinks=true` is **required** | CLAUDE.md done previously; **this PR** closes the README side |

Sub-task 4 is now complete. Combined with #518 (sub-task 1) and #520 (sub-task 3 AC3), only **sub-task 2** (real-storage perf job) remains open on #357.

## Test plan

- [x] README renders (it's prose; no tests)
- [ ] CI green

Closes #357 sub-task 4. Refs #357.

🤖 Generated with [Claude Code](https://claude.com/claude-code)