### PR TITLE
docs: align alpha review routing with bot authority

### DIFF
--- a/docs/adr/0004-alpha-review-routing-with-existing-reasons.md
+++ b/docs/adr/0004-alpha-review-routing-with-existing-reasons.md
@@ -3,6 +3,7 @@
 **Date:** 2026-06-07  
 **Status:** proposed  
 **Level:** L1
+**Related:** BicameralAI/bicameral-bot ADR-0022
 
 ## Problem
 
@@ -15,30 +16,41 @@ authority confusion.
 
 ## Decision
 
-Alpha review routing stays within the existing owner/member and configured
-approver model. MCP may produce `DecisionCandidate`, `BindingEvidence`,
-`ReviewCommand`, or advisory observations, but it must not introduce built-in
-domain-role routing fields such as `payments_owner`, `risk_owner`,
-`compliance_owner`, or `suggested_review_context`.
+Alpha review routing stays within the product owner/member model. The product
+owner is the implicit reviewer for product-scoped Decision review; members may
+contribute evidence or request review according to workspace policy. MCP may
+produce `DecisionCandidate`, `BindingEvidence`, `ReviewCommand`, or advisory
+observations, but it must not introduce built-in domain-role routing fields such
+as `payments_owner`, `risk_owner`, `compliance_owner`, or
+`suggested_review_context`.
+
+This ownership boundary is defined by `bicameral-bot` ADR-0022. MCP consumes
+that authority structure; it does not define product ownership semantics.
 
 When a candidate or command needs review, MCP and governance responses should
 use the existing `reason` fields deliberately. The reason should be a short,
-source-grounded explanation of the evidence gap or decision rationale, not a new
-role assignment layer.
+source-grounded explanation of the evidence gap or decision rationale, not a
+reviewer-assignment layer.
+
+Existing schema fields such as `required_reviewers` or `assigned_reviewers`
+remain compatibility plumbing for older governance paths, but alpha product UX
+must not use them as per-candidate reviewer routing. The reviewer is derived
+from the current product/workspace owner boundary. A later hosted or premium
+configuration may support multiple products, each with its own owner/member set.
 
 Example:
 
 ```json
 {
   "verdict": "needs_review",
-  "reason": "ADR covers successful card captures, but no reviewed source specifies reversal timing for failed authorizations.",
-  "required_reviewers": ["configured-approver-or-member"]
+  "reason": "ADR covers successful card captures, but no reviewed source specifies reversal timing for failed authorizations."
 }
 ```
 
 ## Consequences
 
 Alpha reduces context reconstruction for EMs without making Bicameral own the
-customer's org chart. Rich role routing remains a hosted or premium product
-line candidate, where ownership metadata, codeowners, Jira components, Slack
+customer's org chart or route every candidate to a bespoke reviewer list. Rich
+multi-product ownership and role routing remain hosted or premium product-line
+candidates, where ownership metadata, codeowners, Jira components, Slack
 groups, or compliance workflows can justify the added configuration surface.

--- a/docs/spec-alpha-review-routing-state-machine.md
+++ b/docs/spec-alpha-review-routing-state-machine.md
@@ -2,9 +2,13 @@
 
 This spec defines the alpha routing behavior for MCP reads and writes that
 surface governance-relevant observations. It follows ADR-0004: alpha uses the
-existing owner/member and configured approver model, and it uses existing
-`reason` fields to reduce context reconstruction without adding domain-role
+product owner/member model, and it uses existing `reason` fields to reduce
+context reconstruction without adding domain-role or per-candidate reviewer
 routing fields.
+
+The product authority structure is defined by `bicameral-bot` ADR-0022. MCP is
+the local agent-facing tool surface; it consumes the bot-owned Product Owner /
+Workspace Member boundary instead of defining reviewer authority itself.
 
 ## Goals
 
@@ -12,8 +16,8 @@ routing fields.
   authority.
 - Let MCP reads and writes both surface useful `DecisionCandidate` and binding
   observations.
