### PR TITLE
chore: integrate dev to main (7/1 alpha capability tools)

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,6 +83,8 @@ MCP exposes only ToolRequest-backed tools:
 | `bicameral.governance.inbox` | `governance.inbox.list` |
 | `bicameral.governance.inspect` | `governance.inspect` |
 | `bicameral.governance.resolve` | `governance.resolve_contradiction` |
+| `bicameral.recall.inspect_evidence` | `recall.inspect_evidence` |
+| `bicameral.recall.expand_scope` | `recall.expand_scope` |
 | `bicameral.request_correction` | `correction.request` |
 
 ## Troubleshooting: Daemon Handshake Failures

--- a/daemon_client.py
+++ b/daemon_client.py
@@ -45,6 +45,7 @@ class CapabilityReport:
         "daemon_protocol_version",
         "mcp_protocol_version",
         "supported_commands",
+        "deferred_commands",
         "daemon_endpoint",
     )
 
@@ -54,11 +55,13 @@ class CapabilityReport:
         daemon_protocol_version: str,
         mcp_protocol_version: str,
         supported_commands: tuple[str, ...],
+        deferred_commands: tuple[str, ...] = (),
         daemon_endpoint: str,
     ) -> None:
         self.daemon_protocol_version = daemon_protocol_version
         self.mcp_protocol_version = mcp_protocol_version
         self.supported_commands = supported_commands
+        self.deferred_commands = deferred_commands
         self.daemon_endpoint = daemon_endpoint
 
 

--- a/responses.py
+++ b/responses.py
@@ -595,6 +595,13 @@ def build_recovery_payload(
             "correct it if the daemon is running elsewhere."
         )
 
+    if details.get("deferred"):
+        recovery["deferred"] = True
+        operator_action = (
+            "This command is deferred in the current alpha daemon. "
+            "It may become available in a future daemon release."
+        )
+
     recovery["operator_action"] = operator_action
     return recovery
 

