### PR TITLE
docs(context): define lookup correction vocabulary

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -57,3 +57,15 @@ Structured result from the daemon capability handshake. It reports daemon-advert
 _Authority verbs_: return, inspect
 _Avoid_: command grant, governance authority, fallback authority, local policy bypass
 _Related_: #606
+
+**RecallPacket**:
+Daemon-authored lookup result that describes searched scope, unknown scope, matches, evidence references, freshness/readiness labels, and allowed next actions. MCP may render the packet but must not strengthen it into a completeness, safety, compliance, or no-conflict claim.
+_Authority verbs_: return, render
+_Avoid_: compliance result, global search result, no-conflict proof, merge-safety signal
+_Related_: #638, #639
+
+**correction_id**:
+Daemon-assigned identifier for an accepted correction request outcome. It identifies the daemon-mediated request result; it is not local MCP approval, proof of ledger materialization, or evidence that a correction has become canonical.
+_Authority verbs_: return, reference
+_Avoid_: approval id, ledger event id, canonical decision id, local write token
+_Related_: #639, #640


### PR DESCRIPTION
## Summary

- Define RecallPacket as a daemon-authored lookup result that MCP may render without strengthening claims.
- Define correction_id as a daemon-assigned correction request outcome identifier, not local approval or ledger authority.

## Validation

- Docs-only change; no runtime tests run.
- Local commit hook reported a failure, but the hook log only contained config/schema verification entries and no actionable error.

Refs #638
Refs #639
Refs #640

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added clearer semantic definitions for two language terms used in AI-related workflows.
  * Clarified how lookup results should be interpreted, including scope, evidence, freshness, readiness, and permitted next actions.
  * Added guidance for an accepted correction identifier so it is not mistaken for approval or canonical validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->