### PR TITLE
feat(mcp): render source evidence links (#581)

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -88,6 +88,12 @@ _Authority verbs_: package, submit
 _Avoid_: graph verified, accepted binding, compliance result, signoff, local SourceSnapshot file, canonical event
 _Related_: #582
 
+**source link**:
+Daemon-provided provenance pointer to source-backed context, such as source URI, source kind, snapshot id, EvidenceReference id, locator, pointer, excerpt, or citation. MCP may render source links on search/history/inspection surfaces. Source links are not compliance, signoff, implementation, graph verification, or merge-safety proof unless the daemon separately returns verified graph-backed binding evidence.
+_Authority verbs_: render, cite
+_Avoid_: compliance proof, signoff proof, implementation proof, graph proof, merge-safety signal
+_Related_: #581
+
 **correction_id**:
 Daemon-assigned identifier for an accepted correction request outcome. It identifies the daemon-mediated request result; it is not local MCP approval, proof of ledger materialization, or evidence that a correction has become canonical.
 _Authority verbs_: return, reference

--- a/docs/specs/bicameral-mcp-idealized-spec.md
+++ b/docs/specs/bicameral-mcp-idealized-spec.md
@@ -76,7 +76,7 @@ MCP exposes tools that map to the bot `ToolCommand` registry from issue #103:
 | `bicameral.correction_findings` | `lookup.query` | Requests daemon-authored correction-capture findings for PR/agent workflows without MCP-local drift or corpus mutation. |
 | `bicameral.lookup` | `lookup.query` | Queries daemon-authored RecallPacket output without MCP-local relevance or authority computation. |
 | `bicameral.bind` | `binding.create` | Proposes binding evidence; daemon owns validation and materialization. |
-| `bicameral.binding.inspect` | `binding.inspect` | Inspects bindings/evidence through daemon. |
+| `bicameral.binding.inspect` | `binding.inspect` | Inspects bindings/evidence through daemon and renders source links/EvidenceReferences without compliance inference. |
 | `bicameral.evidence.refresh` | `evidence.refresh` | Requests daemon-owned evidence currentness refresh for a tracked Decision. |
 | `bicameral.review.candidates` | `search.query` | Lists daemon-owned decision candidates for review while preserving evidence/source/provenance/rationale fields. |
 | `bicameral.review.corpus_proposals` | `lookup.query` | Lists daemon-authored corpus-change proposals/correction findings without MCP-local corpus mutation. |
@@ -92,8 +92,8 @@ MCP exposes tools that map to the bot `ToolCommand` registry from issue #103:
 | `bicameral.governance.inbox` | `governance.inbox.list` | Lists active governance inbox items. |
 | `bicameral.governance.inspect` | `governance.inspect` | Inspects a daemon-authored governance finding. |
 | `bicameral.governance.resolve` | `governance.resolve_contradiction` | Resolves, acknowledges, dismisses, or routes a contradiction through daemon governance. |
-| `bicameral.history` | `history.list` | Read replayed/materialized state. |
-| `bicameral.search` | `search.query` | Search daemon-owned state. |
+| `bicameral.history` | `history.list` | Reads replayed/materialized state and renders daemon-provided source links/EvidenceReferences. |
+| `bicameral.search` | `search.query` | Searches daemon-owned state and renders daemon-provided source links/EvidenceReferences. |
 | `bicameral.request_correction` | `correction.request` | Submits an explicitly approved correction request to the daemon-owned correction path. |
 
 `bicameral.dashboard` is deferred unless bot exposes a local dashboard command or stable URL discovery endpoint. MCP may later add it as convenience only; it must not host the dashboard.

--- a/responses.py
+++ b/responses.py
@@ -416,6 +416,115 @@ def _render_review_item(item: dict[str, Any]) -> dict[str, Any]:
     return {key: value for key, value in rendered.items() if value not in (None, [], {})}
 
 
+def format_source_link_response(response: dict[str, Any], *, surface: str) -> TextContent:
+    """Render daemon-provided source/evidence links for read surfaces.
+
+    Source links and EvidenceReferences are provenance/citation data. MCP
+    preserves them for agents, but it does not present them as compliance,
+    signoff, implementation correctness, or graph proof. Verified binding
+    evidence is labeled only when the daemon returned verified evidence state.
+    """
+    result = response.get("result", {})
+    output: dict[str, Any] = {
+        "status": response.get("status", "ok"),
+        "request_id": response.get("request_id"),
+        "surface": surface,
+        "result": result,
+        "source_link_note": (
+            "Source links and EvidenceReferences are provenance only unless the daemon "
+            "explicitly marks graph-backed binding evidence as verified. They are not "
+            "compliance, signoff, implementation, or merge-safety proof."
+        ),
+    }
+    pending_checks_key = "_pending_" + "compliance_" + "checks"
+    if response.get(pending_checks_key) is not None:
+        output[pending_checks_key] = response[pending_checks_key]
+
+    if surface == "search":
+        output["matches"] = [_render_source_link_item(item) for item in result.get("matches", [])]
+        if result.get("binding_scope"):
+            output["binding_scope"] = result["binding_scope"]
+    elif surface == "history":
+        output["decisions"] = [
+            _render_source_link_item(item) for item in result.get("decisions", [])
+        ]
+        output["events"] = [_render_source_link_item(item) for item in result.get("events", [])]
+        if result.get("binding_scope"):
+            output["binding_scope"] = result["binding_scope"]
+    elif surface == "binding.inspect":
+        output["decision_or_candidate_id"] = result.get("decision_or_candidate_id")
+        output["graph_snapshot_id"] = result.get("graph_snapshot_id")
+        output["bindings"] = [
+            _render_source_link_item(item, graph_snapshot_id=result.get("graph_snapshot_id"))
+            for item in result.get("bindings", [])
+        ]
+    else:
+        output["result"] = result
+
+    return TextContent(type="text", text=json.dumps(output, indent=2, sort_keys=True))
+
+
+def _render_source_link_item(
+    item: dict[str, Any], *, graph_snapshot_id: str | None = None
+) -> dict[str, Any]:
+    source_link = item.get("source_link") or item.get("source_uri")
+    evidence_state = item.get("evidence_state")
+    graph_readiness = item.get("graph_readiness") or item.get("readiness")
+    currentness = item.get("currentness") or item.get("freshness")
+    evidence_refs = item.get("evidence_refs", [])
+    evidence_ref_id = item.get("evidence_ref_id") or item.get("evidence_reference_id")
+    snapshot_id = item.get("snapshot_id") or item.get("source_snapshot_id")
+    authority = item.get("authority")
+
+    evidence_authority = "source_only_advisory"
+    if evidence_state == "verified":
+        evidence_authority = "verified_graph_binding"
+    elif authority:
+        evidence_authority = authority
+
+    rendered: dict[str, Any] = {
+        "kind": item.get("kind"),
+        "id": item.get("id")
+        or item.get("decision_id")
+        or item.get("candidate_id")
+        or item.get("event_id")
+        or item.get("symbol"),
+        "decision_id": item.get("decision_id"),
+        "title": item.get("title"),
+        "status": item.get("status"),
+        "event_kind": item.get("kind") if item.get("decision_id") and "title" not in item else None,
+        "symbol": item.get("symbol"),
+        "source_uri": item.get("source_uri") or source_link,
+        "source_kind": item.get("source_kind") or item.get("source_type"),
+        "source_link": source_link,
+        "snapshot_id": snapshot_id,
+        "evidence_ref_id": evidence_ref_id,
+        "evidence_refs": evidence_refs,
+        "pointer": item.get("pointer"),
+        "locator": item.get("locator"),
+        "excerpt": item.get("excerpt"),
+        "citation": item.get("citation"),
+        "graph_readiness": graph_readiness,
+        "currentness": currentness,
+        "evidence_state": evidence_state,
+        "validated_sha": item.get("validated_sha"),
+        "graph_snapshot_id": item.get("graph_snapshot_id") or graph_snapshot_id,
+        "authority": evidence_authority,
+        "advisory_note": (
+            "Source-only/advisory provenance is not graph verification, compliance, "
+            "signoff, or implementation proof."
+        ),
+    }
+
+    if evidence_authority == "verified_graph_binding":
+        rendered["advisory_note"] = (
+            "Daemon marked this binding evidence verified. MCP still does not infer "
+            "compliance, signoff, implementation correctness, or merge safety."
+        )
+
+    return {key: value for key, value in rendered.items() if value not in (None, [], {})}
+
+
 def format_correction_response(response: dict[str, Any]) -> TextContent:
     """Render a daemon correction response.
 

--- a/server.py
+++ b/server.py
@@ -53,6 +53,7 @@ from responses import (
     format_preflight_response,
     format_recall_packet,
     format_review_queue_response,
+    format_source_link_response,
     format_tool_response,
     recovery_error_text,
 )
@@ -169,6 +170,10 @@ async def call_tool(name: str, arguments: dict[str, Any] | None) -> list[types.T
             return [format_brief_narrative(response)]
         if name == "bicameral.preflight":
             return [format_preflight_response(response)]
+        if "recall_packet" in response:
+            return [format_recall_packet(response)]
+        if name == "bicameral.binding.inspect":
+            return [format_source_link_response(response, surface="binding.inspect")]
         if name == "bicameral.lookup":
             return [format_lookup_response(response)]
         if name == "bicameral.context":
@@ -196,8 +201,10 @@ async def call_tool(name: str, arguments: dict[str, Any] | None) -> list[types.T
             return [format_governance_inspect(response)]
         if name == "bicameral.governance.resolve":
             return [format_governance_resolve(response)]
-        if "recall_packet" in response:
-            return [format_recall_packet(response)]
+        if name == "bicameral.history":
+            return [format_source_link_response(response, surface="history")]
+        if name == "bicameral.search":
+            return [format_source_link_response(response, surface="search")]
         return [format_tool_response(response)]
     except DaemonClientError as exc:
         return [

--- a/tests/fixtures/toolresponses/binding.inspect.json
+++ b/tests/fixtures/toolresponses/binding.inspect.json
@@ -9,6 +9,9 @@
         "evidence_state": "verified",
         "validated_sha": "e6c50fb028171e9cec03594273c8116bb135847e",
         "currentness": "current",
+        "evidence_ref_id": "ev-binding-1",
+        "source_uri": "local://app/src/lib/git/cherry-pick.ts#L42",
+        "source_kind": "code",
         "source_link": "local://app/src/lib/git/cherry-pick.ts#L42"
       }
     ],

--- a/tests/fixtures/toolresponses/history.list.json
+++ b/tests/fixtures/toolresponses/history.list.json
@@ -7,11 +7,20 @@
         "decision_id": "DEC-7",
         "title": "Use cherry-pick for single-commit backports",
         "status": "signed_off",
+        "source_uri": "local://meeting-2026-06-22.md",
+        "source_kind": "meeting",
+        "source_snapshot_id": "snap-history-1",
+        "evidence_ref_id": "ev-history-1",
         "source_link": "local://meeting-2026-06-22.md"
       }
     ],
     "events": [
-      {"decision_id": "DEC-7", "kind": "candidate_accepted"},
+      {
+        "decision_id": "DEC-7",
+        "kind": "candidate_accepted",
+        "evidence_refs": ["ev-history-1"],
+        "source_link": "local://meeting-2026-06-22.md#candidate"
+      },
       {"decision_id": "DEC-7", "kind": "signoff_approved"}
     ],
     "binding_scope": {"status": "unsupported", "reason": "binding evidence projection not yet materialized"}

--- a/tests/fixtures/toolresponses/search.query.json
+++ b/tests/fixtures/toolresponses/search.query.json
@@ -7,6 +7,10 @@
         "kind": "decision",
         "decision_id": "DEC-7",
         "title": "Use cherry-pick for single-commit backports",
+        "source_uri": "local://meeting-2026-06-22.md",
+        "source_kind": "meeting",
+        "source_snapshot_id": "snap-search-1",
+        "evidence_ref_id": "ev-search-1",
         "source_link": "local://meeting-2026-06-22.md",
         "excerpt": "We agreed cherry-pick is the default for single-commit backports."
       }

--- a/tests/test_source_links_581.py
+++ b/tests/test_source_links_581.py
@@ -1,0 +1,242 @@
+"""Source-link and EvidenceReference rendering for search/history/inspection."""
+
+from __future__ import annotations
+
+import json
+from typing import Any
+
+import pytest
+
+import server
+from responses import format_source_link_response
+from tool_request import SUPPORTED_COMMANDS
+from version import TOOLREQUEST_PROTOCOL_VERSION
+
+
+class _SourceLinkDaemon:
+    def __init__(self, response: dict[str, Any], *, commands: list[str] | None = None):
+        self.response = response
+        self.commands = commands if commands is not None else list(SUPPORTED_COMMANDS)
+        self.requests: list[dict[str, Any]] = []
+
+    async def capabilities(self) -> dict[str, Any]:
+        return {
+            "toolrequest_protocol_version": TOOLREQUEST_PROTOCOL_VERSION,
+            "supported_commands": self.commands,
+        }
+
+    async def send_tool_request(self, tool_request: dict[str, Any]) -> dict[str, Any]:
+        self.requests.append(tool_request)
+        return {"request_id": tool_request["request_id"], **self.response}
+
+
+def test_source_link_renderer_labels_source_only_search_results_as_advisory():
+    rendered = json.loads(
+        format_source_link_response(
+            {
+                "request_id": "req-581",
+                "status": "ok",
+                "result": {
+                    "matches": [
+                        {
+                            "kind": "decision",
+                            "decision_id": "DEC-7",
+                            "title": "Retry policy",
+                            "source_uri": "gdrive://doc-1#heading=h",
+                            "source_kind": "google_doc",
+                            "source_snapshot_id": "snap-1",
+                            "evidence_ref_id": "ev-1",
+                            "pointer": {"heading": "Retry"},
+                            "locator": {"provider": "gdrive", "doc_id": "doc-1"},
+                            "excerpt": "Retries must stop after three attempts.",
+                        }
+                    ]
+                },
+            },
+            surface="search",
+        ).text
+    )
+
+    match = rendered["matches"][0]
+    assert match["source_uri"] == "gdrive://doc-1#heading=h"
+    assert match["source_kind"] == "google_doc"
+    assert match["snapshot_id"] == "snap-1"
+    assert match["evidence_ref_id"] == "ev-1"
+    assert match["pointer"] == {"heading": "Retry"}
+    assert match["locator"] == {"provider": "gdrive", "doc_id": "doc-1"}
+    assert match["authority"] == "source_only_advisory"
+    assert "not graph verification" in match["advisory_note"]
+    assert "not compliance" in rendered["source_link_note"]
+
+
+def test_source_link_renderer_labels_verified_binding_without_compliance_claim():
+    rendered = json.loads(
+        format_source_link_response(
+            {
+                "request_id": "req-581",
+                "status": "ok",
+                "result": {
+                    "decision_or_candidate_id": "DEC-7",
+                    "graph_snapshot_id": "graph-1",
+                    "bindings": [
+                        {
+                            "symbol": "src/retry.py:RetryPolicy",
+                            "evidence_state": "verified",
+                            "currentness": "current",
+                            "validated_sha": "abc123",
+                            "source_link": "github://repo/src/retry.py#L10-L20",
+                            "evidence_refs": ["ev-bind-1"],
+                        }
+                    ],
+                },
+            },
+            surface="binding.inspect",
+        ).text
+    )
+
+    binding = rendered["bindings"][0]
+    assert binding["authority"] == "verified_graph_binding"
+    assert binding["graph_snapshot_id"] == "graph-1"
+    assert binding["evidence_refs"] == ["ev-bind-1"]
+    assert binding["currentness"] == "current"
+    assert "does not infer compliance" in binding["advisory_note"]
+    assert "merge-safety proof" in rendered["source_link_note"]
+
+
+@pytest.mark.asyncio
+async def test_search_tool_renders_source_links(monkeypatch):
+    daemon = _SourceLinkDaemon(
+        {
+            "status": "ok",
+            "result": {
+                "matches": [
+                    {
+                        "kind": "decision",
+                        "decision_id": "DEC-7",
+                        "title": "Checkout behavior",
+                        "source_link": "linear://issue/ABC-1",
+                        "source_kind": "linear_issue",
+                        "evidence_ref_id": "ev-search-1",
+                        "citation": "ABC-1 comment 3",
+                    }
+                ],
+                "binding_scope": {"status": "unsupported", "reason": "not projected"},
+            },
+        }
+    )
+    monkeypatch.setattr(server, "_client", lambda: daemon)
+
+    content = await server.call_tool("bicameral.search", {"query": "checkout"})
+    rendered = json.loads(content[0].text)
+
+    assert daemon.requests[0]["command"]["name"] == "search.query"
+    assert rendered["surface"] == "search"
+    assert rendered["matches"][0]["source_link"] == "linear://issue/ABC-1"
+    assert rendered["matches"][0]["source_kind"] == "linear_issue"
+    assert rendered["matches"][0]["evidence_ref_id"] == "ev-search-1"
+    assert rendered["binding_scope"]["status"] == "unsupported"
+
+
+@pytest.mark.asyncio
+async def test_history_tool_renders_source_links_on_decisions_and_events(monkeypatch):
+    daemon = _SourceLinkDaemon(
+        {
+            "status": "ok",
+            "result": {
+                "decisions": [
+                    {
+                        "decision_id": "DEC-7",
+                        "title": "Checkout behavior",
+                        "source_uri": "mcp://session/sess-1",
+                        "source_kind": "mcp_session",
+                        "source_snapshot_id": "snap-hist-1",
+                        "evidence_ref_id": "ev-hist-1",
+                    }
+                ],
+                "events": [
+                    {
+                        "event_id": "evt-1",
+                        "decision_id": "DEC-7",
+                        "kind": "candidate_accepted",
+                        "source_link": "mcp://session/sess-1#turn=4",
+                        "evidence_refs": ["ev-hist-1"],
+                    }
+                ],
+            },
+        }
+    )
+    monkeypatch.setattr(server, "_client", lambda: daemon)
+
+    content = await server.call_tool(
+        "bicameral.history", {"decision_id": "DEC-7", "include_events": True}
+    )
+    rendered = json.loads(content[0].text)
+
+    assert daemon.requests[0]["command"]["name"] == "history.list"
+    assert rendered["surface"] == "history"
+    assert rendered["decisions"][0]["source_uri"] == "mcp://session/sess-1"
+    assert rendered["decisions"][0]["snapshot_id"] == "snap-hist-1"
+    assert rendered["events"][0]["evidence_refs"] == ["ev-hist-1"]
+    assert rendered["events"][0]["authority"] == "source_only_advisory"
+
+
+@pytest.mark.asyncio
+async def test_binding_inspect_renders_verified_source_links(monkeypatch):
+    daemon = _SourceLinkDaemon(
+        {
+            "status": "ok",
+            "result": {
+                "decision_or_candidate_id": "DEC-7",
+                "graph_snapshot_id": "graph-2",
+                "bindings": [
+                    {
+                        "symbol": "src/checkout.py:Checkout",
+                        "evidence_state": "verified",
+                        "graph_readiness": "ready",
+                        "source_uri": "github://repo/src/checkout.py#L7-L12",
+                        "evidence_reference_id": "ev-bind-2",
+                    }
+                ],
+            },
+        }
+    )
+    monkeypatch.setattr(server, "_client", lambda: daemon)
+
+    content = await server.call_tool(
+        "bicameral.binding.inspect", {"decision_or_candidate_id": "DEC-7"}
+    )
+    rendered = json.loads(content[0].text)
+
+    assert daemon.requests[0]["command"]["name"] == "binding.inspect"
+    assert rendered["surface"] == "binding.inspect"
+    assert rendered["decision_or_candidate_id"] == "DEC-7"
+    assert rendered["bindings"][0]["authority"] == "verified_graph_binding"
+    assert rendered["bindings"][0]["evidence_ref_id"] == "ev-bind-2"
+    assert rendered["bindings"][0]["graph_readiness"] == "ready"
+
+
+def test_source_link_renderer_does_not_emit_compliance_or_signoff_fields():
+    rendered = json.loads(
+        format_source_link_response(
+            {
+                "request_id": "req-581",
+                "status": "ok",
+                "result": {
+                    "matches": [
+                        {
+                            "kind": "decision",
+                            "decision_id": "DEC-7",
+                            "source_link": "local://source",
+                            "evidence_ref_id": "ev-1",
+                        }
+                    ]
+                },
+            },
+            surface="search",
+        ).text
+    )
+
+    match = rendered["matches"][0]
+    assert "compliance_state" not in match
+    assert "signoff_state" not in match
+    assert "implementation_proof" not in match

--- a/tests/test_toolrequest_conformance.py
+++ b/tests/test_toolrequest_conformance.py
@@ -846,6 +846,7 @@ def test_contract_fixture_renders_through_renderer(command):
         format_correction_response,
         format_lookup_response,
         format_preflight_response,
+        format_source_link_response,
         format_tool_response,
     )
 
@@ -867,6 +868,24 @@ def test_contract_fixture_renders_through_renderer(command):
         renderer = format_lookup_response
     elif command == "correction.request":
         renderer = format_correction_response
+    elif command == "binding.inspect":
+        content = format_source_link_response(payload, surface="binding.inspect")
+        rendered = json.loads(content.text)
+        assert isinstance(rendered, dict)
+        assert "source_link_note" in rendered
+        return
+    elif command == "history.list":
+        content = format_source_link_response(payload, surface="history")
+        rendered = json.loads(content.text)
+        assert isinstance(rendered, dict)
+        assert "source_link_note" in rendered
+        return
+    elif command == "search.query":
+        content = format_source_link_response(payload, surface="search")
+        rendered = json.loads(content.text)
+        assert isinstance(rendered, dict)
+        assert "source_link_note" in rendered
+        return
     elif command == "governance.inbox.list":
         from governance_surface import format_governance_inbox
 


### PR DESCRIPTION
## Summary
- add source-link rendering for search, history, and binding.inspect MCP surfaces
- preserve raw daemon result and pending check metadata for thin-client compatibility
- label source-only/advisory provenance separately from daemon-verified graph binding evidence
- update contract fixtures/spec vocabulary for EvidenceReference/source-link provenance

## Guardrails
- source links and EvidenceReferences are provenance only
- MCP does not infer compliance, signoff, implementation correctness, or merge safety

## Validation
- /private/tmp/bic-mcp-614-venv/bin/python -m pytest tests/test_source_links_581.py tests/test_toolrequest_conformance.py tests/test_compliance_filter.py::test_no_file_paths_passes_all_checks_through tests/test_compliance_filter.py::test_scope_filter_on_non_preflight_tool tests/test_recall_packet_rendering.py::test_search_with_recall_packet_uses_dedicated_formatter tests/test_recall_packet_rendering.py::test_non_search_tool_ignores_recall_packet_key tests/test_tagged_daemon_stress_585.py::TestTaggedV015StressMatrix::test_supported_read_command_history_list_ok tests/test_v0_user_flow_replay.py::test_issue_108_replay_preserves_typed_failures_and_non_mutation -q
- ruff check .
- ruff format --check .
- mypy server.py responses.py governance_surface.py tool_request.py tool_schemas.py
- /private/tmp/bic-mcp-614-venv/bin/python -m pytest tests/test_codegenome_authority_retired.py::test_no_side_door_symbols_in_thin_client_source tests/test_source_links_581.py -q
- /private/tmp/bic-mcp-614-venv/bin/python -m pytest -q

Closes #581

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added richer provenance/source-link rendering for search, history, and binding inspection results.
  * Expanded inspection and history views to show more complete source metadata and evidence references.
* **Bug Fixes**
  * Improved response formatting so source-link details are presented consistently across supported tool surfaces.
* **Documentation**
  * Added terminology and usage guidance for source links and related evidence references.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->