### PR TITLE
feat(mcp): expose relevance-time context packets (#613)

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -64,6 +64,12 @@ _Authority verbs_: return, render
 _Avoid_: compliance result, global search result, no-conflict proof, merge-safety signal
 _Related_: #638, #639
 
+**ContextPacket**:
+Daemon-authored relevance-time context artifact assembled after core-owned narrowing and ranking. It may contain trusted corpus entries, reviewed Decisions, constraints, candidate findings, evidence links, risk, confidence, freshness, rationale, and required actions while preserving authority labels. MCP may request and render it; MCP must not assemble, rank, enrich, or canonize it locally.
+_Authority verbs_: return, render
+_Avoid_: raw source dump, MCP-ranked context, local canonical truth, merge-safety signal
+_Related_: #613
+
 **correction_id**:
 Daemon-assigned identifier for an accepted correction request outcome. It identifies the daemon-mediated request result; it is not local MCP approval, proof of ledger materialization, or evidence that a correction has become canonical.
 _Authority verbs_: return, reference

--- a/README.md
+++ b/README.md
@@ -60,8 +60,11 @@ MCP exposes only ToolRequest-backed tools:
 |---|---|
 | `bicameral.ingest` | `ingest.submit_local` |
 | `bicameral.preflight` | `preflight.run` |
+| `bicameral.context` | `lookup.query` |
+| `bicameral.lookup` | `lookup.query` |
 | `bicameral.bind` | `binding.create` |
 | `bicameral.binding.inspect` | `binding.inspect` |
+| `bicameral.evidence.refresh` | `evidence.refresh` |
 | `bicameral.review.accept_candidate` | `review.accept_candidate` |
 | `bicameral.review.reject_candidate` | `review.reject_candidate` |
 | `bicameral.review.approve_signoff` | `review.approve_signoff` |
@@ -69,6 +72,7 @@ MCP exposes only ToolRequest-backed tools:
 | `bicameral.review.resolve_compliance` | `review.resolve_compliance` |
 | `bicameral.history` | `history.list` |
 | `bicameral.search` | `search.query` |
+| `bicameral.request_correction` | `correction.request` |
 
 ## Troubleshooting: Daemon Handshake Failures
 

--- a/docs/specs/bicameral-mcp-idealized-spec.md
+++ b/docs/specs/bicameral-mcp-idealized-spec.md
@@ -71,8 +71,11 @@ MCP exposes tools that map to the bot `ToolCommand` registry from issue #103:
 |---|---|---|
 | `bicameral.ingest` | `ingest.submit_local` | Local actor submits source/session evidence or candidate drafts. |
 | `bicameral.preflight` | `preflight.run` | Reads relevant decisions and graph-scoped evidence via daemon. |
+| `bicameral.context` | `lookup.query` | Requests daemon-authored relevance-time ContextPacket/RecallPacket output for agent and developer workflows. |
+| `bicameral.lookup` | `lookup.query` | Queries daemon-authored RecallPacket output without MCP-local relevance or authority computation. |
 | `bicameral.bind` | `binding.create` | Proposes binding evidence; daemon owns validation and materialization. |
 | `bicameral.binding.inspect` | `binding.inspect` | Inspects bindings/evidence through daemon. |
+| `bicameral.evidence.refresh` | `evidence.refresh` | Requests daemon-owned evidence currentness refresh for a tracked Decision. |
 | `bicameral.review.accept_candidate` | `review.accept_candidate` | Review command, not direct ledger mutation. |
 | `bicameral.review.reject_candidate` | `review.reject_candidate` | Review command, not direct ledger mutation. |
 | `bicameral.review.approve_signoff` | `review.approve_signoff` | Review command gated by bot policy. |
@@ -80,6 +83,7 @@ MCP exposes tools that map to the bot `ToolCommand` registry from issue #103:
 | `bicameral.review.resolve_compliance` | `review.resolve_compliance` | Review command gated by bot policy and evidence state. |
 | `bicameral.history` | `history.list` | Read replayed/materialized state. |
 | `bicameral.search` | `search.query` | Search daemon-owned state. |
+| `bicameral.request_correction` | `correction.request` | Submits an explicitly approved correction request to the daemon-owned correction path. |
 
 `bicameral.dashboard` is deferred unless bot exposes a local dashboard command or stable URL discovery endpoint. MCP may later add it as convenience only; it must not host the dashboard.
 

--- a/responses.py
+++ b/responses.py
@@ -211,6 +211,65 @@ def format_lookup_response(response: dict[str, Any]) -> TextContent:
     return TextContent(type="text", text=json.dumps(mcp_output, indent=2, sort_keys=True))
 
 
+def format_context_packet_response(response: dict[str, Any]) -> TextContent:
+    """Render a daemon-authored relevance-time context packet.
+
+    The packet is a lookup/read artifact. MCP preserves daemon-authored source
+    distinction, freshness/readiness, rationale, risk, confidence, and required
+    actions when present, but it does not compute relevance, infer completeness,
+    or convert no-match/partial coverage into safety or compliance claims.
+    """
+    packet = response.get("context_packet") or response.get("recall_packet") or {}
+    matches = packet.get("matches", [])
+    searched_sources = packet.get("searched_sources") or packet.get("searched_scope", [])
+    unknown_scope = packet.get("unknown_scope", [])
+
+    rendered_matches: list[dict[str, Any]] = []
+    for match in matches:
+        rendered: dict[str, Any] = {
+            "match_id": match.get("match_id") or match.get("id"),
+            "kind": match.get("kind"),
+            "title": match.get("title"),
+            "summary": match.get("summary"),
+            "authority": match.get("authority"),
+            "evidence_refs": match.get("evidence_refs", []),
+            "relevance_reasons": match.get("relevance_reasons", []),
+            "freshness_state": match.get("freshness_state") or match.get("freshness"),
+            "review_state": match.get("review_state") or match.get("readiness"),
+            "risk": match.get("risk"),
+            "confidence": match.get("confidence"),
+            "rationale": match.get("rationale"),
+            "required_actions": match.get("required_actions", []),
+        }
+        rendered_matches.append(
+            {key: value for key, value in rendered.items() if value not in (None, [], {})}
+        )
+
+    output: dict[str, Any] = {
+        "status": response.get("status", "ok"),
+        "request_id": response.get("request_id"),
+        "context_packet": {
+            "packet_id": packet.get("packet_id"),
+            "request": packet.get("request", {}),
+            "corpus": packet.get("corpus", {}),
+            "searched_sources": searched_sources,
+            "matches": rendered_matches,
+            "unknown_scope": unknown_scope,
+            "allowed_next_actions": packet.get("allowed_next_actions", []),
+            "receipt_ref": packet.get("receipt_ref"),
+        },
+        "session_directive": response.get("session_directive", {"mode": "continue"}),
+    }
+
+    if not matches:
+        output["context_packet"]["no_match_note"] = (
+            "No relevant items were returned for the searched sources. "
+            "This does not imply absence outside searched or configured scope."
+        )
+
+    return TextContent(type="text", text=json.dumps(output, indent=2, sort_keys=True))
+
+
 def format_correction_response(response: dict[str, Any]) -> TextContent:
     """Render a daemon correction response.
 

--- a/server.py
+++ b/server.py
@@ -39,6 +39,7 @@ from erasure_gate import (
 from prompts import get_prompt_result, list_prompt_definitions
 from responses import (
     error_text,
+    format_context_packet_response,
     format_correction_response,
     format_lookup_response,
     format_preflight_no_fire,
@@ -161,6 +162,8 @@ async def call_tool(name: str, arguments: dict[str, Any] | None) -> list[types.T
             return [format_preflight_response(response)]
         if name == "bicameral.lookup":
             return [format_lookup_response(response)]
+        if name == "bicameral.context":
+            return [format_context_packet_response(response)]
         if name == "bicameral.request_correction":
             return [format_correction_response(response)]
         if "recall_packet" in response:

--- a/tests/test_context_packet_613.py
+++ b/tests/test_context_packet_613.py
@@ -1,0 +1,240 @@
+"""Conformance tests for relevance-time context packets (issue #613)."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+import server
+from responses import format_context_packet_response
+from tool_request import MCP_TOOL_COMMANDS, SUPPORTED_COMMANDS
+from tool_schemas import tool_for_name
+from version import TOOLREQUEST_PROTOCOL_VERSION
+
+
+class _ContextDaemon:
+    def __init__(
+        self, *, commands: list[str] | None = None, response: dict[str, Any] | None = None
+    ):
+        self.commands = commands if commands is not None else list(SUPPORTED_COMMANDS)
+        self.response = response or _CONTEXT_RESPONSE
+        self.requests: list[dict[str, Any]] = []
+
+    async def capabilities(self) -> dict[str, Any]:
+        return {
+            "toolrequest_protocol_version": TOOLREQUEST_PROTOCOL_VERSION,
+            "supported_commands": self.commands,
+        }
+
+    async def send_tool_request(self, tool_request: dict[str, Any]) -> dict[str, Any]:
+        self.requests.append(tool_request)
+        return {"request_id": tool_request["request_id"], **self.response}
+
+
+_CONTEXT_ARGS = {
+    "query": "update billing retry behavior",
+    "ticket": "BILL-123",
+    "branch": "feature/retry-timeout",
+    "pr": "https://github.com/example/repo/pull/42",
+    "repo": "example/repo",
+    "files": ["src/billing/retry.py"],
+    "symbols": ["RetryPolicy"],
+    "code_region": {"path": "src/billing/retry.py", "start_line": 20, "end_line": 44},
+    "feature_area": "billing",
+    "agent_session_context": {"checkpoint": "pre_work", "tool": "codex"},
+    "planned_action": "change timeout default",
+    "checkpoint_hint": "pre_work",
+    "scope": "trusted_corpus",
+    "include_context": True,
+    "actor_id": "agent-1",
+    "workspace": "/repo",
+    "unknown_local_knob": "must not be forwarded",
+}
+
+_CONTEXT_RESPONSE = {
+    "status": "ok",
+    "context_packet": {
+        "packet_id": "rp_613",
+        "request": {
+            "intent": "lookup",
+            "checkpoint_hint": "pre_work",
+            "query": "update billing retry behavior",
+            "files": ["src/billing/retry.py"],
+        },
+        "corpus": {
+            "corpus_id": "workspace",
+            "version": "idx-123",
+            "authority_spine": "decision_ledger",
+            "trusted_sources": ["decision_ledger", "product_docs"],
+        },
+        "searched_sources": [
+            {"source_id": "decision_ledger", "status": "searched"},
+            {"source_id": "product_docs", "status": "searched"},
+        ],
+        "matches": [
+            {
+                "match_id": "DEC-7",
+                "kind": "accepted_decision",
+                "title": "Retry defaults",
+                "summary": "Billing retries use a bounded timeout.",
+                "authority": "canonical",
+                "evidence_refs": ["ev-1"],
+                "relevance_reasons": ["file overlap", "feature area"],
+                "freshness_state": "current",
+                "review_state": "accepted",
+                "risk": "medium",
+                "confidence": 0.84,
+                "rationale": "Daemon-ranked corpus match.",
+                "required_actions": [],
+            },
+            {
+                "match_id": "cand-9",
+                "kind": "contradiction_candidate",
+                "title": "Ticket asks for different timeout",
+                "summary": "Source-only ticket may conflict with trusted corpus.",
+                "authority": "candidate",
+                "evidence_refs": ["ticket:BILL-123"],
+                "relevance_reasons": ["ticket overlap"],
+                "freshness_state": "unknown",
+                "review_state": "review_needed",
+                "risk": "high",
+                "confidence": 0.61,
+                "required_actions": ["review_needed", "request_correction"],
+            },
+        ],
+        "unknown_scope": [
+            {
+                "scope": "private product notes",
+                "reason": "permission_missing",
+                "expand_action": "connect_product_notes",
+            }
+        ],
+        "allowed_next_actions": ["expand_scope", "request_correction"],
+        "receipt_ref": "lookup-trace-1",
+    },
+    "session_directive": {"mode": "continue"},
+}
+
+
+def test_context_tool_schema_exposes_relevance_time_hints():
+    tool = tool_for_name("bicameral.context")
+
+    assert tool is not None
+    props = tool.inputSchema["properties"]
+    for key in (
+        "ticket",
+        "branch",
+        "pr",
+        "repo",
+        "files",
+        "code_region",
+        "feature_area",
+        "agent_session_context",
+        "planned_action",
+        "checkpoint_hint",
+    ):
+        assert key in props
+
+
+@pytest.mark.asyncio
+async def test_context_maps_to_lookup_query_without_local_ranking(monkeypatch):
+    daemon = _ContextDaemon()
+    monkeypatch.setattr(server, "_client", lambda: daemon)
+
+    content = await server.call_tool("bicameral.context", dict(_CONTEXT_ARGS))
+    rendered = json.loads(content[0].text)
+
+    assert MCP_TOOL_COMMANDS["bicameral.context"] == "lookup.query"
+    assert len(daemon.requests) == 1
+    request = daemon.requests[0]
+    assert request["command"]["name"] == "lookup.query"
+    assert request["authority"]["audit_metadata"]["mcp_tool"] == "bicameral.context"
+    assert "unknown_local_knob" not in request["command"]["params"]
+    assert "actor_id" not in request["command"]["params"]
+    assert request["command"]["params"]["ticket"] == "BILL-123"
+    assert request["command"]["params"]["agent_session_context"] == {
+        "checkpoint": "pre_work",
+        "tool": "codex",
+    }
+    assert rendered["context_packet"]["matches"][0]["authority"] == "canonical"
+    assert rendered["context_packet"]["matches"][1]["authority"] == "candidate"
+
+
+@pytest.mark.asyncio
+async def test_context_is_capability_gated_on_lookup_query(monkeypatch):
+    daemon = _ContextDaemon(commands=[c for c in SUPPORTED_COMMANDS if c != "lookup.query"])
+    monkeypatch.setattr(server, "_client", lambda: daemon)
+
+    content = await server.call_tool("bicameral.context", {"ticket": "BILL-123"})
+    rendered = json.loads(content[0].text)
+
+    assert rendered["status"] == "error"
+    assert rendered["error_code"] == "daemon_capability_error"
+    assert rendered["recovery"]["requested_tool"] == "bicameral.context"
+    assert rendered["recovery"]["requested_command"] == "lookup.query"
+    assert daemon.requests == []
+
+
+def test_context_renderer_preserves_source_distinction_and_required_actions():
+    rendered = json.loads(
+        format_context_packet_response({"request_id": "req-1", **_CONTEXT_RESPONSE}).text
+    )
+
+    packet = rendered["context_packet"]
+    assert packet["packet_id"] == "rp_613"
+    assert packet["corpus"]["authority_spine"] == "decision_ledger"
+    assert packet["matches"][0]["authority"] == "canonical"
+    assert packet["matches"][1]["authority"] == "candidate"
+    assert packet["matches"][1]["review_state"] == "review_needed"
+    assert packet["matches"][1]["required_actions"] == ["review_needed", "request_correction"]
+    assert packet["unknown_scope"][0]["reason"] == "permission_missing"
+    assert packet["allowed_next_actions"] == ["expand_scope", "request_correction"]
+
+    text = json.dumps(rendered).lower()
+    for forbidden in ("safe to change", "no conflict", "compliant", "signoff approved"):
+        assert forbidden not in text
+
+
+def test_context_renderer_no_matches_does_not_infer_completeness():
+    rendered = json.loads(
+        format_context_packet_response(
+            {
+                "request_id": "req-empty",
+                "status": "ok",
+                "context_packet": {
+                    "searched_sources": [{"source_id": "decision_ledger", "status": "searched"}],
+                    "matches": [],
+                    "unknown_scope": [{"scope": "wiki", "reason": "not_configured"}],
+                },
+            }
+        ).text
+    )
+
+    packet = rendered["context_packet"]
+    assert packet["matches"] == []
+    assert packet["unknown_scope"] == [{"scope": "wiki", "reason": "not_configured"}]
+    assert "does not imply absence outside searched or configured scope" in packet["no_match_note"]
+
+
+@pytest.mark.asyncio
+async def test_context_call_creates_no_local_artifacts(monkeypatch, tmp_path):
+    daemon = _ContextDaemon()
+    monkeypatch.setattr(server, "_client", lambda: daemon)
+    monkeypatch.chdir(tmp_path)
+
+    before = _snapshot_local_files(tmp_path)
+    await server.call_tool("bicameral.context", {"ticket": "BILL-123"})
+    after = _snapshot_local_files(tmp_path)
+
+    assert before == after
+
+
+def _snapshot_local_files(workspace: Path) -> set[Path]:
+    found: set[Path] = set()
+    for path in workspace.rglob("*"):
+        if path.is_file():
+            found.add(path)
+    return found

--- a/tests/test_toolrequest_conformance.py
+++ b/tests/test_toolrequest_conformance.py
@@ -46,6 +46,8 @@ FIXTURE_DIR = Path(__file__).parent / "fixtures" / "toolresponses"
 # Read-model MCP tools: per the data-flow spec these are read-only and must
 # never drive a mutating canonical event. Everything else may append events.
 READ_MODEL_TOOLS = {
+    "bicameral.context",
+    "bicameral.lookup",
     "bicameral.preflight",
     "bicameral.binding.inspect",
     "bicameral.brief",
@@ -117,7 +119,44 @@ COMMAND_SPECS: dict[str, _CommandSpec] = {
             "branch": "feature/x",
             **_CONTROL_AND_NOISE,
         },
-        expected_params={"files", "symbols", "diff_context", "branch"},
+        expected_params={"files", "symbols", "diff_context", "branch", "checkpoint_hint"},
+        required=set(),
+    ),
+    "bicameral.context": _CommandSpec(
+        command="lookup.query",
+        args={
+            "query": "payment retry behavior",
+            "ticket": "PROD-123",
+            "branch": "feature/context-packet",
+            "pr": "https://github.com/example/repo/pull/7",
+            "repo": "example/repo",
+            "files": ["src/payments/retry.py"],
+            "symbols": ["RetryPolicy"],
+            "code_region": {"path": "src/payments/retry.py", "start_line": 10, "end_line": 40},
+            "feature_area": "billing",
+            "agent_session_context": {"session_id": "sess-1", "checkpoint": "pre_work"},
+            "planned_action": "change retry timeout",
+            "checkpoint_hint": "pre_work",
+            "scope": "trusted_corpus",
+            "include_context": True,
+            **_CONTROL_AND_NOISE,
+        },
+        expected_params={
+            "query",
+            "ticket",
+            "branch",
+            "pr",
+            "repo",
+            "files",
+            "symbols",
+            "code_region",
+            "feature_area",
+            "agent_session_context",
+            "planned_action",
+            "checkpoint_hint",
+            "scope",
+            "include_context",
+        },
         required=set(),
     ),
     "bicameral.bind": _CommandSpec(
@@ -486,6 +525,7 @@ async def test_evidence_refresh_typed_currentness_passthrough(state, monkeypatch
 def test_read_model_tools_map_only_to_read_commands():
     read_commands = {MCP_TOOL_COMMANDS[t] for t in READ_MODEL_TOOLS}
     assert read_commands == {
+        "lookup.query",
         "preflight.run",
         "binding.inspect",
         "brief.render",
@@ -513,6 +553,7 @@ async def test_read_model_tool_dispatches_exactly_one_read_command(tool_name, mo
         emitted = daemon.requests[0]["command"]["name"]
     assert emitted == spec.command
     assert emitted in {
+        "lookup.query",
         "preflight.run",
         "binding.inspect",
         "brief.render",
@@ -569,6 +610,7 @@ def _load_fixture(command: str) -> dict:
 @pytest.mark.parametrize("command", sorted(set(MCP_TOOL_COMMANDS.values())))
 def test_contract_fixture_renders_through_renderer(command):
     from responses import (
+        format_context_packet_response,
         format_correction_response,
         format_lookup_response,
         format_preflight_response,
@@ -586,6 +628,10 @@ def test_contract_fixture_renders_through_renderer(command):
     elif command == "preflight.run":
         renderer = format_preflight_response
     elif command == "lookup.query":
+        renderer = format_context_packet_response
+        content = renderer(payload)
+        rendered = json.loads(content.text)
+        assert isinstance(rendered, dict)
         renderer = format_lookup_response
     elif command == "correction.request":
         renderer = format_correction_response

--- a/tool_request.py
+++ b/tool_request.py
@@ -14,6 +14,7 @@ log = logging.getLogger(__name__)
 MCP_TOOL_COMMANDS: dict[str, str] = {
     "bicameral.ingest": "ingest.submit_local",
     "bicameral.preflight": "preflight.run",
+    "bicameral.context": "lookup.query",
     "bicameral.lookup": "lookup.query",
     "bicameral.request_correction": "correction.request",
     "bicameral.bind": "binding.create",
@@ -101,7 +102,23 @@ def _command_params(command_name: str, params: dict[str, Any]) -> dict[str, Any]
     if command_name == "search.query":
         return _only(cleaned, "query", "scope", "filters", "limit")
     if command_name == "lookup.query":
-        return _only(cleaned, "files", "symbols", "scope", "include_context")
+        return _only(
+            cleaned,
+            "query",
+            "ticket",
+            "branch",
+            "pr",
+            "repo",
+            "files",
+            "symbols",
+            "code_region",
+            "feature_area",
+            "agent_session_context",
+            "planned_action",
+            "checkpoint_hint",
+            "scope",
+            "include_context",
+        )
     if command_name == "correction.request":
         return _only(cleaned, "packet_id", "excerpt", "diff", "correction_request", "reason")
     if command_name == "privacy.erase_subject":

--- a/tool_schemas.py
+++ b/tool_schemas.py
@@ -103,6 +103,61 @@ SUPPORTED_TOOLS: tuple[Tool, ...] = (
         ),
     ),
     Tool(
+        name="bicameral.context",
+        description=(
+            "Request a compact relevance-time context packet from the daemon for an "
+            "agent or developer workflow. Core owns narrowing, ranking, authority, "
+            "freshness, and canonical truth; MCP only forwards request hints and renders "
+            "the daemon-authored packet."
+        ),
+        inputSchema=_schema(
+            {
+                "query": {
+                    "type": "string",
+                    "description": "Optional natural-language task or lookup query.",
+                },
+                "ticket": {
+                    "type": "string",
+                    "description": "Ticket, issue, or work item identifier or URL.",
+                },
+                "branch": {"type": "string"},
+                "pr": {
+                    "type": "string",
+                    "description": "Pull request identifier or URL.",
+                },
+                "repo": {"type": "string"},
+                "files": {"type": "array", "items": {"type": "string"}},
+                "symbols": {"type": "array", "items": {"type": "string"}},
+                "code_region": {
+                    "type": "object",
+                    "description": "Optional daemon-interpreted code region hint.",
+                },
+                "feature_area": {"type": "string"},
+                "agent_session_context": {
+                    "type": "object",
+                    "description": "Bounded agent-session hints; not a raw transcript dump.",
+                },
+                "planned_action": {"type": "string"},
+                "checkpoint_hint": {
+                    "type": "string",
+                    "enum": ["pre_work", "mid_session", "pre_write", "manual_lookup"],
+                    "description": (
+                        "Optional inert checkpoint metadata. It does not grant capture, "
+                        "blocking, enforcement, ranking, or persistence authority to MCP."
+                    ),
+                },
+                "scope": {
+                    "type": "string",
+                    "description": "Optional daemon-defined corpus or lookup scope hint.",
+                },
+                "include_context": {
+                    "type": "boolean",
+                    "description": "Ask daemon for compact context fields when supported.",
+                },
+            }
+        ),
+    ),
+    Tool(
         name="bicameral.bind",
         description="Propose binding evidence for a decision or candidate.",
         inputSchema=_schema(


### PR DESCRIPTION
## Summary

- Add `bicameral.context` as a relevance-time context packet MCP surface backed by daemon `lookup.query`.
- Forward ticket/branch/PR/repo/file/symbol/code-region/feature/session hints without local ranking or authority computation.
- Render daemon-authored `context_packet` / `recall_packet` fields while preserving source distinction, authority labels, freshness, risk, confidence, rationale, required actions, unknown scope, and no-completeness semantics.
- Document `ContextPacket` vocabulary and update tool tables.

## Validation

- `/private/tmp/bic-mcp-594-venv/bin/python -m pytest -q` -> 298 passed
- `/private/tmp/bic-mcp-594-venv/bin/python -m ruff check .` -> pass
- `/private/tmp/bic-mcp-594-venv/bin/python -m ruff format --check .` -> pass
- `/private/tmp/bic-mcp-594-venv/bin/python -m mypy server.py responses.py tool_request.py tool_schemas.py` -> pass

## Notes

- Commit hook reported `Bicameral post-commit hook failed`, but `/Users/silongtan/.bicameral/hook-errors.log` only contained config/schema verification entries and no actionable error.

Closes #613
