### PR TITLE
fix: constrain daemon endpoint controls (#674)

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -19,6 +19,24 @@ bicameral-mcp is a local-install developer tool. **The trust boundary is the OS 
 See [`docs/specs/bicameral-mcp-idealized-spec.md`](docs/specs/bicameral-mcp-idealized-spec.md)
 for the canonical MCP cutover scope.
 
+## Application controls
+
+The MCP package is a thin client and treats all MCP tool arguments as untrusted
+transport input. Tool calls are converted through allowlisted ToolRequest
+commands/params, approval-gated operations fail closed, and daemon capability
+handshake failures do not fall back to MCP-owned legacy handlers.
+
+Daemon access is constrained to local endpoints. `BICAMERAL_DAEMON_URL` and
+`BICAMERAL_BOT_DAEMON_URL` may only target loopback/localhost HTTP(S) daemon
+roots, must not include embedded credentials, query strings, fragments, or path
+prefixes, and are redacted before appearing in recovery output. The optional
+`BICAMERAL_DAEMON_TIMEOUT` override is bounded between 0.1 and 60 seconds.
+
+The MCP package does not invoke external model or automation providers directly.
+Provider, storage, and data-use controls for captured evidence remain owned by
+the configured local `bicameral-bot` daemon. Until team-mode/auth-shim work
+lands, confidential-data access is limited to the local OS-user boundary.
+
 ## Software supply chain
 
 Each release ships signed artifacts on the [Releases page](https://github.com/BicameralAI/bicameral-mcp/releases):

--- a/daemon_client.py
+++ b/daemon_client.py
@@ -2,9 +2,11 @@
 
 from __future__ import annotations
 
+import ipaddress
 import json
 import os
 import urllib.error
+import urllib.parse
 import urllib.request
 from dataclasses import dataclass
 from typing import Any
@@ -67,6 +69,9 @@ class CapabilityReport:
 
 DAEMON_URL_ENV_VARS = ("BICAMERAL_DAEMON_URL", "BICAMERAL_BOT_DAEMON_URL")
 DEFAULT_DAEMON_URL = "http://127.0.0.1:37373"
+DEFAULT_DAEMON_TIMEOUT_SECONDS = 10.0
+MIN_DAEMON_TIMEOUT_SECONDS = 0.1
+MAX_DAEMON_TIMEOUT_SECONDS = 60.0
 
 
 @dataclass(frozen=True)
@@ -81,16 +86,121 @@ def resolve_daemon_endpoint() -> DaemonEndpoint:
     for env_var in DAEMON_URL_ENV_VARS:
         value = os.environ.get(env_var)
         if value:
+            url = _validate_daemon_endpoint(value, env_var=env_var)
             return DaemonEndpoint(
-                url=value.rstrip("/"),
+                url=url,
                 override_env_var=env_var,
-                override_value=value,
+                override_value=_redact_url(value),
             )
     return DaemonEndpoint(
         url=DEFAULT_DAEMON_URL,
         override_env_var=None,
         override_value=None,
     )
+
+
+def resolve_daemon_endpoint_for_display() -> DaemonEndpoint:
+    """Resolve daemon endpoint details for recovery payloads without failing.
+
+    ``DaemonClient.from_env`` owns enforcement. Recovery rendering must still
+    work when the configured override is invalid, so this helper returns a
+    redacted display value instead of raising during error formatting.
+    """
+    for env_var in DAEMON_URL_ENV_VARS:
+        value = os.environ.get(env_var)
+        if value:
+            display_value = _redact_url(value)
+            return DaemonEndpoint(
+                url=display_value.rstrip("/"),
+                override_env_var=env_var,
+                override_value=display_value,
+            )
+    return DaemonEndpoint(
+        url=DEFAULT_DAEMON_URL,
+        override_env_var=None,
+        override_value=None,
+    )
+
+
+def _validate_daemon_endpoint(value: str, *, env_var: str) -> str:
+    raw_value = value.strip()
+    parsed = urllib.parse.urlparse(raw_value)
+    if parsed.scheme not in {"http", "https"}:
+        raise DaemonConnectionError(
+            f"{env_var} must use http:// or https:// for the local daemon endpoint",
+            daemon_endpoint=_redact_url(raw_value),
+        )
+    if not parsed.hostname:
+        raise DaemonConnectionError(
+            f"{env_var} must include a local daemon hostname",
+            daemon_endpoint=_redact_url(raw_value),
+        )
+    if parsed.username or parsed.password:
+        raise DaemonConnectionError(
+            f"{env_var} must not include credentials in the daemon URL",
+            daemon_endpoint=_redact_url(raw_value),
+        )
+    if parsed.query or parsed.fragment:
+        raise DaemonConnectionError(
+            f"{env_var} must not include query strings or fragments",
+            daemon_endpoint=_redact_url(raw_value),
+        )
+    if parsed.path not in ("", "/"):
+        raise DaemonConnectionError(
+            f"{env_var} must point at the daemon root, not a path prefix",
+            daemon_endpoint=_redact_url(raw_value),
+        )
+    if not _is_loopback_host(parsed.hostname):
+        raise DaemonConnectionError(
+            f"{env_var} must point to a loopback/localhost daemon endpoint",
+            daemon_endpoint=_redact_url(raw_value),
+        )
+
+    sanitized = urllib.parse.urlunparse((parsed.scheme, parsed.netloc, "", "", "", ""))
+    return sanitized.rstrip("/")
+
+
+def _is_loopback_host(hostname: str) -> bool:
+    normalized = hostname.rstrip(".").lower()
+    if normalized == "localhost" or normalized.endswith(".localhost"):
+        return True
+    try:
+        return ipaddress.ip_address(normalized).is_loopback
+    except ValueError:
+        return False
+
+
+def _resolve_timeout_seconds() -> float:
+    raw_value = os.environ.get("BICAMERAL_DAEMON_TIMEOUT")
+    if raw_value is None:
+        return DEFAULT_DAEMON_TIMEOUT_SECONDS
+    try:
+        timeout = float(raw_value)
+    except ValueError as exc:
+        raise DaemonConnectionError("BICAMERAL_DAEMON_TIMEOUT must be a number of seconds") from exc
+    if not MIN_DAEMON_TIMEOUT_SECONDS <= timeout <= MAX_DAEMON_TIMEOUT_SECONDS:
+        raise DaemonConnectionError(
+            "BICAMERAL_DAEMON_TIMEOUT must be between "
+            f"{MIN_DAEMON_TIMEOUT_SECONDS} and {MAX_DAEMON_TIMEOUT_SECONDS} seconds"
+        )
+    return timeout
+
+
+def _redact_url(value: str) -> str:
+    parsed = urllib.parse.urlparse(value.strip())
+    if not parsed.netloc:
+        return urllib.parse.urlunparse((parsed.scheme, parsed.netloc, parsed.path, "", "", ""))
+    host = parsed.hostname or ""
+    if ":" in host and not host.startswith("["):
+        host = f"[{host}]"
+    netloc = host
+    try:
+        port = parsed.port
+    except ValueError:
+        port = None
+    if port is not None:
+        netloc = f"{netloc}:{port}"
+    return urllib.parse.urlunparse((parsed.scheme, netloc, parsed.path, "", "", ""))
 
 
 @dataclass(frozen=True)
@@ -101,7 +211,7 @@ class DaemonClient:
     @classmethod
     def from_env(cls) -> DaemonClient:
         endpoint = resolve_daemon_endpoint()
-        timeout = float(os.environ.get("BICAMERAL_DAEMON_TIMEOUT", "10"))
+        timeout = _resolve_timeout_seconds()
         return cls(base_url=endpoint.url, timeout_seconds=timeout)
 
     async def capabilities(self) -> dict[str, Any]:
@@ -132,6 +242,8 @@ class DaemonClient:
         payload: dict[str, Any] | None = None,
     ) -> dict[str, Any]:
         url = f"{self.base_url}{path}"
+        display_url = _redact_url(url)
+        display_endpoint = _redact_url(self.base_url)
         body = None if payload is None else json.dumps(payload).encode("utf-8")
         request = urllib.request.Request(
             url,
@@ -145,24 +257,24 @@ class DaemonClient:
         except urllib.error.HTTPError as exc:
             detail = exc.read().decode("utf-8", errors="replace")
             raise DaemonConnectionError(
-                f"daemon HTTP {exc.code} at {url}: {detail}",
-                daemon_endpoint=self.base_url,
+                f"daemon HTTP {exc.code} at {display_url}: {detail}",
+                daemon_endpoint=display_endpoint,
             ) from exc
         except urllib.error.URLError as exc:
             raise DaemonConnectionError(
-                f"cannot reach bicameral-bot daemon at {url}: {exc}",
-                daemon_endpoint=self.base_url,
+                f"cannot reach bicameral-bot daemon at {display_url}: {exc}",
+                daemon_endpoint=display_endpoint,
             ) from exc
         except TimeoutError as exc:
             raise DaemonConnectionError(
-                f"timed out reaching bicameral-bot daemon at {url}",
-                daemon_endpoint=self.base_url,
+                f"timed out reaching bicameral-bot daemon at {display_url}",
+                daemon_endpoint=display_endpoint,
             ) from exc
 
         try:
             decoded = json.loads(raw)
         except json.JSONDecodeError as exc:
-            raise DaemonProtocolError(f"daemon returned invalid JSON at {url}") from exc
+            raise DaemonProtocolError(f"daemon returned invalid JSON at {display_url}") from exc
         if not isinstance(decoded, dict):
-            raise DaemonProtocolError(f"daemon returned non-object JSON at {url}")
+            raise DaemonProtocolError(f"daemon returned non-object JSON at {display_url}")
         return decoded

--- a/responses.py
+++ b/responses.py
@@ -8,7 +8,7 @@ from typing import Any
 
 from mcp.types import TextContent
 
-from daemon_client import DaemonClientError, resolve_daemon_endpoint
+from daemon_client import DaemonClientError, resolve_daemon_endpoint_for_display
 from version import TOOLREQUEST_PROTOCOL_VERSION
 
 PREFLIGHT_STAGES = ("capture", "projection", "lookup", "enforcement")
@@ -657,7 +657,7 @@ def build_recovery_payload(
     """
     details = details or {}
     guidance = RECOVERY_GUIDANCE.get(error_code, RECOVERY_GUIDANCE["daemon_error"])
-    endpoint = resolve_daemon_endpoint()
+    endpoint = resolve_daemon_endpoint_for_display()
 
     operator_action = guidance["operator_action"]
     recovery: dict[str, Any] = {

--- a/server.py
+++ b/server.py
@@ -166,8 +166,8 @@ async def call_tool(name: str, arguments: dict[str, Any] | None) -> list[types.T
             return gate_result
 
     command_name = MCP_TOOL_COMMANDS[name]
-    client = _client()
     try:
+        client = _client()
         capability_report = await _ensure_protocol_compatible(client)
         _ensure_command_advertised(command_name, capability_report)
 

--- a/tests/test_toolrequest_thin_client.py
+++ b/tests/test_toolrequest_thin_client.py
@@ -10,7 +10,9 @@ import server
 from daemon_client import (
     DEFAULT_DAEMON_URL,
     DaemonCapabilityError,
+    DaemonClient,
     DaemonConnectionError,
+    resolve_daemon_endpoint,
 )
 from responses import build_recovery_payload, format_preflight_response
 from tool_request import (
@@ -630,11 +632,11 @@ async def test_capability_error_recovery_includes_tool_and_command(monkeypatch):
 
 @pytest.mark.asyncio
 async def test_wrong_daemon_url_calls_out_env_override(monkeypatch):
-    monkeypatch.setenv("BICAMERAL_BOT_DAEMON_URL", "http://wrong-host:1234")
+    monkeypatch.setenv("BICAMERAL_BOT_DAEMON_URL", "http://localhost:1234")
     fake = _RaisingClient(
         capabilities_error=DaemonConnectionError(
             "cannot reach bicameral-bot daemon",
-            daemon_endpoint="http://wrong-host:1234",
+            daemon_endpoint="http://localhost:1234",
         )
     )
     monkeypatch.setattr(server, "_client", lambda: fake)
@@ -644,13 +646,13 @@ async def test_wrong_daemon_url_calls_out_env_override(monkeypatch):
 
     recovery = response["recovery"]
     assert recovery["daemon_url_override"]["env_var"] == "BICAMERAL_BOT_DAEMON_URL"
-    assert recovery["daemon_url_override"]["value"] == "http://wrong-host:1234"
+    assert recovery["daemon_url_override"]["value"] == "http://localhost:1234"
     assert "BICAMERAL_BOT_DAEMON_URL" in recovery["operator_action"]
-    assert recovery["daemon_endpoint"] == "http://wrong-host:1234"
+    assert recovery["daemon_endpoint"] == "http://localhost:1234"
 
 
 def test_build_recovery_payload_env_override_hint(monkeypatch):
-    monkeypatch.setenv("BICAMERAL_DAEMON_URL", "http://example.invalid:9999")
+    monkeypatch.setenv("BICAMERAL_DAEMON_URL", "http://127.0.0.1:9999")
 
     recovery = build_recovery_payload(
         error_code="daemon_unavailable",
@@ -659,9 +661,40 @@ def test_build_recovery_payload_env_override_hint(monkeypatch):
     )
 
     assert recovery["daemon_url_override"]["env_var"] == "BICAMERAL_DAEMON_URL"
-    assert recovery["daemon_url_override"]["value"] == "http://example.invalid:9999"
+    assert recovery["daemon_url_override"]["value"] == "http://127.0.0.1:9999"
     assert "BICAMERAL_DAEMON_URL" in recovery["operator_action"]
-    assert recovery["daemon_endpoint"] == "http://example.invalid:9999"
+    assert recovery["daemon_endpoint"] == "http://127.0.0.1:9999"
+
+
+def test_daemon_endpoint_rejects_external_hosts(monkeypatch):
+    monkeypatch.setenv("BICAMERAL_DAEMON_URL", "http://example.invalid:9999")
+
+    with pytest.raises(DaemonConnectionError, match="loopback/localhost"):
+        resolve_daemon_endpoint()
+
+
+@pytest.mark.asyncio
+async def test_daemon_endpoint_credentials_are_rejected_and_redacted(monkeypatch):
+    monkeypatch.setenv("BICAMERAL_DAEMON_URL", "http://user:secret@localhost:37373")
+
+    content = await server.call_tool("bicameral.history", {})
+    response = json.loads(content[0].text)
+
+    assert response["status"] == "error"
+    assert response["error_code"] == "daemon_unavailable"
+    recovery = response["recovery"]
+    assert recovery["daemon_url_override"]["value"] == "http://localhost:37373"
+    assert recovery["daemon_endpoint"] == "http://localhost:37373"
+    assert "secret" not in content[0].text
+    assert "user:" not in content[0].text
+
+
+def test_daemon_timeout_override_is_bounded(monkeypatch):
+    _clear_daemon_url_env(monkeypatch)
+    monkeypatch.setenv("BICAMERAL_DAEMON_TIMEOUT", "9999")
+
+    with pytest.raises(DaemonConnectionError, match="between"):
+        DaemonClient.from_env()
 
 
 def test_build_recovery_payload_no_override_uses_default_endpoint(monkeypatch):


### PR DESCRIPTION
Closes #674

## Summary
- constrain daemon URL overrides to loopback/localhost endpoints
- reject embedded credentials, query strings, fragments, and path prefixes
- redact daemon endpoint recovery output
- bound daemon timeout overrides
- document SOC2 application controls

## Validation
- /private/tmp/bic-mcp-614-venv/bin/python -m pytest -q
- /private/tmp/bic-mcp-614-venv/bin/python -m ruff check .
- /private/tmp/bic-mcp-614-venv/bin/python -m ruff format --check .
- /private/tmp/bic-mcp-614-venv/bin/python -m mypy .
- /private/tmp/bic-mcp-614-venv/bin/python scripts/validate_governance_boundary.py

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Security**
  * Tightened daemon connection handling with stricter validation of endpoint settings and safer redaction in recovery messages.
  * Added bounds for connection timeout settings to prevent invalid values.

* **Bug Fixes**
  * Improved recovery behavior when daemon client setup fails, so errors are handled more gracefully instead of surfacing unexpectedly.
  * Updated recovery details to show sanitized endpoint information when configuration is invalid.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->