### PR TITLE
fix(ledger): #562 — validate caller-controlled record ids before SurrealQL (P0)

### DIFF
--- a/.github/workflows/test-mcp-regression.yml
+++ b/.github/workflows/test-mcp-regression.yml
@@ -153,6 +153,7 @@ jobs:
           tests/test_extract_go_substrate.py
           tests/test_m_shadow_divergence_log.py
           tests/test_shadow_dispatch.py
+          tests/test_query_safety_562.py
           -v --tb=short
           --junitxml=test-results/results.xml
           --html=test-results/report.html --self-contained-html

--- a/codegenome/continuity_service.py
+++ b/codegenome/continuity_service.py
@@ -24,6 +24,7 @@ import logging
 from dataclasses import dataclass
 
 from contracts import CodeRegionSummary, ContinuityResolution
+from ledger.queries import _validated_record_id
 
 from .adapter import CodeGenomeAdapter, SubjectIdentity
 from .continuity import find_continuity_match
@@ -233,6 +234,7 @@ async def evaluate_continuity_for_drift(
 
 async def _resolve_code_subject_id(ledger, decision_id: str) -> str | None:
     """Walk decision -> about -> code_subject; return the first subject id."""
+    decision_id = _validated_record_id(decision_id, "decision")
     rows = await ledger._client.query(  # type: ignore[attr-defined]
         f"SELECT type::string(id) AS subject_id FROM {decision_id}->about->code_subject LIMIT 1",
     )

--- a/handlers/ratify.py
+++ b/handlers/ratify.py
@@ -17,7 +17,7 @@ import logging
 from datetime import UTC, datetime
 
 from contracts import RatifyResponse
-from ledger.queries import decision_exists, project_decision_status
+from ledger.queries import _validated_record_id, decision_exists, project_decision_status
 from preflight_telemetry import telemetry_enabled, write_engagement
 
 logger = logging.getLogger(__name__)
@@ -42,6 +42,7 @@ async def handle_ratify(
     Idempotent: calling with the same action on an already-finalized decision
     returns was_new=False and leaves the existing signoff untouched.
     """
+    decision_id = _validated_record_id(decision_id, "decision")
     if action not in ("ratify", "reject"):
         raise ValueError(f"Unknown action '{action}'; must be 'ratify' or 'reject'")
 

--- a/handlers/remove_decision.py
+++ b/handlers/remove_decision.py
@@ -36,7 +36,7 @@ import logging
 from datetime import UTC, datetime
 
 from contracts import RemoveDecisionResponse
-from ledger.queries import decision_exists
+from ledger.queries import _validated_record_id, decision_exists
 
 logger = logging.getLogger(__name__)
 
@@ -54,6 +54,7 @@ async def handle_remove_decision(
     subsequent calls because the row is no longer present — the event
     journal already records the original removal.
     """
+    decision_id = _validated_record_id(decision_id, "decision")
     if not reason or not reason.strip():
         raise ValueError("remove_decision requires a non-empty 'reason' (audit-trail obligation)")
 
@@ -162,6 +163,7 @@ async def _hard_delete_decision(client, decision_id: str) -> None:
     NONE on any decision that pointed at this id, so they become
     root-level decisions instead of dangling pointers.
     """
+    decision_id = _validated_record_id(decision_id, "decision")
     # NULL out child pointers so hierarchical decisions don't dangle.
     await client.query(
         f"UPDATE decision SET parent_decision_id = NONE WHERE parent_decision_id = '{decision_id}'"

--- a/handlers/remove_source.py
+++ b/handlers/remove_source.py
@@ -34,6 +34,7 @@ from datetime import UTC, datetime
 
 from contracts import RemoveSourcePlan, RemoveSourceResponse
 from ledger.queries import (
+    _validated_record_id,
     get_decisions_for_span,
     get_input_span_row,
     input_span_exists,
@@ -161,10 +162,12 @@ async def _apply_cascading_remove(
     """Soft-delete each decision in ``decision_ids`` and hard-delete the span
     row + its outgoing ``yields`` edges. Returns the list of decision ids
     that were actually mutated."""
+    span_id = _validated_record_id(span_id, "input_span")
     now_iso = datetime.now(UTC).isoformat()
     cascaded: list[str] = []
 
     for did in decision_ids:
+        did = _validated_record_id(did, "decision")
         existing = await client.query(
             f"SELECT signoff FROM {did} LIMIT 1",
         )

--- a/handlers/resolve_collision.py
+++ b/handlers/resolve_collision.py
@@ -25,6 +25,7 @@ from datetime import UTC, datetime
 
 from contracts import ResolveCollisionResponse
 from ledger.queries import (
+    _validated_record_id,
     decision_exists,
     project_decision_status,
     relate_context_for,
@@ -52,6 +53,14 @@ async def handle_resolve_collision(
 
     inner = getattr(ledger, "_inner", ledger)
     client = inner._client
+    if new_id is not None:
+        new_id = _validated_record_id(new_id, "decision")
+    if old_id is not None:
+        old_id = _validated_record_id(old_id, "decision")
+    if span_id is not None:
+        span_id = _validated_record_id(span_id, "input_span")
+    if decision_id is not None:
+        decision_id = _validated_record_id(decision_id, "decision")
 
     _session_id = getattr(ctx, "session_id", None) or ""
     _now_iso = datetime.now(UTC).isoformat()

--- a/ledger/adapter.py
+++ b/ledger/adapter.py
@@ -15,6 +15,7 @@ from pathlib import Path
 
 from .client import LedgerClient, LedgerError
 from .queries import (
+    _validated_record_id,
     create_code_region,
     decision_exists,
     find_subject_identities_for_decision,
@@ -437,6 +438,7 @@ class SurrealDBLedgerAdapter:
 
     async def get_decision_description(self, decision_id: str) -> str:
         await self._ensure_connected()
+        decision_id = _validated_record_id(decision_id, "decision")
         rows = await self._client.query(f"SELECT description FROM {decision_id} LIMIT 1")
         return str((rows or [{}])[0].get("description", "")) if rows else ""
 
@@ -1811,6 +1813,7 @@ class SurrealDBLedgerAdapter:
         Idempotent. Returns the projected decision status after the write.
         """
         await self._ensure_connected()
+        decision_id = _validated_record_id(decision_id, "decision")
         await self._client.query(
             f"UPDATE {decision_id} SET signoff = $signoff, updated_at = time::now()",
             {"signoff": signoff},
@@ -1834,6 +1837,8 @@ class SurrealDBLedgerAdapter:
         UPDATE is a full overwrite. Returns ``{"old_status": "superseded"}``.
         """
         await self._ensure_connected()
+        new_id = _validated_record_id(new_id, "decision")
+        old_id = _validated_record_id(old_id, "decision")
         await relate_supersedes(
             self._client,
             new_id,

--- a/ledger/queries.py
+++ b/ledger/queries.py
@@ -1020,6 +1020,7 @@ async def promote_ephemeral_verdict(
 
 async def decision_exists(client: LedgerClient, decision_id: str) -> bool:
     """Return True iff a decision row exists with the given record id."""
+    decision_id = _validated_record_id(decision_id, "decision")
     rows = await client.query(f"SELECT id FROM {decision_id} LIMIT 1")
     return bool(rows)
 
@@ -1033,6 +1034,7 @@ async def get_decisions_for_span(client: LedgerClient, span_id: str) -> list[str
     Returns an empty list when the span has no derived decisions or does
     not exist.
     """
+    span_id = _validated_record_id(span_id, "input_span")
     rows = await client.query(
         f"SELECT type::string(id) AS decision_id FROM decision "
         f"WHERE <-yields<-input_span CONTAINS {span_id}",
@@ -1042,6 +1044,7 @@ async def get_decisions_for_span(client: LedgerClient, span_id: str) -> list[str
 
 async def input_span_exists(client: LedgerClient, span_id: str) -> bool:
     """Return True iff an input_span row exists with the given record id."""
+    span_id = _validated_record_id(span_id, "input_span")
     rows = await client.query(f"SELECT id FROM {span_id} LIMIT 1")
     return bool(rows)
 
@@ -1050,6 +1053,7 @@ async def get_input_span_row(client: LedgerClient, span_id: str) -> dict | None:
     """Return the full input_span row (text, source_ref, source_type,
     meeting_date, speakers, created_at) for use in the source_removed.completed
     event payload. Returns None when the row does not exist."""
+    span_id = _validated_record_id(span_id, "input_span")
     rows = await client.query(
         f"SELECT text, source_ref, source_type, meeting_date, speakers, created_at "
         f"FROM {span_id} LIMIT 1",
@@ -1069,6 +1073,7 @@ async def get_decision_level(client: LedgerClient, decision_id: str) -> str | No
     ``"L3"`` rows are intentionally ungrounded at the identity layer
     and produce no ``code_subject`` / ``subject_identity`` writes.
     """
+    decision_id = _validated_record_id(decision_id, "decision")
     rows = await client.query(
         f"SELECT decision_level FROM {decision_id} LIMIT 1",
     )
@@ -1088,6 +1093,7 @@ async def get_decision_source(client: LedgerClient, decision_id: str) -> str | N
     PostHog — the source_type value space is a fixed enum from the
     ingest contract, not user content.
     """
+    decision_id = _validated_record_id(decision_id, "decision")
     rows = await client.query(
         f"SELECT source_type FROM {decision_id} LIMIT 1",
     )
@@ -1099,6 +1105,7 @@ async def get_decision_source(client: LedgerClient, decision_id: str) -> str | N
 
 async def region_exists(client: LedgerClient, region_id: str) -> bool:
     """Return True iff a code_region row exists with the given record id."""
+    region_id = _validated_record_id(region_id, "code_region")
     rows = await client.query(f"SELECT id FROM {region_id} LIMIT 1")
     return bool(rows)
 
@@ -1118,6 +1125,7 @@ async def get_region_descriptor(
     Line numbers (start_line / end_line) are deliberately excluded — they
     shift across replays and would make cross-author matching brittle.
     """
+    region_id = _validated_record_id(region_id, "code_region")
     rows = await client.query(
         f"SELECT repo, file_path, symbol_name, content_hash FROM {region_id} LIMIT 1"
     )
@@ -1187,6 +1195,8 @@ async def relate_yields(
     decision_id: str,
 ) -> None:
     """Create input_span → yields → decision edge. Idempotent via UNIQUE(in, out)."""
+    span_id = _validated_record_id(span_id, "input_span")
+    decision_id = _validated_record_id(decision_id, "decision")
     await _execute_idempotent_edge(
         client,
         f"RELATE {span_id}->yields->{decision_id} SET created_at=time::now()",
@@ -1201,6 +1211,8 @@ async def relate_binds_to(
     provenance: dict | None = None,
 ) -> None:
     """Create decision → binds_to → code_region edge. Idempotent via UNIQUE(in, out)."""
+    decision_id = _validated_record_id(decision_id, "decision")
+    region_id = _validated_record_id(region_id, "code_region")
     prov = provenance or {}
     await _execute_idempotent_edge(
         client,
@@ -1216,6 +1228,8 @@ async def relate_locates(
     confidence: float = 0.8,
 ) -> None:
     """Create symbol → locates → code_region edge. Idempotent via UNIQUE(in, out)."""
+    symbol_id = _validated_record_id(symbol_id, "symbol")
+    region_id = _validated_record_id(region_id, "code_region")
     await _execute_idempotent_edge(
         client,
         f"RELATE {symbol_id}->locates->{region_id} SET confidence=$c, created_at=time::now()",
@@ -1430,6 +1444,7 @@ async def update_decision_status(
     status: str,
 ) -> None:
     """Update the cached status on a decision node."""
+    decision_id = _validated_record_id(decision_id, "decision")
     await client.execute(
         f"UPDATE {decision_id} SET status = $s, updated_at = time::now()",
         {"s": status},
@@ -1510,6 +1525,7 @@ async def get_canonical_id(
     decision_id: str,
 ) -> str | None:
     """Return the canonical_id for a local decision row, or None."""
+    decision_id = _validated_record_id(decision_id, "decision")
     rows = await client.query(
         f"SELECT canonical_id FROM {decision_id} LIMIT 1",
     )
@@ -1595,6 +1611,7 @@ async def update_region_hash(
     pinned_commit: str = "",
 ) -> None:
     """Update content_hash + pinned_commit on a code_region after link_commit."""
+    region_id = _validated_record_id(region_id, "code_region")
     await client.execute(
         f"UPDATE {region_id} SET content_hash=$h, pinned_commit=$c",
         {"h": content_hash, "c": pinned_commit},
@@ -1719,6 +1736,8 @@ async def delete_binds_to_edge(
     Used when a caller returns a not_relevant verdict — retrieval made a
     mistake and the binding should not be kept.
     """
+    decision_id = _validated_record_id(decision_id, "decision")
+    region_id = _validated_record_id(region_id, "code_region")
     try:
         await client.execute(
             f"DELETE FROM binds_to WHERE in = {decision_id} AND out = {region_id}",
@@ -1761,6 +1780,7 @@ async def set_decision_pruned(
     reason: str = "binding_didnt_survive_merge",
 ) -> None:
     """Transition a decision's signoff to 'pruned' terminal state (#157)."""
+    decision_id = _validated_record_id(decision_id, "decision")
     from datetime import datetime
 
     now = datetime.now(UTC).isoformat()
@@ -1857,6 +1877,7 @@ async def project_decision_status(
     are retired from tracking — callers must skip them before calling this
     function.
     """
+    decision_id = _validated_record_id(decision_id, "decision")
     dec_rows = await client.query(
         f"SELECT signoff, status FROM {decision_id} LIMIT 1",
     )
@@ -2026,6 +2047,8 @@ async def relate_supersedes(
     reason: str = "",
 ) -> None:
     """Write decision → supersedes → decision edge. Idempotent via UNIQUE(in, out)."""
+    new_id = _validated_record_id(new_id, "decision")
+    old_id = _validated_record_id(old_id, "decision")
     await _execute_idempotent_edge(
         client,
         f"RELATE {new_id}->supersedes->{old_id} "
@@ -2047,6 +2070,8 @@ async def relate_context_for(
     state: 'confirmed' | 'rejected' | 'proposed'
     Idempotent: updates state if edge already exists (via UPSERT on unique pair).
     """
+    span_id = _validated_record_id(span_id, "input_span")
+    decision_id = _validated_record_id(decision_id, "decision")
     try:
         await client.execute(
             f"RELATE {span_id}->context_for->{decision_id} "

--- a/tests/test_query_safety_562.py
+++ b/tests/test_query_safety_562.py
@@ -1,0 +1,182 @@
+"""#562 — daemon/projection query-safety guards.
+
+Two layers:
+
+1. **Static anti-regression** (`test_no_unvalidated_record_id_interpolation`):
+   AST-scans every module that builds SurrealQL with caller-controlled record
+   ids and fails if any function interpolates an id-bearing variable
+   (``Name``/``Attribute`` whose name ends in ``id`` — covering ``decision_id``
+   and short forms like ``did``/``csid``/``siid`` so a rename cannot evade) into
+   an f-string without first routing it through ``_validated_record_id``. Each
+   documented exception is in ``_ALLOWLIST`` with a reason.
+   Known limitation: only f-string (``ast.JoinedStr``) interpolation is
+   inspected — ``.format()``/``%``/concatenation are not (none are used to build
+   SurrealQL in the scanned modules today); the behavioral layer + validate-at-
+   entry pattern are the runtime backstop.
+
+2. **Behavioral** (sociable, ``memory://``): malicious record-id inputs are
+   rejected with ``LedgerError`` through the real query functions; well-formed
+   ids are accepted.
+"""
+
+from __future__ import annotations
+
+import ast
+import pathlib
+
+import pytest
+
+from ledger.client import LedgerClient, LedgerError
+from ledger.queries import decision_exists, relate_binds_to
+from ledger.schema import init_schema, migrate
+
+_ROOT = pathlib.Path(__file__).resolve().parent.parent
+
+# Modules that construct SurrealQL touching caller-controlled record ids.
+# (Repo-wide audit 2026-06-08 found the id-interpolation surface confined to
+# these; cli/_ledger_io_engine.py is an operator-trust import boundary tracked
+# as a separate follow-up and is intentionally out of this guard's scope.)
+_SCAN = [
+    "ledger/queries.py",
+    "ledger/adapter.py",
+    "handlers/remove_decision.py",
+    "handlers/remove_source.py",
+    "handlers/resolve_collision.py",
+    "handlers/ratify.py",
+    "codegenome/continuity_service.py",
+    "codegenome/bind_service.py",
+]
+
+# (relative_path, function, interpolated-name) that are safe for a documented
+# reason other than the shared _validated_record_id choke point.
+# Names ending in '_id' that are NOT SurrealDB record ids — session/flow
+# correlators that may legitimately appear interpolated (and only ever reach
+# SQL as bound parameters, never as a record-id position).
+_NOT_RECORD_IDS = {"session_id", "_session_id", "flow_id"}
+
+_ALLOWLIST = {
+    # DB-derived (value originates from a ledger row, not the caller):
+    ("ledger/queries.py", "lookup_vocab_cache", "top_id"),  # rows[0]["id"] of a vocab_cache hit
+    (
+        "ledger/adapter.py",
+        "ingest_commit",
+        "region_id",
+    ),  # region.get("region_id"); also via validated update_region_hash
+    (
+        "codegenome/bind_service.py",
+        "_rollback_partial_bind",
+        "table_id",
+    ),  # subject/identity ids from daemon-side upserts
+    # Validated by a function-specific guard, not the shared helper:
+    (
+        "ledger/queries.py",
+        "update_decision_level",
+        "decision_id",
+    ),  # _DECISION_ID_RE -> ValueError before SQL (test_update_decision_level_query.py)
+}
+
+
+def _is_id_name(name: str) -> bool:
+    # ends in 'id' (covers '<x>_id' and short forms did/csid/siid/svid/rid),
+    # minus session/flow correlators that are not record ids.
+    return name.endswith("id") and name not in _NOT_RECORD_IDS
+
+
+def _interp_name(node: ast.AST) -> str | None:
+    """The interpolated identifier if it is a record-id-bearing Name/Attribute."""
+    if isinstance(node, ast.Name) and _is_id_name(node.id):
+        return node.id
+    if isinstance(node, ast.Attribute) and _is_id_name(node.attr):
+        return node.attr
+    return None
+
+
+def _validated_names(fn: ast.AST) -> set[str]:
+    names: set[str] = set()
+    for node in ast.walk(fn):
+        if isinstance(node, ast.Assign) and isinstance(node.value, ast.Call):
+            func = node.value.func
+            if isinstance(func, ast.Name) and func.id == "_validated_record_id":
+                names.update(t.id for t in node.targets if isinstance(t, ast.Name))
+    return names
+
+
+def _interpolated_ids(fn: ast.AST) -> set[str]:
+    hits: set[str] = set()
+    for node in ast.walk(fn):
+        if isinstance(node, ast.JoinedStr):
+            for piece in node.values:
+                if isinstance(piece, ast.FormattedValue):
+                    name = _interp_name(piece.value)
+                    if name:
+                        hits.add(name)
+    return hits
+
+
+@pytest.mark.parametrize("relpath", _SCAN)
+def test_no_unvalidated_record_id_interpolation(relpath: str) -> None:
+    tree = ast.parse((_ROOT / relpath).read_text(encoding="utf-8"))
+    offenders: list[str] = []
+    for node in ast.walk(tree):
+        if not isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)):
+            continue
+        validated = _validated_names(node)
+        for name in _interpolated_ids(node):
+            if name in validated:
+                continue
+            if (relpath, node.name, name) in _ALLOWLIST:
+                continue
+            offenders.append(f"{relpath}::{node.name} interpolates unvalidated {{{name}}}")
+    assert not offenders, (
+        "Caller-controlled record id interpolated into SurrealQL without "
+        "_validated_record_id (route it through the choke point — #562):\n  "
+        + "\n  ".join(offenders)
+    )
+
+
+async def _fresh_client(suffix: str) -> LedgerClient:
+    client = LedgerClient(url="memory://", ns=f"qs562_{suffix}", db="ledger_test")
+    await client.connect()
+    await init_schema(client)
+    await migrate(client, allow_destructive=True)
+    return client
+
+
+_MALICIOUS = [
+    "decision:abc; DROP TABLE decision",  # statement injection
+    "decision:abc OR true",  # boolean tamper
+    "decision:abc:def",  # second colon
+    "not_a_record_id",  # no table prefix
+    "../../etc/passwd",  # path-ish
+    "",  # empty
+]
+
+
+@pytest.mark.asyncio
+async def test_malicious_decision_id_rejected() -> None:
+    client = await _fresh_client("mal")
+    for bad in _MALICIOUS:
+        with pytest.raises(LedgerError):
+            await decision_exists(client, bad)
+
+
+@pytest.mark.asyncio
+async def test_wrong_table_prefix_rejected() -> None:
+    client = await _fresh_client("tbl")
+    with pytest.raises(LedgerError):
+        await decision_exists(client, "code_region:abc123")
+
+
+@pytest.mark.asyncio
+async def test_valid_decision_id_accepted() -> None:
+    client = await _fresh_client("ok")
+    assert await decision_exists(client, "decision:abc123") is False
+
+
+@pytest.mark.asyncio
+async def test_relate_binds_to_rejects_injection_in_either_arg() -> None:
+    client = await _fresh_client("rel")
+    with pytest.raises(LedgerError):
+        await relate_binds_to(client, "decision:ok; DELETE code_region", "code_region:r1")
+    with pytest.raises(LedgerError):
+        await relate_binds_to(client, "decision:ok", "code_region:r1 OR 1=1")


### PR DESCRIPTION
Closes #562. Replaces #543.

## Invariant

Caller/model-controlled record identifiers must never reach daemon-owned SurrealDB projection queries as raw query text. (SurrealDB is the daemon-owned Enforcement Memory Projection — projection compromise corrupts enforcement memory, preflight/search/compliance answers, and paid-pilot trust in the local daemon boundary.)

## Fix

Routes every caller-controlled record id through the single choke point `_validated_record_id(value, expected_table)` (`ledger/queries.py` — fullmatch shape regex + table-prefix check, raises `LedgerError` before any query) at the entry of each function that interpolates one, across the full **handlers → adapter → ledger-queries** path:

- **ledger/queries.py** — 20 query functions (existence checks, descriptors, `relate_*`, `update_*`, `set_decision_pruned`, `project_decision_status`, `relate_supersedes`, `relate_context_for`, `get_decisions_for_span`, `get_input_span_row`).
- **ledger/adapter.py** — `get_decision_description`, `apply_ratify`, `apply_supersede`.
- **handlers/** — `handle_remove_decision` + `_hard_delete_decision`, `_apply_cascading_remove` (+ per-row `did`), `handle_resolve_collision` (conditional on optional kwargs), `handle_ratify` — protection is now **deliberate**, not incidental on an upstream `*_exists` gate.
- **codegenome/continuity_service.py** — `_resolve_code_subject_id` (the one sink with no upstream gate).

Tables validated against `schema.py`; SurrealDB auto-generated ids satisfy the shape regex (no false rejections).

## Anti-regression — `tests/test_query_safety_562.py`

- **Static AST guard** scans all 8 id-interpolating modules and fails if any function interpolates a record-id-bearing variable (any `Name`/`Attribute` ending in `id`, so a rename like `decision_id`→`did` cannot evade) into an f-string without routing it through `_validated_record_id`. Documented allowlist for DB-derived ids and the `_DECISION_ID_RE`-guarded `update_decision_level`.
- **Sociable behavioral tests** prove malicious ids (statement injection, boolean tamper, wrong table, malformed, empty) are rejected with `LedgerError` over a real `memory://` ledger.

## Acceptance (issue #562)

- [x] No caller/model-controlled id interpolated directly into SurrealQL.
- [x] Deterministic tests cover malicious record-id inputs and prove rejection.
- [x] Static anti-regression prevents reintroduction of raw id interpolation.
- [x] Documents obsolete #543 callsites vs the daemon/projection paths now owning the invariant (this PR; the pre-split MCP ledger helpers #543 referenced are superseded by the daemon-owned projection path validated here).

## Review

Adversarially reviewed by the `code-reviewer` agent (two passes). First pass found the initial audit was scoped too narrowly (queries+adapter only) and surfaced the continuity + handler sinks; all were remediated. Re-review verdict: **P0 closed for the MCP (model-controlled) attack surface** — every model-reachable record-id sink validates before interpolation, no ordering gaps.

Aligns with bicameral-bot ADR-0001 (local daemon / event-store substrates), ADR-0008 (repository split & protocol transition), ADR-0015 (Enforcement Memory Projection).

## Follow-up (out of scope, tracked)

`cli/_ledger_io_engine.py` (the `ledger-import` CLI) interpolates record ids + table names from an operator-supplied JSONL dump. Verified **not reachable from any MCP tool** — it is an operator-trust boundary (operator importing their own dump), not the model-controlled surface this P0 closes. Lower-priority hardening item.

Unblocks #557's Bandit gate flip to blocking (clears the B608 backlog on the ledger/CLI paths).
