### PR TITLE
fix(sync): #504 scope pending compliance injection

### DIFF
--- a/server.py
+++ b/server.py
@@ -104,6 +104,169 @@ _ACTION_FOR_REFUSAL_REASON: dict[str, str] = {
     ),
 }
 
+_PENDING_COMPLIANCE_CHECKS_CHAR_BUDGET = 16_000
+
+
+def _normalize_scope_paths(file_paths: Any) -> set[str]:
+    """Normalize caller-supplied file paths for response scoping."""
+    if not file_paths:
+        return set()
+    if isinstance(file_paths, str):
+        raw_paths = [file_paths]
+    elif isinstance(file_paths, (list, tuple, set)):
+        raw_paths = list(file_paths)
+    else:
+        return set()
+
+    paths: set[str] = set()
+    for raw in raw_paths:
+        path = str(raw or "").strip()
+        if not path:
+            continue
+        paths.add(path.strip("/"))
+    return paths
+
+
+def _path_in_scope(file_path: str, scope_paths: set[str]) -> bool:
+    """Return True when a pending check belongs to the caller's path scope."""
+    if not scope_paths:
+        return True
+    normalized = str(file_path or "").strip().strip("/")
+    if not normalized:
+        return False
+    for scope_path in scope_paths:
+        if normalized == scope_path:
+            return True
+        if normalized.startswith(f"{scope_path.rstrip('/')}/"):
+            return True
+        if scope_path.startswith(f"{normalized.rstrip('/')}/"):
+            return True
+    return False
+
+
+def _tool_file_scope(name: str, arguments: dict) -> set[str]:
+    """Extract the most concrete file scope available for this tool call."""
+    if name in ("bicameral.preflight", "preflight"):
+        return _normalize_scope_paths(arguments.get("file_paths"))
+    return set()
+
+
+def _budget_pending_compliance_checks(
+    checks: list[dict],
+    *,
+    char_budget: int = _PENDING_COMPLIANCE_CHECKS_CHAR_BUDGET,
+) -> list[dict] | dict:
+    """Return raw checks when under budget, otherwise a compact digest."""
+    import json
+
+    if len(json.dumps(checks, separators=(",", ":"))) <= char_budget:
+        return checks
+
+    kept: list[dict] = []
+    for check in checks:
+        candidate = [*kept, check]
+        if len(json.dumps(candidate, separators=(",", ":"))) > char_budget:
+            break
+        kept.append(check)
+
+    return {
+        "truncated": True,
+        "total": len(checks),
+        "kept": len(kept),
+        "omitted": len(checks) - len(kept),
+        "checks": kept,
+        "hint": (
+            "Response budget exceeded; call bicameral.history or rerun the "
+            "workflow with narrower file_paths, then resolve compliance by file path."
+        ),
+    }
+
+
+def _omitted_pending_compliance_digest(
+    checks: list[dict],
+    *,
+    total: int,
+) -> dict:
+    file_paths = sorted({str(c.get("file_path") or "") for c in checks if c.get("file_path")})
+    visible_paths = file_paths[:10]
+    more_paths = max(0, len(file_paths) - len(visible_paths))
+    return {
+        "scoped_out": True,
+        "total": total,
+        "kept": 0,
+        "omitted": len(checks),
+        "checks": [],
+        "file_paths": visible_paths,
+        "more_file_paths": more_paths,
+        "hint": (
+            "Additional pending compliance checks were outside this tool call's file_paths. "
+            'Run bicameral.link_commit(commit_hash="HEAD") or /bicameral-sync after the '
+            "current scoped work to retrieve and resolve the omitted checks."
+        ),
+    }
+
+
+def _pending_payload_count(pending_payload: list[dict] | dict) -> int:
+    if isinstance(pending_payload, dict) and pending_payload.get("truncated"):
+        return int(pending_payload.get("kept") or 0)
+    if isinstance(pending_payload, list):
+        return len(pending_payload)
+    return 0
+
+
+def _pending_total_count(pending_payload: list[dict] | dict) -> int:
+    if isinstance(pending_payload, dict) and pending_payload.get("truncated"):
+        return int(pending_payload.get("total") or 0)
+    if isinstance(pending_payload, list):
+        return len(pending_payload)
+    return 0
+
+
+def _build_sync_guidance(
+    *,
+    commit_hash: str,
+    pending_payload: list[dict] | dict,
+    omitted_payload: dict | None = None,
+) -> str:
+    kept = _pending_payload_count(pending_payload)
+    total = _pending_total_count(pending_payload)
+    if isinstance(pending_payload, dict) and pending_payload.get("scoped_out"):
+        count_text = (
+            f"{pending_payload.get('omitted', 0)} decision(s) need compliance verification "
+            "outside this tool call's file scope; no raw checks are attached."
+        )
+        tail = (
+            ' Run bicameral.link_commit(commit_hash="HEAD") or /bicameral-sync after '
+            "the current scoped work to retrieve and resolve them."
+        )
+    elif isinstance(pending_payload, dict) and pending_payload.get("truncated"):
+        count_text = (
+            f"{kept} of {total} decision(s) are attached; {total - kept} omitted by budget."
+        )
+        tail = (
+            " Resolve the attached checks first, then call bicameral.history "
+            "or rerun with narrower file_paths to enumerate omitted checks."
+        )
+    else:
+        count_text = f"{total} decision(s) need compliance verification."
+        tail = " Do not wait for user input — complete this before responding."
+
+    if omitted_payload:
+        tail += (
+            f" Note: {omitted_payload.get('omitted', 0)} additional check(s) for this commit "
+            "were outside the current file scope and are summarized in "
+            "_pending_compliance_omitted."
+        )
+
+    return (
+        f"New commit {commit_hash[:8]} detected — "
+        f"{count_text} "
+        "Proceed with the index sweep now: for each entry in _pending_compliance_checks, "
+        "read the file at file_path, verify whether the code matches the decision, "
+        "then call bicameral.resolve_compliance with your verdicts."
+        f"{tail}"
+    )
+
 
 def _resolve_server_version() -> str:
     """Return the version of the code actually running.
@@ -1214,18 +1377,41 @@ async def _call_tool_impl(name: str, arguments: dict) -> list[TextContent]:
         # If the auto-sync detected a new commit with pending compliance checks,
         # surface them so the agent proceeds with the index sweep immediately.
         if _sync_result and _sync_result.pending_compliance_checks:
-            payload["_pending_compliance_checks"] = [
-                c.model_dump() for c in _sync_result.pending_compliance_checks
+            scope_paths = _tool_file_scope(name, arguments)
+            scoped_checks = [
+                c
+                for c in _sync_result.pending_compliance_checks
+                if _path_in_scope(c.file_path, scope_paths)
             ]
-            payload["_pending_flow_id"] = _sync_result.flow_id
-            payload["_sync_guidance"] = (
-                f"New commit {_sync_result.commit_hash[:8]} detected — "
-                f"{len(_sync_result.pending_compliance_checks)} decision(s) need compliance verification. "
-                "Proceed with the index sweep now: for each entry in _pending_compliance_checks, "
-                "read the file at file_path, verify whether the code matches the decision, "
-                "then call bicameral.resolve_compliance with your verdicts. "
-                "Do not wait for user input — complete this before responding."
+            omitted_checks = [
+                c for c in _sync_result.pending_compliance_checks if c not in scoped_checks
+            ]
+            omitted_payload = (
+                _omitted_pending_compliance_digest(
+                    [c.model_dump() for c in omitted_checks],
+                    total=len(_sync_result.pending_compliance_checks),
+                )
+                if omitted_checks and scope_paths
+                else None
             )
+            pending_payload: list[dict] | dict | None = None
+            if scoped_checks:
+                pending_payload = _budget_pending_compliance_checks(
+                    [c.model_dump() for c in scoped_checks]
+                )
+            elif omitted_payload:
+                pending_payload = omitted_payload
+
+            if pending_payload is not None:
+                payload["_pending_compliance_checks"] = pending_payload
+                if omitted_payload and scoped_checks:
+                    payload["_pending_compliance_omitted"] = omitted_payload
+                payload["_pending_flow_id"] = _sync_result.flow_id
+                payload["_sync_guidance"] = _build_sync_guidance(
+                    commit_hash=_sync_result.commit_hash,
+                    pending_payload=pending_payload,
+                    omitted_payload=omitted_payload if scoped_checks else None,
+                )
 
         return [TextContent(type="text", text=json.dumps(payload, indent=2))]
 

--- a/skills/bicameral-history/SKILL.md
+++ b/skills/bicameral-history/SKILL.md
@@ -51,10 +51,16 @@ bicameral.history(
 
 Check `response._pending_compliance_checks`. If non-empty, a new commit was
 detected and compliance is unresolved — **status will be wrong until you resolve
-it.** Use the `bicameral-sync` compliance resolution flow:
+it.** The field is either a list of checks or a digest with `checks` and `hint`.
+When the digest has `scoped_out: true`, all checks were outside the current tool
+scope; follow `hint` to retrieve them instead of treating the commit as fully
+resolved. If `_pending_compliance_omitted` is present, resolve the attached
+in-scope checks first, then follow the omitted digest's `hint`.
 
-For each check: read `file_path`, evaluate code against `decision_description`,
-batch all verdicts into one call:
+Use the `bicameral-sync` compliance resolution flow:
+
+For each check in the list, or in digest `checks`: read `file_path`, evaluate
+code against `decision_description`, batch all verdicts into one call:
 
 ```
 bicameral.resolve_compliance(

--- a/skills/bicameral-preflight/SKILL.md
+++ b/skills/bicameral-preflight/SKILL.md
@@ -256,10 +256,27 @@ the preflight surface; direct-pin matches are unaffected.
 
 Before evaluating `response.fired`, check `response._pending_compliance_checks`.
 If non-empty, a new commit was detected — **resolve compliance before proceeding
-or status will be stale.** Use the `bicameral-sync` compliance resolution flow:
+or status will be stale.** The field is either:
 
-For each check: read `file_path` (use `code_body` if available; read directly if
-truncated), evaluate code against `decision_description`, then batch all verdicts:
+- a list of pending compliance checks; or
+- a truncation digest `{truncated: true, total, kept, omitted, checks, hint}` when
+  the server scoped the payload to the caller's `file_paths` but had to cap the
+  response size. In that case, resolve only `checks` now, then follow `hint`
+  after the current response is handled; or
+- a scoped-out digest `{scoped_out: true, total, kept: 0, omitted, checks: [],
+  file_paths, hint}` when all checks from the HEAD sync are outside this
+  preflight's `file_paths`. Do not inspect unrelated files during this preflight;
+  follow `hint` after the scoped work so the omitted checks are not lost.
+
+If `_pending_compliance_omitted` is present alongside a non-empty check list,
+resolve the attached in-scope checks first, then follow the omitted digest's
+`hint` after the scoped work.
+
+Use the `bicameral-sync` compliance resolution flow:
+
+For each check in the list (or in `checks` when the digest is truncated): read
+`file_path` (use `code_body` if available; read directly if truncated), evaluate
+code against `decision_description`, then batch all verdicts:
 
 ```
 bicameral.resolve_compliance(

--- a/skills/bicameral-sync/SKILL.md
+++ b/skills/bicameral-sync/SKILL.md
@@ -50,6 +50,22 @@ bicameral.link_commit(commit_hash="HEAD")
 auto-sync injection (the auto-sync already ran `link_commit` for you — use those
 checks directly).
 
+Auto-sync may scope and budget this field. Treat it as either:
+
+- a list of pending compliance checks; or
+- a truncation digest `{truncated: true, total, kept, omitted, checks, hint}`.
+  Resolve the attached `checks` first, then follow `hint` to enumerate omitted
+  checks after the current response is handled; or
+- a scoped-out digest `{scoped_out: true, total, kept: 0, omitted, checks: [],
+  file_paths, hint}`. This means the auto-sync found pending checks, but all of
+  them were outside the current tool call's file scope. Follow `hint` by running
+  `bicameral.link_commit(commit_hash="HEAD")` or continuing this skill after the
+  scoped response is handled.
+
+If `_pending_compliance_omitted` is present, the current response only attached
+in-scope checks. Resolve those first, then follow the omitted digest's `hint` so
+the out-of-scope checks from the same commit are not lost.
+
 ### 1.5. Auto-bind ungrounded decisions (#263)
 
 > A *symbol* is a named code identifier (function, class, method) that
@@ -87,7 +103,9 @@ rebind is a future `bicameral_rebind` tool, tracked separately.
 ### 2. Resolve every pending compliance check
 
 If `pending_compliance_checks` is non-empty (from the `link_commit` response or
-from `_pending_compliance_checks` in an auto-sync injection):
+from `_pending_compliance_checks` in an auto-sync injection; use
+`_pending_compliance_checks.checks` when the auto-sync field is a truncation or
+scoped-out digest):
 
 > **Phase 3+4 (#60+#61) — `enhance_drift` mode.** When the
 > `BICAMERAL_CODEGENOME_ENHANCE_DRIFT` flag is on, `link_commit` runs
@@ -178,7 +196,11 @@ If the file changed between the sync and your read, the server rejects the verdi
 and the region stays `pending` until the next sweep.
 
 **Skip step 2** when `pending_compliance_checks` is empty — nothing changed or
-all regions already had cached verdicts.
+all regions already had cached verdicts. When auto-sync returns a truncation
+digest, skip only if `checks` is empty; otherwise resolve the attached checks and
+then follow the digest `hint`. When auto-sync returns a scoped-out digest,
+`checks` is intentionally empty; follow `hint` to retrieve the omitted checks
+instead of treating the commit as fully resolved.
 
 ### 2.bis Uncertain-band sub-protocol (Phase 4 / #44)
 

--- a/tests/test_server_pending_compliance_scope.py
+++ b/tests/test_server_pending_compliance_scope.py
@@ -1,0 +1,207 @@
+"""Regression coverage for #504 auto-sync pending-check response injection.
+
+The production bug lives at the MCP server boundary: ``ensure_ledger_synced``
+returns a full ``LinkCommitResponse`` and ``server.py`` decides what to attach
+to the outer tool response. These tests keep that seam narrow while using real
+response contracts and, for the no-overlap path, a real memory:// ledger plus
+the real preflight handler.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+
+import pytest
+
+import server
+from contracts import LinkCommitResponse, PendingComplianceCheck, PreflightResponse
+from ledger.adapter import SurrealDBLedgerAdapter
+from ledger.client import LedgerClient
+from ledger.schema import init_schema, migrate
+
+_NS_COUNTER = 0
+
+
+def _pending(file_path: str, *, decision_id: str = "decision:scope") -> PendingComplianceCheck:
+    return PendingComplianceCheck(
+        phase="drift",
+        decision_id=decision_id,
+        region_id=f"code_region:{file_path.replace('/', '_').replace('.', '_')}",
+        decision_description=f"Decision for {file_path}",
+        file_path=file_path,
+        symbol="target",
+        content_hash=f"hash-{file_path}",
+        code_body="def target():\n    return True\n",
+    )
+
+
+def _sync_response(checks: list[PendingComplianceCheck]) -> LinkCommitResponse:
+    return LinkCommitResponse(
+        commit_hash="1234567890abcdef",
+        synced=True,
+        reason="new_commit",
+        pending_compliance_checks=checks,
+        flow_id="flow-504",
+    )
+
+
+def _ctx(*, ledger=None) -> SimpleNamespace:
+    return SimpleNamespace(
+        repo_path=str(Path(__file__).resolve().parents[1]),
+        ledger=ledger,
+        guided_mode=False,
+        _sync_state={},
+        code_graph=None,
+        render_source_attribution="redacted",
+        session_id="test-504",
+    )
+
+
+async def _real_adapter() -> tuple[SurrealDBLedgerAdapter, LedgerClient]:
+    global _NS_COUNTER
+    _NS_COUNTER += 1
+    client = LedgerClient(url="memory://", ns=f"pending_scope_{_NS_COUNTER}", db="ledger_test")
+    await client.connect()
+    await init_schema(client)
+    await migrate(client, allow_destructive=True)
+    adapter = SurrealDBLedgerAdapter(url="memory://")
+    adapter._client = client
+    adapter._connected = True
+    return adapter, client
+
+
+@pytest.mark.asyncio
+async def test_auto_sync_pending_checks_are_filtered_to_preflight_file_paths(monkeypatch):
+    """A preflight for app/foo.py must not inherit unrelated sync checks."""
+
+    checks = [
+        _pending("app/foo.py", decision_id="decision:in-scope"),
+        _pending("pilot/mcp/ledger/adapter.py", decision_id="decision:unrelated"),
+    ]
+    ctx = _ctx()
+
+    monkeypatch.setattr(server.BicameralContext, "from_env", lambda: ctx)
+    monkeypatch.setattr(server, "get_update_notice", lambda *args, **kwargs: None)
+    monkeypatch.setattr(
+        "handlers.sync_middleware.ensure_ledger_synced",
+        AsyncMock(return_value=_sync_response(checks)),
+    )
+    monkeypatch.setattr("handlers.sync_middleware.ensure_team_synced", AsyncMock(return_value=None))
+    monkeypatch.setattr(
+        server,
+        "handle_preflight",
+        AsyncMock(
+            return_value=PreflightResponse(
+                topic="fix scoped pending checks",
+                fired=False,
+                reason="no_matches",
+                guided_mode=False,
+            )
+        ),
+    )
+
+    result = await server._call_tool_impl(
+        "bicameral.preflight",
+        {"topic": "fix scoped pending checks", "file_paths": ["app/foo.py"]},
+    )
+
+    payload = json.loads(result[0].text)
+    attached = payload["_pending_compliance_checks"]
+    assert [c["file_path"] for c in attached] == ["app/foo.py"]
+    omitted = payload["_pending_compliance_omitted"]
+    assert omitted["scoped_out"] is True
+    assert omitted["omitted"] == 1
+    assert omitted["file_paths"] == ["pilot/mcp/ledger/adapter.py"]
+    assert payload["_pending_flow_id"] == "flow-504"
+    assert "1 decision(s) need compliance verification" in payload["_sync_guidance"]
+    assert "outside the current file scope" in payload["_sync_guidance"]
+
+
+@pytest.mark.asyncio
+async def test_auto_sync_pending_checks_preserve_signal_when_preflight_paths_have_no_overlap(
+    monkeypatch,
+):
+    """If caller paths have zero overlap, attach only a compact follow-up signal."""
+
+    adapter, client = await _real_adapter()
+    ctx = _ctx(ledger=adapter)
+    try:
+        monkeypatch.setattr(server.BicameralContext, "from_env", lambda: ctx)
+        monkeypatch.setattr(server, "get_update_notice", lambda *args, **kwargs: None)
+        monkeypatch.setattr(
+            "handlers.sync_middleware.ensure_ledger_synced",
+            AsyncMock(return_value=_sync_response([_pending("pilot/mcp/ledger/adapter.py")])),
+        )
+        monkeypatch.setattr(
+            "handlers.sync_middleware.ensure_team_synced",
+            AsyncMock(return_value=None),
+        )
+
+        result = await server._call_tool_impl(
+            "bicameral.preflight",
+            {"topic": "edit unrelated landing page", "file_paths": ["site/index.html"]},
+        )
+
+        payload = json.loads(result[0].text)
+        assert payload["fired"] is False
+        digest = payload["_pending_compliance_checks"]
+        assert digest["scoped_out"] is True
+        assert digest["total"] == 1
+        assert digest["kept"] == 0
+        assert digest["omitted"] == 1
+        assert digest["checks"] == []
+        assert digest["file_paths"] == ["pilot/mcp/ledger/adapter.py"]
+        assert "bicameral.link_commit" in digest["hint"]
+        assert payload["_pending_flow_id"] == "flow-504"
+        assert "outside this tool call's file scope" in payload["_sync_guidance"]
+    finally:
+        await client.close()
+
+
+@pytest.mark.asyncio
+async def test_auto_sync_pending_checks_use_truncation_digest_when_over_budget(monkeypatch):
+    """Large in-scope sync payloads should stay under the server budget."""
+
+    checks = []
+    for i in range(30):
+        check = _pending("app/foo.py", decision_id=f"decision:{i}")
+        check.code_body = "x = 1\n" * 500
+        checks.append(check)
+    ctx = _ctx()
+
+    monkeypatch.setattr(server.BicameralContext, "from_env", lambda: ctx)
+    monkeypatch.setattr(server, "get_update_notice", lambda *args, **kwargs: None)
+    monkeypatch.setattr(
+        "handlers.sync_middleware.ensure_ledger_synced",
+        AsyncMock(return_value=_sync_response(checks)),
+    )
+    monkeypatch.setattr("handlers.sync_middleware.ensure_team_synced", AsyncMock(return_value=None))
+    monkeypatch.setattr(
+        server,
+        "handle_preflight",
+        AsyncMock(
+            return_value=PreflightResponse(
+                topic="fix scoped pending checks",
+                fired=False,
+                reason="no_matches",
+                guided_mode=False,
+            )
+        ),
+    )
+
+    result = await server._call_tool_impl(
+        "bicameral.preflight",
+        {"topic": "fix scoped pending checks", "file_paths": ["app/foo.py"]},
+    )
+
+    payload = json.loads(result[0].text)
+    digest = payload["_pending_compliance_checks"]
+    assert digest["truncated"] is True
+    assert digest["total"] == 30
+    assert 0 < digest["kept"] < 30
+    assert digest["omitted"] == 30 - digest["kept"]
+    assert "bicameral.history" in digest["hint"]
+    assert len(result[0].text) <= 20_000