--- a/responses.py
+++ b/responses.py
@@ -525,6 +525,93 @@ def _render_source_link_item(
     return {key: value for key, value in rendered.items() if value not in (None, [], {})}
 
 
+def format_recall_inspect_evidence(response: dict[str, Any]) -> TextContent:
+    """Render daemon-authored evidence detail from a RecallPacket match.
+
+    This is a read-only evidence inspection. MCP preserves daemon-authored
+    evidence refs, source links, freshness, readiness, and searched/unknown
+    scope without adding compliance, signoff, or verification claims.
+    """
+    result = response.get("result", {})
+    evidence = result.get("evidence") or result.get("evidence_detail") or {}
+    searched_scope = result.get("searched_scope") or evidence.get("searched_scope", [])
+    unknown_scope = result.get("unknown_scope") or evidence.get("unknown_scope", [])
+
+    output: dict[str, Any] = {
+        "status": response.get("status", "ok"),
+        "request_id": response.get("request_id"),
+        "packet_id": result.get("packet_id"),
+        "match_id": result.get("match_id"),
+        "evidence": evidence,
+        "searched_scope": searched_scope,
+        "unknown_scope": unknown_scope,
+        "scope_note": (
+            "Evidence shown is limited to the searched scope. "
+            "Unknown scope is not searched and may contain additional evidence."
+        ),
+    }
+    return TextContent(type="text", text=json.dumps(output, indent=2, sort_keys=True))
+
+
+def format_recall_expand_scope(response: dict[str, Any]) -> TextContent:
+    """Render a daemon-authored expanded RecallPacket.
+
+    The daemon widens the searched scope and returns updated matches.
+    MCP preserves searched/unknown scope, matches, and allowed next
+    actions without adding compliance, signoff, or verification claims.
+    """
+    recall = response.get("recall_packet", response.get("result", {}))
+    searched_scope = recall.get("searched_scope", [])
+    unknown_scope = recall.get("unknown_scope", [])
+    matches = recall.get("matches", [])
+    allowed_next_actions = recall.get("allowed_next_actions", [])
+
+    rendered_matches: list[dict[str, Any]] = []
+    for match in matches:
+        rendered: dict[str, Any] = {
+            "kind": match.get("kind"),
+            "id": match.get("id"),
+            "title": match.get("title"),
+        }
+        if match.get("evidence_refs"):
+            rendered["evidence_refs"] = match["evidence_refs"]
+        if match.get("freshness"):
+            rendered["freshness"] = match["freshness"]
+        if match.get("readiness"):
+            rendered["readiness"] = match["readiness"]
+        if match.get("source_link"):
+            rendered["source_link"] = match["source_link"]
+        if match.get("excerpt"):
+            rendered["excerpt"] = match["excerpt"]
+        rendered_matches.append(rendered)
+
+    output: dict[str, Any] = {
+        "status": response.get("status", "ok"),
+        "request_id": response.get("request_id"),
+        "packet_id": recall.get("packet_id"),
+        "searched_scope": searched_scope,
+        "unknown_scope": unknown_scope,
+        "matches": rendered_matches,
+    }
+
+    if not matches:
+        scope_desc = ", ".join(searched_scope) if searched_scope else "expanded scope"
+        output["no_match_note"] = (
+            f"Expanded lookup found no relevant items within: {scope_desc}. "
+            "This does not imply absence outside searched scope."
+        )
+
+    if allowed_next_actions:
+        output["allowed_next_actions"] = allowed_next_actions
+
+    output["scope_note"] = (
+        "Scope was expanded by the daemon. Unknown scope after expansion "
+        "is surfaced explicitly and has not been searched."
+    )
+
+    return TextContent(type="text", text=json.dumps(output, indent=2, sort_keys=True))
+
+
 def format_correction_response(response: dict[str, Any]) -> TextContent:
     """Render a daemon correction response.
 

--- a/server.py
+++ b/server.py
@@ -51,6 +51,8 @@ from responses import (
     format_lookup_response,
     format_preflight_no_fire,
     format_preflight_response,
+    format_recall_expand_scope,
+    format_recall_inspect_evidence,
     format_recall_packet,
     format_review_queue_response,
     format_source_link_response,
@@ -182,6 +184,10 @@ async def call_tool(name: str, arguments: dict[str, Any] | None) -> list[types.T
             return [format_correction_findings_response(response)]
         if name == "bicameral.review.corpus_proposals":
             return [format_correction_findings_response(response)]
+        if name == "bicameral.recall.inspect_evidence":
+            return [format_recall_inspect_evidence(response)]
+        if name == "bicameral.recall.expand_scope":
+            return [format_recall_expand_scope(response)]
         if name == "bicameral.review.candidates":
             return [format_review_queue_response(response, item_key="decision_candidates")]
         if name in {

--- a/server.py
+++ b/server.py
@@ -58,7 +58,7 @@ from responses import (
     recovery_error_text,
 )
 from sync_payload_filter import filter_pending_checks
-from tool_request import MCP_TOOL_COMMANDS, build_tool_request
+from tool_request import LOCAL_ONLY_TOOLS, MCP_TOOL_COMMANDS, build_tool_request
 from tool_schemas import SUPPORTED_TOOLS
 from version import SERVER_NAME, SERVER_VERSION, TOOLREQUEST_PROTOCOL_VERSION
 
@@ -89,26 +89,53 @@ async def _ensure_protocol_compatible(client: DaemonClient) -> CapabilityReport:
             mcp_protocol_version=TOOLREQUEST_PROTOCOL_VERSION,
         )
     supported_commands = tuple(capabilities.get("supported_commands", []))
+    deferred_commands = tuple(capabilities.get("deferred_commands", []))
     endpoint = resolve_daemon_endpoint()
     return CapabilityReport(
         daemon_protocol_version=protocol_version,
         mcp_protocol_version=TOOLREQUEST_PROTOCOL_VERSION,
         supported_commands=supported_commands,
+        deferred_commands=deferred_commands,
         daemon_endpoint=endpoint.url,
     )
 
 
 def _ensure_command_advertised(command_name: str, capability_report: CapabilityReport) -> None:
+    if command_name in capability_report.deferred_commands:
+        raise DaemonCapabilityError(
+            f"daemon reports ToolRequest command as deferred: {command_name}",
+            deferred=True,
+        )
     if command_name not in capability_report.supported_commands:
         raise DaemonCapabilityError(
             f"daemon does not advertise ToolRequest command: {command_name}"
         )
 
 
+def _filter_tools_by_capability(capability_report: CapabilityReport) -> list[types.Tool]:
+    """Exclude tools whose daemon command is deferred or absent."""
+    deferred = frozenset(capability_report.deferred_commands)
+    supported = frozenset(capability_report.supported_commands)
+    result: list[types.Tool] = []
+    for tool in SUPPORTED_TOOLS:
+        if tool.name in LOCAL_ONLY_TOOLS:
+            result.append(tool)
+            continue
+        command = MCP_TOOL_COMMANDS.get(tool.name)
+        if command is None:
+            continue
+        if command in deferred:
+            continue
+        if command not in supported:
+            continue
+        result.append(tool)
+    return result
+
+
 @server.list_tools()
 async def list_tools() -> list[types.Tool]:
-    await _ensure_protocol_compatible(_client())
-    return list(SUPPORTED_TOOLS)
+    capability_report = await _ensure_protocol_compatible(_client())
+    return _filter_tools_by_capability(capability_report)
 
 
 @server.call_tool()

--- a/tests/fixtures/toolresponses/recall.expand_scope.json
+++ b/tests/fixtures/toolresponses/recall.expand_scope.json
@@ -1,0 +1,20 @@
+{
+  "request_id": "ffffffff-ffff-4fff-8fff-ffffffffffff",
+  "status": "ok",
+  "result": {
+    "packet_id": "pkt-conformance-002",
+    "searched_scope": ["local_ledger", "source_docs", "team_prs"],
+    "unknown_scope": ["external_docs"],
+    "matches": [
+      {
+        "kind": "decision",
+        "id": "DEC-EXPAND-1",
+        "title": "Retry timeout must be 30s",
+        "evidence_refs": ["ev-expand-1"],
+        "freshness": "current"
+      }
+    ],
+    "allowed_next_actions": ["inspect_evidence"]
+  },
+  "responded_at": "2026-07-02T00:00:00Z"
+}

--- a/tests/fixtures/toolresponses/recall.inspect_evidence.json
+++ b/tests/fixtures/toolresponses/recall.inspect_evidence.json
@@ -1,0 +1,18 @@
+{
+  "request_id": "eeeeeeee-eeee-4eee-8eee-eeeeeeeeeeee",
+  "status": "ok",
+  "result": {
+    "packet_id": "pkt-conformance-001",
+    "match_id": "match-conformance-A",
+    "evidence": {
+      "evidence_id": "ev-conformance-1",
+      "excerpt": "Decision requires retry timeout of 30s",
+      "source_link": "local://meeting.md",
+      "freshness": "current",
+      "readiness": "verified"
+    },
+    "searched_scope": ["local_ledger", "source_docs"],
+    "unknown_scope": ["team_prs", "external_docs"]
+  },
+  "responded_at": "2026-07-02T00:00:00Z"
+}

--- a/tests/test_toolrequest_conformance.py
+++ b/tests/test_toolrequest_conformance.py
@@ -493,6 +493,28 @@ COMMAND_SPECS: dict[str, _CommandSpec] = {
         expected_params={"report_id", "action", "reason", "route_to"},
         required={"report_id", "action"},
     ),
+    "bicameral.recall.inspect_evidence": _CommandSpec(
+        command="recall.inspect_evidence",
+        args={
+            "packet_id": "pkt-conformance-001",
+            "match_id": "match-conformance-A",
+            "evidence_id": "ev-conformance-1",
+            **_CONTROL_AND_NOISE,
+        },
+        expected_params={"packet_id", "match_id", "evidence_id"},
+        required={"packet_id", "match_id"},
+    ),
+    "bicameral.recall.expand_scope": _CommandSpec(
+        command="recall.expand_scope",
+        args={
+            "packet_id": "pkt-conformance-002",
+            "expand_to": ["source-extra-A"],
+            "reason": "wider coverage needed",
+            **_CONTROL_AND_NOISE,
+        },
+        expected_params={"packet_id", "expand_to", "reason"},
+        required={"packet_id"},
+    ),
 }
 
 _CONTROL_KEYS = {"actor_id", "session_id", "workspace", "policy_scope"}
@@ -898,6 +920,22 @@ def test_contract_fixture_renders_through_renderer(command):
         from governance_surface import format_governance_resolve
 
         renderer = format_governance_resolve
+    elif command == "recall.inspect_evidence":
+        from responses import format_recall_inspect_evidence
+
+        content = format_recall_inspect_evidence(payload)
+        rendered = json.loads(content.text)
+        assert isinstance(rendered, dict)
+        assert "scope_note" in rendered
+        return
+    elif command == "recall.expand_scope":
+        from responses import format_recall_expand_scope
+
+        content = format_recall_expand_scope(payload)
+        rendered = json.loads(content.text)
+        assert isinstance(rendered, dict)
+        assert "scope_note" in rendered
+        return
     else:
         renderer = format_tool_response
     content = renderer(payload)

--- a/tests/test_toolrequest_thin_client.py
+++ b/tests/test_toolrequest_thin_client.py
@@ -751,3 +751,133 @@ def test_ingest_schema_exposes_decision_level():
     assert "decision_level" in props
     assert props["decision_level"]["type"] == "string"
     assert props["decision_level"]["enum"] == ["L1", "L2", "L3"]
+
+
+# ---------------------------------------------------------------------------
+# Deferred capability handling (#677)
+# ---------------------------------------------------------------------------
+
+
+class _DeferredCapabilityClient(_FakeClient):
+    """Fake daemon that reports review.resolve_compliance as deferred."""
+
+    async def capabilities(self) -> dict:
+        caps = await super().capabilities()
+        caps["supported_commands"] = [
+            cmd for cmd in caps["supported_commands"] if cmd != "review.resolve_compliance"
+        ]
+        caps["deferred_commands"] = ["review.resolve_compliance"]
+        return caps
+
+
+class _AbsentCapabilityClient(_FakeClient):
+    """Fake daemon that does not advertise review.resolve_compliance at all."""
+
+    async def capabilities(self) -> dict:
+        caps = await super().capabilities()
+        caps["supported_commands"] = [
+            cmd for cmd in caps["supported_commands"] if cmd != "review.resolve_compliance"
+        ]
+        return caps
+
+
+@pytest.mark.asyncio
+async def test_deferred_command_hidden_from_list_tools(monkeypatch):
+    """When daemon reports a command as deferred, its MCP tool is hidden."""
+    monkeypatch.setattr(server, "_client", lambda: _DeferredCapabilityClient())
+
+    tools = await server.list_tools()
+    names = {tool.name for tool in tools}
+
+    assert "bicameral.review.resolve_compliance" not in names
+    # Other tools remain visible.
+    assert "bicameral.preflight" in names
+    assert "bicameral.history" in names
+
+
+@pytest.mark.asyncio
+async def test_deferred_command_call_returns_typed_error(monkeypatch):
+    """Calling a deferred command returns a typed daemon_capability_error with deferred flag."""
+    monkeypatch.setattr(server, "_client", lambda: _DeferredCapabilityClient())
+
+    content = await server.call_tool(
+        "bicameral.review.resolve_compliance",
+        {"target_id": "DEC-1", "compliance_verdict": "reflected"},
+    )
+    response = json.loads(content[0].text)
+
+    assert response["status"] == "error"
+    assert response["error_code"] == "daemon_capability_error"
+    assert response["recovery"]["deferred"] is True
+    assert response["recovery"]["requested_tool"] == "bicameral.review.resolve_compliance"
+    assert response["recovery"]["requested_command"] == "review.resolve_compliance"
+
+
+@pytest.mark.asyncio
+async def test_absent_command_hidden_from_list_tools(monkeypatch):
+    """When daemon does not advertise a command at all, its MCP tool is hidden."""
+    monkeypatch.setattr(server, "_client", lambda: _AbsentCapabilityClient())
+
+    tools = await server.list_tools()
+    names = {tool.name for tool in tools}
+
+    assert "bicameral.review.resolve_compliance" not in names
+    assert "bicameral.preflight" in names
+
+
+@pytest.mark.asyncio
+async def test_absent_command_call_returns_capability_error(monkeypatch):
+    """Calling an absent command returns daemon_capability_error without deferred flag."""
+    monkeypatch.setattr(server, "_client", lambda: _AbsentCapabilityClient())
+
+    content = await server.call_tool(
+        "bicameral.review.resolve_compliance",
+        {"target_id": "DEC-1", "compliance_verdict": "reflected"},
+    )
+    response = json.loads(content[0].text)
+
+    assert response["status"] == "error"
+    assert response["error_code"] == "daemon_capability_error"
+    assert "deferred" not in response["recovery"]
+    assert response["recovery"]["requested_tool"] == "bicameral.review.resolve_compliance"
+
+
+@pytest.mark.asyncio
+async def test_supported_command_visible_and_callable(monkeypatch):
+    """When daemon reports a command as supported, its MCP tool works normally."""
+    fake = _FakeClient()
+    monkeypatch.setattr(server, "_client", lambda: fake)
+
+    tools = await server.list_tools()
+    names = {tool.name for tool in tools}
+    assert "bicameral.review.resolve_compliance" in names
+
+    content = await server.call_tool(
+        "bicameral.review.resolve_compliance",
+        {"target_id": "DEC-1", "compliance_verdict": "reflected"},
+    )
+    response = json.loads(content[0].text)
+    assert response["status"] == "ok"
+
+
+@pytest.mark.asyncio
+async def test_local_only_tools_always_visible(monkeypatch):
+    """Local-only tools remain visible regardless of daemon capability report."""
+    monkeypatch.setattr(server, "_client", lambda: _DeferredCapabilityClient())
+
+    tools = await server.list_tools()
+    names = {tool.name for tool in tools}
+
+    for local_tool in LOCAL_ONLY_TOOLS:
+        assert local_tool in names
+
+
+def test_resolve_compliance_description_does_not_imply_alpha_support():
+    """Tool description for review.resolve_compliance must not imply alpha support."""
+    from tool_schemas import tool_for_name
+
+    tool = tool_for_name("bicameral.review.resolve_compliance")
+    assert tool is not None
+    desc = tool.description.lower()
+    assert "deferred" in desc
+    assert "alpha" in desc

--- a/tests/test_toolrequest_thin_client.py
+++ b/tests/test_toolrequest_thin_client.py
@@ -751,3 +751,219 @@ def test_ingest_schema_exposes_decision_level():
     assert "decision_level" in props
     assert props["decision_level"]["type"] == "string"
     assert props["decision_level"]["enum"] == ["L1", "L2", "L3"]
+
+
+# ---------------------------------------------------------------------------
+# recall.inspect_evidence & recall.expand_scope (#678)
+# ---------------------------------------------------------------------------
+
+
+def test_recall_inspect_evidence_schema_exists():
+    from tool_schemas import tool_for_name
+
+    tool = tool_for_name("bicameral.recall.inspect_evidence")
+    assert tool is not None
+    props = tool.inputSchema["properties"]
+    assert "packet_id" in props
+    assert "match_id" in props
+    assert "evidence_id" in props
+    assert tool.inputSchema["required"] == ["packet_id", "match_id"]
+
+
+def test_recall_inspect_evidence_description_honesty_language():
+    from tool_schemas import tool_for_name
+
+    tool = tool_for_name("bicameral.recall.inspect_evidence")
+    assert tool is not None
+    desc = tool.description
+    assert "searched scope" in desc.lower() or "unknown scope" in desc.lower()
+    for forbidden in ("compliance", "signoff", "enforcement"):
+        assert forbidden not in desc.lower() or "not create, mutate, or verify" in desc.lower()
+
+
+def test_recall_expand_scope_schema_exists():
+    from tool_schemas import tool_for_name
+
+    tool = tool_for_name("bicameral.recall.expand_scope")
+    assert tool is not None
+    props = tool.inputSchema["properties"]
+    assert "packet_id" in props
+    assert "expand_to" in props
+    assert "reason" in props
+    assert tool.inputSchema["required"] == ["packet_id"]
+
+
+def test_recall_expand_scope_description_honesty_language():
+    from tool_schemas import tool_for_name
+
+    tool = tool_for_name("bicameral.recall.expand_scope")
+    assert tool is not None
+    desc = tool.description
+    assert "unknown scope" in desc.lower() or "searched" in desc.lower()
+    for forbidden in ("compliance", "signoff", "enforcement"):
+        assert forbidden not in desc.lower() or "not create, mutate, or verify" in desc.lower()
+
+
+def test_recall_inspect_evidence_toolrequest_shape():
+    request = build_tool_request(
+        command_name="recall.inspect_evidence",
+        params={
+            "packet_id": "pkt-001",
+            "match_id": "match-A",
+            "evidence_id": "ev-1",
+            "actor_id": "should-be-stripped",
+        },
+        authority={"actor_id": "u", "auth_method": "mcp_session"},
+    )
+    assert request["command"] == {
+        "name": "recall.inspect_evidence",
+        "params": {
+            "packet_id": "pkt-001",
+            "match_id": "match-A",
+            "evidence_id": "ev-1",
+        },
+    }
+    assert "actor_id" not in request["command"]["params"]
+    assert request["authority"]["auth_method"] == "mcp_session"
+
+
+def test_recall_expand_scope_toolrequest_shape():
+    request = build_tool_request(
+        command_name="recall.expand_scope",
+        params={
+            "packet_id": "pkt-002",
+            "expand_to": ["source-B", "source-C"],
+            "reason": "wider coverage needed",
+            "actor_id": "should-be-stripped",
+        },
+        authority={"actor_id": "u", "auth_method": "mcp_session"},
+    )
+    assert request["command"] == {
+        "name": "recall.expand_scope",
+        "params": {
+            "packet_id": "pkt-002",
+            "expand_to": ["source-B", "source-C"],
+            "reason": "wider coverage needed",
+        },
+    }
+    assert "actor_id" not in request["command"]["params"]
+
+
+def test_recall_expand_scope_toolrequest_minimal():
+    request = build_tool_request(
+        command_name="recall.expand_scope",
+        params={"packet_id": "pkt-003"},
+        authority={"actor_id": "u", "auth_method": "mcp_session"},
+    )
+    assert request["command"]["params"] == {"packet_id": "pkt-003"}
+
+
+@pytest.mark.asyncio
+async def test_recall_inspect_evidence_maps_to_daemon(monkeypatch):
+    fake = _FakeClient()
+    monkeypatch.setattr(server, "_client", lambda: fake)
+
+    content = await server.call_tool(
+        "bicameral.recall.inspect_evidence",
+        {"packet_id": "pkt-100", "match_id": "match-X"},
+    )
+    response = json.loads(content[0].text)
+
+    assert response["status"] == "ok"
+    assert response["scope_note"]
+    req = fake.requests[-1]
+    assert req["command"]["name"] == "recall.inspect_evidence"
+    assert req["command"]["params"] == {"packet_id": "pkt-100", "match_id": "match-X"}
+
+
+@pytest.mark.asyncio
+async def test_recall_expand_scope_maps_to_daemon(monkeypatch):
+    fake = _FakeClient()
+    monkeypatch.setattr(server, "_client", lambda: fake)
+
+    content = await server.call_tool(
+        "bicameral.recall.expand_scope",
+        {"packet_id": "pkt-200", "expand_to": ["extra-source"]},
+    )
+    response = json.loads(content[0].text)
+
+    assert response["status"] == "ok"
+    assert response["scope_note"]
+    req = fake.requests[-1]
+    assert req["command"]["name"] == "recall.expand_scope"
+    assert req["command"]["params"] == {
+        "packet_id": "pkt-200",
+        "expand_to": ["extra-source"],
+    }
+
+
+@pytest.mark.asyncio
+async def test_recall_inspect_evidence_absent_capability_returns_error(monkeypatch):
+    """When daemon does not advertise recall.inspect_evidence, MCP returns a typed error."""
+
+    class _NoRecallInspectClient(_FakeClient):
+        async def capabilities(self) -> dict:
+            caps = await super().capabilities()
+            caps["supported_commands"] = [
+                c for c in caps["supported_commands"] if c != "recall.inspect_evidence"
+            ]
+            return caps
+
+    fake = _NoRecallInspectClient()
+    monkeypatch.setattr(server, "_client", lambda: fake)
+
+    content = await server.call_tool(
+        "bicameral.recall.inspect_evidence",
+        {"packet_id": "pkt-absent", "match_id": "m1"},
+    )
+    response = json.loads(content[0].text)
+
+    assert response["status"] == "error"
+    assert response["error_code"] == "daemon_capability_error"
+    assert response["recovery"]["requested_tool"] == "bicameral.recall.inspect_evidence"
+    assert response["recovery"]["requested_command"] == "recall.inspect_evidence"
+    assert fake.requests == []
+
+
+@pytest.mark.asyncio
+async def test_recall_expand_scope_absent_capability_returns_error(monkeypatch):
+    """When daemon does not advertise recall.expand_scope, MCP returns a typed error."""
+
+    class _NoRecallExpandClient(_FakeClient):
+        async def capabilities(self) -> dict:
+            caps = await super().capabilities()
+            caps["supported_commands"] = [
+                c for c in caps["supported_commands"] if c != "recall.expand_scope"
+            ]
+            return caps
+
+    fake = _NoRecallExpandClient()
+    monkeypatch.setattr(server, "_client", lambda: fake)
+
+    content = await server.call_tool(
+        "bicameral.recall.expand_scope",
+        {"packet_id": "pkt-absent"},
+    )
+    response = json.loads(content[0].text)
+
+    assert response["status"] == "error"
+    assert response["error_code"] == "daemon_capability_error"
+    assert response["recovery"]["requested_tool"] == "bicameral.recall.expand_scope"
+    assert response["recovery"]["requested_command"] == "recall.expand_scope"
+    assert fake.requests == []
+
+
+def test_recall_command_mapping_completeness():
+    """Verify recall.inspect_evidence and recall.expand_scope are mapped."""
+    assert MCP_TOOL_COMMANDS["bicameral.recall.inspect_evidence"] == "recall.inspect_evidence"
+    assert MCP_TOOL_COMMANDS["bicameral.recall.expand_scope"] == "recall.expand_scope"
+
+
+def test_recall_request_correction_not_in_new_recall_namespace():
+    """recall.request_correction is NOT exposed in bicameral.recall.* namespace (bot#663 open)."""
+    recall_tools = [name for name in MCP_TOOL_COMMANDS if name.startswith("bicameral.recall.")]
+    assert "bicameral.recall.request_correction" not in recall_tools
+    assert set(recall_tools) == {
+        "bicameral.recall.inspect_evidence",
+        "bicameral.recall.expand_scope",
+    }

--- a/tests/test_toolrequest_thin_client.py
+++ b/tests/test_toolrequest_thin_client.py
@@ -881,3 +881,85 @@ def test_resolve_compliance_description_does_not_imply_alpha_support():
     desc = tool.description.lower()
     assert "deferred" in desc
     assert "alpha" in desc
+
+
+# ---------------------------------------------------------------------------
+# Extended capability filtering (#676)
+# ---------------------------------------------------------------------------
+
+
+class _DualListCapabilityClient(_FakeClient):
+    """Fake daemon that reports a command in both supported and deferred."""
+
+    async def capabilities(self) -> dict:
+        caps = await super().capabilities()
+        caps["deferred_commands"] = ["binding.inspect"]
+        return caps
+
+
+@pytest.mark.asyncio
+async def test_deferred_wins_over_supported_in_list_tools(monkeypatch):
+    """If a command appears in both supported and deferred, deferred wins."""
+    monkeypatch.setattr(server, "_client", lambda: _DualListCapabilityClient())
+
+    tools = await server.list_tools()
+    names = {tool.name for tool in tools}
+
+    assert "bicameral.binding.inspect" not in names
+    assert "bicameral.bind" in names
+    assert "bicameral.preflight" in names
+
+
+@pytest.mark.asyncio
+async def test_deferred_wins_over_supported_in_call_tool(monkeypatch):
+    """If a command appears in both supported and deferred, call_tool returns deferred error."""
+    fake = _DualListCapabilityClient()
+    monkeypatch.setattr(server, "_client", lambda: fake)
+
+    content = await server.call_tool(
+        "bicameral.binding.inspect",
+        {"decision_or_candidate_id": "DEC-1"},
+    )
+    response = json.loads(content[0].text)
+
+    assert response["status"] == "error"
+    assert response["error_code"] == "daemon_capability_error"
+    assert response["recovery"]["deferred"] is True
+    assert fake.requests == []
+
+
+@pytest.mark.asyncio
+async def test_minimal_supported_set_hides_all_others(monkeypatch):
+    """Protocol-compatible daemon with only two supported commands hides all others."""
+
+    class _MinimalClient(_FakeClient):
+        async def capabilities(self) -> dict:
+            return {
+                "toolrequest_protocol_version": TOOLREQUEST_PROTOCOL_VERSION,
+                "supported_commands": ["preflight.run", "lookup.query"],
+            }
+
+    monkeypatch.setattr(server, "_client", lambda: _MinimalClient())
+
+    tools = await server.list_tools()
+    names = {tool.name for tool in tools}
+
+    assert "bicameral.preflight" in names
+    assert "bicameral.lookup" in names
+    assert "bicameral.context" in names  # also maps to lookup.query
+    assert "bicameral.bind" not in names
+    assert "bicameral.history" not in names
+    assert "bicameral.search" not in names
+    assert "bicameral.ingest" not in names
+    assert LOCAL_ONLY_TOOLS <= names
+
+
+@pytest.mark.asyncio
+async def test_full_capabilities_exposes_complete_tool_surface(monkeypatch):
+    """When daemon supports all commands, list_tools returns the full tool set."""
+    monkeypatch.setattr(server, "_client", lambda: _FakeClient())
+
+    tools = await server.list_tools()
+    names = {tool.name for tool in tools}
+
+    assert names == set(MCP_TOOL_COMMANDS) | LOCAL_ONLY_TOOLS

--- a/tool_request.py
+++ b/tool_request.py
@@ -31,6 +31,8 @@ MCP_TOOL_COMMANDS: dict[str, str] = {
     "bicameral.review.approve_signoff": "review.approve_signoff",
     "bicameral.review.reject_signoff": "review.reject_signoff",
     "bicameral.review.resolve_compliance": "review.resolve_compliance",
+    "bicameral.recall.inspect_evidence": "recall.inspect_evidence",
+    "bicameral.recall.expand_scope": "recall.expand_scope",
     "bicameral.brief": "brief.render",
     "bicameral.history": "history.list",
     "bicameral.search": "search.query",
@@ -143,6 +145,10 @@ def _command_params(command_name: str, params: dict[str, Any]) -> dict[str, Any]
             "scoping_relationship",
             "approval_proof",
         )
+    if command_name == "recall.inspect_evidence":
+        return _only(cleaned, "packet_id", "match_id", "evidence_id")
+    if command_name == "recall.expand_scope":
+        return _only(cleaned, "packet_id", "expand_to", "reason")
     if command_name == "recall.request_correction":
         return _only(
             cleaned,

--- a/tool_schemas.py
+++ b/tool_schemas.py
@@ -443,7 +443,12 @@ SUPPORTED_TOOLS: tuple[Tool, ...] = (
     ),
     Tool(
         name="bicameral.review.resolve_compliance",
-        description="Resolve compliance state for a decision through bot governance.",
+        description=(
+            "Deferred in alpha. Resolve compliance state for a decision through "
+            "bot governance when the daemon advertises this command as supported. "
+            "Hidden from the tool list when deferred; returns a typed daemon "
+            "capability error if called directly."
+        ),
         inputSchema=_schema(
             {
                 "target_id": {"type": "string"},

--- a/tool_schemas.py
+++ b/tool_schemas.py
@@ -513,6 +513,70 @@ SUPPORTED_TOOLS: tuple[Tool, ...] = (
         ),
     ),
     Tool(
+        name="bicameral.recall.inspect_evidence",
+        description=(
+            "Inspect cited evidence from a daemon-authored RecallPacket. Returns "
+            "daemon-owned evidence detail for the specified match within the "
+            "packet's searched scope. Unknown scope is surfaced explicitly; "
+            "absence of evidence in the searched scope does not imply absence "
+            "in unknown or un-searched sources. This is a read-only lookup; "
+            "it does not create, mutate, or verify Decisions, candidates, "
+            "BindingEvidence, signoff, compliance, or trusted-corpus state."
+        ),
+        inputSchema=_schema(
+            {
+                "packet_id": {
+                    "type": "string",
+                    "description": "RecallPacket ID returned by a prior lookup or preflight.",
+                },
+                "match_id": {
+                    "type": "string",
+                    "description": "Match ID within the RecallPacket to inspect.",
+                },
+                "evidence_id": {
+                    "type": "string",
+                    "description": "Optional specific evidence reference ID to inspect.",
+                },
+            },
+            ["packet_id", "match_id"],
+        ),
+    ),
+    Tool(
+        name="bicameral.recall.expand_scope",
+        description=(
+            "Request the daemon to expand the search scope of a prior "
+            "RecallPacket lookup. The daemon decides which additional sources "
+            "to search and returns an updated RecallPacket with expanded "
+            "searched-scope and any newly discovered matches. Unknown scope "
+            "after expansion is surfaced explicitly. This is a read-only "
+            "scope-widening request; it does not create, mutate, or verify "
+            "Decisions, candidates, BindingEvidence, signoff, compliance, "
+            "or trusted-corpus state."
+        ),
+        inputSchema=_schema(
+            {
+                "packet_id": {
+                    "type": "string",
+                    "description": "RecallPacket ID whose scope should be expanded.",
+                },
+                "expand_to": {
+                    "type": "array",
+                    "items": {"type": "string"},
+                    "description": (
+                        "Optional list of additional source identifiers to include "
+                        "in the expanded search. When omitted the daemon uses its "
+                        "default expansion strategy."
+                    ),
+                },
+                "reason": {
+                    "type": "string",
+                    "description": "Optional reason for requesting scope expansion.",
+                },
+            },
+            ["packet_id"],
+        ),
+    ),
+    Tool(
         name="bicameral.review.contradictions",
         description=(
             "List active contradiction findings for review. Alias for the daemon "


### PR DESCRIPTION
## Summary

Integration PR: dev -> main for the alpha capability/tooling chain merged to dev.

Included PRs:
- #684 / #677: mark deferred MCP commands with honest alpha behavior
- #685 / #678: expose daemon-supported recall inspect and expand-scope actions
- #683 / #676: add extended capability-filtering tests, including deferred-wins-over-supported

## Notes

- Merge method: merge commit, not squash.
- MCP remains a thin ToolRequest client: command support and deferred state come from daemon CapabilityReport.
- Recall tools are daemon-gated and do not create, mutate, or verify Decisions, candidates, BindingEvidence, signoff, compliance, or trusted-corpus state.

## Validation

PR checks ran green on #683, #684, and #685 before merge to dev. #685 was rebased on current dev and locally validated with:
- /private/tmp/bic-mcp-614-venv/bin/python -m pytest -q -> 528 passed
- /private/tmp/bic-mcp-614-venv/bin/python -m ruff check . -> passed
- /private/tmp/bic-mcp-614-venv/bin/python -m ruff format --check . -> passed
- /private/tmp/bic-mcp-614-venv/bin/python -m mypy server.py responses.py governance_surface.py tool_request.py tool_schemas.py -> passed

Closes #676
Closes #677
Closes #678

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added two new recall tools for inspecting evidence and expanding a previous search scope.
  * Tool listings now better reflect what’s available, hiding commands that are temporarily unavailable or deferred.

* **Bug Fixes**
  * Improved error responses when a requested tool isn’t supported or is deferred, with clearer recovery guidance.
  * Enhanced recall response details to include scope notes and next-step actions where relevant.

* **Documentation**
  * Updated the supported tools reference to include the new recall capabilities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->