### PR TITLE
fix(bind): #334 Shape 2 — server-enforced snapshot handshake

### DIFF
--- a/handlers/bind.py
+++ b/handlers/bind.py
@@ -62,13 +62,32 @@ async def handle_bind(
 ) -> BindResponse:
     """Create decision→code_region bindings from caller-LLM-supplied locations.
 
+    Each binding is a dict with these fields:
+
+      - ``decision_id`` (required) — target decision row.
+      - ``file_path`` (required) — repo-relative path.
+      - ``symbol_name`` (required) — symbol to bind to.
+      - ``start_line`` / ``end_line`` (optional) — span hint; tree-sitter
+        resolves on miss.
+      - ``purpose`` (optional) — human-readable label.
+      - ``expected_indexed_at_sha`` (optional, #334 Shape 2) — the SHA the
+        caller's ``validate_symbols`` was indexed at (returned as
+        ``indexed_at_sha`` on each ``ValidatedSymbol``). When supplied, the
+        handler rejects the binding with ``snapshot_mismatch`` if it differs
+        from the ref bind is about to resolve at. Threading this field
+        upgrades the validate→bind handshake from a doc-only convention to a
+        server-enforced contract. Omit to preserve pre-Shape-2 behavior.
+
     For each binding:
       1. Verify decision exists (return error if not).
-      2. Use start_line/end_line if supplied; else resolve via tree-sitter.
+      2. Snapshot handshake — if ``expected_indexed_at_sha`` is supplied and
+         disagrees with bind's effective ref, reject with
+         ``snapshot_mismatch`` (#334 Shape 2).
+      3. Use start_line/end_line if supplied; else resolve via tree-sitter.
          Error if symbol not found.
-      3. Compute content_hash against authoritative_sha.
-      4. Upsert code_region + binds_to edge, transition decision ungrounded→pending.
-      5. Return PendingComplianceCheck for immediate caller verification.
+      4. Compute content_hash against authoritative_sha.
+      5. Upsert code_region + binds_to edge, transition decision ungrounded→pending.
+      6. Return PendingComplianceCheck for immediate caller verification.
 
     V1 A2-light: the whole handler body runs under ``repo_write_barrier``
     so two concurrent bind calls against the same repo are serialized.
@@ -128,6 +147,7 @@ async def _do_bind(ctx, bindings: list[dict]) -> BindResponse:
         start_line = b.get("start_line")
         end_line = b.get("end_line")
         purpose = str(b.get("purpose") or "")
+        expected_indexed_at_sha = str(b.get("expected_indexed_at_sha") or "")
 
         if not decision_id or not file_path or not symbol_name:
             results.append(
@@ -136,6 +156,29 @@ async def _do_bind(ctx, bindings: list[dict]) -> BindResponse:
                     region_id="",
                     content_hash="",
                     error="decision_id, file_path, and symbol_name are required",
+                )
+            )
+            continue
+
+        # #334 Shape 2 — snapshot handshake. When the caller threads through
+        # the ``indexed_at_sha`` they got from ``validate_symbols``, refuse to
+        # write if it disagrees with the ref bind is about to resolve at.
+        # Empty / missing field falls back to the pre-Shape-2 behavior (no
+        # enforcement) so existing callers don't regress. Cheap rejection —
+        # placed before decision lookup so a stale snapshot doesn't burn DB
+        # round-trips.
+        if expected_indexed_at_sha and expected_indexed_at_sha != effective_ref:
+            results.append(
+                BindResult(
+                    decision_id=decision_id,
+                    region_id="",
+                    content_hash="",
+                    error=(
+                        f"snapshot_mismatch: validate_symbols indexed at "
+                        f"{expected_indexed_at_sha} but bind resolves at "
+                        f"{effective_ref} — re-run validate_symbols against "
+                        f"the current snapshot and retry"
+                    ),
                 )
             )
             continue

--- a/skills/bicameral-bind/SKILL.md
+++ b/skills/bicameral-bind/SKILL.md
@@ -82,6 +82,40 @@ Skipping this check is what made the field bug in #334 (Jacob, 2026-05):
 branch after the most recent `link_commit`. The caller bound and got
 `"not found at <authoritative_sha>"`.
 
+### Server-enforced handshake (#334 Shape 2)
+
+Beyond the client-side comparison above, **thread `indexed_at_sha` into the
+bind call as `expected_indexed_at_sha`**. The handler then rejects the
+binding with `snapshot_mismatch` if it disagrees with the ref bind would
+resolve at. This upgrades the validate→bind handshake from "please check"
+to a hard contract — recommended for every bind call.
+
+```
+# Step 1
+validated = validate_symbols(["ProcessOrder"])
+# validated[0].indexed_at_sha == "abc123"
+
+# Step 2 — thread the SHA forward
+bicameral_bind(bindings=[{
+    "decision_id": "...",
+    "file_path": "...",
+    "symbol_name": "ProcessOrder",
+    "expected_indexed_at_sha": validated[0].indexed_at_sha,  # ← Shape 2
+}])
+```
+
+Behavior:
+
+- **SHA matches** bind's effective ref → bind proceeds as normal.
+- **SHA mismatches** → bind rejects with
+  `snapshot_mismatch: validate_symbols indexed at <X> but bind resolves at <Y>
+   — re-run validate_symbols against the current snapshot and retry`.
+- **Field omitted** (empty / missing) → bind falls back to pre-Shape-2
+  behavior (no enforcement). Backward-compatible.
+
+When in doubt: pass the field. The cost is one extra dict key; the benefit
+is the handler catches stale snapshots before any DB write.
+
 ## Anti-patterns — REJECT these
 
 | Anti-pattern | Why it fails |
@@ -98,12 +132,15 @@ branch after the most recent `link_commit`. The caller bound and got
 
 ```
 {
-  "decision_id": "...",          # required — must exist in the ledger
-  "file_path": "src/lib/...",    # required — must exist at HEAD (or ref)
-  "symbol_name": "ProcessOrder", # required — must resolve via validate_symbols
-  "start_line": 42,              # optional — if omitted, tree-sitter resolves
-  "end_line": 89,                #            from symbol_name
-  "purpose": "implements ..."    # optional — short rationale, indexed
+  "decision_id": "...",                 # required — must exist in the ledger
+  "file_path": "src/lib/...",           # required — must exist at HEAD (or ref)
+  "symbol_name": "ProcessOrder",        # required — must resolve via validate_symbols
+  "start_line": 42,                     # optional — if omitted, tree-sitter resolves
+  "end_line": 89,                       #            from symbol_name
+  "purpose": "implements ...",          # optional — short rationale, indexed
+  "expected_indexed_at_sha": "abc123",  # optional (#334 Shape 2) — pass the
+                                        # `indexed_at_sha` from validate_symbols
+                                        # for server-enforced snapshot handshake
 }
 ```
 
@@ -131,6 +168,7 @@ The handler rejects with a structured `error` (and `region_id=""`) when:
 | `file_path` doesn't exist at the SHA | `"does not exist at <sha> — only bind to existing code"` |
 | `symbol_name` doesn't resolve via tree-sitter | `"symbol '<name>' not found in <file> at <sha>"` |
 | Caller-supplied span doesn't overlap resolved span | `"span mismatch (#280)"` |
+| `expected_indexed_at_sha` disagrees with bind's effective ref (#334 Shape 2) | `"snapshot_mismatch: validate_symbols indexed at <X> but bind resolves at <Y>"` |
 
 Errors are returned per-binding (the handler keeps processing the rest of the
 list); a partial response is normal when one binding fails.

--- a/tests/test_bind_snapshot_handshake.py
+++ b/tests/test_bind_snapshot_handshake.py
@@ -1,0 +1,256 @@
+"""Tests for #334 Shape 2 — server-enforced validate/bind snapshot handshake.
+
+When the caller threads ``expected_indexed_at_sha`` (from a prior
+``validate_symbols`` response) into a ``bicameral_bind`` binding, the handler
+must:
+
+1. Accept the binding when the SHA matches the ref bind will resolve at.
+2. Reject with ``snapshot_mismatch`` when the SHA disagrees, before any DB
+   round-trip or git resolution.
+3. Fall back to pre-Shape-2 behavior (no enforcement) when the field is
+   omitted or empty — backward compatibility for existing callers.
+4. The rejection happens before decision-exists lookup, so a stale snapshot
+   on an unknown decision still reports ``snapshot_mismatch`` not
+   ``unknown_decision_id`` — the snapshot mismatch is the actionable signal.
+
+Sociable tests per ``CLAUDE.md`` — real ``SurrealDBLedgerAdapter`` over
+``memory://``; only the file/symbol resolution path is patched, since the
+Shape 2 reject runs entirely before that path on mismatched bindings.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import patch
+
+import pytest
+
+from handlers.bind import handle_bind
+from ledger.client import LedgerClient
+from ledger.schema import init_schema, migrate
+
+
+async def _fresh_client() -> LedgerClient:
+    c = LedgerClient(url="memory://", ns="snapshot_test", db="ledger_test")
+    await c.connect()
+    await init_schema(c)
+    await migrate(c, allow_destructive=True)
+    return c
+
+
+async def _seed_decision(client: LedgerClient, description: str = "test decision") -> str:
+    rows = await client.query(
+        "CREATE decision SET description = $d, source_type = 'manual', status = 'ungrounded'",
+        {"d": description},
+    )
+    return str(rows[0]["id"])
+
+
+class _StubCtx:
+    """Minimal ctx — authoritative_sha pinned so we know exactly what bind resolves at."""
+
+    def __init__(self, ledger, authoritative_sha: str = "abc123") -> None:
+        self.ledger = ledger
+        self.repo_path = "/tmp/test-repo"
+        self.authoritative_sha = authoritative_sha
+
+
+@pytest.mark.phase2
+@pytest.mark.asyncio
+@patch("ledger.status.resolve_symbol_lines", return_value=(10, 30))
+@patch("ledger.status.get_git_content", return_value="# stub")
+async def test_snapshot_handshake_match_accepts(_mock_git, _mock_resolve):
+    """Matching expected_indexed_at_sha → binding accepted as normal."""
+    client = await _fresh_client()
+    try:
+        from ledger.adapter import SurrealDBLedgerAdapter
+
+        adapter = SurrealDBLedgerAdapter(url="memory://")
+        adapter._client = client
+        adapter._connected = True
+
+        decision_id = await _seed_decision(client, "decision under snapshot match")
+        ctx = _StubCtx(adapter, authoritative_sha="abc123")
+
+        resp = await handle_bind(
+            ctx,
+            bindings=[
+                {
+                    "decision_id": decision_id,
+                    "file_path": "server.py",
+                    "symbol_name": "handle_search",
+                    "start_line": 10,
+                    "end_line": 30,
+                    "expected_indexed_at_sha": "abc123",
+                }
+            ],
+        )
+
+        assert len(resp.bindings) == 1
+        b = resp.bindings[0]
+        assert b.error is None, f"unexpected error on matching SHA: {b.error}"
+        assert b.region_id != ""
+    finally:
+        await client.close()
+
+
+@pytest.mark.phase2
+@pytest.mark.asyncio
+async def test_snapshot_handshake_mismatch_rejects():
+    """Mismatched expected_indexed_at_sha → snapshot_mismatch error, no DB write.
+
+    The reject path runs before decision-exists lookup, so we do not need to
+    patch git resolution — the handler bails before touching it.
+    """
+    client = await _fresh_client()
+    try:
+        from ledger.adapter import SurrealDBLedgerAdapter
+
+        adapter = SurrealDBLedgerAdapter(url="memory://")
+        adapter._client = client
+        adapter._connected = True
+
+        decision_id = await _seed_decision(client, "decision under stale snapshot")
+        ctx = _StubCtx(adapter, authoritative_sha="abc123")
+
+        resp = await handle_bind(
+            ctx,
+            bindings=[
+                {
+                    "decision_id": decision_id,
+                    "file_path": "server.py",
+                    "symbol_name": "handle_search",
+                    "start_line": 10,
+                    "end_line": 30,
+                    "expected_indexed_at_sha": "def456",  # stale
+                }
+            ],
+        )
+
+        assert len(resp.bindings) == 1
+        b = resp.bindings[0]
+        assert b.error is not None
+        assert "snapshot_mismatch" in b.error
+        assert "def456" in b.error and "abc123" in b.error
+        assert b.region_id == ""
+    finally:
+        await client.close()
+
+
+@pytest.mark.phase2
+@pytest.mark.asyncio
+@patch("ledger.status.resolve_symbol_lines", return_value=(10, 30))
+@patch("ledger.status.get_git_content", return_value="# stub")
+async def test_snapshot_handshake_omitted_preserves_legacy_behavior(_mock_git, _mock_resolve):
+    """Field omitted entirely → bind behaves as pre-Shape-2 (no enforcement)."""
+    client = await _fresh_client()
+    try:
+        from ledger.adapter import SurrealDBLedgerAdapter
+
+        adapter = SurrealDBLedgerAdapter(url="memory://")
+        adapter._client = client
+        adapter._connected = True
+
+        decision_id = await _seed_decision(client, "decision via legacy caller")
+        ctx = _StubCtx(adapter, authoritative_sha="abc123")
+
+        resp = await handle_bind(
+            ctx,
+            bindings=[
+                {
+                    "decision_id": decision_id,
+                    "file_path": "server.py",
+                    "symbol_name": "handle_search",
+                    "start_line": 10,
+                    "end_line": 30,
+                    # expected_indexed_at_sha intentionally omitted
+                }
+            ],
+        )
+
+        assert len(resp.bindings) == 1
+        b = resp.bindings[0]
+        assert b.error is None, f"unexpected error on omitted field: {b.error}"
+        assert b.region_id != ""
+    finally:
+        await client.close()
+
+
+@pytest.mark.phase2
+@pytest.mark.asyncio
+@patch("ledger.status.resolve_symbol_lines", return_value=(10, 30))
+@patch("ledger.status.get_git_content", return_value="# stub")
+async def test_snapshot_handshake_empty_string_preserves_legacy_behavior(_mock_git, _mock_resolve):
+    """Field present but empty string → no enforcement (matches omitted case)."""
+    client = await _fresh_client()
+    try:
+        from ledger.adapter import SurrealDBLedgerAdapter
+
+        adapter = SurrealDBLedgerAdapter(url="memory://")
+        adapter._client = client
+        adapter._connected = True
+
+        decision_id = await _seed_decision(client, "decision via empty-sha caller")
+        ctx = _StubCtx(adapter, authoritative_sha="abc123")
+
+        resp = await handle_bind(
+            ctx,
+            bindings=[
+                {
+                    "decision_id": decision_id,
+                    "file_path": "server.py",
+                    "symbol_name": "handle_search",
+                    "start_line": 10,
+                    "end_line": 30,
+                    "expected_indexed_at_sha": "",  # explicit empty
+                }
+            ],
+        )
+
+        assert len(resp.bindings) == 1
+        b = resp.bindings[0]
+        assert b.error is None, f"unexpected error on empty SHA: {b.error}"
+        assert b.region_id != ""
+    finally:
+        await client.close()
+
+
+@pytest.mark.phase2
+@pytest.mark.asyncio
+async def test_snapshot_mismatch_short_circuits_before_decision_lookup():
+    """Stale SHA + unknown decision_id → snapshot_mismatch (not unknown_decision_id).
+
+    The Shape 2 reject runs before the decision-exists check, so the
+    snapshot signal is the one the caller acts on. This is the cheap-reject
+    contract: avoid DB round-trips when the snapshot is already known stale.
+    """
+    client = await _fresh_client()
+    try:
+        from ledger.adapter import SurrealDBLedgerAdapter
+
+        adapter = SurrealDBLedgerAdapter(url="memory://")
+        adapter._client = client
+        adapter._connected = True
+
+        ctx = _StubCtx(adapter, authoritative_sha="abc123")
+
+        resp = await handle_bind(
+            ctx,
+            bindings=[
+                {
+                    "decision_id": "decision:does_not_exist",
+                    "file_path": "server.py",
+                    "symbol_name": "handle_search",
+                    "start_line": 10,
+                    "end_line": 30,
+                    "expected_indexed_at_sha": "stale_sha_xyz",
+                }
+            ],
+        )
+
+        assert len(resp.bindings) == 1
+        b = resp.bindings[0]
+        assert b.error is not None
+        assert "snapshot_mismatch" in b.error
+        assert "unknown_decision_id" not in b.error
+    finally:
+        await client.close()


