### PR TITLE
feat(mcp): expose evidence.refresh ToolRequest (#594)

### DIFF
--- a/prompts.py
+++ b/prompts.py
@@ -25,6 +25,12 @@ PROMPTS: dict[str, str] = {
         "bicameral.history for replayed ledger state and bicameral.search for "
         "querying decisions, candidates, and bindings."
     ),
+    "evidence_refresh": (
+        "Request manual evidence currentness refresh through Bicameral. Call "
+        "bicameral.evidence.refresh with a decision_id. Display the daemon-authored "
+        "currentness or typed rejection as-is; do not run local link_commit, mutate "
+        "ledger state, rebuild graphs, or infer compliance/signoff."
+    ),
 }
 
 

--- a/server.py
+++ b/server.py
@@ -21,6 +21,7 @@ from mcp.server.models import InitializationOptions
 from authority import build_authority_context
 from daemon_client import (
     CapabilityReport,
+    DaemonCapabilityError,
     DaemonClient,
     DaemonClientError,
     DaemonProtocolError,
@@ -70,6 +71,13 @@ async def _ensure_protocol_compatible(client: DaemonClient) -> CapabilityReport:
     )
 
 
+def _ensure_command_advertised(command_name: str, capability_report: CapabilityReport) -> None:
+    if command_name not in capability_report.supported_commands:
+        raise DaemonCapabilityError(
+            f"daemon does not advertise ToolRequest command: {command_name}"
+        )
+
+
 @server.list_tools()
 async def list_tools() -> list[types.Tool]:
     await _ensure_protocol_compatible(_client())