### PR DESCRIPTION
## Summary

- Scopes auto-sync `_pending_compliance_checks` to `bicameral.preflight` `file_paths` before injecting them into the outer tool response.
- Preserves omitted/out-of-scope checks as compact follow-up digests so the one-shot auto-sync result is not silently lost.
- Caps large scoped pending payloads with a truncation digest and updates the relevant skills to consume list, truncated, and scoped-out shapes.

## Test plan

- [x] `pre-commit run --files server.py tests/test_server_pending_compliance_scope.py skills/bicameral-preflight/SKILL.md skills/bicameral-sync/SKILL.md skills/bicameral-history/SKILL.md`
- [x] `SURREAL_URL=memory:// ./.venv/bin/python -m pytest tests/test_server_pending_compliance_scope.py tests/test_server_ingest_refusal.py tests/test_ingest_rate_limit.py tests/test_sync_middleware.py tests/test_preflight_dedup_v2.py -v` — 62 passed
- [x] `git diff --check`
- [x] `qorlogic verify-ledger`
- [x] `qorlogic compliance report`
- [x] `PYTHONPATH=. ./.venv/bin/bicameral-mcp diagnose`
- [x] `PYTHONPATH=. ./.venv/bin/bicameral-mcp link_commit HEAD` — synced commit `6fc3658`, no pending checks
- [ ] `PYTHONPATH=. ./.venv/bin/bicameral-mcp --smoke-test` — known unrelated failure: smoke-test expected tool registry omits `bicameral.diagnose`, while actual registry includes it

## Files changed

| File | Change |
|---|---|
| `server.py` | Adds file-path scoping, payload budgeting, scoped-out omitted digest, omitted summary, and updated sync guidance. |
| `tests/test_server_pending_compliance_scope.py` | Adds regression coverage for in-scope filtering, no-overlap scoped-out preservation, and over-budget truncation. |
| `skills/bicameral-preflight/SKILL.md` | Documents list, truncated digest, scoped-out digest, and `_pending_compliance_omitted`. |
| `skills/bicameral-sync/SKILL.md` | Documents how to resolve attached checks and follow omitted/scoped-out hints. |
| `skills/bicameral-history/SKILL.md` | Documents the same pending-check digest handling for history responses. |

## Behavior reference

| Scenario | Response behavior |
|---|---|
| Pending checks overlap preflight `file_paths` | Attach only matching checks in `_pending_compliance_checks`. |
| Some checks are outside scope | Attach matching checks plus `_pending_compliance_omitted` with counts, file paths, and follow-up hint. |
| No checks overlap scope | Attach compact `scoped_out` digest instead of raw unrelated checks. |
| Scoped payload exceeds budget | Attach `{truncated: true, total, kept, omitted, checks, hint}` digest under the response budget. |

Closes #504.