### PR TITLE
fix(ci): #528 — e2e assertions auth via ANTHROPIC_API_KEY

### DIFF
--- a/.github/workflows/v0-user-flow-e2e.yml
+++ b/.github/workflows/v0-user-flow-e2e.yml
@@ -43,9 +43,14 @@ jobs:
   assertions:
     name: e2e assertions (auto)
     runs-on: ubuntu-latest
-    # production env provides CLAUDE_CODE_OAUTH_TOKEN. No required reviewers
-    # on this env → PR triggers flow through automatically.
-    environment: production
+    # ci-test env provides ANTHROPIC_API_KEY. No required reviewers on this
+    # env → PR triggers flow through automatically. Switched from the
+    # `production` env's CLAUDE_CODE_OAUTH_TOKEN after #528: the org
+    # subscription was disabled (oauth_org_not_allowed 403), and `claude -p`
+    # honours ANTHROPIC_API_KEY directly — decoupling CI from subscription
+    # policy. Same env already used by test-mcp-regression.yml and
+    # preflight-eval.yml.
+    environment: ci-test
     timeout-minutes: 25
     steps:
       - uses: actions/checkout@v4
@@ -85,22 +90,26 @@ jobs:
           test -f docs/process/roadmap.md
           test -f app/src/lib/git/cherry-pick.ts
 
-      - name: Claude Code OAuth token visibility probe
+      # ANTHROPIC_API_KEY (NOT CLAUDE_CODE_OAUTH_TOKEN) — #528: the org
+      # subscription tied to the OAuth token was disabled, surfacing as
+      # oauth_org_not_allowed 403 on every flow before turn 1. `claude -p`
+      # honours ANTHROPIC_API_KEY natively, sidestepping subscription policy.
+      - name: Anthropic API key visibility probe
         run: |
           set +e
-          if [ -n "${CLAUDE_CODE_OAUTH_TOKEN}" ]; then
-            echo "CLAUDE_CODE_OAUTH_TOKEN: present (length=${#CLAUDE_CODE_OAUTH_TOKEN})"
+          if [ -n "${ANTHROPIC_API_KEY}" ]; then
+            echo "ANTHROPIC_API_KEY: present (length=${#ANTHROPIC_API_KEY})"
           else
-            echo "CLAUDE_CODE_OAUTH_TOKEN: EMPTY or UNSET"
-            echo "  secret expression non-empty: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN != '' }}"
+            echo "ANTHROPIC_API_KEY: EMPTY or UNSET"
+            echo "  secret expression non-empty: ${{ secrets.ANTHROPIC_API_KEY != '' }}"
             exit 1
           fi
         env:
-          CLAUDE_CODE_OAUTH_TOKEN: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
 
       - name: Run v0 user flow e2e (assertion-only, blocking)
         env:
-          CLAUDE_CODE_OAUTH_TOKEN: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
         run: python tests/e2e/run_e2e_flows.py
 
       - name: Upload e2e transcripts

--- a/tests/e2e/README.md
+++ b/tests/e2e/README.md
@@ -70,7 +70,9 @@ GitHub Actions workflow: `.github/workflows/v0-user-flow-e2e.yml`.
 
 - Triggers on PRs touching `tests/e2e/**`, `handlers/**`, `ledger/**`,
   `contracts.py`, `skills/bicameral-*/**`, or the workflow itself.
-- Runs in the `production` GitHub environment for `CLAUDE_CODE_OAUTH_TOKEN`.
+- Runs in the `ci-test` GitHub environment for `ANTHROPIC_API_KEY`
+  (switched from `production` + `CLAUDE_CODE_OAUTH_TOKEN` in #528 after the
+  org subscription was disabled).
 - Pinned `desktop/desktop` commit in the workflow file (update by editing
   the env var).
 - Uploads `test-results/e2e/*.ndjson` as job artifacts (30-day retention)

--- a/tests/e2e/run_e2e_flows.py
+++ b/tests/e2e/run_e2e_flows.py
@@ -19,8 +19,11 @@ experiences it. The handler-replay sim at ``scripts/sim_issue_108_flows.py``
 remains useful for fast dev iteration on handler logic.
 
 Required env:
-  CLAUDE_CODE_OAUTH_TOKEN  Claude Code CLI auth (set by GitHub Actions
-                           ``production`` environment in CI).
+  ANTHROPIC_API_KEY        Claude Code CLI auth — `claude -p` honours this
+                           directly (set by GitHub Actions ``ci-test``
+                           environment in CI). Switched from
+                           CLAUDE_CODE_OAUTH_TOKEN in #528 after the org
+                           subscription was disabled (oauth_org_not_allowed).
   DESKTOP_REPO_PATH        Path to a local clone of github.com/desktop/desktop.
 
 CI: see .github/workflows/v0-user-flow-e2e.yml.


### PR DESCRIPTION
## Summary

- Switch `v0-user-flow-e2e.yml` assertions job from `production` env (`CLAUDE_CODE_OAUTH_TOKEN`) to `ci-test` env (`ANTHROPIC_API_KEY`)
- Decouples CI from the org Claude Code subscription, which was disabled and surfaced as `oauth_org_not_allowed` 403 on every flow before turn 1
- Aligns the assertions job with the recording job (already on `ANTHROPIC_API_KEY`) and with `test-mcp-regression.yml` + `preflight-eval.yml`

Closes #528.

## Why ANTHROPIC_API_KEY, not Copilot or re-enabling the subscription

- `claude -p` (the harness's call surface) honours `ANTHROPIC_API_KEY` natively — no other changes needed
- The harness exists to validate the **Claude Code + bicameral-mcp** surface end-to-end; swapping the LLM (Copilot) defeats the test, and Copilot doesn't host MCP tool calls the same way
- Re-enabling the org subscription is an external blocker (already disabled once); API key bills per-run and only on PRs that touch the e2e surface

## Test plan

- [ ] CI: the new run on this PR shows `ANTHROPIC_API_KEY: present (length=…)` in the visibility probe and all 7 flows reach turn ≥ 1
- [ ] No `oauth_org_not_allowed` lines in any flow's `.ndjson`
- [ ] Once green, PRs #527, #524, #516 should rerun cleanly without further changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated CI/CD pipeline configuration to use Anthropic API credentials for end-to-end testing.
  * Migrated test environment setup for improved credential management.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/BicameralAI/bicameral-mcp/pull/529?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->