### PR TITLE
ci: adopt org reusable SBOM workflow (#105)

### DIFF
--- a/.github/workflows/sbom.yml
+++ b/.github/workflows/sbom.yml
@@ -1,0 +1,23 @@
+name: SBOM
+
+# Adopts the org reusable SBOM workflow owned by bicameral-integrations (#105).
+# OIDC + build provenance attestations enabled per the org-wide decision (#105).
+on:
+  release:
+    types: [published]
+  workflow_dispatch: {}
+
+permissions:
+  contents: read
+
+jobs:
+  sbom:
+    # SBOM needs id-token + attestations write for provenance; it does not write
+    # repo contents, so contents stays read (Scorecard Token-Permissions).
+    permissions:
+      contents: read
+      id-token: write
+      attestations: write
+    uses: BicameralAI/bicameral-integrations/.github/workflows/_reusable-sbom.yml@f28ab9dd21e2ffc2f79597c587dcf3c575f9d2ea
+    with:
+      attest: ${{ github.event_name == 'release' }}


### PR DESCRIPTION
## Adopt org reusable SBOM workflow (#105)

Closes the SBOM gap for `bicameral-mcp` per the org-wide governance + SBOM rollout (#105).

- Adds `.github/workflows/sbom.yml` calling `bicameral-integrations`' reusable SBOM workflow,
  **pinned by SHA** (`f28ab9d`).
- Runs on `release: published` (+ `workflow_dispatch`); emits an SPDX SBOM and, on release,
  **build provenance attestations** (OIDC `id-token` + `attestations: write`) per the org-wide
  OIDC decision recorded on #105.
- `mcp` already has CodeQL, Scorecard, and dependency-review — SBOM was the only gap.

> Cross-repo reusable-workflow call: `bicameral-integrations` is public, so its reusable
> workflows are callable here. If org Actions policy blocks it, the fallback is vendoring the
> reusable workflow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
