### PR TITLE
docs: codify human review branch controls (#675)

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,3 +1,7 @@
 # CODEOWNERS for BicameralAI/bicameral-mcp.
+#
+# SOC2 control #675: all production changes require at least one approval
+# from a named human reviewer. AI agents and automation identities are not
+# standing approvers and must not be added as code owners.
 
 * @jinhongkuan

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -14,6 +14,10 @@
 - [ ] `ruff check . && ruff format --check .` passes locally.
 - [ ] CI regression suite passes (ubuntu + windows).
 
+## Review Control
+
+- [ ] This PR has, or will receive before merge, approval from a named human reviewer. AI agents and automation identities do not satisfy the approval requirement.
+
 ## Notes
 
 <!-- Anything reviewers should know: tradeoffs, follow-ups, known limitations. -->

--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -34,11 +34,24 @@ compliance outcomes.
 
 ## Branch protection plan
 
-The default branch should be protected with:
+The default branch must be protected with the repository's SOC2 compensating
+control for limited team size:
 
-- Pull request review before merge
-- Status checks for tests, lint/typecheck, and secret scanning
-- Restrict force pushes on `main` and release branches
+- Changes to `main` land by pull request; direct pushes are blocked.
+- At least one approving review from a named human reviewer is required before merge.
+- `CODEOWNERS` designates the required human reviewer set. AI agents and automation
+  identities are untrusted contributors for approval purposes and have no standing
+  self-approval.
+- Required status checks must pass before merge, including deterministic tests,
+  lint/typecheck, secret scanning, security scanning, dependency review, governance
+  boundary, factory attestation, and CodeQL where enabled.
+- Branch protection applies to administrators; admin bypass of the human-review gate
+  requires an explicit documented exception.
+- Force pushes and branch deletion are restricted on `main` and release branches.
+
+As of the #675 control review, GitHub reports `main` as protected. Detailed branch
+protection settings are maintained in GitHub repository settings and require an
+administrator to verify or change.
 
 ## Contribution guidelines
 


### PR DESCRIPTION
## Summary
- codify the SOC2 human-review branch protection control in GOVERNANCE.md
- document that AI agents and automation identities are not standing approvers
- make the PR template require named human approval before merge
- annotate CODEOWNERS with the #675 control intent

## Repository Settings Observed
- GitHub API reports main as protected via branches/main
- rulesets endpoint returns no visible rulesets for this token
- detailed branch protection endpoint returns 404 for this token, so admin verification is still needed for exact settings
- current CODEOWNERS already designates @jinhongkuan for all paths

## Remaining Admin Verification
- require at least one approving human review before merge
- block direct pushes to main
- require status checks before merge
- enforce protection for administrators
- confirm no AI/automation identity can self-approve or bypass deployment gates
- confirm org MFA and collaborator least privilege

## Validation
- python3 scripts/validate_governance_boundary.py
- git diff --check

Refs #675