### PR TITLE
docs: align MCP constraint lookup terminology (#564)

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,6 +87,25 @@ MCP exposes only ToolRequest-backed tools:
 | `bicameral.recall.expand_scope` | `recall.expand_scope` |
 | `bicameral.request_correction` | `correction.request` |
 
+## Product Terminology
+
+`bicameral.preflight` is the MCP surface for constraint lookup and readiness
+context before or during implementation. It maps to the bot-owned
+`preflight.run` command for historical protocol compatibility, but MCP does not
+turn lookup output into a governed work gate, compliance decision, signoff, or
+merge-safety claim.
+
+Use these terms consistently:
+
+- Constraint Lookup: retrieve relevant daemon-authored Decisions, source links,
+  evidence references, and readiness labels.
+- Constraint Correction Capture: submit or review proposed corpus corrections.
+- Code Grounding: inspect daemon-owned binding and graph evidence.
+- Code Compliance: review daemon-owned compliance state when the daemon exposes
+  that capability.
+- Governed Work Gate: future policy-controlled blocking/routing behavior; not
+  implied by ordinary lookup or preflight output.
+
 ## Troubleshooting: Daemon Handshake Failures
 
 MCP stays fail-fast on daemon capability handshake failures. It never starts,
@@ -130,7 +149,7 @@ bot-owned or CLI-owned, not MCP-owned.
 ## Prompts And Skills
 
 MCP may expose MCP prompts for generic Bicameral workflows over supported tools,
-such as preflight, binding, ingest, history, search, and brief.
+such as constraint lookup, binding, ingest, history, search, and brief.
 
 Repo-local skills are outside MCP. Keep repo/team behavior in repo skills:
 when to run Bicameral, which ADRs to read, contribution policy, factory

--- a/docs/specs/bicameral-mcp-idealized-spec.md
+++ b/docs/specs/bicameral-mcp-idealized-spec.md
@@ -71,7 +71,7 @@ MCP exposes tools that map to the bot `ToolCommand` registry from issue #103:
 |---|---|---|
 | `bicameral.ingest` | `ingest.submit_local` | Local actor submits source/session evidence or candidate drafts. |
 | `bicameral.capture_context` | `ingest.submit_local` | Submits MCP session/tool/command/code-hint context as bot-owned Source/SourceSnapshot/EvidenceReference-compatible local ingest input. |
-| `bicameral.preflight` | `preflight.run` | Reads relevant decisions and graph-scoped evidence via daemon. |
+| `bicameral.preflight` | `preflight.run` | Constraint Lookup/readiness surface: reads relevant decisions and graph-scoped evidence via daemon without implying a governed work gate. |
 | `bicameral.context` | `lookup.query` | Requests daemon-authored relevance-time ContextPacket/RecallPacket output for agent and developer workflows. |
 | `bicameral.correction_findings` | `lookup.query` | Requests daemon-authored correction-capture findings for PR/agent workflows without MCP-local drift or corpus mutation. |
 | `bicameral.lookup` | `lookup.query` | Queries daemon-authored RecallPacket output without MCP-local relevance or authority computation. |
@@ -106,9 +106,30 @@ Removal and erasure behavior is not a thin-client concern. Old MCP `remove_decis
 
 History, search, candidate review, signoff review, and compliance review are not separate MCP subsystems. They are existing bot-owned read/write concepts reached through `ToolRequest` command routing.
 
+## Product Terminology Boundary
+
+MCP-facing language must distinguish lookup, correction capture, grounding,
+compliance review, and work gating:
+
+- **Constraint Lookup** retrieves relevant daemon-authored Decisions,
+  source links, evidence references, and readiness labels before or during work.
+  `bicameral.preflight` currently belongs here even though its bot command name
+  remains `preflight.run`.
+- **Constraint Correction Capture** collects proposed corpus changes or drift
+  findings for daemon-owned review. MCP may request and render these artifacts;
+  it does not promote them into canonical truth.
+- **Code Grounding** inspects daemon-owned binding and graph evidence. MCP may
+  forward hints and render typed evidence states only.
+- **Code Compliance** is daemon-owned review state. MCP must not infer
+  compliance from lookup, binding, source links, or no-match output.
+- **Governed Work Gate** means policy-controlled block/route/interrupt behavior.
+  Ordinary `bicameral.preflight`, `bicameral.lookup`, or context packet output
+  must not be described as a gate unless the daemon explicitly returns a gate
+  decision through a future command.
+
 ## Prompts And Skills Boundary
 
-MCP may expose MCP prompts for generic Bicameral workflows that mainly guide the caller to use MCP tools, such as preflight, binding, local ingest, history, and search. These prompts are versioned with the MCP package and must call only supported ToolRequest-backed tools.
+MCP may expose MCP prompts for generic Bicameral workflows that mainly guide the caller to use MCP tools, such as constraint lookup, binding, local ingest, history, and search. These prompts are versioned with the MCP package and must call only supported ToolRequest-backed tools.
 
 MCP does not own repo-local skills. Repo skills are reserved for repo/team behavior: when to run Bicameral in that repository, which ADRs or context files to read, contribution policy, factory attestation, and workflows that span beyond Bicameral MCP.
 

--- a/responses.py
+++ b/responses.py
@@ -155,9 +155,11 @@ def format_preflight_response(response: dict[str, Any]) -> TextContent:
 
     Extracts the ``staged`` key added by bot#323 and surfaces each stage
     status at the top level of the MCP output.  Stages missing from the
-    daemon payload are rendered as ``unsupported``.  ``enforcement.status``
-    of ``not_configured`` is never promoted to warn/pause/block behavior.
-    ``session_directive`` is forwarded as-is from the daemon.
+    daemon payload are rendered as ``unsupported``.  The preflight surface is
+    constraint lookup/readiness, not an MCP-owned governed work gate:
+    ``enforcement.status`` of ``not_configured`` is never promoted to
+    warn/pause/block behavior.  ``session_directive`` is forwarded as-is from
+    the daemon.
     """
     staged: dict[str, Any] = response.get("staged", {})
     stages: dict[str, Any] = {}

--- a/tests/test_toolrequest_thin_client.py
+++ b/tests/test_toolrequest_thin_client.py
@@ -82,6 +82,21 @@ async def test_list_tools_exposes_only_toolrequest_backed_surface(monkeypatch):
 
 
 @pytest.mark.asyncio
+async def test_preflight_description_labels_lookup_and_denies_gate_claims(monkeypatch):
+    monkeypatch.setattr(server, "_client", lambda: _FakeClient())
+
+    tools = await server.list_tools()
+    preflight = next(tool for tool in tools if tool.name == "bicameral.preflight")
+    description = preflight.description.lower()
+
+    assert "constraint lookup" in description
+    assert "readiness" in description
+    assert "not an mcp compliance decision" in description
+    assert "signoff" in description
+    assert "governed work gate" in description
+
+
+@pytest.mark.asyncio
 async def test_call_tool_maps_to_canonical_toolrequest(monkeypatch):
     fake = _FakeClient()
     monkeypatch.setattr(server, "_client", lambda: fake)

--- a/tool_schemas.py
+++ b/tool_schemas.py
@@ -135,7 +135,11 @@ SUPPORTED_TOOLS: tuple[Tool, ...] = (
     ),
     Tool(
         name="bicameral.preflight",
-        description="Surface relevant decisions before implementation.",
+        description=(
+            "Run daemon-owned constraint lookup/readiness context before or during "
+            "implementation. This is not an MCP compliance decision, signoff, or "
+            "governed work gate."
+        ),
         inputSchema=_schema(
             {
                 "files": {"type": "array", "items": {"type": "string"}},


### PR DESCRIPTION
## Summary
- define MCP-facing product terminology for Constraint Lookup, Correction Capture, Code Grounding, Code Compliance, and Governed Work Gate
- describe bicameral.preflight as daemon-owned constraint lookup/readiness, not an MCP compliance/signoff/gate surface
- add a regression test for the public bicameral.preflight tool description

## Validation
- /private/tmp/bic-mcp-614-venv/bin/python -m pytest tests/test_toolrequest_thin_client.py -q
- /private/tmp/bic-mcp-614-venv/bin/python -m ruff check .
- /private/tmp/bic-mcp-614-venv/bin/python -m ruff format --check .
- /private/tmp/bic-mcp-614-venv/bin/python -m mypy .

Refs #564

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added clearer product terminology to define key concepts consistently.
  * Updated guidance so “constraint lookup” is used instead of “preflight” in relevant descriptions.

* **New Features**
  * Improved tool descriptions to clearly explain readiness, signoff, and governed work gate wording.
  * Clarified that lookup-style outputs should not be presented as a compliance decision unless explicitly stated.

* **Tests**
  * Added coverage to verify the updated tool description text appears as expected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->