### PR TITLE
docs(governance): sibling registry + community-health set

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,66 @@
+# Contributor Covenant Code of Conduct
+
+## Our Pledge
+
+We as members, contributors, and leaders pledge to make participation in our community a
+harassment-free experience for everyone, regardless of age, body size, visible or invisible
+disability, ethnicity, sex characteristics, gender identity and expression, level of
+experience, education, socio-economic status, nationality, personal appearance, race,
+religion, or sexual identity and orientation.
+
+We pledge to act and interact in ways that contribute to an open, welcoming, diverse,
+inclusive, and healthy community.
+
+## Our Standards
+
+Examples of behavior that contributes to a positive environment include:
+
+- Demonstrating empathy and kindness toward other people
+- Being respectful of differing opinions, viewpoints, and experiences
+- Giving and gracefully accepting constructive feedback
+- Accepting responsibility and apologizing to those affected by our mistakes, and learning
+  from the experience
+- Focusing on what is best for the overall community
+
+Examples of unacceptable behavior include:
+
+- The use of sexualized language or imagery, and sexual attention or advances of any kind
+- Trolling, insulting or derogatory comments, and personal or political attacks
+- Public or private harassment
+- Publishing others' private information without their explicit permission
+- Other conduct which could reasonably be considered inappropriate in a professional setting
+
+## Enforcement Responsibilities
+
+Community leaders are responsible for clarifying and enforcing our standards of acceptable
+behavior and will take appropriate and fair corrective action in response to any behavior
+that they deem inappropriate, threatening, offensive, or harmful.
+
+## Scope
+
+This Code of Conduct applies within all community spaces, and also applies when an
+individual is officially representing the community in public spaces.
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be reported to the
+community leaders responsible for enforcement at **conduct@bicameral.ai**. All complaints
+will be reviewed and investigated promptly and fairly. All community leaders are obligated
+to respect the privacy and security of the reporter of any incident.
+
+## Enforcement Guidelines
+
+Community leaders will follow these Community Impact Guidelines in determining the
+consequences for any action they deem in violation of this Code of Conduct:
+
+1. **Correction** — private, written warning with clarity about the violation.
+2. **Warning** — a warning with consequences for continued behavior.
+3. **Temporary Ban** — a temporary ban from interaction or public communication.
+4. **Permanent Ban** — a permanent ban from public interaction within the community.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant][homepage], version 2.1,
+available at https://www.contributor-covenant.org/version/2/1/code_of_conduct.html.
+
+[homepage]: https://www.contributor-covenant.org

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,54 @@
+# Contributing to Bicameral MCP
+
+Thank you for considering a contribution. This repo provides agent-facing Bicameral MCP
+tools for ingest, preflight, binding, and review commands. The tools emit protocol-shaped
+objects and route through governance; they never own canonical state.
+
+## How to contribute
+
+1. Fork the repository (or branch, if you have access).
+2. Create a topic branch for your change.
+3. Keep tool behavior aligned with the authority boundaries in `README.md` and `docs/`.
+4. Add or update tests when behavior changes.
+5. Run the local checks below before opening a pull request.
+6. Open a pull request against the default branch using the repository's conventions.
+
+## Local checks
+
+These mirror the CI gates (`lint-and-typecheck`, tests, `secret-scan`):
+
+```bash
+pip install -e ".[test]"
+ruff check .
+ruff format --check .
+mypy .
+pytest
+```
+
+If you have [`pre-commit`](https://pre-commit.com/) installed, hooks run on commit:
+
+```bash
+pip install pre-commit && pre-commit install
+pre-commit run --all-files
+```
+
+## Bring your own tools — the sibling registry
+
+You are **not** required to adopt the maintainer's process tooling. The only thing your PR
+must satisfy is the shared **bic-logic** contract plus the local checks above. Everything
+you run *locally* — a governance system, an AI assistant, an IDE plugin, or a homegrown
+framework — is welcome as a **registered sibling**: leak-guarded, never tracked, never
+referenced.
+
+To use your own tool: add a row to [`docs/governance/SIBLINGS.md`](docs/governance/SIBLINGS.md),
+add its scratch root to `.gitignore`, and keep its artifacts out of tracked files.
+
+## Issue reports
+
+Use the issue templates for bugs, feature requests, and documentation problems. Include
+reproduction steps, expected behavior, and any relevant protocol contracts.
+
+## License
+
+By contributing, you agree that your contributions are licensed under the license that
+governs this repository.

--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -1,0 +1,53 @@
+# Project Governance
+
+## Project
+
+Bicameral MCP — agent-facing MCP tools for ingest, preflight, binding, and review commands.
+
+## Maintainers
+
+BicameralAI maintainers steward repository direction, review contributions, and preserve
+the authority boundaries documented in `README.md` and `docs/`.
+
+## Decision making
+
+Source of truth for behavior is the protocol contract: the MCP tools emit candidates,
+evidence, hints, signals, and advisories through protocol-compatible paths; they must not
+write canonical state directly. Blocking and enforcement remain governance decisions, not
+tool side effects.
+
+## Process governance (three layers)
+
+Repository **process** governance is layered:
+
+- **Shared process (bic-logic)** — factory-owned doctrine, owned upstream in
+  `bicameral-factory` and consumed here. This is the **one mandatory layer**: the contract
+  every PR must satisfy.
+- **Sibling tools (registry)** — any local process, governance, or AI tooling a contributor
+  uses is a *registered sibling*: leak-guarded, never tracked, never referenced. The registry
+  is [`docs/governance/SIBLINGS.md`](docs/governance/SIBLINGS.md). The maintainer's own tooling
+  is itself a registered sibling, not a requirement on contributors.
+
+Contributors are free to bring their own tooling — see `CONTRIBUTING.md` → *Bring your own
+tools*. This is repo/process governance only; it never produces product Decisions, gates, or
+compliance outcomes.
+
+## Branch protection plan
+
+The default branch should be protected with:
+
+- Pull request review before merge
+- Status checks for tests, lint/typecheck, and secret scanning
+- Restrict force pushes on `main` and release branches
+
+## Contribution guidelines
+
+See `CONTRIBUTING.md`.
+
+## Code of conduct
+
+See `CODE_OF_CONDUCT.md`.
+
+## Security policy
+
+See `SECURITY.md`.

--- a/docs/governance/README.md
+++ b/docs/governance/README.md
@@ -1,0 +1,12 @@
+# Governance (tracked)
+
+This directory holds the **tracked, public-facing** governance contract. It declares
+*which classes* of artifact are local versus shared, and never reproduces local contents.
+
+| File | Purpose |
+|---|---|
+| [`SIBLINGS.md`](SIBLINGS.md) | The sibling registry — every leak-guarded local tool (Qor-logic, FailSafe, contributor tooling) and the rules that keep it out of commits. |
+
+**Doctrine is shared upstream.** The shared process rules (bic-logic) are owned in
+`bicameral-factory` and consumed here — not copied. **Local artifacts are never here**:
+any sibling's scratch stays local and gitignored.

--- a/docs/governance/SIBLINGS.md
+++ b/docs/governance/SIBLINGS.md
@@ -1,0 +1,61 @@
+# Sibling Registry
+
+**Status**: Active · **Last reviewed**: 2026-06-08
+
+This file is the single source of truth for **sibling tools** — local process,
+governance, or AI tooling that touches this checkout but must **never** leak into a
+commit or a tracked reference.
+
+The **only** mandatory layer for a pull request is the shared **bic-logic** contract
+(the factory-owned process). Below that line, your choice of local tooling is free — as
+long as the tool is **registered as a sibling** here and its artifacts stay out of the
+repo.
+
+> The maintainer's own process tooling is itself a registered sibling, not a requirement
+> placed on contributors. Bring whatever helps you work.
+
+## What a sibling is
+
+A sibling is any tool that:
+
+- runs **locally** against this checkout (a governance system, an agent harness, an IDE
+  assistant, a homegrown framework, a sibling product);
+- writes **scratch/state** into the working tree (a dotdir, generated docs, logs, plans);
+- must be **leak-guarded** — its roots are gitignored and never committed;
+- is **never referenced** by any tracked file.
+
+A sibling has **no product authority**. The MCP tools emit ingest, preflight, binding, and
+review signals through protocol-compatible paths; they never own canonical state.
+
+## The rules (invariants)
+
+1. **Local-only** — a sibling's artifacts are never committed.
+2. **Leak-guarded** — every registered root is in `.gitignore`.
+3. **Never-referenced** — no tracked file names a sibling's internal files, paths, or APIs.
+4. **Registry ⇔ `.gitignore` agree** — every root below has a matching `.gitignore` entry,
+   and every agent-scratch `.gitignore` entry has a row here.
+
+## Registry
+
+| Sibling | Root(s) | Owner | Rule |
+|---|---|---|---|
+| **Qor-logic** | `.qor/` | maintainer | local process governance; never tracked |
+| **FailSafe** | `.failsafe/` | sibling MythologIQ product | leak-prevention only; never referenced |
+| **Bicameral factory (local)** | `.bicameral/` | factory tooling | local install state; never tracked |
+| **Claude Code** | `.claude/worktrees/` | contributor (AI assistant) | agent scratch; never tracked |
+| **Cursor** | `.cursor/` | contributor (AI assistant) | agent scratch; never tracked |
+| **Windsurf** | `.windsurf/` | contributor (AI assistant) | agent scratch; never tracked |
+| **Generic agent scratch** | `.agent/`, `plan-*.md` | contributor | run plans, context bundles, raw logs; never tracked |
+
+## How to register your own tool
+
+You do **not** need maintainer permission to use your own tooling. To register it:
+
+1. **Add a row** to the table above: tool name, scratch root(s), you as owner, and the rule.
+2. **Add the root to `.gitignore`**, so the tool is provably un-committable.
+3. **Keep artifacts out of tracked files** — never commit the tool's output and never name
+   its internals in a tracked doc.
+
+Open the change as a normal PR; the only thing it must satisfy is the shared bic-logic
+contract and a clean working tree. See [`CONTRIBUTING.md`](../../CONTRIBUTING.md) →
+*Bring your own tools*.


### PR DESCRIPTION
## Summary

Propagates the generalized governance boundary from `bicameral-bot` and closes the
community-health gap. The boundary's third layer is now a **tracked sibling registry**:
any contributor may use their own local tooling as a registered sibling (leak-guarded,
never tracked, never referenced). The only mandatory layer is the shared **bic-logic**
contract.

## Changes

- `docs/governance/SIBLINGS.md` + `README.md` — sibling registry (seeded from `.gitignore`)
- `CONTRIBUTING.md` — new; Python local checks + **Bring your own tools** section
- `GOVERNANCE.md` — new; three-layer process governance
- `CODE_OF_CONDUCT.md` — new; Contributor Covenant 2.1

Docs-only; no tool or protocol behavior changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
