### PR TITLE
fix(ci): #540 — skip key-dependent steps on dependabot PRs

### DIFF
--- a/.github/workflows/test-mcp-regression.yml
+++ b/.github/workflows/test-mcp-regression.yml
@@ -276,8 +276,12 @@ jobs:
       # bind handler / skill / fixture must keep recall ≥ 0.80, precision
       # ≥ 0.85, abort_rate ≤ 0.30 — OR explicitly re-record the cache
       # after a deliberate skill-prompt change. "Deliberate not drift."
+      # #540: dependabot-triggered PRs don't receive env-scoped secrets, so this
+      # key-dependent gate can't authenticate (every case errors -> recall 0.000).
+      # Skip it on dependabot runs; pytest + deterministic gates above still
+      # validate the dependency change.
       - name: M2 grounding-recall eval (hard gate)
-        if: matrix.os == 'ubuntu-latest'
+        if: matrix.os == 'ubuntu-latest' && github.actor != 'dependabot[bot]'
         env:
           ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
           BICAMERAL_GROUNDING_EVAL_MODEL: claude-haiku-4-5-20251001
@@ -352,8 +356,9 @@ jobs:
       # BICAMERAL_PREFLIGHT_EVAL_RECORD=1 /
       # BICAMERAL_PREFLIGHT_INVOCATION_EVAL_RECORD=1 after a deliberate
       # skill-prompt change. "Deliberate not drift."
+      # #540: skip on dependabot runs (no env-scoped ANTHROPIC_API_KEY).
       - name: M_skill_preflight Step-1 (hard gate)
-        if: matrix.os == 'ubuntu-latest'
+        if: matrix.os == 'ubuntu-latest' && github.actor != 'dependabot[bot]'
         env:
           ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
           BICAMERAL_PREFLIGHT_EVAL_MODEL: claude-haiku-4-5-20251001
@@ -362,8 +367,9 @@ jobs:
           --gate-mode hard
           -o test-results/skill-step1.json
 
+      # #540: skip on dependabot runs (no env-scoped ANTHROPIC_API_KEY).
       - name: M_skill_preflight Step-0 (hard gate)
-        if: matrix.os == 'ubuntu-latest'
+        if: matrix.os == 'ubuntu-latest' && github.actor != 'dependabot[bot]'
         env:
           ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
           BICAMERAL_PREFLIGHT_INVOCATION_EVAL_MODEL: claude-haiku-4-5-20251001

--- a/.github/workflows/v0-user-flow-e2e.yml
+++ b/.github/workflows/v0-user-flow-e2e.yml
@@ -94,7 +94,12 @@ jobs:
       # subscription tied to the OAuth token was disabled, surfacing as
       # oauth_org_not_allowed 403 on every flow before turn 1. `claude -p`
       # honours ANTHROPIC_API_KEY natively, sidestepping subscription policy.
+      # #540: dependabot-triggered PRs don't receive env-scoped secrets, so the
+      # key probe (and the e2e run below) can't authenticate. Skip them on
+      # dependabot runs — the install/setup steps above still validate the
+      # dependency change, and the job stays green instead of fast-failing.
       - name: Anthropic API key visibility probe
+        if: github.actor != 'dependabot[bot]'
         run: |
           set +e
           if [ -n "${ANTHROPIC_API_KEY}" ]; then
@@ -108,6 +113,7 @@ jobs:
           ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
 
       - name: Run v0 user flow e2e (assertion-only, blocking)
+        if: github.actor != 'dependabot[bot]'
         env:
           ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
         run: python tests/e2e/run_e2e_flows.py


### PR DESCRIPTION
## What

Stop dependabot PRs from hard-failing on auth-gated CI checks they structurally can't pass. Closes #540.

Dependabot-triggered PRs run with `Secret source: Dependabot` and don't receive the `ci-test` environment's `ANTHROPIC_API_KEY`. Diagnosed via `/qor-debug` on #522: the sigstore bump resolved cleanly (pip → sigstore 4.2.0, no conflict; repo usage is stub-only) — both red checks were purely the missing key. #523 (cocoindex) and #417 (bm25s) fail for the same reason.

## How (gating-as-observability — same family as #537/#539)

Skip only the **key-dependent** steps when `github.actor == 'dependabot[bot]'`, **step-level** (not job-level) so the required checks still report green rather than skipped/blocked:

- `test-mcp-regression.yml`: `M2 grounding-recall`, `M_skill_preflight Step-0`, `Step-1`.
- `v0-user-flow-e2e.yml` (`assertions` job): the API-key visibility probe + the e2e run step.

**Preserved on dependabot runs:** dependency install, the full pytest suite, and the deterministic gates (`M_shadow_parity`, `M_surrealql_coverage`) — i.e. the real signal that a bump didn't break anything.

## Verification

Both workflows pass `yaml.safe_load`. Real verification is re-running a dependabot PR (#522/#523/#417) against this branch once merged — the auth steps should skip and the checks go green. No unit-testable surface (workflow-only change).

## Notes

- **Targets `dev`** (where the dependabot PRs are based).
- **Do not merge — `agent-needs-human`.**
- Complementary option (not done here): mirror `ANTHROPIC_API_KEY` into Dependabot secrets to let the gates run normally instead of skipping.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
