### PR TITLE
test(parity): #611 substrate parity fixture — hook-firing portability gate

### DIFF
--- a/tests/substrate_parity/README.md
+++ b/tests/substrate_parity/README.md
@@ -1,0 +1,79 @@
+# Substrate parity fixture (GH #611)
+
+**Why this exists.** #610/#148 capture leans on Claude Code hooks (`SessionEnd`,
+`PreCompact`, `PostToolUse`, …). #148's portability bar — "capture must work
+across interactive Claude Code, headless `claude -p`, and the hosted/cron runner"
+— hinges on a fact the docs do **not** pin down: *which hook events actually fire
+under each substrate.* Until that is measured, any portability claim is unproven.
+
+This fixture is the cheap, decisive instrument #611 proposed: a no-op hook on
+every event that records `{event, substrate, ts}`, run under each substrate, then
+diffed. It converts the assumption into a checked fact and **gates** #148.
+
+## Components
+
+| File | Role |
+|------|------|
+| `parity_hook.py` | No-op probe. Appends one JSON line per hook firing. Never blocks, always exits 0. |
+| `settings.fixture.json` | `.claude` hooks block registering the probe on every event. |
+| `diff_parity.py` | Diffs per-substrate logs; **exits non-zero if a capture-critical event is missing** in any substrate. |
+| `test_parity_fixture.py` | Deterministic tests of the probe + gate logic (runs in CI; no live substrates needed). |
+
+`CAPTURE_CRITICAL = SessionEnd, PreCompact, Stop, PostToolUse` — the events #610
+Phase-1 capture cannot lose. A gap in any of these in any substrate is
+portability-blocking.
+
+## Running the three legs
+
+For each substrate, merge the `hooks` block from `settings.fixture.json` into that
+substrate's `.claude/settings.json`, then export the two env vars and run the
+**same** representative workload (e.g. one implementing prompt that edits a file
+and stops).
+
+**1. Interactive (reference):**
+```bash
+export BICAMERAL_PARITY_SUBSTRATE=interactive
+export BICAMERAL_PARITY_LOG="$PWD/parity-interactive.jsonl"
+# launch Claude Code interactively, run the workload, end the session
+```
+
+**2. Headless `claude -p`:**
+```bash
+export BICAMERAL_PARITY_SUBSTRATE=headless
+export BICAMERAL_PARITY_LOG="$PWD/parity-headless.jsonl"
+claude -p "edit README, then stop"   # same workload as the reference
+```
+
+**3. Cron / cloud agent:**
+```bash
+# In the scheduled-agent runner config, set:
+#   BICAMERAL_PARITY_SUBSTRATE=cron
+#   BICAMERAL_PARITY_LOG=/abs/path/parity-cron.jsonl
+# and run the same workload on the schedule, then collect the log.
+```
+
+> Note for unattended substrates (cron/`/loop`/cloud): even where capture-critical
+> events fire, there is **no operator to ratify at capture time** — captures must
+> stay tentative/low-authority (reinforces #58 / the strength-authority axis).
+
+## Diffing + the gate
+
+```bash
+python tests/substrate_parity/diff_parity.py \
+  --log interactive=parity-interactive.jsonl \
+  --log headless=parity-headless.jsonl \
+  --log cron=parity-cron.jsonl
+# exit 0 = all capture-critical events fired everywhere (portability OK so far)
+# exit 2 = a capture-critical event is missing in some substrate (BLOCKS #148)
+# add --strict to also fail on non-critical divergences
+# add --json to emit a machine-readable report (CI artifact)
+```
+
+## What this does and does not prove
+
+- **Proves:** which hook events fire in each substrate that was actually run.
+- **Does not prove:** anything about a substrate you didn't run. Coverage of the
+  hosted runner is deferred to GA (#610). Until the headless and cron legs are
+  run and pass, #148's portability acceptance stays open — do not claim it.
+- The git `post-commit` signal (#610 Signal B) is a git hook, not a Claude Code
+  hook; verify it separately under each substrate's commit path.

--- a/tests/substrate_parity/README.md
+++ b/tests/substrate_parity/README.md
@@ -77,3 +77,35 @@ python tests/substrate_parity/diff_parity.py \
   run and pass, #148's portability acceptance stays open — do not claim it.
 - The git `post-commit` signal (#610 Signal B) is a git hook, not a Claude Code
   hook; verify it separately under each substrate's commit path.
+
+## Measured results (2026-06-19, first run)
+
+Probe wired via `--settings` (isolated; live config untouched), tool-using
+workload (Read a file, reply) on `claude` 2.1.x.
+
+| event | interactive | headless `claude -p` |
+|-------|:-----------:|:--------------------:|
+| SessionStart | fired | fired |
+| UserPromptSubmit | fired | fired |
+| PreToolUse | fired | fired |
+| PostToolUse ★ | fired | fired |
+| Stop ★ | fired | fired |
+| SessionEnd ★ | fired | fired |
+| PreCompact ★ | not exercised | not exercised |
+
+`diff_parity.py interactive vs headless` → exit 0, no divergence. **`SessionEnd`
+fires under headless `claude -p`** — the load-bearing assumption for #610/#148,
+now verified and at parity with interactive.
+
+Honest scope of this run:
+- The interactive leg was `claude` (non-`-p`) driven via piped stdin + EOF — it
+  exercises the interactive (non-print) hook path but is **one turn**, not a
+  human-at-keyboard TTY. A confirmatory true-TTY pass is still worth doing.
+- **`PreCompact` is unverified.** It fires only on actual context compaction;
+  a trivial workload has nothing to compact, and a piped-stdin `/compact` is not
+  processed as a turn. To capture it, run a real interactive session that either
+  reaches the auto-compact threshold or issues `/compact` with substantive
+  context loaded, with the fixture settings active, then re-run `diff_parity.py`.
+- **Cron / hosted-runner leg not run** (deferred to GA per #610). Until the cron
+  leg and `PreCompact` are confirmed, #148 full portability stays open — the
+  interactive+headless parity above materially de-risks it but does not close it.

--- a/tests/substrate_parity/diff_parity.py
+++ b/tests/substrate_parity/diff_parity.py
@@ -1,0 +1,178 @@
+#!/usr/bin/env python3
+"""Diff substrate parity logs and gate on capture-critical hook coverage.
+
+Consumes the JSONL logs produced by ``parity_hook.py`` under each substrate
+(interactive / headless `claude -p` / cron) and answers the #611 question: does
+the same workload fire the same hook events everywhere?
+
+Gate semantics (the part #148 portability hangs on):
+- ``CAPTURE_CRITICAL`` events are the ones #610 capture leans on. If any of them
+  is observed in the *reference* substrate but missing from another tested
+  substrate, that substrate cannot carry #610 capture — the tool exits non-zero.
+- ``--strict`` additionally fails on ANY event-coverage divergence, not just the
+  capture-critical ones.
+
+This converts "we assume SessionEnd fires under `claude -p`" into a checked fact
+before any portability claim is made. Per GH #611.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+
+# Events #610 Phase-1 capture depends on. SessionEnd drains the transcript
+# queue; PreCompact can drop assistant text before that drain; PostToolUse /
+# Stop / SubagentStop bound the turn. If any of these does not fire in a
+# substrate, capture silently loses data there.
+CAPTURE_CRITICAL = ("SessionEnd", "PreCompact", "Stop", "PostToolUse")
+
+# The reference substrate every other substrate is compared against.
+DEFAULT_REFERENCE = "interactive"
+
+
+def _load_log(path: str) -> dict[str, int]:
+    """Return {event_name: count} for one substrate's JSONL log."""
+    counts: dict[str, int] = {}
+    try:
+        with open(path, encoding="utf-8") as fh:
+            for line in fh:
+                line = line.strip()
+                if not line:
+                    continue
+                try:
+                    rec = json.loads(line)
+                except ValueError:
+                    continue
+                event = rec.get("event", "unknown")
+                counts[event] = counts.get(event, 0) + 1
+    except OSError as exc:
+        print(f"warning: cannot read {path}: {exc}", file=sys.stderr)
+    return counts
+
+
+def _parse_log_args(raw: list[str]) -> dict[str, str]:
+    """Parse ``substrate=path`` / ``substrate:path`` pairs into a mapping."""
+    out: dict[str, str] = {}
+    for item in raw:
+        sep = "=" if "=" in item else (":" if ":" in item else None)
+        if sep is None:
+            raise SystemExit(f"--log expects substrate=path, got: {item!r}")
+        substrate, path = item.split(sep, 1)
+        out[substrate.strip()] = path.strip()
+    return out
+
+
+def build_report(logs: dict[str, dict[str, int]], reference: str) -> dict:
+    """Compute the event x substrate matrix plus divergence findings."""
+    substrates = sorted(logs)
+    all_events = sorted({e for counts in logs.values() for e in counts})
+
+    matrix = {event: {sub: logs[sub].get(event, 0) for sub in substrates} for event in all_events}
+
+    ref_events = set(logs.get(reference, {}))
+    missing_critical: list[dict] = []
+    divergences: list[dict] = []
+
+    for sub in substrates:
+        if sub == reference:
+            continue
+        sub_events = set(logs[sub])
+        for event in sorted(ref_events - sub_events):
+            finding = {"event": event, "present_in": reference, "missing_in": sub}
+            divergences.append(finding)
+            if event in CAPTURE_CRITICAL:
+                missing_critical.append(finding)
+
+    return {
+        "reference": reference,
+        "substrates": substrates,
+        "events": all_events,
+        "matrix": matrix,
+        "divergences": divergences,
+        "missing_critical": missing_critical,
+        "capture_critical": list(CAPTURE_CRITICAL),
+    }
+
+
+def render(report: dict) -> str:
+    subs = report["substrates"]
+    width = max([len("event")] + [len(e) for e in report["events"]] + [4])
+    lines = ["", "Substrate parity matrix (event firing counts)", ""]
+    header = "  " + "event".ljust(width) + "  " + "  ".join(s.rjust(10) for s in subs)
+    lines.append(header)
+    lines.append("  " + "-" * (len(header) - 2))
+    for event in report["events"]:
+        crit = " *" if event in report["capture_critical"] else "  "
+        row = (
+            "  "
+            + event.ljust(width)
+            + "  "
+            + "  ".join(str(report["matrix"][event][s]).rjust(10) for s in subs)
+        )
+        lines.append(row + crit)
+    lines.append("")
+    lines.append("  (* = capture-critical for #610)")
+    lines.append(f"  reference substrate: {report['reference']}")
+    if report["missing_critical"]:
+        lines.append("")
+        lines.append("  CAPTURE-CRITICAL GAPS (portability-blocking):")
+        for f in report["missing_critical"]:
+            lines.append(
+                f"    - {f['event']} fires in {f['present_in']} but NOT in {f['missing_in']}"
+            )
+    elif report["divergences"]:
+        lines.append("")
+        lines.append("  Non-critical divergences:")
+        for f in report["divergences"]:
+            lines.append(
+                f"    - {f['event']} fires in {f['present_in']} but NOT in {f['missing_in']}"
+            )
+    else:
+        lines.append("")
+        lines.append("  No divergences: all substrates fired the reference's event set.")
+    lines.append("")
+    return "\n".join(lines)
+
+
+def main(argv: list[str] | None = None) -> int:
+    ap = argparse.ArgumentParser(description="Diff substrate parity logs (GH #611).")
+    ap.add_argument(
+        "--log",
+        action="append",
+        default=[],
+        metavar="SUBSTRATE=PATH",
+        help="a substrate label and its parity JSONL log (repeatable)",
+    )
+    ap.add_argument("--reference", default=DEFAULT_REFERENCE, help="reference substrate")
+    ap.add_argument(
+        "--strict", action="store_true", help="fail on ANY divergence, not just capture-critical"
+    )
+    ap.add_argument("--json", action="store_true", help="emit the report as JSON")
+    args = ap.parse_args(argv)
+
+    if len(args.log) < 2:
+        ap.error("need at least two --log substrate=path entries to diff")
+
+    paths = _parse_log_args(args.log)
+    logs = {sub: _load_log(path) for sub, path in paths.items()}
+    if args.reference not in logs:
+        ap.error(f"reference {args.reference!r} not among substrates {sorted(logs)}")
+
+    report = build_report(logs, args.reference)
+
+    if args.json:
+        print(json.dumps(report, indent=2, sort_keys=True))
+    else:
+        print(render(report))
+
+    if report["missing_critical"]:
+        return 2
+    if args.strict and report["divergences"]:
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/substrate_parity/parity_hook.py
+++ b/tests/substrate_parity/parity_hook.py
@@ -1,0 +1,84 @@
+#!/usr/bin/env python3
+"""Substrate parity probe — a no-op Claude Code hook that records which event
+fired, in which substrate, and when.
+
+Prereq for #610/#148 (GH #611 Finding 2): "which hook events actually fire under
+`claude -p` and cron/cloud agents" is currently *unverified*. This hook is the
+cheap, decisive instrument that converts that assumption into a fact. Register it
+on every hook event (see ``settings.fixture.json``), run the same workload under
+each substrate, then diff the logs with ``diff_parity.py``.
+
+Contract:
+- Reads the Claude Code hook payload as JSON on stdin (``hook_event_name``,
+  ``session_id``, ``cwd``, ... per the hooks spec). Tolerates non-JSON / empty
+  stdin so it can also be driven from a git hook or a bare cron command.
+- Appends ONE JSON line ``{event, substrate, ts, session_id, cwd, pid}`` to the
+  log at ``$BICAMERAL_PARITY_LOG``.
+- Is a strict no-op: never blocks, never emits a decision, always exits 0. A
+  capture probe that changes behavior would poison the very measurement.
+
+Env:
+- ``BICAMERAL_PARITY_LOG``       path to the JSONL log (default: ./parity-<substrate>.jsonl)
+- ``BICAMERAL_PARITY_SUBSTRATE`` substrate label: ``interactive`` | ``headless`` | ``cron`` (default: ``unknown``)
+
+The event name is taken from the stdin payload's ``hook_event_name``; ``--event``
+overrides it for substrates that cannot supply stdin JSON.
+"""
+
+from __future__ import annotations
+
+import argparse
+import datetime as _dt
+import json
+import os
+import sys
+
+
+def _read_payload() -> dict:
+    """Best-effort parse of the hook payload from stdin. Never raises."""
+    try:
+        raw = sys.stdin.read()
+    except Exception:
+        return {}
+    if not raw or not raw.strip():
+        return {}
+    try:
+        parsed = json.loads(raw)
+        return parsed if isinstance(parsed, dict) else {}
+    except (ValueError, TypeError):
+        return {}
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(add_help=False)
+    ap.add_argument("--event", default=None, help="override hook_event_name")
+    args, _ignored = ap.parse_known_args()
+
+    payload = _read_payload()
+    substrate = os.environ.get("BICAMERAL_PARITY_SUBSTRATE", "unknown")
+    log_path = os.environ.get("BICAMERAL_PARITY_LOG", f"parity-{substrate}.jsonl")
+
+    record = {
+        "event": args.event or payload.get("hook_event_name") or "unknown",
+        "substrate": substrate,
+        "ts": _dt.datetime.now(_dt.UTC).isoformat(),
+        "session_id": payload.get("session_id"),
+        "cwd": payload.get("cwd") or os.getcwd(),
+        "pid": os.getpid(),
+    }
+
+    # Append-only; create parent dirs. Swallow IO errors — the probe must never
+    # break the session it is observing.
+    try:
+        parent = os.path.dirname(os.path.abspath(log_path))
+        os.makedirs(parent, exist_ok=True)
+        with open(log_path, "a", encoding="utf-8") as fh:
+            fh.write(json.dumps(record) + "\n")
+    except OSError:
+        pass
+
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/substrate_parity/settings.fixture.json
+++ b/tests/substrate_parity/settings.fixture.json
@@ -1,0 +1,32 @@
+{
+  "_comment": "Substrate parity fixture (GH #611). Merge the `hooks` block into the .claude/settings.json of the substrate under test (interactive project settings, the env used by `claude -p`, or the cron/cloud-agent runner config). Set BICAMERAL_PARITY_SUBSTRATE and BICAMERAL_PARITY_LOG in that substrate's environment before the run. Each command is a strict no-op probe; --event is passed explicitly so substrates that do not deliver stdin JSON still record a correct event name. $CLAUDE_PROJECT_DIR is provided by Claude Code at hook execution time.",
+  "hooks": {
+    "SessionStart": [
+      { "hooks": [{ "type": "command", "command": "python3 \"$CLAUDE_PROJECT_DIR/tests/substrate_parity/parity_hook.py\" --event SessionStart" }] }
+    ],
+    "UserPromptSubmit": [
+      { "hooks": [{ "type": "command", "command": "python3 \"$CLAUDE_PROJECT_DIR/tests/substrate_parity/parity_hook.py\" --event UserPromptSubmit" }] }
+    ],
+    "PreToolUse": [
+      { "matcher": "*", "hooks": [{ "type": "command", "command": "python3 \"$CLAUDE_PROJECT_DIR/tests/substrate_parity/parity_hook.py\" --event PreToolUse" }] }
+    ],
+    "PostToolUse": [
+      { "matcher": "*", "hooks": [{ "type": "command", "command": "python3 \"$CLAUDE_PROJECT_DIR/tests/substrate_parity/parity_hook.py\" --event PostToolUse" }] }
+    ],
+    "Notification": [
+      { "hooks": [{ "type": "command", "command": "python3 \"$CLAUDE_PROJECT_DIR/tests/substrate_parity/parity_hook.py\" --event Notification" }] }
+    ],
+    "Stop": [
+      { "hooks": [{ "type": "command", "command": "python3 \"$CLAUDE_PROJECT_DIR/tests/substrate_parity/parity_hook.py\" --event Stop" }] }
+    ],
+    "SubagentStop": [
+      { "hooks": [{ "type": "command", "command": "python3 \"$CLAUDE_PROJECT_DIR/tests/substrate_parity/parity_hook.py\" --event SubagentStop" }] }
+    ],
+    "PreCompact": [
+      { "hooks": [{ "type": "command", "command": "python3 \"$CLAUDE_PROJECT_DIR/tests/substrate_parity/parity_hook.py\" --event PreCompact" }] }
+    ],
+    "SessionEnd": [
+      { "hooks": [{ "type": "command", "command": "python3 \"$CLAUDE_PROJECT_DIR/tests/substrate_parity/parity_hook.py\" --event SessionEnd" }] }
+    ]
+  }
+}

--- a/tests/substrate_parity/test_parity_fixture.py
+++ b/tests/substrate_parity/test_parity_fixture.py
@@ -1,0 +1,165 @@
+"""Tests for the substrate parity fixture (GH #611).
+
+These validate the *instrument* deterministically with synthetic logs, so CI
+proves the diff/gate logic works without needing to spin up the three live
+substrates. The live cross-substrate run is a manual/CI-scheduled step
+documented in README.md; this file guarantees the analysis it feeds is sound.
+
+Sociable where it counts: the hook test runs the real ``parity_hook.py`` as a
+subprocess over real stdin + a real log file (no mocks).
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+_HERE = Path(__file__).parent
+
+
+def _load_diff_module():
+    spec = importlib.util.spec_from_file_location(
+        "parity_diff_under_test", _HERE / "diff_parity.py"
+    )
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+diff_parity = _load_diff_module()
+
+
+# ── parity_hook.py (sociable: real subprocess + real file) ───────────────────
+
+
+def test_hook_appends_record_from_stdin_payload(tmp_path):
+    log = tmp_path / "parity-headless.jsonl"
+    payload = {
+        "hook_event_name": "SessionEnd",
+        "session_id": "abc-123",
+        "cwd": "/repo",
+    }
+    proc = subprocess.run(
+        [sys.executable, str(_HERE / "parity_hook.py")],
+        input=json.dumps(payload),
+        capture_output=True,
+        text=True,
+        env={
+            "BICAMERAL_PARITY_LOG": str(log),
+            "BICAMERAL_PARITY_SUBSTRATE": "headless",
+            "PATH": __import__("os").environ.get("PATH", ""),
+            "SYSTEMROOT": __import__("os").environ.get("SYSTEMROOT", ""),
+        },
+    )
+    assert proc.returncode == 0, proc.stderr
+    assert proc.stdout == "", "probe must be a strict no-op (no stdout)"
+
+    rec = json.loads(log.read_text(encoding="utf-8").strip())
+    assert rec["event"] == "SessionEnd"
+    assert rec["substrate"] == "headless"
+    assert rec["session_id"] == "abc-123"
+    assert "ts" in rec
+
+
+def test_hook_event_arg_overrides_and_tolerates_empty_stdin(tmp_path):
+    log = tmp_path / "parity-cron.jsonl"
+    proc = subprocess.run(
+        [sys.executable, str(_HERE / "parity_hook.py"), "--event", "SessionStart"],
+        input="",  # cron/bare invocation: no stdin JSON
+        capture_output=True,
+        text=True,
+        env={
+            "BICAMERAL_PARITY_LOG": str(log),
+            "BICAMERAL_PARITY_SUBSTRATE": "cron",
+            "PATH": __import__("os").environ.get("PATH", ""),
+            "SYSTEMROOT": __import__("os").environ.get("SYSTEMROOT", ""),
+        },
+    )
+    assert proc.returncode == 0, proc.stderr
+    rec = json.loads(log.read_text(encoding="utf-8").strip())
+    assert rec["event"] == "SessionStart"
+    assert rec["substrate"] == "cron"
+
+
+# ── diff_parity.py gate logic ────────────────────────────────────────────────
+
+
+def _counts(*events):
+    out = {}
+    for e in events:
+        out[e] = out.get(e, 0) + 1
+    return out
+
+
+def test_clean_parity_has_no_divergence():
+    logs = {
+        "interactive": _counts("SessionStart", "PostToolUse", "Stop", "SessionEnd"),
+        "headless": _counts("SessionStart", "PostToolUse", "Stop", "SessionEnd"),
+    }
+    report = diff_parity.build_report(logs, reference="interactive")
+    assert report["divergences"] == []
+    assert report["missing_critical"] == []
+
+
+def test_missing_capture_critical_event_is_flagged():
+    # headless never fired SessionEnd — the exact #611 failure mode.
+    logs = {
+        "interactive": _counts("SessionStart", "PostToolUse", "SessionEnd"),
+        "headless": _counts("SessionStart", "PostToolUse"),
+    }
+    report = diff_parity.build_report(logs, reference="interactive")
+    assert any(f["event"] == "SessionEnd" for f in report["missing_critical"])
+
+
+def test_non_critical_divergence_not_treated_as_critical():
+    logs = {
+        "interactive": _counts("SessionStart", "UserPromptSubmit", "SessionEnd", "PostToolUse"),
+        "cron": _counts("SessionStart", "SessionEnd", "PostToolUse"),  # no UserPromptSubmit
+    }
+    report = diff_parity.build_report(logs, reference="interactive")
+    assert report["missing_critical"] == []
+    assert any(f["event"] == "UserPromptSubmit" for f in report["divergences"])
+
+
+def test_main_exit_code_2_on_capture_critical_gap(tmp_path):
+    ref = tmp_path / "i.jsonl"
+    hl = tmp_path / "h.jsonl"
+    ref.write_text("\n".join(json.dumps({"event": e}) for e in ("SessionStart", "SessionEnd")))
+    hl.write_text(json.dumps({"event": "SessionStart"}))
+    rc = diff_parity.main(["--log", f"interactive={ref}", "--log", f"headless={hl}"])
+    assert rc == 2
+
+
+def test_main_exit_code_0_when_clean(tmp_path):
+    ref = tmp_path / "i.jsonl"
+    hl = tmp_path / "h.jsonl"
+    for p in (ref, hl):
+        p.write_text(
+            "\n".join(
+                json.dumps({"event": e})
+                for e in ("SessionStart", "SessionEnd", "Stop", "PostToolUse")
+            )
+        )
+    rc = diff_parity.main(["--log", f"interactive={ref}", "--log", f"headless={hl}"])
+    assert rc == 0
+
+
+def test_strict_mode_fails_on_non_critical_divergence(tmp_path):
+    ref = tmp_path / "i.jsonl"
+    cr = tmp_path / "c.jsonl"
+    ref.write_text(
+        "\n".join(
+            json.dumps({"event": e})
+            for e in ("SessionStart", "UserPromptSubmit", "SessionEnd", "Stop", "PostToolUse")
+        )
+    )
+    cr.write_text(
+        "\n".join(
+            json.dumps({"event": e}) for e in ("SessionStart", "SessionEnd", "Stop", "PostToolUse")
+        )
+    )
+    assert diff_parity.main(["--log", f"interactive={ref}", "--log", f"cron={cr}"]) == 0
+    assert diff_parity.main(["--log", f"interactive={ref}", "--log", f"cron={cr}", "--strict"]) == 1


### PR DESCRIPTION
## What

Substrate parity fixture (GH #611) under `tests/substrate_parity/` — the cheap, decisive instrument that converts "which Claude Code hook events actually fire under `claude -p` and cron/cloud agents" from an **unverified assumption** into a **checked fact**. This is the gating prerequisite for #148's portability acceptance and #610's capture coverage.

## Why

#610/#148 capture leans on hooks (`SessionEnd`, `PreCompact`, `PostToolUse`, …). #148's portability bar — works across interactive / headless `claude -p` / hosted-cron — was never measured. Per the [#611 determination](https://github.com/BicameralAI/bicameral-mcp/issues/611), this fixture gates that claim.

## Contents

- `parity_hook.py` — strict no-op probe; appends `{event, substrate, ts, session_id, cwd}` per hook firing. Never blocks, always exits 0.
- `settings.fixture.json` — `.claude` hooks block registering the probe on every event.
- `diff_parity.py` — diffs per-substrate logs; **exits 2 if a capture-critical event (`SessionEnd`/`PreCompact`/`Stop`/`PostToolUse`) is missing in any substrate** (the portability gate); `--strict` fails on any divergence; `--json` for CI artifacts.
- `test_parity_fixture.py` — 8 tests: the probe runs as a real subprocess over real stdin + a real log file (sociable); gate logic validated on synthetic logs.

## Verification

- `pytest tests/substrate_parity/` → 8 passed.
- `ruff check` + `ruff format --check` → clean.

## Scope / follow-on

- This lands the **harness**, CI-tested so its verdict is trustworthy. The **live three-leg run** (interactive / `claude -p` / cron) is a separate step; **#148 portability stays open** until the headless + cron legs are run and pass.
- Capture-scope decision (parent-only Phase 1) and the child-session follow-on (#620) are recorded on #611/#610.

Refs #611, #610, #148, #620.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added comprehensive substrate parity testing framework to verify consistent behavior of Claude Code across multiple deployment environments and validate critical event capture functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->