### PR TITLE
fix(skill): #402 — bicameral-preflight auto-fires on /qor-plan + impl-intent slash-commands

### DIFF
--- a/.github/workflows/test-mcp-regression.yml
+++ b/.github/workflows/test-mcp-regression.yml
@@ -154,6 +154,8 @@ jobs:
           tests/test_m_shadow_divergence_log.py
           tests/test_shadow_dispatch.py
           tests/test_query_safety_562.py
+          tests/test_preflight_intent.py
+          tests/test_preflight_hook.py
           -v --tb=short
           --junitxml=test-results/results.xml
           --html=test-results/report.html --self-contained-html

--- a/scripts/hooks/preflight_intent.py
+++ b/scripts/hooks/preflight_intent.py
@@ -3,11 +3,20 @@
 Single source of truth for the verb list used by the bicameral-preflight
 SKILL.md description and the UserPromptSubmit hook. Deterministic: no
 LLM, no network, no I/O beyond a string scan.
+
+#402 — Slash-command surface forms (``/qor-plan <issue-url>``) are
+recognized via a dedicated implementation-intent slash-command set,
+because the verb list alone misses commands like ``/qor-plan`` and
+``/qor-debug`` where the implementation-intent verb is encoded in the
+command name and not the prompt body. The classifier returns both a
+``fire`` decision and a ``prompt_surface_form`` label so downstream
+telemetry can spot future trigger-surface regressions before users do.
 """
 
 from __future__ import annotations
 
 import re
+from typing import NamedTuple
 
 IMPLEMENTATION_VERBS: frozenset[str] = frozenset(
     {
@@ -52,6 +61,30 @@ INDIRECT_INTENT_PHRASES: tuple[str, ...] = (
     "what's the cleanest way to refactor",
 )
 
+# Slash-commands whose invocation implies imminent code-implementation work.
+# #402: ``/qor-plan <issue-url>`` was silently skipping preflight because
+# ``plan`` is not in the free-text verb list and the verb is encoded in the
+# slash-command name. Slash-commands listed here short-circuit to ``fire`` no
+# matter what their argument is (URL, plain text, or empty).
+#
+# Keep this in lockstep with the ``description:`` field in
+# ``skills/bicameral-preflight/SKILL.md`` — that string is what Claude Code's
+# skill-discovery layer reads for the Tier-2 (caller-LLM) gate. Tier-1
+# (this hook) and Tier-2 (the skill description) must agree on the slash-
+# command surface or the gates drift.
+IMPL_INTENT_SLASH_COMMANDS: frozenset[str] = frozenset(
+    {
+        "qor-plan",
+        "qor-implement",
+        "qor-refactor",
+        "qor-debug",
+        "qor-remediate",
+        "qor-organize",
+        "qor-auto-dev-1",
+        "qor-auto-dev",
+    }
+)
+
 SKIP_PATTERNS: tuple[re.Pattern[str], ...] = (
     re.compile(r"\bfix\b.*\btypo\b", re.IGNORECASE),
     re.compile(r"\bbump\b.*\b(?:to|from)\b.*\d+\.\d+", re.IGNORECASE),
@@ -75,15 +108,89 @@ _VERB_REGEX = re.compile(
     re.IGNORECASE,
 )
 
+_SLASH_COMMAND_RE = re.compile(r"^\s*/([A-Za-z][\w-]*)")
+_URL_ONLY_RE = re.compile(r"^https?://\S+\s*$", re.IGNORECASE)
 
-def should_fire_preflight(prompt: str) -> bool:
-    """Return True iff prompt indicates code-implementation intent."""
+# Public surface-form labels — also referenced by the telemetry event field
+# ``prompt_surface_form`` so the dashboard query is stable.
+SURFACE_FREE_TEXT = "free_text"
+SURFACE_SLASH_WITH_URL = "slash_command_with_url"
+SURFACE_SLASH_WITH_TEXT = "slash_command_with_text"
+SURFACE_SLASH_BARE = "slash_command_bare"
+SURFACE_EMPTY = "empty"
+
+
+class ClassifyResult(NamedTuple):
+    """Result of :func:`classify_prompt`.
+
+    Attributes:
+        fire: True when the hook should inject the preflight reminder.
+        prompt_surface_form: One of ``SURFACE_*`` — recorded to telemetry
+            so we can spot regressions in the trigger surface (#402).
+        slash_command: Lowercased slash-command name when the prompt began
+            with one (e.g. ``"qor-plan"``); ``None`` otherwise. Useful for
+            triage but not part of the fire decision contract.
+    """
+
+    fire: bool
+    prompt_surface_form: str
+    slash_command: str | None
+
+
+def _detect_surface_form(prompt: str) -> tuple[str, str | None, str]:
+    """Return ``(surface_form, slash_command_or_None, remainder_text)``."""
+    stripped = prompt.strip()
+    if not stripped:
+        return (SURFACE_EMPTY, None, "")
+    match = _SLASH_COMMAND_RE.match(stripped)
+    if not match:
+        return (SURFACE_FREE_TEXT, None, stripped)
+    command = match.group(1).lower()
+    remainder = stripped[match.end() :].strip()
+    if not remainder:
+        return (SURFACE_SLASH_BARE, command, "")
+    if _URL_ONLY_RE.match(remainder):
+        return (SURFACE_SLASH_WITH_URL, command, remainder)
+    return (SURFACE_SLASH_WITH_TEXT, command, remainder)
+
+
+def classify_prompt(prompt: str) -> ClassifyResult:
+    """Classify a user prompt for preflight auto-fire.
+
+    The classifier is layered:
+      1. Empty / whitespace-only prompts never fire.
+      2. Slash-commands in :data:`IMPL_INTENT_SLASH_COMMANDS` fire
+         unconditionally — the command name itself encodes implementation
+         intent (e.g. ``/qor-plan``).
+      3. Otherwise fall through to the free-text classifier: skip
+         patterns suppress, verb regex or indirect-intent phrases fire.
+    """
     if not prompt or not prompt.strip():
-        return False
+        return ClassifyResult(False, SURFACE_EMPTY, None)
+
+    surface_form, command, _remainder = _detect_surface_form(prompt)
+
+    if command is not None and command in IMPL_INTENT_SLASH_COMMANDS:
+        return ClassifyResult(True, surface_form, command)
+
     for skip in SKIP_PATTERNS:
         if skip.search(prompt):
-            return False
+            return ClassifyResult(False, surface_form, command)
+
     if _VERB_REGEX.search(prompt):
-        return True
+        return ClassifyResult(True, surface_form, command)
+
     lowered = prompt.lower()
-    return any(phrase in lowered for phrase in INDIRECT_INTENT_PHRASES)
+    if any(phrase in lowered for phrase in INDIRECT_INTENT_PHRASES):
+        return ClassifyResult(True, surface_form, command)
+
+    return ClassifyResult(False, surface_form, command)
+
+
+def should_fire_preflight(prompt: str) -> bool:
+    """Return True iff prompt indicates code-implementation intent.
+
+    Backward-compatible wrapper around :func:`classify_prompt` — preserves
+    the original boolean contract for existing callers and tests.
+    """
+    return classify_prompt(prompt).fire

--- a/scripts/hooks/preflight_reminder.py
+++ b/scripts/hooks/preflight_reminder.py
@@ -14,6 +14,13 @@ discovery the rest of the contract depends on — preflight needs
 can't extract file paths if we forbid it from looking at the codebase
 first.
 
+#402: Slash-command prompts (``/qor-plan <issue-url>``) were silently
+skipping the gate because the classifier's verb list missed ``plan``
+and had no slash-command awareness. The hook now defers to
+:func:`classify_prompt` and records a ``trigger_evaluated`` JSONL event
+carrying the ``prompt_surface_form`` so regressions in the trigger
+surface are visible to the operator.
+
 Updated contract:
   - Read / Grep / Glob FIRST — caller LLM resolves "the reorder feature"
     to concrete file paths.
@@ -35,11 +42,13 @@ broken hook never blocks a user.
 from __future__ import annotations
 
 import json
+import os
 import sys
+from datetime import UTC, datetime
 from pathlib import Path
 
 sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
-from hooks.preflight_intent import should_fire_preflight  # noqa: E402
+from hooks.preflight_intent import ClassifyResult, classify_prompt  # noqa: E402
 
 REMINDER_TEXT = (
     "<system-reminder>\n"
@@ -69,6 +78,59 @@ REMINDER_TEXT = (
     "</system-reminder>"
 )
 
+# #402 — trigger_evaluated telemetry: where the hook records each prompt's
+# classification + surface form. Local JSONL, append-only, mode 0o600.
+# The PostHog uplink for this stream is deferred — the hook is a subprocess
+# that exits in ~ms, so synchronous network I/O is not viable. A follow-up
+# will drain this file from the long-lived MCP server.
+_TRIGGER_LOG = Path.home() / ".bicameral" / "preflight_trigger_evaluated.jsonl"
+_TELEMETRY_OFF = frozenset({"0", "false", "no", "off"})
+
+
+def _telemetry_disabled() -> bool:
+    """Return True iff the operator has globally disabled bicameral telemetry.
+
+    Mirrors the check in ``telemetry.py`` so the trigger log obeys the same
+    opt-out switch users already know. Default: enabled.
+    """
+    raw = os.environ.get("BICAMERAL_TELEMETRY", "").strip().lower()
+    return raw in _TELEMETRY_OFF
+
+
+def _record_trigger_evaluated(result: ClassifyResult) -> None:
+    """Append a single ``trigger_evaluated`` row to the local JSONL log.
+
+    Best-effort: any I/O failure is swallowed so a broken telemetry path
+    never blocks a user prompt. Privacy: the prompt itself is NOT
+    recorded — only the classifier's surface-form label and fire bit,
+    plus the slash-command name when present (already public — the user
+    just typed it).
+    """
+    if _telemetry_disabled():
+        return
+    try:
+        _TRIGGER_LOG.parent.mkdir(parents=True, exist_ok=True)
+        record = {
+            "event": "preflight.trigger_evaluated",
+            "ts": datetime.now(UTC).isoformat(),
+            "fired": result.fire,
+            "prompt_surface_form": result.prompt_surface_form,
+            "slash_command": result.slash_command,
+        }
+        line = json.dumps(record, separators=(",", ":")) + "\n"
+        flags = os.O_WRONLY | os.O_CREAT | os.O_APPEND
+        fd = os.open(str(_TRIGGER_LOG), flags, 0o600)
+        try:
+            with os.fdopen(fd, "ab") as f:
+                f.write(line.encode("utf-8"))
+        except Exception:
+            try:
+                os.close(fd)
+            except OSError:
+                pass
+    except OSError:
+        return
+
 
 def main() -> int:
     try:
@@ -76,7 +138,9 @@ def main() -> int:
     except (json.JSONDecodeError, ValueError):
         return 0
     prompt = payload.get("prompt", "") if isinstance(payload, dict) else ""
-    if should_fire_preflight(prompt):
+    result = classify_prompt(prompt)
+    _record_trigger_evaluated(result)
+    if result.fire:
         json.dump(
             {
                 "hookSpecificOutput": {

--- a/skills/bicameral-preflight/SKILL.md
+++ b/skills/bicameral-preflight/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: bicameral-preflight
-description: Pre-flight context check BEFORE implementing code. AUTO-FIRES on ANY prompt that involves writing, changing, or touching source code — including: "add", "build", "create", "implement", "modify", "refactor", "update", "fix", "change", "write", "edit", "move", "rename", "remove", "delete", "extract", "convert", "integrate", "deploy", "ship", "configure", "connect", "extend", "migrate", "wire up", "hook up", "set up", "complete", "finish", "continue". Also fires when user asks HOW to implement something (they are about to implement it). Surfaces prior decisions, drifted regions, divergences, and open questions BEFORE Claude writes any code. SKIP ONLY FOR — purely read-only questions with zero code intent, documentation-only typo fixes, dependency version bumps with no semantic change.
+description: Pre-flight context check BEFORE implementing code. AUTO-FIRES on ANY prompt that involves writing, changing, or touching source code — including: "add", "build", "create", "implement", "modify", "refactor", "update", "fix", "change", "write", "edit", "move", "rename", "remove", "delete", "extract", "convert", "integrate", "deploy", "ship", "configure", "connect", "extend", "migrate", "wire up", "hook up", "set up", "complete", "finish", "continue". Also fires when user asks HOW to implement something (they are about to implement it). ALSO auto-fires when the user invokes any implementation-intent slash-command — /qor-plan, /qor-implement, /qor-refactor, /qor-debug, /qor-remediate, /qor-organize, /qor-auto-dev-1 (or its /qor-auto-dev alias) — regardless of whether the argument is a GitHub issue URL, plain English, or empty. Surfaces prior decisions, drifted regions, divergences, and open questions BEFORE Claude writes any code. SKIP ONLY FOR — purely read-only questions with zero code intent, documentation-only typo fixes, dependency version bumps with no semantic change, and read-only slash-commands like /qor-status, /qor-help, /qor-audit, /qor-validate.
 ---
 
 # Bicameral Preflight
@@ -43,6 +43,18 @@ redundant check. Examples:
 - *"rename the function to snake_case"*
 - *"remove the deprecated API call"*
 - *"set up the webhook integration"*
+- *"/qor-plan https://github.com/BicameralAI/bicameral-mcp/issues/1"* (#402 — slash-command with issue URL still counts as "about to implement")
+- *"/qor-implement add Stripe webhook handler"*
+- *"/qor-refactor the rate limiter"*
+- *"/qor-auto-dev-1"* (bare invocation — the whole automated dev cycle implies code work)
+
+The deterministic Tier-1 gate (`scripts/hooks/preflight_intent.py`)
+recognizes both free-text verbs and the implementation-intent slash-
+command set: `qor-plan`, `qor-implement`, `qor-refactor`, `qor-debug`,
+`qor-remediate`, `qor-organize`, `qor-auto-dev-1`, `qor-auto-dev`. Keep
+this list in lockstep with `IMPL_INTENT_SLASH_COMMANDS` in the Python
+module — both must be edited together until #402's future-
+configurability work deduplicates them.
 
 ## Tier-2 semantic relevance gate (#300)
 

--- a/tests/e2e/prompts/flow-6-slash-command-preflight.md
+++ b/tests/e2e/prompts/flow-6-slash-command-preflight.md
@@ -1,0 +1,1 @@
+/qor-plan https://github.com/BicameralAI/bicameral-daemon/issues/1

--- a/tests/test_preflight_hook.py
+++ b/tests/test_preflight_hook.py
@@ -14,6 +14,7 @@ broken contract regardless of whether the hook process exits cleanly.
 from __future__ import annotations
 
 import json
+import os
 import subprocess
 import sys
 from pathlib import Path
@@ -22,14 +23,18 @@ REPO_ROOT = Path(__file__).resolve().parent.parent
 HOOK_SCRIPT = REPO_ROOT / "scripts" / "hooks" / "preflight_reminder.py"
 
 
-def _run_hook(stdin_text: str) -> tuple[int, str, str]:
+def _run_hook(stdin_text: str, env_overrides: dict[str, str] | None = None) -> tuple[int, str, str]:
     """Invoke the hook with stdin_text on stdin; return (rc, stdout, stderr)."""
+    env = os.environ.copy()
+    if env_overrides:
+        env.update(env_overrides)
     proc = subprocess.run(
         [sys.executable, str(HOOK_SCRIPT)],
         input=stdin_text,
         capture_output=True,
         text=True,
         timeout=10,
+        env=env,
     )
     return proc.returncode, proc.stdout, proc.stderr
 
@@ -120,3 +125,81 @@ def test_reminder_gates_writes_not_discovery():
     # Negative: must NOT forbid file-inspection tools (the old shape).
     assert "before any file-inspection tool" not in ctx
     assert "Before invoking any file-inspection tool" not in ctx
+
+
+# ── #402: slash-command surface form coverage ─────────────────────────
+
+
+def test_hook_fires_on_qor_plan_with_issue_url(tmp_path):
+    """End-to-end sociable test of the exact #402 reproduction.
+
+    The hook is run as a real subprocess (same shape as Claude Code 2.x
+    invokes it) with the literal failing prompt — ``/qor-plan
+    <github-issue-url>``. It must emit the preflight ``hookSpecificOutput``
+    envelope and write a ``trigger_evaluated`` row to the local JSONL log
+    with ``prompt_surface_form == "slash_command_with_url"``.
+
+    The classifier and the hook are NOT mocked — this is the contract
+    the agent layer actually sees.
+    """
+    payload = {"prompt": ("/qor-plan https://github.com/BicameralAI/bicameral-daemon/issues/1")}
+    env = {"HOME": str(tmp_path), "USERPROFILE": str(tmp_path)}
+    rc, out, _ = _run_hook(json.dumps(payload), env_overrides=env)
+    assert rc == 0
+    inner = _hook_output(json.loads(out))
+    assert "additionalContext" in inner
+    assert "bicameral.preflight" in inner["additionalContext"]
+
+    # The trigger_evaluated row carries the surface-form label so we can
+    # spot future regressions in the dashboard before users do.
+    log_file = tmp_path / ".bicameral" / "preflight_trigger_evaluated.jsonl"
+    assert log_file.exists(), "hook must write the trigger_evaluated row"
+    lines = [json.loads(line) for line in log_file.read_text().splitlines() if line]
+    assert any(
+        row.get("fired") is True
+        and row.get("prompt_surface_form") == "slash_command_with_url"
+        and row.get("slash_command") == "qor-plan"
+        for row in lines
+    ), f"expected trigger_evaluated row not found in {lines!r}"
+
+
+def test_hook_does_not_fire_for_qor_status(tmp_path):
+    """Read-only slash-commands must not produce ``hookSpecificOutput`` but
+    still record a ``fired: false`` telemetry row so we can spot future
+    over-fire regressions symmetrically."""
+    payload = {"prompt": "/qor-status"}
+    env = {"HOME": str(tmp_path), "USERPROFILE": str(tmp_path)}
+    rc, out, _ = _run_hook(json.dumps(payload), env_overrides=env)
+    assert rc == 0
+    parsed = json.loads(out) if out.strip() else {}
+    assert "hookSpecificOutput" not in parsed
+
+    log_file = tmp_path / ".bicameral" / "preflight_trigger_evaluated.jsonl"
+    assert log_file.exists()
+    lines = [json.loads(line) for line in log_file.read_text().splitlines() if line]
+    assert any(
+        row.get("fired") is False
+        and row.get("prompt_surface_form") == "slash_command_bare"
+        and row.get("slash_command") == "qor-status"
+        for row in lines
+    )
+
+
+def test_hook_telemetry_disabled_env_skips_jsonl(tmp_path):
+    """``BICAMERAL_TELEMETRY=0`` must suppress the trigger_evaluated log
+    without affecting the gate decision — opt-out parity with the
+    existing relay telemetry."""
+    payload = {"prompt": "/qor-plan add stripe webhook"}
+    env = {
+        "HOME": str(tmp_path),
+        "USERPROFILE": str(tmp_path),
+        "BICAMERAL_TELEMETRY": "0",
+    }
+    rc, out, _ = _run_hook(json.dumps(payload), env_overrides=env)
+    assert rc == 0
+    # Gate still fires — telemetry opt-out is decoupled from the gate.
+    inner = _hook_output(json.loads(out))
+    assert "additionalContext" in inner
+    # JSONL log is absent because telemetry is disabled.
+    log_file = tmp_path / ".bicameral" / "preflight_trigger_evaluated.jsonl"
+    assert not log_file.exists(), "BICAMERAL_TELEMETRY=0 must suppress the log file"

--- a/tests/test_preflight_intent.py
+++ b/tests/test_preflight_intent.py
@@ -9,9 +9,16 @@ REPO_ROOT = Path(__file__).resolve().parent.parent
 sys.path.insert(0, str(REPO_ROOT))
 
 from scripts.hooks.preflight_intent import (  # noqa: E402
+    IMPL_INTENT_SLASH_COMMANDS,
     IMPLEMENTATION_VERBS,
     INDIRECT_INTENT_PHRASES,
     SKIP_PATTERNS,
+    SURFACE_EMPTY,
+    SURFACE_FREE_TEXT,
+    SURFACE_SLASH_BARE,
+    SURFACE_SLASH_WITH_TEXT,
+    SURFACE_SLASH_WITH_URL,
+    classify_prompt,
     should_fire_preflight,
 )
 
@@ -68,3 +75,139 @@ def test_natural_contradiction_prompt():
 def test_empty_prompt_does_not_fire():
     assert not should_fire_preflight("")
     assert not should_fire_preflight("   \n\t")
+
+
+# ── #402: slash-command surface forms ─────────────────────────────────
+
+
+def test_qor_plan_with_issue_url_fires():
+    """The exact failing invocation from #402 must fire.
+
+    Hypothesis 1 from the issue: the verb-regex classifier missed
+    ``/qor-plan <issue-url>`` because ``plan`` is not in the verb list
+    and the implementation-intent verb is encoded in the slash-command
+    name rather than the prompt body. With the IMPL_INTENT_SLASH_COMMANDS
+    short-circuit, this now fires.
+    """
+    prompt = "/qor-plan https://github.com/BicameralAI/bicameral-daemon/issues/1"
+    result = classify_prompt(prompt)
+    assert result.fire is True
+    assert result.prompt_surface_form == SURFACE_SLASH_WITH_URL
+    assert result.slash_command == "qor-plan"
+
+
+def test_qor_plan_with_plain_english_prompt_fires():
+    """Regression coverage from #402 acceptance: plain-English /qor-plan
+    must also fire, not just URL-arg form."""
+    prompt = "/qor-plan add a Stripe webhook handler for payment_intent.succeeded"
+    result = classify_prompt(prompt)
+    assert result.fire is True
+    assert result.prompt_surface_form == SURFACE_SLASH_WITH_TEXT
+
+
+def test_qor_implement_with_url_fires():
+    """``/qor-implement`` already fired pre-#402 via the ``implement`` verb;
+    regression coverage so we don't trade one trigger gap for another."""
+    prompt = "/qor-implement https://github.com/BicameralAI/bicameral-mcp/issues/123"
+    result = classify_prompt(prompt)
+    assert result.fire is True
+    assert result.prompt_surface_form == SURFACE_SLASH_WITH_URL
+
+
+def test_qor_implement_with_plain_prompt_fires():
+    prompt = "/qor-implement wire up the new endpoint to the frontend"
+    result = classify_prompt(prompt)
+    assert result.fire is True
+    assert result.prompt_surface_form == SURFACE_SLASH_WITH_TEXT
+
+
+def test_all_impl_intent_slash_commands_fire_with_url():
+    """Every command in IMPL_INTENT_SLASH_COMMANDS must fire when invoked
+    with a URL-only argument. Locks the contract so the Tier-1 (hook) and
+    Tier-2 (skill description) gates stay aligned."""
+    url = "https://github.com/BicameralAI/bicameral-mcp/issues/1"
+    for command in IMPL_INTENT_SLASH_COMMANDS:
+        prompt = f"/{command} {url}"
+        result = classify_prompt(prompt)
+        assert result.fire is True, f"impl-intent /{command} did not fire"
+        assert result.prompt_surface_form == SURFACE_SLASH_WITH_URL
+
+
+def test_bare_slash_command_in_impl_set_fires():
+    """``/qor-auto-dev-1`` with no argument still implies implementation
+    intent — the operator is launching the full dev cycle."""
+    result = classify_prompt("/qor-auto-dev-1")
+    assert result.fire is True
+    assert result.prompt_surface_form == SURFACE_SLASH_BARE
+    assert result.slash_command == "qor-auto-dev-1"
+
+
+def test_non_impl_slash_commands_do_not_fire():
+    """Read-only / informational slash-commands must not fire. Guards
+    against the opposite regression — accidentally treating every slash-
+    command as implementation intent."""
+    for command in ("qor-status", "qor-help", "qor-audit", "qor-validate"):
+        prompt = f"/{command}"
+        result = classify_prompt(prompt)
+        assert result.fire is False, f"/{command} should not fire"
+        assert result.prompt_surface_form == SURFACE_SLASH_BARE
+
+
+def test_non_impl_slash_command_with_url_does_not_fire():
+    """A URL alone after a non-impl command must not fire — the URL has
+    no implementation verbs and the command is not in IMPL_INTENT."""
+    prompt = "/qor-status https://github.com/BicameralAI/bicameral-mcp/issues/1"
+    result = classify_prompt(prompt)
+    assert result.fire is False
+    assert result.prompt_surface_form == SURFACE_SLASH_WITH_URL
+
+
+def test_free_text_surface_form_classification():
+    """Free-text prompts get the free_text surface form."""
+    result = classify_prompt("please refactor the rate limiter")
+    assert result.fire is True
+    assert result.prompt_surface_form == SURFACE_FREE_TEXT
+    assert result.slash_command is None
+
+
+def test_empty_prompt_classification():
+    """Empty prompts get a dedicated surface-form label for telemetry."""
+    result = classify_prompt("")
+    assert result.fire is False
+    assert result.prompt_surface_form == SURFACE_EMPTY
+
+
+def test_classify_prompt_and_should_fire_preflight_agree():
+    """The backward-compat wrapper must mirror :func:`classify_prompt`'s
+    fire bit for every input — no semantic drift between the two APIs."""
+    fixtures = (
+        "/qor-plan https://github.com/foo/bar/issues/1",
+        "/qor-implement add stripe webhook",
+        "/qor-status",
+        "please refactor the rate limiter",
+        "fix the typo in README",
+        "",
+        "how should I implement the retry logic?",
+    )
+    for prompt in fixtures:
+        assert classify_prompt(prompt).fire == should_fire_preflight(prompt), (
+            f"divergence on prompt {prompt!r}"
+        )
+
+
+def test_slash_command_names_lowercased():
+    """Command name in ClassifyResult is lowercased so callers can
+    membership-test against the canonical set without case dancing."""
+    result = classify_prompt("/QOR-PLAN https://github.com/foo/bar/issues/1")
+    assert result.slash_command == "qor-plan"
+    assert result.fire is True
+
+
+def test_unknown_slash_command_falls_through_to_verb_check():
+    """A slash-command not in IMPL_INTENT falls through to the free-text
+    verb classifier on the full prompt — so ``/some-future-cmd add X``
+    still fires via the ``add`` verb match."""
+    result = classify_prompt("/some-future-cmd add the new webhook handler")
+    assert result.fire is True
+    assert result.prompt_surface_form == SURFACE_SLASH_WITH_TEXT
+    assert result.slash_command == "some-future-cmd"


### PR DESCRIPTION
Closes #402. Supersedes the closed #524.

## Why this is a revival

PR #524 fixed #402 correctly but was **closed only because the `v0 user flow e2e` CI failed on stale-auth substrate — not the diff** (per the closing comment). That e2e workflow is now shelved to dispatch-only (#556), so the blocker is gone. This PR rebases #524's proven 6-file change onto current `main` (all files applied cleanly) and re-verifies it.

## Bug (re-reproduced on current main before fixing)

`should_fire_preflight("/qor-plan https://github.com/…/issues/1")` returned **False** — `bicameral-preflight` never fired, so `/qor-plan <issue-url>` ran planning blind to the ledger (no prior-decisions / drift / open-questions surfacing).

## Root cause (Hypothesis 1, confirmed)

The `UserPromptSubmit` classifier (`scripts/hooks/preflight_intent.py`) matched only free-text `IMPLEMENTATION_VERBS` and had no slash-command awareness. `plan` is not a verb, so `/qor-plan` (and `/qor-debug`, `/qor-auto-dev-1`) never fired. Sibling commands worked by coincidence (`/qor-implement`→`implement`, `/qor-refactor`→`refactor`). Hypothesis 3 (skill-chain ordering) **refuted**: `UserPromptSubmit` fires on raw text before slash-command resolution.

## Fix

- `IMPL_INTENT_SLASH_COMMANDS` frozenset — impl-intent slash-commands short-circuit to fire regardless of argument (URL / text / empty).
- Layered `classify_prompt()` → `ClassifyResult(fire, prompt_surface_form, slash_command)`; `preflight_reminder.py` records `prompt_surface_form` to telemetry so a future trigger-surface regression is observable. `should_fire_preflight()` preserved (delegates).
- `SKILL.md` (Tier-2 caller-LLM gate) updated **in lockstep** with the Tier-1 hook set; read-only commands (`/qor-status`, `/qor-help`, `/qor-audit`, `/qor-validate`) correctly stay on SKIP.

## Verification

- Bug → fixed: `/qor-plan <url>` and `/qor-debug 402` now return `fire=True`.
- 28 preflight unit tests pass; ruff + mypy clean.
- **Regression guard now runs in CI:** `test_preflight_intent.py` + `test_preflight_hook.py` added to `test-mcp-regression.yml` (they were in no workflow — dormant). flow-6 e2e prompt added for reference (e2e harness is dispatch-only per #556; the unit tests are the durable gate).
