### PR TITLE
test(mcp): guard source runtime retirement (#623)

### DIFF
--- a/docs/validation-623-source-runtime-retirement.md
+++ b/docs/validation-623-source-runtime-retirement.md
@@ -1,0 +1,45 @@
+# MCP Source Runtime Retirement Validation (#623)
+
+Date: 2026-06-24
+
+## MCP Status
+
+`bicameral-mcp` no longer contains the source-acquisition runtime paths named in
+#623:
+
+- `cli/sync_and_brief_cli.py`
+- `cli/drive_renew_cli.py`
+- `sources/`
+- `events/sources/`
+- `webhooks/`
+
+The packaged runtime remains the thin ToolRequest client modules listed in
+`pyproject.toml`. Local MCP ingest maps only to daemon command
+`ingest.submit_local`; MCP does not accept or route `ExternalIngestEnvelope`.
+
+## Guard Added
+
+`tests/test_source_runtime_retired_623.py` locks this boundary by asserting:
+
+- source-acquisition and Drive/webhook runtime paths stay absent;
+- package metadata cannot include source runtime paths;
+- production Python does not call the old in-process ingest/runtime surfaces;
+- MCP keeps only the local `ingest.submit_local` ToolRequest mapping.
+
+## Cross-Repo Blocker
+
+Final #623 closure still depends on the integration-side prerequisite recorded
+in the issue:
+
+`bicameral-integrations/runtime/gateway_mapping.py` must emit
+`ExternalIngestEnvelope` to bot `POST /api/v1/external-ingest`.
+
+As of this validation pass, the integrations `main` branch still maps
+`AdapterEmission` to the legacy v1 `IngestRequest` shape. MCP should not add any
+compatibility shim for that contract. Integrations must acquire and emit the
+external envelope; bot materializes; MCP remains routing-only.
+
+## Recovery Pointer
+
+Removed MCP-owned behavior remains recoverable from pre-refactor commit
+`0827444c80d45fe3474f68002166e1fc35708eda`.

--- a/tests/test_source_runtime_retired_623.py
+++ b/tests/test_source_runtime_retired_623.py
@@ -1,0 +1,67 @@
+"""Regression guards for retiring MCP source/Drive runtime authority (#623)."""
+
+from pathlib import Path
+
+FORBIDDEN_RUNTIME_PATHS = {
+    "cli/sync_and_brief_cli.py",
+    "cli/drive_renew_cli.py",
+    "sources",
+    "events/sources",
+    "webhooks",
+}
+
+FORBIDDEN_RUNTIME_TOKENS = {
+    "handle_ingest(",
+    "sources.google_drive",
+    "sources.github",
+    "events.sources",
+    "webhooks.google_drive",
+    "webhooks.github",
+    "drive_renew_cli",
+    "drive_watch_cli",
+    "sync_and_brief_cli",
+}
+
+PRODUCTION_PYTHON_FILES = {
+    path for path in Path(".").glob("*.py") if path.name not in {"setup.py"}
+} | set(Path("scripts").glob("*.py"))
+
+
+def test_source_acquisition_runtime_paths_are_absent():
+    for forbidden in FORBIDDEN_RUNTIME_PATHS:
+        assert not Path(forbidden).exists(), f"MCP source runtime path reintroduced: {forbidden}"
+
+
+def test_packaged_surface_cannot_include_source_runtime():
+    text = Path("pyproject.toml").read_text()
+
+    for forbidden in [
+        "cli/",
+        "sources/",
+        "events/",
+        "webhooks/",
+        "google_drive",
+        "drive_renew",
+        "sync_and_brief",
+    ]:
+        assert forbidden not in text
+
+
+def test_production_python_does_not_call_source_ingest_runtime():
+    findings: list[str] = []
+    for path in sorted(PRODUCTION_PYTHON_FILES):
+        text = path.read_text()
+        for token in FORBIDDEN_RUNTIME_TOKENS:
+            if token in text:
+                findings.append(f"{path}:{token}")
+
+    assert findings == []
+
+
+def test_mcp_keeps_only_local_toolrequest_ingest_mapping():
+    text = Path("tool_request.py").read_text()
+
+    assert '"bicameral.ingest": "ingest.submit_local"' in text
+    assert "ExternalIngestEnvelope" not in text
+    assert "external-ingest" not in text
+    assert "ingest.submit_managed" not in text


### PR DESCRIPTION
## Summary

Starts #623 on the MCP side.

Current `bicameral-mcp` already has the source/Drive runtime paths removed, so this PR adds a regression guard and validation note instead of deleting nonexistent runtime code:

- adds `tests/test_source_runtime_retired_623.py`;
- asserts MCP source-acquisition, Drive renewal, and webhook runtime paths stay absent;
- asserts package metadata cannot include source runtime paths;
- asserts production Python does not call the old in-process source ingest/runtime surfaces;
- documents the current MCP-side state in `docs/validation-623-source-runtime-retirement.md`.

## Boundary

This PR does not add a compatibility shim for the integrations legacy `IngestRequest` contract.

Final #623 closure remains blocked until `bicameral-integrations/runtime/gateway_mapping.py` emits `ExternalIngestEnvelope` to bot `POST /api/v1/external-ingest`. As of this PR, integrations `main` still maps `AdapterEmission` to the legacy v1 `IngestRequest` shape.

## Validation

- `/private/tmp/bic-mcp-594-venv/bin/python -m pytest tests/test_source_runtime_retired_623.py -q`
- `/private/tmp/bic-mcp-594-venv/bin/python -m pytest -q`
- `/private/tmp/bic-mcp-594-venv/bin/python -m ruff check .`
- `/private/tmp/bic-mcp-594-venv/bin/python -m ruff format --check .`
- `/private/tmp/bic-mcp-594-venv/bin/python -m mypy .`

## Domain Entity Candidates

None. This is a retirement-boundary guard only.

## Factory Learning Signals

- MCP-side source runtime is already absent after the thin-client cutover.
- The remaining #623 risk is cross-repo: integrations must emit the external envelope before final closure.

Refs #623.
Refs BicameralAI/bicameral-bot#218.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a note documenting the retirement of legacy source-runtime paths and the current packaged runtime boundaries.
  * Clarified the supported ingestion flow and removed ambiguity around older compatibility behavior.

* **Tests**
  * Added regression coverage to ensure retired runtime files and references stay absent.
  * Verified the packaged surface remains limited to the expected local ingestion mapping.
  * Confirmed production code does not reintroduce legacy runtime calls.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->