### PR TITLE
chore: integrate brief prompt follow-up to main (#333)

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,7 +113,7 @@ bot-owned or CLI-owned, not MCP-owned.
 ## Prompts And Skills
 
 MCP may expose MCP prompts for generic Bicameral workflows over supported tools,
-such as preflight, binding, ingest, history, and search.
+such as preflight, binding, ingest, history, search, and brief.
 
 Repo-local skills are outside MCP. Keep repo/team behavior in repo skills:
 when to run Bicameral, which ADRs to read, contribution policy, factory

--- a/prompts.py
+++ b/prompts.py
@@ -34,6 +34,15 @@ PROMPTS: dict[str, str] = {
         "currentness or typed rejection as-is; do not run local link_commit, mutate "
         "ledger state, rebuild graphs, or infer compliance/signoff."
     ),
+    "brief": (
+        "Generate a decision context brief through Bicameral for onboarding or "
+        "decision explanation. Call bicameral.brief with the feature area or "
+        "cross-cutting topic. Optionally pass decision_ids to narrow to specific "
+        "decisions, since to limit the timeline start, and include_graph to add "
+        "decision graph edges. The result is a daemon-authored Markdown narrative "
+        "with timeline, open items, and decision graph — display it as-is. Do not "
+        "infer compliance, completeness, or safety beyond what the daemon states."
+    ),
 }
 
 

--- a/tests/test_toolrequest_thin_client.py
+++ b/tests/test_toolrequest_thin_client.py
@@ -245,7 +245,7 @@ async def test_prompts_are_generic_tool_workflows(monkeypatch):
     prompts = await server.list_prompts()
     names = {prompt.name for prompt in prompts}
 
-    assert {"preflight", "bind", "ingest", "history_search", "evidence_refresh"} <= names
+    assert {"preflight", "bind", "ingest", "history_search", "evidence_refresh", "brief"} <= names
     prompt = await server.get_prompt("preflight", {"branch": "feature/x"})
     text = prompt.messages[0].content.text
     assert "bicameral.preflight" in text


### PR DESCRIPTION
## Summary

Integrates the #333 follow-up prompt work from dev to main:

- PR #655 — bicameral.brief prompt for onboarding/explanation workflows

## Validation

Source PR #655 passed bicameral-factory-attestation, ruff + mypy, pytest deterministic, Python floor smoke test, CodeQL, dependency review, and secret/security scans.

## Notes

Integration-only PR; no new implementation beyond the merged dev branch.