### PR TITLE
chore: require factory attestation on PRs

### DIFF
--- a/.bicameral/factory-attestations/bd8447c0daf3c2cbbac2a40c2ca5c03f00f3a190.json
+++ b/.bicameral/factory-attestations/bd8447c0daf3c2cbbac2a40c2ca5c03f00f3a190.json
@@ -1,0 +1,24 @@
+{
+  "version": 1,
+  "factory_repo": "BicameralAI/bicameral-factory",
+  "factory_commit": "bd8447c0daf3c2cbbac2a40c2ca5c03f00f3a190",
+  "loaded_context": [
+    "README.md",
+    "CONTRIBUTING.md",
+    "PAMA.md",
+    "CONTEXT.md",
+    "INSTRUCTIONS.md",
+    "blueprints/factory-attestation.md",
+    "skills/factory-skill-manifest.json",
+    "skills/mattpocock/engineering/bic:grill-with-docs/SKILL.md"
+  ],
+  "local_setup_divergence": {
+    "checked": true,
+    "resolution": "none"
+  },
+  "end_of_session_capture": {
+    "run": true
+  },
+  "attested_by": "Codex GPT-5",
+  "timestamp": "2026-06-06T21:45:00-07:00"
+}

--- a/.github/workflows/factory-attestation.yml
+++ b/.github/workflows/factory-attestation.yml
@@ -1,0 +1,11 @@
+name: Bicameral factory attestation
+
+on:
+  pull_request:
+    branches: [dev, main]
+
+jobs:
+  factory-attestation:
+    uses: BicameralAI/bicameral-factory/.github/workflows/factory-attestation.yml@main
+    with:
+      attestation_path: .bicameral/factory-attestations


### PR DESCRIPTION
## Summary
- add the reusable Bicameral factory attestation workflow for PRs targeting dev/main
- add this branch commit-grounded factory attestation under .bicameral/factory-attestations

## Validation
- python3 /Users/jinhongkuan/github/bicameral-factory/scripts/validate-factory-attestation.py .bicameral/factory-attestations --context-root /Users/jinhongkuan/github/bicameral-factory

## Factory attestation
- .bicameral/factory-attestations/bd8447c0daf3c2cbbac2a40c2ca5c03f00f3a190.json