### PR DESCRIPTION
## Summary

- Adds optional `expected_indexed_at_sha` field on each `bicameral_bind` binding.
- When supplied, the handler rejects with `snapshot_mismatch` if the SHA disagrees with the ref bind would resolve at — turns the validate→bind handshake from a doc-mediated convention into a server-enforced contract.
- Empty/missing field preserves pre-Shape-2 behavior (backward compatible).
- Companion to #527 (option c — `validate_symbols` returns `indexed_at_sha`). With both in place, the caller-LLM threads the SHA forward and any disagreement surfaces as a specific actionable error instead of the prior cryptic `symbol not found at <sha>`.

## Why now

Hardens the contract before the daemon migration promotes it into `bicameral-protocol` (#497 Phase 2). Cheap to add now; protocol revision later if we wait.

Closes #334.

## Files

| File | Change |
|---|---|
| `handlers/bind.py` | +47 lines — docstring expansion + per-binding snapshot reject placed before decision-exists lookup (cheap rejection, no DB round-trip) |
| `skills/bicameral-bind/SKILL.md` | +45 lines — new "Server-enforced handshake (#334 Shape 2)" section, format example with the new field, snapshot_mismatch row added to the enforcement table. Mandatory per CLAUDE.md "Tool Changes Require Skill Changes". |
| `tests/test_bind_snapshot_handshake.py` | new file, 5 sociable tests |

## Test plan

- [x] 5 new Shape 2 tests: match-accepts, mismatch-rejects, omitted-preserves-legacy, empty-string-preserves-legacy, mismatch-short-circuits-before-decision-lookup
- [x] 8 existing `tests/test_bind.py` tests still pass — no regression
- [x] `tests/test_validate_symbols_indexed_at_sha.py` (#527 companion) still passes
- [x] Sociable per CLAUDE.md — real `SurrealDBLedgerAdapter` over `memory://`, `_StubCtx` not `MagicMock`, only file/symbol resolution patched
- [ ] CI green

## Behavior reference

| Caller passes... | Bind result |
|---|---|
| Matching SHA | accepts as normal |
| Mismatched SHA | rejects with `snapshot_mismatch: validate_symbols indexed at <X> but bind resolves at <Y> — re-run validate_symbols against the current snapshot and retry` |
| Empty / missing | accepts as pre-Shape-2 (backward compatible) |

🤖 Generated with [Claude Code](https://claude.com/claude-code)