### PR TITLE
feat(ingest): #393 — hard-exclude driver-free dev-process decisions

### DIFF
--- a/contracts.py
+++ b/contracts.py
@@ -28,6 +28,7 @@ class IngestDiagnostic(BaseModel):
     decisions_ingested: int = 0
     g2_candidates_evaluated: int = 0
     g2_dropped_hard_exclude: int = 0
+    g2_dropped_dev_process: int = 0
     g2_dropped_l3: int = 0
     g2_dropped_gate1: int = 0
     g2_dropped_gate2: int = 0

--- a/server.py
+++ b/server.py
@@ -830,7 +830,7 @@ async def list_tools() -> list[Tool]:
                             "Skill-level metrics. Field names are strictly validated server-side — "
                             "unknown fields are dropped and echoed back in diagnostic_warning. "
                             "bicameral-ingest fields: decisions_ingested, g2_candidates_evaluated, "
-                            "g2_dropped_hard_exclude, g2_dropped_l3, g2_dropped_gate1, g2_dropped_gate2, "
+                            "g2_dropped_hard_exclude, g2_dropped_dev_process, g2_dropped_l3, g2_dropped_gate1, g2_dropped_gate2, "
                             "g2_dropped_implied, g2_parked_context_pending, g2_proposed_count, "
                             "g2_l1_count, g2_l2_count, g2_user_overrode, g3_decisions_grounded, "
                             "g3_decisions_ungrounded, g6_compliance_checks_received, g6_verdicts_compliant, "

--- a/skills/bicameral-context-sentry/SKILL.md
+++ b/skills/bicameral-context-sentry/SKILL.md
@@ -31,6 +31,30 @@ It does two things — in order, always:
 - A list of candidate decision descriptions (pre-ingest)
 - An `IngestResponse` object (post-ingest, for collision/context-for handling)
 