-- Route review with existing `reason`, `required_reviewers`, and review-state
-  fields.
+- Route review with existing `reason` and review-state fields.
+- Treat the current product owner as the implicit reviewer for alpha.
 - Avoid new domain-role taxonomy such as `payments_owner`, `risk_owner`, or
   `compliance_owner` in alpha.
 
@@ -67,7 +71,7 @@ routing fields.
                   +------------------+       +------------------+ +------------------+
                   | Governance policy|       | Governance policy| | Governance policy|
                   | confidence +     |       | confidence +     | | confidence +     |
-                  | configured review|       | configured review| | configured review|
+                  | owner review     |       | owner review     | | owner review     |
                   +--------+---------+       +--------+---------+ +---------+--------+
                            |                          |                   |
                            v                          v                   v
@@ -130,9 +134,9 @@ routing fields.
            |                               |
            v                               v
 +----------------------+       +---------------------------+
-| owner/member or      |       | reason explains what is   |
-| configured approver  |       | missing, not which domain |
-| reviews command      |       | role must review          |
+| product owner reviews|       | reason explains what is   |
+| command; members may |       | missing, not which domain |
+| contribute evidence  |       | role must review          |
 +----------+-----------+       +---------------------------+
            |
            v
@@ -160,8 +164,7 @@ Good:
 ```json
 {
   "verdict": "needs_review",
-  "reason": "ADR covers successful card captures, but no reviewed source specifies reversal timing for failed authorizations.",
-  "required_reviewers": ["configured-approver-or-member"]
+  "reason": "ADR covers successful card captures, but no reviewed source specifies reversal timing for failed authorizations."
 }
 ```
 
@@ -171,12 +174,13 @@ Bad:
 {
   "verdict": "needs_review",
   "reason": "Compliance owner must review because this violates Reg E.",
-  "domain_role": "compliance_owner"
+  "domain_role": "compliance_owner",
+  "required_reviewers": ["compliance-owner"]
 }
 ```
 
-The bad example adds a domain-role field and overstates a compliance conclusion
-that alpha has not proven.
+The bad example adds reviewer-routing fields and overstates a compliance
+conclusion that alpha has not proven.
 
 ## Alpha Routing Rules
 
@@ -188,12 +192,17 @@ that alpha has not proven.
 | Action implicitly encodes a decision through tests or code | Surface a candidate only when the implementation introduces a material constraint; use `reason` to explain the inferred constraint. |
 | Binding evidence is verified | Allow binding/review command to enter governance. |
 | Binding evidence is weak, missing, stale, or ambiguous | Keep advisory or request evidence; do not materialize binding or compliance authority. |
-| Review is required | Use configured approvers or owner/member capability; do not add alpha domain-role routing. |
+| Review is required | Route to the current product owner implicitly; members may contribute evidence according to workspace policy. |
 
 ## Non-Goals
 
 - Do not add `domain_role`, `suggested_review_context`, or financial-domain
   reviewer fields in alpha.
+- Do not use `required_reviewers` or `assigned_reviewers` as alpha product
+  semantics. Existing fields may remain for compatibility, but the alpha UX
+  should derive review from the current product owner boundary.
+- Do not add multi-product owner/member routing in alpha. That belongs in a
+  later hosted or premium configuration surface.
 - Do not let MCP directly write canonical Decisions, accepted bindings, signoff,
   or compliance state.
 - Do not use `reason` to imply verified compliance or legal conclusions that


### PR DESCRIPTION
## Summary
- update ADR-0004 to reference bicameral-bot ADR-0022 as the product authority source
- clarify that Product Owner is the implicit alpha reviewer
- remove required_reviewers from examples and mark reviewer fields as compatibility plumbing, not alpha product semantics

## Verification
- docs-only change; no tests run

## Merge note
Requested merge target: dev. Owner requested CI bypass for this docs decision.