@@ -85,7 +93,8 @@ async def call_tool(name: str, arguments: dict[str, Any] | None) -> list[types.T
     command_name = MCP_TOOL_COMMANDS[name]
     client = _client()
     try:
-        await _ensure_protocol_compatible(client)
+        capability_report = await _ensure_protocol_compatible(client)
+        _ensure_command_advertised(command_name, capability_report)
         tool_request = build_tool_request(
             command_name=command_name,
             params=arguments,

--- a/tests/fixtures/toolresponses/evidence.refresh.json
+++ b/tests/fixtures/toolresponses/evidence.refresh.json
@@ -1,0 +1,21 @@
+{
+  "request_id": "cccccccc-cccc-4ccc-8ccc-cccccccccccc",
+  "status": "content_changed",
+  "result": {
+    "decision_id": "DEC-7",
+    "currentness": "content_changed",
+    "graph_readiness": "ready",
+    "evaluated_snapshot_id": "snap-2026-06-23",
+    "bindings": [
+      {
+        "binding_id": "bind-0001",
+        "currentness": "content_changed",
+        "detail": "Accepted binding target still exists, but code content changed since validation."
+      }
+    ],
+    "signoff_mutated": false,
+    "compliance_mutated": false,
+    "binding_evidence_mutated": false
+  },
+  "responded_at": "2026-06-23T00:00:00Z"
+}

--- a/tests/test_toolrequest_conformance.py
+++ b/tests/test_toolrequest_conformance.py
@@ -123,6 +123,12 @@ COMMAND_SPECS: dict[str, _CommandSpec] = {
         expected_params={"decision_or_candidate_id", "commit_sha"},
         required={"decision_or_candidate_id"},
     ),
+    "bicameral.evidence.refresh": _CommandSpec(
+        command="evidence.refresh",
+        args={"decision_id": "DEC-7", **_CONTROL_AND_NOISE},
+        expected_params={"decision_id"},
+        required={"decision_id"},
+    ),
     "bicameral.review.accept_candidate": _CommandSpec(
         command="review.accept_candidate",
         args={"target_id": "cand-1", "reason": "ok", **_CONTROL_AND_NOISE},
@@ -358,6 +364,49 @@ async def test_resolve_compliance_deferred_passthrough(monkeypatch):
     # V1 contract: compliance resolution is typed unsupported/deferred, not "ok".
     assert parsed["status"] == "unsupported"
     assert parsed["result"]["deferred"] is True
+
+
+EVIDENCE_REFRESH_TYPED_STATES = [
+    "current",
+    "content_changed",
+    "target_missing",
+    "graph_unavailable",
+    "graph_not_configured",
+    "unsupported_workspace",
+    "needs_index_refresh",
+    "ineligible_decision",
+]
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("state", EVIDENCE_REFRESH_TYPED_STATES)
+async def test_evidence_refresh_typed_currentness_passthrough(state, monkeypatch):
+    def respond(command, _req):
+        if command == "evidence.refresh":
+            return {
+                "status": state,
+                "result": {
+                    "decision_id": "DEC-7",
+                    "currentness": state,
+                    "signoff_mutated": False,
+                    "compliance_mutated": False,
+                    "binding_evidence_mutated": False,
+                },
+                "responded_at": "2026-06-23T00:00:00Z",
+            }
+        return None
+
+    daemon = _RecordingDaemon(response_for=respond)
+    _patch_daemon(monkeypatch, daemon)
+
+    content = await server.call_tool("bicameral.evidence.refresh", {"decision_id": "DEC-7"})
+    parsed = json.loads(content[0].text)
+
+    assert parsed["status"] == state
+    assert parsed["result"]["currentness"] == state
+    assert parsed["result"]["signoff_mutated"] is False
+    assert parsed["result"]["compliance_mutated"] is False
+    assert parsed["result"]["binding_evidence_mutated"] is False
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_toolrequest_thin_client.py
+++ b/tests/test_toolrequest_thin_client.py
@@ -125,7 +125,7 @@ async def test_prompts_are_generic_tool_workflows(monkeypatch):
     prompts = await server.list_prompts()
     names = {prompt.name for prompt in prompts}
 
-    assert {"preflight", "bind", "ingest", "history_search"} <= names
+    assert {"preflight", "bind", "ingest", "history_search", "evidence_refresh"} <= names
     prompt = await server.get_prompt("preflight", {"branch": "feature/x"})
     text = prompt.messages[0].content.text
     assert "bicameral.preflight" in text
@@ -348,6 +348,60 @@ async def test_non_preflight_uses_generic_formatter(monkeypatch):
 
     assert "stages" not in response
     assert response["status"] == "ok"
+
+
+@pytest.mark.asyncio
+async def test_evidence_refresh_maps_to_thin_toolrequest(monkeypatch):
+    fake = _FakeClient()
+    monkeypatch.setattr(server, "_client", lambda: fake)
+
+    content = await server.call_tool(
+        "bicameral.evidence.refresh",
+        {
+            "decision_id": "DEC-7",
+            "workspace": "/repo",
+            "actor_id": "agent-refresh",
+            "link_commit": "must-not-forward",
+            "ensure_ledger_synced": True,
+        },
+    )
+    response = json.loads(content[0].text)
+
+    assert response["status"] == "ok"
+    assert fake.requests[0]["command"] == {
+        "name": "evidence.refresh",
+        "params": {"decision_id": "DEC-7"},
+    }
+    assert fake.requests[0]["authority"]["actor_id"] == "agent-refresh"
+    assert fake.requests[0]["authority"]["workspace"] == "/repo"
+
+
+@pytest.mark.asyncio
+async def test_evidence_refresh_absent_capability_returns_typed_error(monkeypatch):
+    class _NoEvidenceRefreshClient(_FakeClient):
+        async def capabilities(self) -> dict:
+            capabilities = await super().capabilities()
+            capabilities["supported_commands"] = [
+                command
+                for command in capabilities["supported_commands"]
+                if command != "evidence.refresh"
+            ]
+            return capabilities
+
+    fake = _NoEvidenceRefreshClient()
+    monkeypatch.setattr(server, "_client", lambda: fake)
+
+    content = await server.call_tool(
+        "bicameral.evidence.refresh",
+        {"decision_id": "DEC-7"},
+    )
+    response = json.loads(content[0].text)
+
+    assert response["status"] == "error"
+    assert response["error_code"] == "daemon_capability_error"
+    assert response["recovery"]["requested_tool"] == "bicameral.evidence.refresh"
+    assert response["recovery"]["requested_command"] == "evidence.refresh"
+    assert fake.requests == []
 
 
 # ---------------------------------------------------------------------------

--- a/tool_request.py
+++ b/tool_request.py
@@ -11,6 +11,7 @@ MCP_TOOL_COMMANDS: dict[str, str] = {
     "bicameral.preflight": "preflight.run",
     "bicameral.bind": "binding.create",
     "bicameral.binding.inspect": "binding.inspect",
+    "bicameral.evidence.refresh": "evidence.refresh",
     "bicameral.review.accept_candidate": "review.accept_candidate",
     "bicameral.review.reject_candidate": "review.reject_candidate",
     "bicameral.review.approve_signoff": "review.approve_signoff",
@@ -64,6 +65,8 @@ def _command_params(command_name: str, params: dict[str, Any]) -> dict[str, Any]
         return _only(cleaned, "decision_or_candidate_id", "bindings", "commit_sha", "ref_name")
     if command_name == "binding.inspect":
         return _only(cleaned, "decision_or_candidate_id", "commit_sha")
+    if command_name == "evidence.refresh":
+        return _only(cleaned, "decision_id")
     if command_name in {
         "review.accept_candidate",
         "review.reject_candidate",

--- a/tool_schemas.py
+++ b/tool_schemas.py
@@ -88,6 +88,19 @@ SUPPORTED_TOOLS: tuple[Tool, ...] = (
         ),
     ),
     Tool(
+        name="bicameral.evidence.refresh",
+        description="Request daemon-owned evidence currentness refresh for a tracked Decision.",
+        inputSchema=_schema(
+            {
+                "decision_id": {
+                    "type": "string",
+                    "description": "Decision id whose evidence currentness should be refreshed.",
+                },
+            },
+            ["decision_id"],
+        ),
+    ),
+    Tool(
         name="bicameral.review.accept_candidate",
         description="Accept a decision candidate through bot governance.",
         inputSchema=_review_schema(),


### PR DESCRIPTION
## Summary

- Adds `bicameral.evidence.refresh` as a thin MCP tool mapped to canonical bot ToolRequest command `evidence.refresh`.
- Forwards only `decision_id` as command params; control keys stay in `AuthorityContext`, and legacy sync knobs such as `link_commit` / `ensure_ledger_synced` are ignored.
- Adds explicit advertised-capability checking before dispatch, so a daemon that does not advertise `evidence.refresh` returns a typed capability recovery response and receives no ToolRequest.
- Adds an evidence-refresh prompt and deterministic conformance fixture / typed currentness passthrough tests.

## Boundary

MCP remains request/display only. It does not inspect the workspace, rebuild graph snapshots, mutate ledger state, compute currentness, compliance, signoff, or accepted BindingEvidence.

## Validation

- `/private/tmp/bic-mcp-594-venv/bin/python -m pytest tests/test_toolrequest_thin_client.py tests/test_toolrequest_conformance.py -q` — 87 passed
- `/private/tmp/bic-mcp-594-venv/bin/python -m pytest tests/test_toolrequest_conformance.py -q` — 62 passed
- `/private/tmp/bic-mcp-594-venv/bin/python -m ruff check .` — pass
- `/private/tmp/bic-mcp-594-venv/bin/python -m ruff format --check .` — pass
- `/private/tmp/bic-mcp-594-venv/bin/python -m mypy .` — pass
- `/private/tmp/bic-mcp-594-venv/bin/python -m pytest -q` — 176 passed

Closes #594


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Evidence Refresh workflow: Users can now refresh evidence and view currentness assessments directly from the daemon.

* **Improvements**
  * Enhanced tool request handling with validation that the daemon advertises specific commands before sending requests, improving error feedback when commands are unavailable.

* **Tests**
  * Comprehensive test coverage added for the new Evidence Refresh workflow and command capability validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->