+### Step R0 — Dev-process pre-filter (#393)
+
+Before deriving probes, scan the incoming candidate decision descriptions for
+**driver-free dev-process / engineering-workflow statements** and drop them from
+reconciliation. The canonical pattern list and the over-exclusion carve-out live
+in `skills/bicameral-ingest/SKILL.md` (HARD EXCLUDE → "Dev-process /
+engineering-workflow with NO product or business driver") — do not duplicate the
+list here; apply that same rule:
+
+- A candidate is dropped only when **no product or business driver is named in
+  the whole source** (a sibling L1 commitment or a Step-0.5 ledger prior counts
+  as a driver — keep those).
+- Dropped dev-process candidates are added to the returned **dropped list** (see
+  Execution protocol) so the calling flow excludes them from ingest. This is a
+  **mechanical, silent** resolution — no user probe.
+- This is graph-reconciliation hygiene: it prevents dev-process noise from
+  acquiring `feature_group` names, supersession edges, or context-for links in
+  the knowledge graph. Telemetry for the *ingest* path is counted by
+  `g2_dropped_dev_process` in `bicameral-ingest`; sentry-side drops are not
+  separately counted (they feed the same exclusion).
+
+If every incoming candidate is dropped here, skip Phase 2 — there is nothing
+left to reconcile or probe.
+
 ### Step R1 — Derive search probes
 
 From the input, extract 1–3 search probes. Each probe is a short
@@ -208,7 +232,8 @@ Then return control to the calling flow with:
 ## Rules
 
 1. **Mechanical resolutions are always silent.** No output for clear parallel
-   scope, exact name matches, or established driver pattern matches.
+   scope, exact name matches, established driver pattern matches, or the
+   Step R0 dev-process pre-filter drops (#393).
 2. **Cap at 3 supersession probes per sentry call.** Batch the rest.
 3. **Phase 1 empty path is silent.** Zero search results → no output,
    no probing, hand back immediately.

--- a/skills/bicameral-ingest/SKILL.md
+++ b/skills/bicameral-ingest/SKILL.md
@@ -40,6 +40,7 @@ bicameral.skill_end(skill_name="bicameral-ingest", session_id=<stored_id>,
     # G2 fields — extraction filter
     g2_candidates_evaluated: N,
     g2_dropped_hard_exclude: N,
+    g2_dropped_dev_process: N,
     g2_dropped_l3: N,
     g2_dropped_gate1: N,
     g2_dropped_gate2: N,
@@ -192,6 +193,23 @@ Read the source. For each statement, decide whether it's a real implementation d
 | Pure metrics / OKR status | "Q3 OKR is at 78%" / "we're at 84% retention" |
 | Pure question with no directional signal | "has anyone looked at Sentry vs PostHog?" (exploration request, not a direction) |
 | Reversed within the same source | speaker A proposes X → blocked → team agrees on Y → only Y is the decision, X is not |
+| **Dev-process / engineering-workflow with NO product or business driver** (#393) | CI/CD ("we'll use GitHub Actions" / "deploy via ArgoCD"); testing process ("80% coverage gate" / "use Playwright for e2e"); branching/release ("trunk-based development" / "release trains every 2 weeks"); linting/formatting ("enable strict TypeScript" / "Prettier 2-space"); dev tooling ("Docker Compose for local dev" / "switch to pnpm"); code-review process ("PRs need 2 approvals" / "squash-merge only"); monitoring/observability *setup* ("add Datadog APM" / "use Sentry for error tracking"); dependency management ("pin all deps" / "use Renovate") |
+
+> **Dev-process carve-out — do NOT over-exclude (#393).** The dev-process row
+> hard-excludes a statement **only when no product or business driver is named
+> in the same source.** Evaluate the driver against the **whole source**, not the
+> isolated clause — a driver counts if it appears in a sibling L1 in the same
+> source (per the Gate 1 L1-inheritance path below) or in ledger priors pulled in
+> Step 0.5. When a driver is present, do **not** hard-exclude: let the candidate
+> fall through to level classification and the Gate 1 "Keep these
+> (engineering-shaped but business-tied)" path. Examples that **stay tracked**:
+> "Migrate sessions to Redis before Black Friday — committed to 20k concurrent
+> checkout" (SLA driver); "Add PII redaction before logging — required by the GDPR
+> assessment" (regulatory driver). When the source is genuinely silent on a driver
+> but a fork plausibly exists, **park as `context_pending`** rather than
+> hard-excluding — the dev-process hard-exclude is for the driver-free,
+> fork-free engineering-hygiene case. Count every dev-process hard-exclude in
+> `g2_dropped_dev_process`.
 
 **SPECULATIVE PROPOSALS — aspirational, hedged, and exploratory candidates are NOT hard-excluded.** If a statement names a concrete subject (a feature, an architecture, a behavior the product could have), capture it as a `proposed` decision regardless of how tentative the language is. Hedged conditionals ("if infra approves, we'll switch to ScyllaDB"), aspirational statements ("I want to prioritize Google Calendar integration"), exploratory ideas ("we need something like Zoom attendance tracking"), and deferred items ("let's revisit this next quarter") all belong in the ledger — the team ratifies or rejects them there. Bicameral's whole value is serving as the central panel for that judgment; silently dropping speculative items before the team sees them defeats the purpose.
 
@@ -449,6 +467,30 @@ Apply level classification first. This is a feature spec — L1 extraction mode.
 → **Extract: 5 L1 decisions.** All are product commitments — user-observable behaviors the team has committed to. No Gate 1/Gate 2 needed. Descriptions stay in product language (no implementation details). The 90-day limit and 5-minute SLA are not "specs not decisions" — they are specific product commitments that another team might reasonably have set differently (could be 30 days, could be async confirmation). The density limit for L1 from a feature spec is 8, so 5 is fine.
 
 **Anti-pattern caught**: the old filter would have dropped all 5 as "spec, not a decision" (Gate 2 fail — "any team would implement this"). With level classification, these are correctly routed as L1 product commitments that bypass Gate 2.
+
+**Example 8 — Dev-process meeting: hard-exclude driver-free workflow items, KEEP the business-tied one (#393)**
+
+> Infra sync. Raj: "Let's standardize on GitHub Actions for CI and require 2 approvals on every PR." Priya: "Switch local dev to Docker Compose and pin all deps with Renovate." Lena: "We should add Datadog APM — it'll help us debug faster." Sam: "Separately — we committed to 20k concurrent checkouts for Black Friday, so move sessions to Redis before then." Maya: "And we promised users a live status page during incidents; stand up Prometheus + Grafana to feed it."
+
+Apply the **hard-exclude check first** (Step 1, before level classification), evaluating each candidate's driver against the **whole source**:
+
+| Candidate | Driver named in source? | Result |
+|---|---|---|
+| GitHub Actions for CI | None — CI/CD workflow | **HARD EXCLUDE** (dev-process) |
+| Require 2 approvals on every PR | None — code-review process | **HARD EXCLUDE** (dev-process) |
+| Docker Compose for local dev | None — dev tooling | **HARD EXCLUDE** (dev-process) |
+| Pin all deps with Renovate | None — dependency management | **HARD EXCLUDE** (dev-process) |
+| Add Datadog APM ("debug faster") | None — monitoring *setup*, hygiene only | **HARD EXCLUDE** (dev-process) |
+| Move sessions to Redis before Black Friday | ✓ 20k checkout SLA commitment (same source) | **KEEP** → L2, Gate 1 business-tied → `proposed` |
+| Prometheus + Grafana for status page | ✓ sibling L1 "users get a live status page during incidents" (same source) | **KEEP** → L2, business tie inferred from L1 → `proposed` |
+
+→ **Extract: 2 decisions.** Five dev-process items hard-excluded at Step 1
+(`g2_dropped_dev_process = 5`) — they never reach proposal state. The Redis
+move survives on its own named SLA driver; the Prometheus/Grafana monitoring
+survives because a sibling L1 in the same source supplies the product tie
+(monitoring setup that would be hygiene in isolation is business-tied here).
+**The carve-out is the whole point of #393** — dev-process noise is dropped, but
+infrastructure decisions that deliver a product commitment are still tracked.
 
 ### 2. Resolve code regions yourself, then hand explicit pins to the server
 

--- a/skills/bicameral-judge-gaps/SKILL.md
+++ b/skills/bicameral-judge-gaps/SKILL.md
@@ -27,6 +27,13 @@ explicitly rejected in each category's prompt. A finding that's
 technically correct but engineering-focused is a bug in this rubric.
 No codebase crawl is required — reason over `source_excerpt` only.
 
+> **Upstream enforcement (#393)**: dev-process / engineering-workflow
+> decisions with no product or business driver are now hard-excluded at
+> `bicameral-ingest` Step 1 (before they ever reach a brief), so they cannot
+> appear as gaps here in the first place. This rubric's engineering-gap
+> rejection remains the downstream backstop, but the primary filter is the
+> ingest hard-exclude — they share the same definition.
+
 ## When to use
 
 This skill is **not fired directly by user phrasings**. It is a

--- a/tests/test_ingest_dev_process_telemetry.py
+++ b/tests/test_ingest_dev_process_telemetry.py
@@ -1,0 +1,97 @@
+"""Sociable tests for the #393 ``g2_dropped_dev_process`` ingest counter.
+
+These run the real ``_handle_skill_end_impl`` validation path and seam off only
+``telemetry.record_skill_event`` — the external PostHog sink we cannot run in
+tests (CLAUDE.md sociable-testing rule 4/5: "external boundaries we can't run").
+We assert observable behavior — whether the field is accepted (no
+``diagnostic_warning``) and round-trips into the recorded diagnostic — not a mock
+call signature, so the test is not a tautology.
+
+The negative control (``g2_bogus``) proves the assertion would fail if the field
+were *not* declared on ``IngestDiagnostic`` in ``contracts.py`` — the exact
+silent-drop failure mode the model's ``extra="forbid"`` guards against.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+import telemetry
+from handlers.skill import _handle_skill_end_impl
+
+
+@pytest.fixture
+def captured_events(monkeypatch):
+    """Capture every record_skill_event call without touching the real sink."""
+    events: list[dict[str, Any]] = []
+
+    def _capture(
+        skill_name,
+        session_id,
+        duration_ms,
+        errored,
+        server_version,
+        diagnostic=None,
+        error_class=None,
+    ):
+        events.append({"skill_name": skill_name, "diagnostic": diagnostic})
+
+    monkeypatch.setattr(telemetry, "record_skill_event", _capture)
+    return events
+
+
+async def test_g2_dropped_dev_process_is_accepted_and_round_trips(captured_events):
+    """A bicameral-ingest skill_end carrying g2_dropped_dev_process is recorded,
+    not echoed back as an unknown field."""
+    result = await _handle_skill_end_impl(
+        session_id="sess-393",
+        skill_name="bicameral-ingest",
+        server_version="test",
+        diagnostic={
+            "decisions_ingested": 2,
+            "g2_candidates_evaluated": 7,
+            "g2_dropped_hard_exclude": 1,
+            "g2_dropped_dev_process": 5,
+        },
+    )
+
+    # Observable: the field was accepted — no warning surfaced to the LLM.
+    assert result.get("diagnostic_warning") is None
+    assert result["status"] == "recorded"
+
+    # Observable: the value round-tripped into what was handed to the sink.
+    assert len(captured_events) == 1
+    recorded = captured_events[0]["diagnostic"]
+    assert recorded["g2_dropped_dev_process"] == 5
+    assert recorded["g2_dropped_hard_exclude"] == 1
+
+
+async def test_unknown_field_still_warns_but_dev_process_survives(captured_events):
+    """Negative control: a genuinely unknown field IS echoed as a warning and
+    stripped from the recorded diagnostic, while g2_dropped_dev_process — now a
+    declared field — survives in the same payload.
+
+    If g2_dropped_dev_process were NOT declared on IngestDiagnostic, it would
+    appear in diagnostic_warning here and this assertion would fail — that is
+    what makes the positive test above non-vacuous.
+    """
+    result = await _handle_skill_end_impl(
+        session_id="sess-393-neg",
+        skill_name="bicameral-ingest",
+        server_version="test",
+        diagnostic={
+            "g2_dropped_dev_process": 3,
+            "g2_bogus_not_a_real_field": 1,
+        },
+    )
+
+    warning = result.get("diagnostic_warning")
+    assert warning is not None
+    assert "g2_bogus_not_a_real_field" in warning
+    assert "g2_dropped_dev_process" not in warning
+
+    recorded = captured_events[0]["diagnostic"]
+    assert recorded["g2_dropped_dev_process"] == 3
+    assert "g2_bogus_not_a_real_field" not in recorded


### PR DESCRIPTION
Closes #393 (P0).

## What
Dev-process / engineering-workflow decisions (CI/CD, testing process, branching/release, linting, dev tooling, code-review process, monitoring setup, dependency management) with **no product or business driver** are now hard-excluded at `bicameral-ingest` **Step 1, before level classification** — so they never enter the ledger, even as proposals.

## Over-exclusion guard (the load-bearing design choice)
The hard-exclude fires **only when no driver is named in the whole source**. A sibling L1 commitment or a Step-0.5 ledger prior counts as a driver, deferring to the existing Gate 1 business-tie path. Genuinely ambiguous candidates park as `context_pending` rather than dropping. Worked Example 8 proves it:
- ✅ KEEP: "Migrate sessions to Redis before Black Friday — 20k concurrent checkout SLA" (named driver)
- ✅ KEEP: "Prometheus + Grafana" when a sibling L1 ("users get a live status page") supplies the tie
- ❌ DROP: driver-free "add Datadog APM", "PRs need 2 approvals", "use GitHub Actions", etc.

## Sub-deliverables (all four from #393)
1. `skills/bicameral-ingest/SKILL.md` — HARD EXCLUDE row + carve-out + Worked Example 8 + `skill_end` counter
2. `skills/bicameral-context-sentry/SKILL.md` — Step R0 pre-filter (shares the canonical ingest definition by reference; no duplicated pattern list)
3. `skills/bicameral-judge-gaps/SKILL.md` — upstream-enforcement cross-reference (rubric already excluded engineering gaps)
4. `contracts.py` + `server.py` — new `g2_dropped_dev_process` telemetry counter (JSON-blob diagnostic; no schema migration)

## Tests
New sociable test `tests/test_ingest_dev_process_telemetry.py` (real `_handle_skill_end_impl`, narrow seam on the PostHog sink) — asserts the counter is accepted and round-trips, with a load-bearing negative control proving a missing field declaration would be caught. **2/2 pass.** Local: `ruff check`, `ruff format --check`, `test_skill_governance_lint` (22/22) all green.

## Governance
- Risk **L2** — shared ingest contract + telemetry model; no `ledger/schema.py` change → no §4.7 schema-codeowner gate.
- Independent architect-reviewer audit: **PASS** (1 MEDIUM folded in: whole-source driver evaluation incl. sibling L1 / ledger priors).
- Independent substantiation (objective observer): **SUBSTANTIATED** — Reality == Promise across all four sub-deliverables.

🤖 Generated with [Claude Code](https://claude.com/claude-code)